### PR TITLE
multi: manage Taproot Assets over RPC and wavecli

### DIFF
--- a/arkrpc/ark.pb.go
+++ b/arkrpc/ark.pb.go
@@ -251,8 +251,15 @@ type GetInfoResponse struct {
 	// The number of blocks before batch expiry in which a pure refresh
 	// qualifies for a complete fee waiver. Zero disables the waiver.
 	FreeRefreshWindowBlocks uint32 `protobuf:"varint,23,opt,name=free_refresh_window_blocks,json=freeRefreshWindowBlocks,proto3" json:"free_refresh_window_blocks,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// The x-only public key owning the operator's carrier float. Set
+	// when the operator funds the new asset-leaf carriers of
+	// out-of-round transfers from its own float VTXOs; empty when
+	// carrier funding is disabled. Together with the operator's collab
+	// key and exit delay it derives the float's standard VTXO policy,
+	// which is also the script that stocks the float.
+	OorCarrierPubkey []byte `protobuf:"bytes,24,opt,name=oor_carrier_pubkey,json=oorCarrierPubkey,proto3" json:"oor_carrier_pubkey,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *GetInfoResponse) Reset() {
@@ -425,6 +432,148 @@ func (x *GetInfoResponse) GetFreeRefreshWindowBlocks() uint32 {
 	return 0
 }
 
+func (x *GetInfoResponse) GetOorCarrierPubkey() []byte {
+	if x != nil {
+		return x.OorCarrierPubkey
+	}
+	return nil
+}
+
+// LeaseOORCarrierRequest asks the operator to reserve a carrier float
+// VTXO covering at least the given value.
+type LeaseOORCarrierRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// required_sat is the minimum float value the transfer needs: the
+	// sum of the new asset-leaf carriers it will create.
+	RequiredSat   int64 `protobuf:"varint,1,opt,name=required_sat,json=requiredSat,proto3" json:"required_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LeaseOORCarrierRequest) Reset() {
+	*x = LeaseOORCarrierRequest{}
+	mi := &file_ark_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LeaseOORCarrierRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LeaseOORCarrierRequest) ProtoMessage() {}
+
+func (x *LeaseOORCarrierRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LeaseOORCarrierRequest.ProtoReflect.Descriptor instead.
+func (*LeaseOORCarrierRequest) Descriptor() ([]byte, []int) {
+	return file_ark_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *LeaseOORCarrierRequest) GetRequiredSat() int64 {
+	if x != nil {
+		return x.RequiredSat
+	}
+	return 0
+}
+
+// LeaseOORCarrierResponse names the reserved float VTXO. The transfer
+// spends it whole: the new asset-leaf carriers come out of it and the
+// residual returns to the float script as the operator's change.
+type LeaseOORCarrierResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoint identifies the leased float VTXO in "txid:vout" form.
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// value_sat is the float VTXO's full value.
+	ValueSat int64 `protobuf:"varint,2,opt,name=value_sat,json=valueSat,proto3" json:"value_sat,omitempty"`
+	// vtxo_policy_template is the float VTXO's serialized arkscript
+	// policy.
+	VtxoPolicyTemplate []byte `protobuf:"bytes,3,opt,name=vtxo_policy_template,json=vtxoPolicyTemplate,proto3" json:"vtxo_policy_template,omitempty"`
+	// pk_script is the float VTXO's output script, which the
+	// operator's change output must pay.
+	PkScript []byte `protobuf:"bytes,4,opt,name=pk_script,json=pkScript,proto3" json:"pk_script,omitempty"`
+	// expires_at_unix is when the lease lapses if unconsumed, in Unix
+	// seconds.
+	ExpiresAtUnix int64 `protobuf:"varint,5,opt,name=expires_at_unix,json=expiresAtUnix,proto3" json:"expires_at_unix,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LeaseOORCarrierResponse) Reset() {
+	*x = LeaseOORCarrierResponse{}
+	mi := &file_ark_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LeaseOORCarrierResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LeaseOORCarrierResponse) ProtoMessage() {}
+
+func (x *LeaseOORCarrierResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LeaseOORCarrierResponse.ProtoReflect.Descriptor instead.
+func (*LeaseOORCarrierResponse) Descriptor() ([]byte, []int) {
+	return file_ark_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *LeaseOORCarrierResponse) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *LeaseOORCarrierResponse) GetValueSat() int64 {
+	if x != nil {
+		return x.ValueSat
+	}
+	return 0
+}
+
+func (x *LeaseOORCarrierResponse) GetVtxoPolicyTemplate() []byte {
+	if x != nil {
+		return x.VtxoPolicyTemplate
+	}
+	return nil
+}
+
+func (x *LeaseOORCarrierResponse) GetPkScript() []byte {
+	if x != nil {
+		return x.PkScript
+	}
+	return nil
+}
+
+func (x *LeaseOORCarrierResponse) GetExpiresAtUnix() int64 {
+	if x != nil {
+		return x.ExpiresAtUnix
+	}
+	return 0
+}
+
 // EstimateFeeRequest asks the server to estimate the fee for a
 // VTXO operation at current rates and utilization.
 type EstimateFeeRequest struct {
@@ -443,7 +592,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_ark_proto_msgTypes[3]
+	mi := &file_ark_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -455,7 +604,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_proto_msgTypes[3]
+	mi := &file_ark_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -468,7 +617,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_ark_proto_rawDescGZIP(), []int{3}
+	return file_ark_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -521,7 +670,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_ark_proto_msgTypes[4]
+	mi := &file_ark_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -533,7 +682,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_proto_msgTypes[4]
+	mi := &file_ark_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -546,7 +695,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_ark_proto_rawDescGZIP(), []int{4}
+	return file_ark_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -611,7 +760,7 @@ const file_ark_proto_rawDesc = "" +
 	"\x05State\x12\x15\n" +
 	"\x11STATE_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fSTATE_ACTIVE\x10\x01\x12\x12\n" +
-	"\x0eSTATE_DISABLED\x10\x02\"\xd3\x06\n" +
+	"\x0eSTATE_DISABLED\x10\x02\"\x81\a\n" +
 	"\x0fGetInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
 	"\x06pubkey\x18\x02 \x01(\fR\x06pubkey\x12\x18\n" +
@@ -635,7 +784,16 @@ const file_ark_proto_rawDesc = "" +
 	"\x10max_user_balance\x18\x14 \x01(\x03R\x0emaxUserBalance\x120\n" +
 	"\x14selected_ark_version\x18\x15 \x01(\rR\x12selectedArkVersion\x12J\n" +
 	"\x14ark_version_policies\x18\x16 \x03(\v2\x18.arkrpc.ArkVersionPolicyR\x12arkVersionPolicies\x12;\n" +
-	"\x1afree_refresh_window_blocks\x18\x17 \x01(\rR\x17freeRefreshWindowBlocks\"\x7f\n" +
+	"\x1afree_refresh_window_blocks\x18\x17 \x01(\rR\x17freeRefreshWindowBlocks\x12,\n" +
+	"\x12oor_carrier_pubkey\x18\x18 \x01(\fR\x10oorCarrierPubkey\";\n" +
+	"\x16LeaseOORCarrierRequest\x12!\n" +
+	"\frequired_sat\x18\x01 \x01(\x03R\vrequiredSat\"\xc9\x01\n" +
+	"\x17LeaseOORCarrierResponse\x12\x1a\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1b\n" +
+	"\tvalue_sat\x18\x02 \x01(\x03R\bvalueSat\x120\n" +
+	"\x14vtxo_policy_template\x18\x03 \x01(\fR\x12vtxoPolicyTemplate\x12\x1b\n" +
+	"\tpk_script\x18\x04 \x01(\fR\bpkScript\x12&\n" +
+	"\x0fexpires_at_unix\x18\x05 \x01(\x03R\rexpiresAtUnix\"\x7f\n" +
 	"\x12EstimateFeeRequest\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x01 \x01(\x03R\tamountSat\x12\x1f\n" +
@@ -650,11 +808,12 @@ const file_ark_proto_rawDesc = "" +
 	"\rtotal_fee_sat\x18\x04 \x01(\x03R\vtotalFeeSat\x122\n" +
 	"\x15effective_annual_rate\x18\x05 \x01(\x01R\x13effectiveAnnualRate\x121\n" +
 	"\x15min_viable_amount_sat\x18\x06 \x01(\x03R\x12minViableAmountSat\x12,\n" +
-	"\x12below_dust_warning\x18\a \x01(\bR\x10belowDustWarning2\x90\x01\n" +
+	"\x12below_dust_warning\x18\a \x01(\bR\x10belowDustWarning2\xe4\x01\n" +
 	"\n" +
 	"ArkService\x12:\n" +
 	"\aGetInfo\x12\x16.arkrpc.GetInfoRequest\x1a\x17.arkrpc.GetInfoResponse\x12F\n" +
-	"\vEstimateFee\x12\x1a.arkrpc.EstimateFeeRequest\x1a\x1b.arkrpc.EstimateFeeResponseB,Z*github.com/lightninglabs/wavelength/arkrpcb\x06proto3"
+	"\vEstimateFee\x12\x1a.arkrpc.EstimateFeeRequest\x1a\x1b.arkrpc.EstimateFeeResponse\x12R\n" +
+	"\x0fLeaseOORCarrier\x12\x1e.arkrpc.LeaseOORCarrierRequest\x1a\x1f.arkrpc.LeaseOORCarrierResponseB,Z*github.com/lightninglabs/wavelength/arkrpcb\x06proto3"
 
 var (
 	file_ark_proto_rawDescOnce sync.Once
@@ -669,24 +828,28 @@ func file_ark_proto_rawDescGZIP() []byte {
 }
 
 var file_ark_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_ark_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_ark_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_ark_proto_goTypes = []any{
-	(ArkVersionPolicy_State)(0), // 0: arkrpc.ArkVersionPolicy.State
-	(*GetInfoRequest)(nil),      // 1: arkrpc.GetInfoRequest
-	(*ArkVersionPolicy)(nil),    // 2: arkrpc.ArkVersionPolicy
-	(*GetInfoResponse)(nil),     // 3: arkrpc.GetInfoResponse
-	(*EstimateFeeRequest)(nil),  // 4: arkrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil), // 5: arkrpc.EstimateFeeResponse
+	(ArkVersionPolicy_State)(0),     // 0: arkrpc.ArkVersionPolicy.State
+	(*GetInfoRequest)(nil),          // 1: arkrpc.GetInfoRequest
+	(*ArkVersionPolicy)(nil),        // 2: arkrpc.ArkVersionPolicy
+	(*GetInfoResponse)(nil),         // 3: arkrpc.GetInfoResponse
+	(*LeaseOORCarrierRequest)(nil),  // 4: arkrpc.LeaseOORCarrierRequest
+	(*LeaseOORCarrierResponse)(nil), // 5: arkrpc.LeaseOORCarrierResponse
+	(*EstimateFeeRequest)(nil),      // 6: arkrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),     // 7: arkrpc.EstimateFeeResponse
 }
 var file_ark_proto_depIdxs = []int32{
 	0, // 0: arkrpc.ArkVersionPolicy.state:type_name -> arkrpc.ArkVersionPolicy.State
 	2, // 1: arkrpc.GetInfoResponse.ark_version_policies:type_name -> arkrpc.ArkVersionPolicy
 	1, // 2: arkrpc.ArkService.GetInfo:input_type -> arkrpc.GetInfoRequest
-	4, // 3: arkrpc.ArkService.EstimateFee:input_type -> arkrpc.EstimateFeeRequest
-	3, // 4: arkrpc.ArkService.GetInfo:output_type -> arkrpc.GetInfoResponse
-	5, // 5: arkrpc.ArkService.EstimateFee:output_type -> arkrpc.EstimateFeeResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
+	6, // 3: arkrpc.ArkService.EstimateFee:input_type -> arkrpc.EstimateFeeRequest
+	4, // 4: arkrpc.ArkService.LeaseOORCarrier:input_type -> arkrpc.LeaseOORCarrierRequest
+	3, // 5: arkrpc.ArkService.GetInfo:output_type -> arkrpc.GetInfoResponse
+	7, // 6: arkrpc.ArkService.EstimateFee:output_type -> arkrpc.EstimateFeeResponse
+	5, // 7: arkrpc.ArkService.LeaseOORCarrier:output_type -> arkrpc.LeaseOORCarrierResponse
+	5, // [5:8] is the sub-list for method output_type
+	2, // [2:5] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
 	2, // [2:2] is the sub-list for extension extendee
 	0, // [0:2] is the sub-list for field type_name
@@ -703,7 +866,7 @@ func file_ark_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ark_proto_rawDesc), len(file_ark_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/arkrpc/ark.pb.gw.go
+++ b/arkrpc/ark.pb.gw.go
@@ -89,6 +89,33 @@ func local_request_ArkService_EstimateFee_0(ctx context.Context, marshaler runti
 	return msg, metadata, err
 }
 
+func request_ArkService_LeaseOORCarrier_0(ctx context.Context, marshaler runtime.Marshaler, client ArkServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq LeaseOORCarrierRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.LeaseOORCarrier(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ArkService_LeaseOORCarrier_0(ctx context.Context, marshaler runtime.Marshaler, server ArkServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq LeaseOORCarrierRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.LeaseOORCarrier(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterArkServiceHandlerServer registers the http handlers for service ArkService to "mux".
 // UnaryRPC     :call ArkServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -134,6 +161,26 @@ func RegisterArkServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux,
 			return
 		}
 		forward_ArkService_EstimateFee_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ArkService_LeaseOORCarrier_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/arkrpc.ArkService/LeaseOORCarrier", runtime.WithHTTPPathPattern("/v1/ark/lease-oor-carrier"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ArkService_LeaseOORCarrier_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ArkService_LeaseOORCarrier_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -209,15 +256,34 @@ func RegisterArkServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux,
 		}
 		forward_ArkService_EstimateFee_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ArkService_LeaseOORCarrier_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/arkrpc.ArkService/LeaseOORCarrier", runtime.WithHTTPPathPattern("/v1/ark/lease-oor-carrier"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ArkService_LeaseOORCarrier_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ArkService_LeaseOORCarrier_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_ArkService_GetInfo_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "ark", "get-info"}, ""))
-	pattern_ArkService_EstimateFee_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "ark", "estimate-fee"}, ""))
+	pattern_ArkService_GetInfo_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "ark", "get-info"}, ""))
+	pattern_ArkService_EstimateFee_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "ark", "estimate-fee"}, ""))
+	pattern_ArkService_LeaseOORCarrier_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "ark", "lease-oor-carrier"}, ""))
 )
 
 var (
-	forward_ArkService_GetInfo_0     = runtime.ForwardResponseMessage
-	forward_ArkService_EstimateFee_0 = runtime.ForwardResponseMessage
+	forward_ArkService_GetInfo_0         = runtime.ForwardResponseMessage
+	forward_ArkService_EstimateFee_0     = runtime.ForwardResponseMessage
+	forward_ArkService_LeaseOORCarrier_0 = runtime.ForwardResponseMessage
 )

--- a/arkrpc/ark.proto
+++ b/arkrpc/ark.proto
@@ -12,6 +12,13 @@ service ArkService {
     // showing liquidity cost, on-chain share, margin, and minimum
     // viable VTXO at current rates and utilization.
     rpc EstimateFee (EstimateFeeRequest) returns (EstimateFeeResponse);
+
+    // LeaseOORCarrier reserves one of the operator's carrier float
+    // VTXOs for an out-of-round transfer that needs the operator to
+    // fund its new asset-leaf carriers. The lease expires on its own
+    // if no submit consumes the returned outpoint in time.
+    rpc LeaseOORCarrier (LeaseOORCarrierRequest)
+        returns (LeaseOORCarrierResponse);
 }
 
 message GetInfoRequest {
@@ -139,6 +146,45 @@ message GetInfoResponse {
     // The number of blocks before batch expiry in which a pure refresh
     // qualifies for a complete fee waiver. Zero disables the waiver.
     uint32 free_refresh_window_blocks = 23;
+
+    // The x-only public key owning the operator's carrier float. Set
+    // when the operator funds the new asset-leaf carriers of
+    // out-of-round transfers from its own float VTXOs; empty when
+    // carrier funding is disabled. Together with the operator's collab
+    // key and exit delay it derives the float's standard VTXO policy,
+    // which is also the script that stocks the float.
+    bytes oor_carrier_pubkey = 24;
+}
+
+// LeaseOORCarrierRequest asks the operator to reserve a carrier float
+// VTXO covering at least the given value.
+message LeaseOORCarrierRequest {
+    // required_sat is the minimum float value the transfer needs: the
+    // sum of the new asset-leaf carriers it will create.
+    int64 required_sat = 1;
+}
+
+// LeaseOORCarrierResponse names the reserved float VTXO. The transfer
+// spends it whole: the new asset-leaf carriers come out of it and the
+// residual returns to the float script as the operator's change.
+message LeaseOORCarrierResponse {
+    // outpoint identifies the leased float VTXO in "txid:vout" form.
+    string outpoint = 1;
+
+    // value_sat is the float VTXO's full value.
+    int64 value_sat = 2;
+
+    // vtxo_policy_template is the float VTXO's serialized arkscript
+    // policy.
+    bytes vtxo_policy_template = 3;
+
+    // pk_script is the float VTXO's output script, which the
+    // operator's change output must pay.
+    bytes pk_script = 4;
+
+    // expires_at_unix is when the lease lapses if unconsumed, in Unix
+    // seconds.
+    int64 expires_at_unix = 5;
 }
 
 // EstimateFeeRequest asks the server to estimate the fee for a

--- a/arkrpc/ark.yaml
+++ b/arkrpc/ark.yaml
@@ -9,3 +9,6 @@ http:
     - selector: arkrpc.ArkService.EstimateFee
       post: /v1/ark/estimate-fee
       body: "*"
+    - selector: arkrpc.ArkService.LeaseOORCarrier
+      post: /v1/ark/lease-oor-carrier
+      body: "*"

--- a/arkrpc/ark_grpc.pb.go
+++ b/arkrpc/ark_grpc.pb.go
@@ -19,8 +19,9 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ArkService_GetInfo_FullMethodName     = "/arkrpc.ArkService/GetInfo"
-	ArkService_EstimateFee_FullMethodName = "/arkrpc.ArkService/EstimateFee"
+	ArkService_GetInfo_FullMethodName         = "/arkrpc.ArkService/GetInfo"
+	ArkService_EstimateFee_FullMethodName     = "/arkrpc.ArkService/EstimateFee"
+	ArkService_LeaseOORCarrier_FullMethodName = "/arkrpc.ArkService/LeaseOORCarrier"
 )
 
 // ArkServiceClient is the client API for ArkService service.
@@ -33,6 +34,11 @@ type ArkServiceClient interface {
 	// showing liquidity cost, on-chain share, margin, and minimum
 	// viable VTXO at current rates and utilization.
 	EstimateFee(ctx context.Context, in *EstimateFeeRequest, opts ...grpc.CallOption) (*EstimateFeeResponse, error)
+	// LeaseOORCarrier reserves one of the operator's carrier float
+	// VTXOs for an out-of-round transfer that needs the operator to
+	// fund its new asset-leaf carriers. The lease expires on its own
+	// if no submit consumes the returned outpoint in time.
+	LeaseOORCarrier(ctx context.Context, in *LeaseOORCarrierRequest, opts ...grpc.CallOption) (*LeaseOORCarrierResponse, error)
 }
 
 type arkServiceClient struct {
@@ -63,6 +69,16 @@ func (c *arkServiceClient) EstimateFee(ctx context.Context, in *EstimateFeeReque
 	return out, nil
 }
 
+func (c *arkServiceClient) LeaseOORCarrier(ctx context.Context, in *LeaseOORCarrierRequest, opts ...grpc.CallOption) (*LeaseOORCarrierResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(LeaseOORCarrierResponse)
+	err := c.cc.Invoke(ctx, ArkService_LeaseOORCarrier_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ArkServiceServer is the server API for ArkService service.
 // All implementations must embed UnimplementedArkServiceServer
 // for forward compatibility.
@@ -73,6 +89,11 @@ type ArkServiceServer interface {
 	// showing liquidity cost, on-chain share, margin, and minimum
 	// viable VTXO at current rates and utilization.
 	EstimateFee(context.Context, *EstimateFeeRequest) (*EstimateFeeResponse, error)
+	// LeaseOORCarrier reserves one of the operator's carrier float
+	// VTXOs for an out-of-round transfer that needs the operator to
+	// fund its new asset-leaf carriers. The lease expires on its own
+	// if no submit consumes the returned outpoint in time.
+	LeaseOORCarrier(context.Context, *LeaseOORCarrierRequest) (*LeaseOORCarrierResponse, error)
 	mustEmbedUnimplementedArkServiceServer()
 }
 
@@ -88,6 +109,9 @@ func (UnimplementedArkServiceServer) GetInfo(context.Context, *GetInfoRequest) (
 }
 func (UnimplementedArkServiceServer) EstimateFee(context.Context, *EstimateFeeRequest) (*EstimateFeeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EstimateFee not implemented")
+}
+func (UnimplementedArkServiceServer) LeaseOORCarrier(context.Context, *LeaseOORCarrierRequest) (*LeaseOORCarrierResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method LeaseOORCarrier not implemented")
 }
 func (UnimplementedArkServiceServer) mustEmbedUnimplementedArkServiceServer() {}
 func (UnimplementedArkServiceServer) testEmbeddedByValue()                    {}
@@ -146,6 +170,24 @@ func _ArkService_EstimateFee_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ArkService_LeaseOORCarrier_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LeaseOORCarrierRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ArkServiceServer).LeaseOORCarrier(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ArkService_LeaseOORCarrier_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ArkServiceServer).LeaseOORCarrier(ctx, req.(*LeaseOORCarrierRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ArkService_ServiceDesc is the grpc.ServiceDesc for ArkService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -160,6 +202,10 @@ var ArkService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "EstimateFee",
 			Handler:    _ArkService_EstimateFee_Handler,
+		},
+		{
+			MethodName: "LeaseOORCarrier",
+			Handler:    _ArkService_LeaseOORCarrier_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/arkrpc/ark_mailboxrpc.pb.go
+++ b/arkrpc/ark_mailboxrpc.pb.go
@@ -28,6 +28,8 @@ type ArkServiceMailboxServer interface {
 	GetInfo(ctx context.Context, req *GetInfoRequest) (*GetInfoResponse, error)
 	// EstimateFee handles EstimateFee.
 	EstimateFee(ctx context.Context, req *EstimateFeeRequest) (*EstimateFeeResponse, error)
+	// LeaseOORCarrier handles LeaseOORCarrier.
+	LeaseOORCarrier(ctx context.Context, req *LeaseOORCarrierRequest) (*LeaseOORCarrierResponse, error)
 }
 
 // RegisterArkServiceMailboxServer registers handlers for ArkService.
@@ -51,6 +53,16 @@ func RegisterArkServiceMailboxServer(r rpc.Router, impl ArkServiceMailboxServer)
 		}
 
 		return impl.EstimateFee(ctx, req)
+	})
+	r.Handle("arkrpc.ArkService", "LeaseOORCarrier", func() proto.Message {
+		return &LeaseOORCarrierRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*LeaseOORCarrierRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.LeaseOORCarrier(ctx, req)
 	})
 }
 
@@ -93,6 +105,29 @@ func (c *ArkServiceMailboxClient) EstimateFee(ctx context.Context, req *Estimate
 	}
 
 	resp := new(EstimateFeeResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// LeaseOORCarrier calls the LeaseOORCarrier RPC.
+func (c *ArkServiceMailboxClient) LeaseOORCarrier(ctx context.Context, req *LeaseOORCarrierRequest, opts ...rpc.RPCOptions) (*LeaseOORCarrierResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "arkrpc.ArkService",
+		Method:  "LeaseOORCarrier",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(LeaseOORCarrierResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -16,7 +16,7 @@ default `--help` face:
    wavewalletrpc-backed.
 2. **Daemon introspection (group "Introspection")** — getinfo, schema, mcp
    (the built-in `help` command is grouped here too).
-3. **Advanced subtrees (`ark`, `dev`, `recovery`, `taproot-assets`)** — raw
+3. **Advanced subtrees (`ark`, `dev`, `recovery`, `assets`)** — raw
    waverpc/devrpc commands for power users and operator runbooks.
    Hidden from the default `--help` via cobra `Hidden` (not a build tag),
    so they stay compiled and fully runnable in the shipped binary;
@@ -89,11 +89,12 @@ let the swap FSM arm and cancel recovery automatically.
 Generated low-level daemon RPC CLI; see [`devrpc/`](devrpc/). Hidden from
 the default `--help` (revealed with `WAVELENGTH_DEV=1`) but always runnable.
 
-### `taproot-assets.*` prototype commands
+### `assets.*` prototype commands
 
-The `taproot-assets onboard` command reads a complete proof file and invokes
-the durable `waverpc.OnboardTaprootAsset` workflow. It remains in the advanced
-group while the tapd/tap-sdk integration is evaluated.
+The `assets onboard` command (`taproot-assets` remains an alias) invokes the
+durable `waverpc.OnboardTaprootAsset` workflow; without --proof-file the
+daemon exports the proof of its own matching UTXO from tapd. It remains in
+the advanced group while the tapd/tap-sdk integration is evaluated.
 
 ## Key Helpers
 

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -16,7 +16,7 @@ default `--help` face:
    wavewalletrpc-backed.
 2. **Daemon introspection (group "Introspection")** — getinfo, schema, mcp
    (the built-in `help` command is grouped here too).
-3. **Advanced subtrees (`ark`, `dev`, `recovery`, `taproot-assets`)** — raw
+3. **Advanced subtrees (`ark`, `dev`, `recovery`, `assets`)** — raw
    waverpc/devrpc commands for power users and operator runbooks.
    Hidden from the default `--help` via cobra `Hidden` (not a build tag),
    so they stay compiled and fully runnable in the shipped binary;
@@ -89,11 +89,12 @@ let the swap FSM arm and cancel recovery automatically.
 Generated low-level daemon RPC CLI; see [`devrpc/`](devrpc/). Hidden from
 the default `--help` (revealed with `WAVELENGTH_DEV=1`) but always runnable.
 
-### `taproot-assets.*` prototype commands
+### `assets.*` prototype commands
 
-The `taproot-assets onboard` command reads a complete proof file and invokes
-the durable `waverpc.OnboardTaprootAsset` workflow. It remains in the advanced
-group while the tapd/tap-sdk integration is evaluated.
+The `assets onboard` command (`taproot-assets` remains an alias) invokes the
+durable `waverpc.OnboardTaprootAsset` workflow; without --proof-file the
+daemon exports the proof of its own matching UTXO from tapd. It remains in
+the advanced group while the tapd/tap-sdk integration is evaluated.
 
 ## Key Helpers
 

--- a/cmd/wavecli/waveclicommands/cmd_taproot_assets.go
+++ b/cmd/wavecli/waveclicommands/cmd_taproot_assets.go
@@ -11,7 +11,10 @@ import (
 // newTaprootAssetsCmd builds the prototype Taproot Asset command subtree.
 func newTaprootAssetsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "taproot-assets",
+		Use: "assets",
+		Aliases: []string{
+			"taproot-assets",
+		},
 		Short: "Prototype Taproot Asset operations",
 		Long: "Prototype Taproot Asset operations backed by tapd " +
 			"and tap-sdk inside waved. These commands are " +

--- a/cmd/wavecli/waveclicommands/cmd_taproot_assets.go
+++ b/cmd/wavecli/waveclicommands/cmd_taproot_assets.go
@@ -59,8 +59,9 @@ func newTaprootAssetOnboardCmd() *cobra.Command {
 		"complete asset amount held by the selected proof",
 	)
 	flags.String(
-		"proof-file", "",
-		"path to the complete confirmed Taproot Asset proof file",
+		"proof-file", "", "path to the complete confirmed Taproot "+
+			"Asset proof file (empty lets the daemon export "+
+			"the proof of its own matching UTXO from tapd)",
 	)
 	flags.Uint64(
 		"carrier-value-sat", 0, "Bitcoin value carried by the "+
@@ -127,9 +128,6 @@ func taprootAssetOnboardingRequest(cmd *cobra.Command) (
 	case assetAmount == 0:
 		return nil, fmt.Errorf("--asset-amount must be positive")
 
-	case proofPath == "":
-		return nil, fmt.Errorf("--proof-file is required")
-
 	case maxFeeSat == 0:
 		return nil, fmt.Errorf("--max-fee-sat must be positive")
 
@@ -148,20 +146,26 @@ func taprootAssetOnboardingRequest(cmd *cobra.Command) (
 		return nil, err
 	}
 
-	proofPath, err := expandCLIPath(proofPath)
-	if err != nil {
-		return nil, fmt.Errorf("expand --proof-file: %w", err)
-	}
-	// The command's purpose is to read the proof path selected by its
-	// caller and forward those exact bytes to the local daemon.
-	//nolint:gosec
-	proofFile, err := os.ReadFile(proofPath)
-	if err != nil {
-		return nil, fmt.Errorf("read --proof-file %q: %w", proofPath,
-			err)
-	}
-	if len(proofFile) == 0 {
-		return nil, fmt.Errorf("--proof-file must not be empty")
+	// Without an explicit proof file the daemon exports the proof of its
+	// own matching UTXO from tapd.
+	var proofFile []byte
+	if proofPath != "" {
+		expandedPath, err := expandCLIPath(proofPath)
+		if err != nil {
+			return nil, fmt.Errorf("expand --proof-file: %w", err)
+		}
+		// The command's purpose is to read the proof path selected by
+		// its caller and forward those exact bytes to the local
+		// daemon.
+		//nolint:gosec
+		proofFile, err = os.ReadFile(expandedPath)
+		if err != nil {
+			return nil, fmt.Errorf("read --proof-file %q: %w",
+				expandedPath, err)
+		}
+		if len(proofFile) == 0 {
+			return nil, fmt.Errorf("--proof-file must not be empty")
+		}
 	}
 
 	return &waverpc.OnboardTaprootAssetRequest{

--- a/cmd/wavecli/waveclicommands/cmd_taproot_assets.go
+++ b/cmd/wavecli/waveclicommands/cmd_taproot_assets.go
@@ -19,7 +19,11 @@ func newTaprootAssetsCmd() *cobra.Command {
 			"integration is evaluated.",
 	}
 
-	cmd.AddCommand(newTaprootAssetOnboardCmd())
+	cmd.AddCommand(
+		newTaprootAssetOnboardCmd(), newTaprootAssetBoardCmd(),
+		newTaprootAssetClaimCmd(), newTaprootAssetListCmd(),
+		newTaprootAssetBalanceCmd(), newTaprootAssetSendCmd(),
+	)
 
 	return cmd
 }

--- a/cmd/wavecli/waveclicommands/cmd_taproot_assets_manage.go
+++ b/cmd/wavecli/waveclicommands/cmd_taproot_assets_manage.go
@@ -233,10 +233,11 @@ func newTaprootAssetSendCmd() *cobra.Command {
 		Long: "Send Taproot Asset units to another Wavelength user " +
 			"out of round. The daemon spends one asset VTXO; " +
 			"when --amount is below the VTXO's full holding, the " +
-			"change rides on one of the sender's Bitcoin VTXOs. " +
-			"The recipient key comes from the recipient's " +
-			"'ark oor receive'. Without --outpoint the smallest " +
-			"sufficient asset VTXO is selected.",
+			"change rides on a minimal Bitcoin carrier and the " +
+			"rest of the selected Bitcoin VTXO returns as plain " +
+			"change. The recipient key comes from the " +
+			"recipient's 'ark oor receive'. Without --outpoint " +
+			"the smallest sufficient asset VTXO is selected.",
 		Args: cobra.NoArgs,
 		RunE: sendTaprootAsset,
 	}
@@ -254,18 +255,24 @@ func newTaprootAssetSendCmd() *cobra.Command {
 	flags.String(
 		"idempotency-key", "", "stable caller-generated retry key",
 	)
+	flags.Uint64(
+		"change-carrier-sat", 0, "Bitcoin value carrying the asset "+
+			"change of a partial send (zero uses the operator "+
+			"minimum)",
+	)
 
 	return cmd
 }
 
-// sendTaprootAsset resolves the input VTXO and change carrier, then submits
-// the asset OOR intent.
+// sendTaprootAsset resolves the input VTXO, then submits the asset OOR
+// intent.
 func sendTaprootAsset(cmd *cobra.Command, _ []string) error {
 	assetRef, _ := cmd.Flags().GetString("asset-ref")
 	amount, _ := cmd.Flags().GetUint64("amount")
 	recipientPubkey, _ := cmd.Flags().GetString("recipient-pubkey")
 	outpoint, _ := cmd.Flags().GetString("outpoint")
 	idempotencyKey, _ := cmd.Flags().GetString("idempotency-key")
+	changeCarrierSat, _ := cmd.Flags().GetUint64("change-carrier-sat")
 
 	switch {
 	case assetRef == "":
@@ -321,16 +328,12 @@ func sendTaprootAsset(cmd *cobra.Command, _ []string) error {
 		InputVtxoOutpoint:      input.GetOutpoint(),
 	}
 
-	// A partial send needs a Bitcoin VTXO to carry the asset change.
+	// A partial send keeps the asset change on a minimal carrier; the
+	// daemon defaults a zero value to the operator minimum and returns
+	// the rest of the selected Bitcoin VTXO as plain change.
 	if amount < intent.AssetAmount {
-		carrier, err := selectAssetChangeCarrier(ctx, client)
-		if err != nil {
-			return err
-		}
 		intent.RecipientAssetAmount = amount
-		intent.AssetChangeCarrierValueSat = uint64(
-			carrier.GetAmountSat(),
-		)
+		intent.AssetChangeCarrierValueSat = changeCarrierSat
 	}
 	if amount > intent.AssetAmount {
 		return invalidArgs(
@@ -401,36 +404,4 @@ func selectAssetSendInput(ctx context.Context,
 	}
 
 	return selected, nil
-}
-
-// selectAssetChangeCarrier picks the sender's largest live Bitcoin VTXO as
-// the asset-change carrier.
-func selectAssetChangeCarrier(ctx context.Context,
-	client waverpc.DaemonServiceClient) (*waverpc.VTXO, error) {
-
-	response, err := client.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{
-		StatusFilter:           waverpc.VTXOStatus_VTXO_STATUS_LIVE,
-		ExcludeCheckpointPsbts: true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("ListVTXOs RPC failed: %w", err)
-	}
-
-	var carrier *waverpc.VTXO
-	for _, v := range response.Vtxos {
-		if v.GetTaprootAsset() != nil {
-			continue
-		}
-		if carrier == nil ||
-			v.GetAmountSat() > carrier.GetAmountSat() {
-
-			carrier = v
-		}
-	}
-	if carrier == nil {
-		return nil, fmt.Errorf("a partial asset send needs a live " +
-			"Bitcoin VTXO to carry the change")
-	}
-
-	return carrier, nil
 }

--- a/cmd/wavecli/waveclicommands/cmd_taproot_assets_manage.go
+++ b/cmd/wavecli/waveclicommands/cmd_taproot_assets_manage.go
@@ -231,13 +231,14 @@ func newTaprootAssetSendCmd() *cobra.Command {
 		Use:   "send",
 		Short: "Send asset units out of round",
 		Long: "Send Taproot Asset units to another Wavelength user " +
-			"out of round. The daemon spends one asset VTXO; " +
-			"when --amount is below the VTXO's full holding, the " +
-			"change rides on a minimal Bitcoin carrier and the " +
-			"rest of the selected Bitcoin VTXO returns as plain " +
-			"change. The recipient key comes from the " +
-			"recipient's 'ark oor receive'. Without --outpoint " +
-			"the smallest sufficient asset VTXO is selected.",
+			"out of round. The daemon spends one asset VTXO and " +
+			"leases an operator carrier float that funds every " +
+			"new asset leaf at the operator's minimum VTXO " +
+			"amount, so the sender needs no Bitcoin: the asset " +
+			"VTXO's own carrier returns whole as plain change. " +
+			"The recipient key comes from the recipient's 'ark " +
+			"oor receive'. Without --outpoint the smallest " +
+			"sufficient asset VTXO is selected.",
 		Args: cobra.NoArgs,
 		RunE: sendTaprootAsset,
 	}
@@ -255,11 +256,6 @@ func newTaprootAssetSendCmd() *cobra.Command {
 	flags.String(
 		"idempotency-key", "", "stable caller-generated retry key",
 	)
-	flags.Uint64(
-		"change-carrier-sat", 0, "Bitcoin value carrying the asset "+
-			"change of a partial send (zero uses the operator "+
-			"minimum)",
-	)
 
 	return cmd
 }
@@ -272,7 +268,6 @@ func sendTaprootAsset(cmd *cobra.Command, _ []string) error {
 	recipientPubkey, _ := cmd.Flags().GetString("recipient-pubkey")
 	outpoint, _ := cmd.Flags().GetString("outpoint")
 	idempotencyKey, _ := cmd.Flags().GetString("idempotency-key")
-	changeCarrierSat, _ := cmd.Flags().GetUint64("change-carrier-sat")
 
 	switch {
 	case assetRef == "":
@@ -328,12 +323,10 @@ func sendTaprootAsset(cmd *cobra.Command, _ []string) error {
 		InputVtxoOutpoint:      input.GetOutpoint(),
 	}
 
-	// A partial send keeps the asset change on a minimal carrier; the
-	// daemon defaults a zero value to the operator minimum and returns
-	// the rest of the selected Bitcoin VTXO as plain change.
+	// A partial send keeps the asset change on its own operator-funded
+	// carrier; the daemon derives every Bitcoin-side value.
 	if amount < intent.AssetAmount {
 		intent.RecipientAssetAmount = amount
-		intent.AssetChangeCarrierValueSat = changeCarrierSat
 	}
 	if amount > intent.AssetAmount {
 		return invalidArgs(
@@ -344,12 +337,13 @@ func sendTaprootAsset(cmd *cobra.Command, _ []string) error {
 		)
 	}
 
+	// The recipient carrier is daemon-derived (operator floor), so the
+	// amount stays zero.
 	response, err := client.SendOOR(ctx, &waverpc.SendOORRequest{
 		Recipients: []*waverpc.Output{{
 			Destination: &waverpc.Output_Pubkey{
 				Pubkey: recipientKey,
 			},
-			AmountSat: input.GetAmountSat(),
 		}},
 		IdempotencyKey: idempotencyKey,
 		TaprootAsset:   intent,

--- a/cmd/wavecli/waveclicommands/cmd_taproot_assets_manage.go
+++ b/cmd/wavecli/waveclicommands/cmd_taproot_assets_manage.go
@@ -231,14 +231,18 @@ func newTaprootAssetSendCmd() *cobra.Command {
 		Use:   "send",
 		Short: "Send asset units out of round",
 		Long: "Send Taproot Asset units to another Wavelength user " +
-			"out of round. The daemon spends one asset VTXO and " +
-			"leases an operator carrier float that funds every " +
-			"new asset leaf at the operator's minimum VTXO " +
-			"amount, so the sender needs no Bitcoin: the asset " +
-			"VTXO's own carrier returns whole as plain change. " +
-			"The recipient key comes from the recipient's 'ark " +
-			"oor receive'. Without --outpoint the smallest " +
-			"sufficient asset VTXO is selected.",
+			"out of round. The daemon spends up to eight asset " +
+			"VTXOs in ONE atomic transfer (never split into " +
+			"several transfers) and leases an operator carrier " +
+			"float that funds every new asset leaf at the " +
+			"operator's minimum VTXO amount, so the sender needs " +
+			"no Bitcoin: the spent VTXOs' own carriers return as " +
+			"plain change. The recipient key comes from the " +
+			"recipient's 'ark oor receive'. Without --outpoint " +
+			"the daemon selects the inputs: one sufficient VTXO " +
+			"when possible, otherwise the largest VTXOs until " +
+			"the amount is covered. A send needing more than " +
+			"eight inputs fails; consolidate first.",
 		Args: cobra.NoArgs,
 		RunE: sendTaprootAsset,
 	}
@@ -250,8 +254,8 @@ func newTaprootAssetSendCmd() *cobra.Command {
 		"recipient-pubkey", "", "recipient receive pubkey (hex)",
 	)
 	flags.String(
-		"outpoint", "",
-		"asset VTXO to spend (txid:vout; empty selects one)",
+		"outpoint", "", "asset VTXO to spend (txid:vout; empty "+
+			"lets the daemon select up to eight)",
 	)
 	flags.String(
 		"idempotency-key", "", "stable caller-generated retry key",
@@ -309,32 +313,39 @@ func sendTaprootAsset(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := rpcContext(cmd)
 	defer cancel()
 
-	input, err := selectAssetSendInput(
-		ctx, client, assetRef, amount, outpoint,
-	)
-	if err != nil {
-		return err
-	}
-
+	// Without a pinned outpoint the daemon selects the inputs itself and
+	// asset_amount names the units to send.
 	intent := &waverpc.TaprootAssetOORIntent{
 		AssetRef:               assetRef,
-		AssetAmount:            input.GetTaprootAsset().GetAmount(),
+		AssetAmount:            amount,
 		AcknowledgeUnconfirmed: true,
-		InputVtxoOutpoint:      input.GetOutpoint(),
 	}
-
-	// A partial send keeps the asset change on its own operator-funded
-	// carrier; the daemon derives every Bitcoin-side value.
-	if amount < intent.AssetAmount {
-		intent.RecipientAssetAmount = amount
-	}
-	if amount > intent.AssetAmount {
-		return invalidArgs(
-			fmt.Errorf(
-				"VTXO %s holds %d units, cannot send %d",
-				input.GetOutpoint(), intent.AssetAmount, amount,
-			),
+	if outpoint != "" {
+		input, err := selectAssetSendInput(
+			ctx, client, assetRef, outpoint,
 		)
+		if err != nil {
+			return err
+		}
+
+		intent.AssetAmount = input.GetTaprootAsset().GetAmount()
+		intent.InputVtxoOutpoint = input.GetOutpoint()
+
+		// A partial send keeps the asset change on its own
+		// operator-funded carrier; the daemon derives every
+		// Bitcoin-side value.
+		if amount < intent.AssetAmount {
+			intent.RecipientAssetAmount = amount
+		}
+		if amount > intent.AssetAmount {
+			return invalidArgs(
+				fmt.Errorf(
+					"VTXO %s holds %d units, cannot "+
+						"send %d", input.GetOutpoint(),
+					intent.AssetAmount, amount,
+				),
+			)
+		}
 	}
 
 	// The recipient carrier is daemon-derived (operator floor), so the
@@ -355,10 +366,10 @@ func sendTaprootAsset(cmd *cobra.Command, _ []string) error {
 	return printJSON(response)
 }
 
-// selectAssetSendInput resolves the asset VTXO to spend: the named
-// outpoint, or the smallest live VTXO of the asset that covers the amount.
+// selectAssetSendInput resolves the pinned asset VTXO to spend by its
+// outpoint. Amount-only sends skip this entirely: the daemon selects.
 func selectAssetSendInput(ctx context.Context,
-	client waverpc.DaemonServiceClient, assetRef string, amount uint64,
+	client waverpc.DaemonServiceClient, assetRef string,
 	outpoint string) (*waverpc.VTXO, error) {
 
 	response, err := client.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{
@@ -370,32 +381,12 @@ func selectAssetSendInput(ctx context.Context,
 		return nil, fmt.Errorf("ListVTXOs RPC failed: %w", err)
 	}
 
-	var selected *waverpc.VTXO
 	for _, v := range response.Vtxos {
-		if outpoint != "" {
-			if v.GetOutpoint() == outpoint {
-				return v, nil
-			}
-
-			continue
-		}
-		if v.GetTaprootAsset().GetAmount() < amount {
-			continue
-		}
-		if selected == nil || v.GetTaprootAsset().GetAmount() <
-			selected.GetTaprootAsset().GetAmount() {
-
-			selected = v
+		if v.GetOutpoint() == outpoint {
+			return v, nil
 		}
 	}
-	if outpoint != "" {
-		return nil, fmt.Errorf("no live VTXO %s carries asset %s",
-			outpoint, assetRef)
-	}
-	if selected == nil {
-		return nil, fmt.Errorf("no live asset VTXO covers %d "+
-			"units of %s", amount, assetRef)
-	}
 
-	return selected, nil
+	return nil, fmt.Errorf("no live VTXO %s carries asset %s", outpoint,
+		assetRef)
 }

--- a/cmd/wavecli/waveclicommands/cmd_taproot_assets_manage.go
+++ b/cmd/wavecli/waveclicommands/cmd_taproot_assets_manage.go
@@ -1,0 +1,436 @@
+package waveclicommands
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/spf13/cobra"
+)
+
+// newTaprootAssetBoardCmd creates the boarding-completion command.
+func newTaprootAssetBoardCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "board",
+		Short: "Board a confirmed onboarded output into a round",
+		Long: "Complete an onboarded output's path into the next " +
+			"asset round. The daemon rebuilds the boarding " +
+			"disclosure from the onboarding named by the " +
+			"idempotency key, gathers the confirmation and the " +
+			"boarded proof itself, and registers the boarding " +
+			"with a matching asset VTXO request. Rerun safely: " +
+			"an already-boarded output reports already_boarded.",
+		Args: cobra.NoArgs,
+		RunE: boardTaprootAsset,
+	}
+
+	cmd.Flags().String(
+		"idempotency-key", "",
+		"the key passed to the onboard command",
+	)
+
+	return cmd
+}
+
+// boardTaprootAsset invokes the boarding-completion RPC.
+func boardTaprootAsset(cmd *cobra.Command, _ []string) error {
+	key, _ := cmd.Flags().GetString("idempotency-key")
+	if key == "" {
+		return invalidArgs(fmt.Errorf("--idempotency-key is required"))
+	}
+	if err := validateFreeText("--idempotency-key", key); err != nil {
+		return invalidArgs(err)
+	}
+
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	response, err := client.BoardTaprootAsset(
+		ctx, &waverpc.BoardTaprootAssetRequest{
+			IdempotencyKey: key,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("BoardTaprootAsset RPC failed: %w", err)
+	}
+
+	return printJSON(response)
+}
+
+// newTaprootAssetClaimCmd creates the exit-claim command.
+func newTaprootAssetClaimCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "claim",
+		Short: "Claim an exited asset VTXO into the tapd wallet",
+		Long: "Claim an exited asset VTXO once its unrolled anchor " +
+			"has matured past the exit delay. The daemon gathers " +
+			"the lineage confirmations itself and spends the " +
+			"exit path into a fresh tapd-owned anchor, making " +
+			"the units ordinary tapd wallet balance.",
+		Args: cobra.NoArgs,
+		RunE: claimTaprootAssetVTXO,
+	}
+
+	flags := cmd.Flags()
+	flags.String("outpoint", "", "the exited asset VTXO (txid:vout)")
+	flags.Int64(
+		"fee-sat", 0,
+		"miner fee paid out of the carrier value (zero estimates one)",
+	)
+
+	return cmd
+}
+
+// claimTaprootAssetVTXO invokes the exit-claim RPC.
+func claimTaprootAssetVTXO(cmd *cobra.Command, _ []string) error {
+	outpoint, _ := cmd.Flags().GetString("outpoint")
+	feeSat, _ := cmd.Flags().GetInt64("fee-sat")
+	if err := validateOutpoint(outpoint); err != nil {
+		return invalidArgs(err)
+	}
+	if feeSat < 0 {
+		return invalidArgs(fmt.Errorf("--fee-sat must not be negative"))
+	}
+
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	response, err := client.ClaimTaprootAssetVTXO(
+		ctx, &waverpc.ClaimTaprootAssetVTXORequest{
+			Outpoint: outpoint,
+			FeeSat:   feeSat,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("ClaimTaprootAssetVTXO RPC failed: %w", err)
+	}
+
+	return printJSON(response)
+}
+
+// newTaprootAssetListCmd creates the asset VTXO listing command.
+func newTaprootAssetListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List asset-bearing VTXOs",
+		Long: "List VTXOs carrying Taproot Assets. With --asset-ref " +
+			"the daemon filters to one asset; without it every " +
+			"asset-bearing VTXO is shown.",
+		Args: cobra.NoArgs,
+		RunE: listTaprootAssetVTXOs,
+	}
+
+	flags := cmd.Flags()
+	flags.String("asset-ref", "", "restrict to one asset reference")
+	flags.String(
+		"status", "",
+		"restrict to one VTXO status (e.g. VTXO_STATUS_LIVE)",
+	)
+
+	return cmd
+}
+
+// listTaprootAssetVTXOs lists VTXOs and keeps the asset-bearing subset.
+func listTaprootAssetVTXOs(cmd *cobra.Command, _ []string) error {
+	assetRef, _ := cmd.Flags().GetString("asset-ref")
+	statusName, _ := cmd.Flags().GetString("status")
+
+	request := &waverpc.ListVTXOsRequest{
+		AssetRef:               assetRef,
+		ExcludeCheckpointPsbts: true,
+	}
+	if statusName != "" {
+		value, ok := waverpc.VTXOStatus_value[statusName]
+		if !ok {
+			return invalidArgs(
+				fmt.Errorf("unknown --status %q", statusName),
+			)
+		}
+		request.StatusFilter = waverpc.VTXOStatus(value)
+	}
+
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	response, err := client.ListVTXOs(ctx, request)
+	if err != nil {
+		return fmt.Errorf("ListVTXOs RPC failed: %w", err)
+	}
+
+	// Without an explicit reference the command still only reports
+	// asset-bearing VTXOs; plain Bitcoin VTXOs have their own listing.
+	if assetRef == "" {
+		assetVTXOs := make([]*waverpc.VTXO, 0, len(response.Vtxos))
+		for _, v := range response.Vtxos {
+			if v.GetTaprootAsset() != nil {
+				assetVTXOs = append(assetVTXOs, v)
+			}
+		}
+		response.Vtxos = assetVTXOs
+	}
+
+	return printJSON(response)
+}
+
+// newTaprootAssetBalanceCmd creates the per-asset balance command.
+func newTaprootAssetBalanceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "balance",
+		Short: "Show per-asset VTXO balances",
+		Long: "Show the wallet's Taproot Asset holdings broken down " +
+			"by asset reference, in asset units. The carrier " +
+			"satoshis stay part of the Bitcoin balance.",
+		Args: cobra.NoArgs,
+		RunE: taprootAssetBalance,
+	}
+}
+
+// taprootAssetBalance renders the asset section of the daemon balance.
+func taprootAssetBalance(cmd *cobra.Command, _ []string) error {
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	response, err := client.GetBalance(
+		ctx, &waverpc.GetBalanceRequest{},
+	)
+	if err != nil {
+		return fmt.Errorf("GetBalance RPC failed: %w", err)
+	}
+
+	return printJSONFields(response, []string{"taproot_assets"})
+}
+
+// newTaprootAssetSendCmd creates the asset OOR send wrapper.
+func newTaprootAssetSendCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "send",
+		Short: "Send asset units out of round",
+		Long: "Send Taproot Asset units to another Wavelength user " +
+			"out of round. The daemon spends one asset VTXO; " +
+			"when --amount is below the VTXO's full holding, the " +
+			"change rides on one of the sender's Bitcoin VTXOs. " +
+			"The recipient key comes from the recipient's " +
+			"'ark oor receive'. Without --outpoint the smallest " +
+			"sufficient asset VTXO is selected.",
+		Args: cobra.NoArgs,
+		RunE: sendTaprootAsset,
+	}
+
+	flags := cmd.Flags()
+	flags.String("asset-ref", "", "asset reference to send")
+	flags.Uint64("amount", 0, "asset units to send")
+	flags.String(
+		"recipient-pubkey", "", "recipient receive pubkey (hex)",
+	)
+	flags.String(
+		"outpoint", "",
+		"asset VTXO to spend (txid:vout; empty selects one)",
+	)
+	flags.String(
+		"idempotency-key", "", "stable caller-generated retry key",
+	)
+
+	return cmd
+}
+
+// sendTaprootAsset resolves the input VTXO and change carrier, then submits
+// the asset OOR intent.
+func sendTaprootAsset(cmd *cobra.Command, _ []string) error {
+	assetRef, _ := cmd.Flags().GetString("asset-ref")
+	amount, _ := cmd.Flags().GetUint64("amount")
+	recipientPubkey, _ := cmd.Flags().GetString("recipient-pubkey")
+	outpoint, _ := cmd.Flags().GetString("outpoint")
+	idempotencyKey, _ := cmd.Flags().GetString("idempotency-key")
+
+	switch {
+	case assetRef == "":
+		return invalidArgs(fmt.Errorf("--asset-ref is required"))
+
+	case amount == 0:
+		return invalidArgs(fmt.Errorf("--amount must be positive"))
+
+	case recipientPubkey == "":
+		return invalidArgs(fmt.Errorf("--recipient-pubkey is required"))
+
+	case idempotencyKey == "":
+		return invalidArgs(fmt.Errorf("--idempotency-key is required"))
+	}
+	if err := validateFreeText(
+		"--idempotency-key", idempotencyKey,
+	); err != nil {
+		return invalidArgs(err)
+	}
+	if outpoint != "" {
+		if err := validateOutpoint(outpoint); err != nil {
+			return invalidArgs(err)
+		}
+	}
+
+	recipientKey, err := hex.DecodeString(recipientPubkey)
+	if err != nil {
+		return invalidArgs(
+			fmt.Errorf("decode --recipient-pubkey: %w", err),
+		)
+	}
+
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	input, err := selectAssetSendInput(
+		ctx, client, assetRef, amount, outpoint,
+	)
+	if err != nil {
+		return err
+	}
+
+	intent := &waverpc.TaprootAssetOORIntent{
+		AssetRef:               assetRef,
+		AssetAmount:            input.GetTaprootAsset().GetAmount(),
+		AcknowledgeUnconfirmed: true,
+		InputVtxoOutpoint:      input.GetOutpoint(),
+	}
+
+	// A partial send needs a Bitcoin VTXO to carry the asset change.
+	if amount < intent.AssetAmount {
+		carrier, err := selectAssetChangeCarrier(ctx, client)
+		if err != nil {
+			return err
+		}
+		intent.RecipientAssetAmount = amount
+		intent.AssetChangeCarrierValueSat = uint64(
+			carrier.GetAmountSat(),
+		)
+	}
+	if amount > intent.AssetAmount {
+		return invalidArgs(
+			fmt.Errorf(
+				"VTXO %s holds %d units, cannot send %d",
+				input.GetOutpoint(), intent.AssetAmount, amount,
+			),
+		)
+	}
+
+	response, err := client.SendOOR(ctx, &waverpc.SendOORRequest{
+		Recipients: []*waverpc.Output{{
+			Destination: &waverpc.Output_Pubkey{
+				Pubkey: recipientKey,
+			},
+			AmountSat: input.GetAmountSat(),
+		}},
+		IdempotencyKey: idempotencyKey,
+		TaprootAsset:   intent,
+	})
+	if err != nil {
+		return fmt.Errorf("SendOOR RPC failed: %w", err)
+	}
+
+	return printJSON(response)
+}
+
+// selectAssetSendInput resolves the asset VTXO to spend: the named
+// outpoint, or the smallest live VTXO of the asset that covers the amount.
+func selectAssetSendInput(ctx context.Context,
+	client waverpc.DaemonServiceClient, assetRef string, amount uint64,
+	outpoint string) (*waverpc.VTXO, error) {
+
+	response, err := client.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{
+		StatusFilter:           waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+		AssetRef:               assetRef,
+		ExcludeCheckpointPsbts: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ListVTXOs RPC failed: %w", err)
+	}
+
+	var selected *waverpc.VTXO
+	for _, v := range response.Vtxos {
+		if outpoint != "" {
+			if v.GetOutpoint() == outpoint {
+				return v, nil
+			}
+
+			continue
+		}
+		if v.GetTaprootAsset().GetAmount() < amount {
+			continue
+		}
+		if selected == nil || v.GetTaprootAsset().GetAmount() <
+			selected.GetTaprootAsset().GetAmount() {
+
+			selected = v
+		}
+	}
+	if outpoint != "" {
+		return nil, fmt.Errorf("no live VTXO %s carries asset %s",
+			outpoint, assetRef)
+	}
+	if selected == nil {
+		return nil, fmt.Errorf("no live asset VTXO covers %d "+
+			"units of %s", amount, assetRef)
+	}
+
+	return selected, nil
+}
+
+// selectAssetChangeCarrier picks the sender's largest live Bitcoin VTXO as
+// the asset-change carrier.
+func selectAssetChangeCarrier(ctx context.Context,
+	client waverpc.DaemonServiceClient) (*waverpc.VTXO, error) {
+
+	response, err := client.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{
+		StatusFilter:           waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+		ExcludeCheckpointPsbts: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ListVTXOs RPC failed: %w", err)
+	}
+
+	var carrier *waverpc.VTXO
+	for _, v := range response.Vtxos {
+		if v.GetTaprootAsset() != nil {
+			continue
+		}
+		if carrier == nil ||
+			v.GetAmountSat() > carrier.GetAmountSat() {
+
+			carrier = v
+		}
+	}
+	if carrier == nil {
+		return nil, fmt.Errorf("a partial asset send needs a live " +
+			"Bitcoin VTXO to carry the change")
+	}
+
+	return carrier, nil
+}

--- a/cmd/wavecli/waveclicommands/cmd_taproot_assets_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_taproot_assets_test.go
@@ -58,6 +58,23 @@ func TestTaprootAssetOnboardingRequestTargetConf(t *testing.T) {
 	require.Equal(t, uint32(6), request.TargetConf)
 }
 
+// TestTaprootAssetOnboardingRequestWithoutProof verifies an omitted proof
+// file leaves the wire field empty so the daemon resolves the proof itself.
+func TestTaprootAssetOnboardingRequestWithoutProof(t *testing.T) {
+	t.Parallel()
+
+	cmd := newTaprootAssetOnboardCmd()
+	require.NoError(t, cmd.Flags().Set("idempotency-key", "deposit-1"))
+	require.NoError(t, cmd.Flags().Set("asset-ref", "asset-id"))
+	require.NoError(t, cmd.Flags().Set("asset-amount", "42"))
+	require.NoError(t, cmd.Flags().Set("sat-per-vbyte", "2"))
+	require.NoError(t, cmd.Flags().Set("max-fee-sat", "500"))
+
+	request, err := taprootAssetOnboardingRequest(cmd)
+	require.NoError(t, err)
+	require.Empty(t, request.InputProofFile)
+}
+
 func TestTaprootAssetOnboardingRequestRejectsInvalidInput(t *testing.T) {
 	t.Parallel()
 
@@ -85,11 +102,6 @@ func TestTaprootAssetOnboardingRequestRejectsInvalidInput(t *testing.T) {
 			flag:    "asset-amount",
 			value:   "0",
 			wantErr: "--asset-amount must be positive",
-		},
-		{
-			name:    "proof path",
-			flag:    "proof-file",
-			wantErr: "--proof-file is required",
 		},
 		{
 			name:    "fee",

--- a/cmd/wavecli/waveclicommands/devrpc/registry_generated.go
+++ b/cmd/wavecli/waveclicommands/devrpc/registry_generated.go
@@ -143,6 +143,20 @@ func generatedRegistry() []serviceSpec {
 					Comments: "OnboardTaprootAsset moves one complete, isolated Taproot Asset anchor\ninto a standard Wavelength VTXO policy. The request is idempotent: a\nretry resumes publication or operator registration without committing\nanother asset transition.",
 				},
 				{
+					Name:     "BoardTaprootAsset",
+					Aliases:  []string{"board-taproot-asset"},
+					Input:    "waverpc.BoardTaprootAssetRequest",
+					Output:   "waverpc.BoardTaprootAssetResponse",
+					Comments: "BoardTaprootAsset boards a confirmed onboarded output into the next\nasset round. The daemon rebuilds the boarding disclosure from the\nonboarding named by the idempotency key, gathers the confirmation\nand the boarded asset proof itself, and registers the boarding\ntogether with a matching asset VTXO request. Safe to retry.",
+				},
+				{
+					Name:     "ClaimTaprootAssetVTXO",
+					Aliases:  []string{"claim-taproot-asset-vtxo"},
+					Input:    "waverpc.ClaimTaprootAssetVTXORequest",
+					Output:   "waverpc.ClaimTaprootAssetVTXOResponse",
+					Comments: "ClaimTaprootAssetVTXO claims an exited asset VTXO into the daemon's\ntapd wallet once its unrolled anchor has matured past the exit\ndelay. The daemon gathers the lineage confirmations itself.",
+				},
+				{
 					Name:     "PrepareOOR",
 					Aliases:  []string{"prepare-oor"},
 					Input:    "waverpc.PrepareOORRequest",

--- a/cmd/wavecli/waveclicommands/root.go
+++ b/cmd/wavecli/waveclicommands/root.go
@@ -26,7 +26,7 @@ const (
 	groupAdvanced      = "advanced"
 
 	// devModeEnvVar, when set to "1", reveals the advanced subtrees
-	// (ark / dev / recovery / taproot-assets) under an Advanced group in
+	// (ark / dev / recovery / assets) under an Advanced group in
 	// --help. It only changes visibility; it never gates execution.
 	devModeEnvVar = "WAVELENGTH_DEV"
 )

--- a/cmd/wavecli/waveclicommands/root_groups_test.go
+++ b/cmd/wavecli/waveclicommands/root_groups_test.go
@@ -95,7 +95,7 @@ func TestAdvancedCommandsHiddenByDefault(t *testing.T) {
 
 	root := newRootCmd(false)
 	for _, name := range []string{
-		"ark", "dev", "recovery", "taproot-assets",
+		"ark", "dev", "recovery", "assets",
 	} {
 		sub := findRootCommand(t, root, name)
 		require.Truef(t, sub.Hidden, "%q should be hidden", name)
@@ -116,7 +116,7 @@ func TestAdvancedCommandsGroupedUnderDevMode(t *testing.T) {
 	require.Contains(t, rootGroupIDs(root), groupAdvanced)
 
 	for _, name := range []string{
-		"ark", "dev", "recovery", "taproot-assets",
+		"ark", "dev", "recovery", "assets",
 	} {
 		sub := findRootCommand(t, root, name)
 		require.Falsef(t, sub.Hidden, "%q should be visible", name)

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/btcsuite/btcd/txscript/v2 v2.0.0
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
 	github.com/lightninglabs/go-wasmsqlite v0.0.0-20260627090804-0dce68fc5287
-	github.com/lightninglabs/tap-sdk v0.1.1-0.20260812155217-58cdc8fb07ae
+	github.com/lightninglabs/tap-sdk v0.1.1-0.20260818105941-9b4c6c4a0ce4
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/btcsuite/btcd/txscript/v2 v2.0.0
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
 	github.com/lightninglabs/go-wasmsqlite v0.0.0-20260627090804-0dce68fc5287
-	github.com/lightninglabs/tap-sdk v0.1.1-0.20260818105941-9b4c6c4a0ce4
+	github.com/lightninglabs/tap-sdk v0.1.1-0.20260818172001-f657858b0fcc
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1078,8 +1078,8 @@ github.com/lightninglabs/neutrino/cache v1.1.4 h1:KVtvUmBwYr7eKtjfjHG/q6/cQlcrjH
 github.com/lightninglabs/neutrino/cache v1.1.4/go.mod h1:ZqLzxghPggIRfNXeAZN1VtTKofMyK/ALI6niYsPH6OE=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS/00EiEg0qp0FhehxnQfk3vv8U6Xt3nN+rTY=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260812155217-58cdc8fb07ae h1:Tc8FcNhC1f7NLy9ufKxBSZSyIEaUavq/WzFu+wKVlsI=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260812155217-58cdc8fb07ae/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260818105941-9b4c6c4a0ce4 h1:RQVjlhkHHmeeWZ6fVq8YnlmkAthcylcArLDE6eO1tig=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260818105941-9b4c6c4a0ce4/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef h1:4vHoQMzUkpkPoNKHT+QdTUbWoWaz0T5CDx6CWsforXM=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef/go.mod h1:fm0WaNsDpP7jEgR9zMap3hpum7lXVDtjsi783MW9BxY=
 github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260804093026-95bd8d412bef h1:3uhbpFZUp3JwLxSlhdelA56g0dULFfcYlC6Q/wQICk0=

--- a/go.sum
+++ b/go.sum
@@ -1078,8 +1078,8 @@ github.com/lightninglabs/neutrino/cache v1.1.4 h1:KVtvUmBwYr7eKtjfjHG/q6/cQlcrjH
 github.com/lightninglabs/neutrino/cache v1.1.4/go.mod h1:ZqLzxghPggIRfNXeAZN1VtTKofMyK/ALI6niYsPH6OE=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS/00EiEg0qp0FhehxnQfk3vv8U6Xt3nN+rTY=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260818105941-9b4c6c4a0ce4 h1:RQVjlhkHHmeeWZ6fVq8YnlmkAthcylcArLDE6eO1tig=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260818105941-9b4c6c4a0ce4/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260818172001-f657858b0fcc h1:0/t/1pcWhwmivIZdWdsrMbwiisjKd1XM9/eYnv+wVLE=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260818172001-f657858b0fcc/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef h1:4vHoQMzUkpkPoNKHT+QdTUbWoWaz0T5CDx6CWsforXM=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef/go.mod h1:fm0WaNsDpP7jEgR9zMap3hpum7lXVDtjsi783MW9BxY=
 github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260804093026-95bd8d412bef h1:3uhbpFZUp3JwLxSlhdelA56g0dULFfcYlC6Q/wQICk0=

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -87,6 +87,13 @@ type OperatorTerms struct {
 	// operator does not enforce a cap (the client should fall back to
 	// its own conservative default before submitting).
 	MaxOORLineageVBytes uint32
+
+	// OORCarrierPubKey is the key owning the operator's OOR carrier
+	// float. Set when the operator funds the new asset-leaf carriers of
+	// out-of-round transfers from its own float VTXOs; nil when carrier
+	// funding is disabled. Together with the operator's collab key and
+	// exit delay it derives the float's standard VTXO policy.
+	OORCarrierPubKey *btcec.PublicKey
 }
 
 // MinVTXOAmountFloor returns the effective minimum for a VTXO output. The

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -144,6 +144,11 @@ const (
 	transferInputTaprootAssetRootRecordType   tlv.Type = 18
 	transferInputTaprootAssetRefRecordType    tlv.Type = 19
 	transferInputTaprootAssetAmountRecordType tlv.Type = 20
+
+	// transferInputOperatorFundedRecordType marks an operator-funded
+	// float input (snapshot version 8+). The record is written only when
+	// set, so older snapshots decode it to false.
+	transferInputOperatorFundedRecordType tlv.Type = 21
 )
 
 const (
@@ -1547,6 +1552,16 @@ func encodeTransferInputSnapshot(input *TransferInputSnapshot) ([]byte, error) {
 		)
 	}
 
+	if input.OperatorFunded {
+		operatorFunded := uint8(1)
+		records = append(
+			records, tlv.MakePrimitiveRecord(
+				transferInputOperatorFundedRecordType,
+				&operatorFunded,
+			),
+		)
+	}
+
 	stream, err := tlv.NewStream(records...)
 	if err != nil {
 		return nil, err
@@ -1582,6 +1597,7 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 		assetRootRaw       []byte
 		assetRefRaw        []byte
 		assetAmount        uint64
+		operatorFunded     uint8
 	)
 
 	records := []tlv.Record{
@@ -1651,6 +1667,9 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 		tlv.MakePrimitiveRecord(
 			transferInputTaprootAssetAmountRecordType, &assetAmount,
 		),
+		tlv.MakePrimitiveRecord(
+			transferInputOperatorFundedRecordType, &operatorFunded,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -1698,6 +1717,7 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 		RequiredLockTime:   requiredLockTime,
 		TaprootAssetRef:    string(assetRefRaw),
 		TaprootAssetAmount: assetAmount,
+		OperatorFunded:     operatorFunded != 0,
 	}
 
 	if len(condBlob) > 0 {

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -165,6 +165,9 @@ const (
 	incomingMetadataMatchCreatedHeightRecordType  tlv.Type = 13
 	incomingMetadataMatchAncestryPathsRecordType  tlv.Type = 17
 	incomingMetadataMatchOperatorKeyRecordType    tlv.Type = 19
+	incomingMetadataMatchAssetRootRecordType      tlv.Type = 21
+	incomingMetadataMatchAssetRefRecordType       tlv.Type = 23
+	incomingMetadataMatchAssetAmountRecordType    tlv.Type = 25
 )
 
 type startTransferPayload struct {
@@ -737,6 +740,12 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 	chainDepth := uint32(match.Metadata.ChainDepth)
 	createdHeight := uint32(match.Metadata.CreatedHeight)
 	operatorKey := encodeOptionalPubKey(match.Metadata.OperatorKey)
+	var assetRoot []byte
+	if match.Metadata.TaprootAssetRoot != nil {
+		assetRoot = match.Metadata.TaprootAssetRoot[:]
+	}
+	assetRef := []byte(match.Metadata.TaprootAssetRef)
+	assetAmount := match.Metadata.TaprootAssetAmount
 
 	ancestryBytes, err := encodeAncestryList(match.Metadata.Ancestry)
 	if err != nil {
@@ -774,6 +783,16 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 			incomingMetadataMatchOperatorKeyRecordType,
 			&operatorKey,
 		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchAssetRootRecordType, &assetRoot,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchAssetRefRecordType, &assetRef,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchAssetAmountRecordType,
+			&assetAmount,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -803,6 +822,9 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 		createdHeight  uint32
 		ancestryBytes  []byte
 		operatorKey    []byte
+		assetRoot      []byte
+		assetRef       []byte
+		assetAmount    uint64
 	)
 
 	records := []tlv.Record{
@@ -835,6 +857,16 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 		tlv.MakePrimitiveRecord(
 			incomingMetadataMatchOperatorKeyRecordType,
 			&operatorKey,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchAssetRootRecordType, &assetRoot,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchAssetRefRecordType, &assetRef,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchAssetAmountRecordType,
+			&assetAmount,
 		),
 	}
 
@@ -889,16 +921,29 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 	var decodedCommitmentTxID chainhash.Hash
 	copy(decodedCommitmentTxID[:], commitmentTxID)
 
+	var decodedAssetRoot *chainhash.Hash
+	if len(assetRoot) > 0 {
+		root, err := chainhash.NewHash(assetRoot)
+		if err != nil {
+			return IncomingMetadataMatch{}, fmt.Errorf("incoming "+
+				"metadata Taproot Asset root: %w", err)
+		}
+		decodedAssetRoot = root
+	}
+
 	return IncomingMetadataMatch{
 		OutputIndex: outputIndex,
 		Metadata: IncomingVTXOMetadata{
-			RoundID:        string(roundID),
-			CommitmentTxID: decodedCommitmentTxID,
-			BatchExpiry:    decodedBatchExpiry,
-			ChainDepth:     int(decodedChainDepth),
-			CreatedHeight:  decodedCreatedHeight,
-			OperatorKey:    decodedOperatorKey,
-			Ancestry:       ancestry,
+			RoundID:            string(roundID),
+			CommitmentTxID:     decodedCommitmentTxID,
+			BatchExpiry:        decodedBatchExpiry,
+			ChainDepth:         int(decodedChainDepth),
+			CreatedHeight:      decodedCreatedHeight,
+			OperatorKey:        decodedOperatorKey,
+			Ancestry:           ancestry,
+			TaprootAssetRoot:   decodedAssetRoot,
+			TaprootAssetRef:    string(assetRef),
+			TaprootAssetAmount: assetAmount,
 		},
 	}, nil
 }

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -586,6 +586,7 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 
 	sessionID := SessionID(chainhash.Hash{10, 10, 10})
 	commitmentTxID := chainhash.Hash{11, 11, 11}
+	assetRoot := chainhash.Hash{12, 12, 12}
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
@@ -605,6 +606,9 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 						CommitmentTxID: commitmentTxID,
 						TreeDepth:      0,
 					}},
+					TaprootAssetRoot:   &assetRoot,
+					TaprootAssetRef:    "tapr1asset",
+					TaprootAssetAmount: 21,
 				},
 			}},
 		},
@@ -640,6 +644,9 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 		t, commitmentTxID, match.Metadata.Ancestry[0].CommitmentTxID,
 	)
 	require.Nil(t, match.Metadata.Ancestry[0].TreePath)
+	require.Equal(t, &assetRoot, match.Metadata.TaprootAssetRoot)
+	require.Equal(t, "tapr1asset", match.Metadata.TaprootAssetRef)
+	require.EqualValues(t, 21, match.Metadata.TaprootAssetAmount)
 }
 
 // TestDriveEventRequestRoundTripIncomingAckSentEvent asserts

--- a/oor/ark_sign.go
+++ b/oor/ark_sign.go
@@ -135,6 +135,12 @@ func signArkPSBTInput(signer input.Signer, arkPSBT *psbt.Packet, inputIndex int,
 		return err
 	}
 
+	// The operator provides both required leaf signatures for its own
+	// funded float input during cosign; the wallet holds no key for it.
+	if in.OperatorFunded {
+		return nil
+	}
+
 	pInput := &arkPSBT.Inputs[inputIndex]
 
 	// Find the collab leaf by matching against the expected owner

--- a/oor/carrier_lease.go
+++ b/oor/carrier_lease.go
@@ -1,0 +1,79 @@
+package oor
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+// OORCarrierLease is a reservation of one operator carrier-float VTXO. The
+// transfer spends the float whole: the new asset-leaf carriers come out of it
+// and the residual returns to the float pkScript as the operator's change.
+type OORCarrierLease struct {
+	// Outpoint identifies the leased float VTXO.
+	Outpoint wire.OutPoint
+
+	// Value is the float VTXO's full value.
+	Value btcutil.Amount
+
+	// PolicyTemplate is the float VTXO's serialized arkscript policy.
+	PolicyTemplate []byte
+
+	// PkScript is the float VTXO's output script, which the operator's
+	// change output must pay verbatim.
+	PkScript []byte
+
+	// ExpiresAtUnix is when the lease lapses if unconsumed, in Unix
+	// seconds.
+	ExpiresAtUnix int64
+}
+
+// Validate checks the lease names a spendable float VTXO.
+func (l *OORCarrierLease) Validate() error {
+	switch {
+	case l == nil:
+		return fmt.Errorf("carrier lease must be provided")
+
+	case l.Value <= 0 || l.Value > btcutil.MaxSatoshi:
+		return fmt.Errorf("carrier lease value is invalid")
+
+	case len(l.PolicyTemplate) == 0:
+		return fmt.Errorf("carrier lease policy template is required")
+
+	case len(l.PkScript) == 0:
+		return fmt.Errorf("carrier lease pkscript is required")
+	}
+
+	return nil
+}
+
+// FundingEquals reports whether two leases name the same float funding.
+// Expiry is excluded: a re-grant of the same float differs only in its
+// expiry, and the journaled funding is what the transfer graph committed to.
+func (l *OORCarrierLease) FundingEquals(other *OORCarrierLease) bool {
+	if l == nil || other == nil {
+		return l == other
+	}
+
+	return l.Outpoint == other.Outpoint &&
+		l.Value == other.Value &&
+		bytes.Equal(l.PolicyTemplate, other.PolicyTemplate) &&
+		bytes.Equal(l.PkScript, other.PkScript)
+}
+
+// Clone deep-copies the lease.
+func (l *OORCarrierLease) Clone() *OORCarrierLease {
+	if l == nil {
+		return nil
+	}
+
+	return &OORCarrierLease{
+		Outpoint:       l.Outpoint,
+		Value:          l.Value,
+		PolicyTemplate: bytes.Clone(l.PolicyTemplate),
+		PkScript:       bytes.Clone(l.PkScript),
+		ExpiresAtUnix:  l.ExpiresAtUnix,
+	}
+}

--- a/oor/checkpoint_sign.go
+++ b/oor/checkpoint_sign.go
@@ -57,6 +57,13 @@ func SignCheckpointPSBTs(signer input.Signer, inputs []TransferInput,
 	}
 
 	for i := range inputs {
+		// The operator signs both legs of its own funded float input;
+		// the wallet holds no key for it. The operator leg was already
+		// verified above like every other input.
+		if inputs[i].OperatorFunded {
+			continue
+		}
+
 		err = signCheckpointPSBT(signer, &inputs[i], checkpoints[i])
 		if err != nil {
 			return fmt.Errorf("sign checkpoint %d: %w", i, err)

--- a/oor/incoming_metadata_query.go
+++ b/oor/incoming_metadata_query.go
@@ -175,14 +175,27 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (IncomingVTXOMetadata,
 	var commitmentTxID chainhash.Hash
 	copy(commitmentTxID[:], candidate.GetCommitmentTxid())
 
+	var assetRoot *chainhash.Hash
+	if len(candidate.GetTaprootAssetRoot()) > 0 {
+		root, err := chainhash.NewHash(candidate.GetTaprootAssetRoot())
+		if err != nil {
+			return IncomingVTXOMetadata{}, fmt.Errorf("parse "+
+				"indexer vtxo Taproot Asset root: %w", err)
+		}
+		assetRoot = root
+	}
+
 	return IncomingVTXOMetadata{
-		RoundID:        candidate.GetRoundId(),
-		CommitmentTxID: commitmentTxID,
-		BatchExpiry:    candidate.GetBatchExpiryHeight(),
-		ChainDepth:     int(candidate.GetChainDepth()),
-		CreatedHeight:  candidate.GetCreatedHeight(),
-		OperatorKey:    operatorKey,
-		Ancestry:       ancestry,
+		RoundID:            candidate.GetRoundId(),
+		CommitmentTxID:     commitmentTxID,
+		BatchExpiry:        candidate.GetBatchExpiryHeight(),
+		ChainDepth:         int(candidate.GetChainDepth()),
+		CreatedHeight:      candidate.GetCreatedHeight(),
+		OperatorKey:        operatorKey,
+		Ancestry:           ancestry,
+		TaprootAssetRoot:   assetRoot,
+		TaprootAssetRef:    candidate.GetTaprootAssetRef(),
+		TaprootAssetAmount: candidate.GetTaprootAssetAmount(),
 	}, nil
 }
 

--- a/oor/incoming_vtxo.go
+++ b/oor/incoming_vtxo.go
@@ -61,6 +61,17 @@ type IncomingVTXOMetadata struct {
 	// commitment tx. Each entry carries its own TreePath, CommitmentTxID,
 	// InputIndices, and TreeDepth.
 	Ancestry []vtxo.Ancestry
+
+	// TaprootAssetRoot, TaprootAssetRef, and TaprootAssetAmount carry the
+	// indexer's asset identity for the created output. A recipient event
+	// overlays the same identity onto its own output, but a transfer with
+	// several wallet-owned outputs is driven by a single event, so the
+	// remaining asset outputs take their identity from here. The composed
+	// pkScript check during descriptor construction authenticates the
+	// root against the wallet's own policy.
+	TaprootAssetRoot   *chainhash.Hash
+	TaprootAssetRef    string
+	TaprootAssetAmount uint64
 }
 
 // IncomingVTXOConfig describes how to materialize an Ark tx output into a

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -270,6 +270,25 @@ func (h *LocalPersistenceOutboxHandler) handleQueryIncomingMetadata(
 	}}, nil
 }
 
+// incomingAssetIdentity returns the asset identity for one owned recipient.
+// The recipient event overlays asset identity only onto its own output, and a
+// transfer with several wallet-owned outputs is driven by a single event, so
+// the remaining asset outputs take their identity from the indexer metadata.
+// Descriptor construction authenticates the claimed root against the wallet's
+// own policy via the composed pkScript check.
+func incomingAssetIdentity(recipient ArkRecipientOutput,
+	metadata IncomingVTXOMetadata) (*chainhash.Hash, string, uint64) {
+
+	if recipient.TaprootAssetRoot != nil ||
+		metadata.TaprootAssetRoot == nil {
+		return recipient.TaprootAssetRoot, recipient.TaprootAssetRef,
+			recipient.TaprootAssetAmount
+	}
+
+	return metadata.TaprootAssetRoot, metadata.TaprootAssetRef,
+		metadata.TaprootAssetAmount
+}
+
 // FilterIncomingMetadataRecipients returns only the incoming recipients owned
 // by the local wallet. Durable metadata queries use this before asking the
 // server/indexer to prove script ownership, because mixed OOR packages can
@@ -325,7 +344,6 @@ func (h *LocalPersistenceOutboxHandler) materializeIncoming(ctx context.Context,
 	metadataByOutput := make(
 		map[uint32]IncomingVTXOMetadata, len(msg.MetadataMatches),
 	)
-
 	for i := range msg.MetadataMatches {
 		match := msg.MetadataMatches[i]
 		metadataByOutput[match.OutputIndex] = match.Metadata
@@ -422,6 +440,10 @@ func (h *LocalPersistenceOutboxHandler) materializeIncoming(ctx context.Context,
 				"incoming output %d", recipient.OutputIndex)
 		}
 
+		assetRoot, assetRef, assetAmount := incomingAssetIdentity(
+			recipient, metadata,
+		)
+
 		desc, err := BuildIncomingVTXODescriptor(msg.ArkPSBT,
 			IncomingVTXOConfig{
 				OutputIndex: recipient.OutputIndex,
@@ -430,10 +452,9 @@ func (h *LocalPersistenceOutboxHandler) materializeIncoming(ctx context.Context,
 				ExitDelay:   h.ExitDelay,
 				PolicyTemplate: recipient.
 					VTXOPolicyTemplate,
-				TaprootAssetRoot: recipient.TaprootAssetRoot,
-				TaprootAssetRef:  recipient.TaprootAssetRef,
-				TaprootAssetAmount: recipient.
-					TaprootAssetAmount,
+				TaprootAssetRoot:     assetRoot,
+				TaprootAssetRef:      assetRef,
+				TaprootAssetAmount:   assetAmount,
 				Metadata:             metadata,
 				FinalCheckpointPSBTs: msg.FinalCheckpointPSBTs,
 				AncestorPackages:     msg.AncestorPackages,

--- a/oor/operator_funded_input_test.go
+++ b/oor/operator_funded_input_test.go
@@ -1,0 +1,399 @@
+package oor
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestOperatorFundedInput builds a leased float input the way the daemon
+// does: policy template and owner leaf come from the lease, no client key.
+func newTestOperatorFundedInput(t *testing.T, floatKey *btcec.PrivateKey,
+	operatorKey *btcec.PublicKey, outpoint wire.OutPoint,
+	amount btcutil.Amount) TransferInput {
+
+	t.Helper()
+
+	const exitDelay = uint32(10)
+	policyBytes, err := arkscript.EncodeStandardVTXOTemplate(
+		floatKey.PubKey(), operatorKey, exitDelay,
+	)
+	require.NoError(t, err)
+
+	template, err := arkscript.DecodePolicyTemplate(policyBytes)
+	require.NoError(t, err)
+	pkScript, err := template.PkScript()
+	require.NoError(t, err)
+
+	ownerLeafPolicy, err := arkscript.LeafTemplate{
+		Node: &arkscript.Multisig{
+			Keys: []*btcec.PublicKey{
+				floatKey.PubKey(),
+				operatorKey,
+			},
+		},
+	}.Encode()
+	require.NoError(t, err)
+
+	return TransferInput{
+		VTXO: &vtxo.Descriptor{
+			Outpoint:       outpoint,
+			Amount:         amount,
+			PkScript:       pkScript,
+			PolicyTemplate: policyBytes,
+			OperatorKey:    operatorKey,
+			RelativeExpiry: exitDelay,
+		},
+		VTXOPolicyTemplate: policyBytes,
+		OwnerLeafPolicy:    ownerLeafPolicy,
+		OperatorFunded:     true,
+	}
+}
+
+// signFloatOwnerLegForTest models the operator adding the float-owner leg to
+// its own funded input's checkpoint during cosign.
+func signFloatOwnerLegForTest(t *testing.T, floatKey *btcec.PrivateKey,
+	in *TransferInput, checkpoint *psbt.Packet) {
+
+	t.Helper()
+
+	spendPath, err := in.EffectiveSpendPath()
+	require.NoError(t, err)
+
+	prevOut := &wire.TxOut{
+		Value:    int64(in.VTXO.Amount),
+		PkScript: in.VTXO.PkScript,
+	}
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		prevOut.PkScript, prevOut.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(checkpoint.UnsignedTx, prevFetcher)
+	signDesc := spendPath.SpendInfo.BuildSignDescriptor(
+		keychain.KeyDescriptor{
+			PubKey: floatKey.PubKey(),
+		},
+		prevOut,
+		sigHashes,
+		prevFetcher,
+		0,
+	)
+
+	signer := input.NewMockSigner([]*btcec.PrivateKey{floatKey}, nil)
+	sig, err := signer.SignOutputRaw(checkpoint.UnsignedTx, signDesc)
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		psbtutil.AddTaprootScriptSpendSig(
+			&checkpoint.Inputs[0], floatKey.PubKey(),
+			spendPath.WitnessScript, sig.Serialize(),
+			signDesc.HashType,
+		),
+	)
+}
+
+// TestOperatorFundedInputValidate pins the marked input's contract: the lease
+// supplies everything and no local key material may sneak in.
+func TestOperatorFundedInputValidate(t *testing.T) {
+	t.Parallel()
+
+	floatKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	valid := newTestOperatorFundedInput(
+		t, floatKey, operatorKey.PubKey(), wire.OutPoint{
+			Hash:  [32]byte{0x0f},
+			Index: 0,
+		},
+		25_000,
+	)
+	require.NoError(t, valid.Validate())
+	require.NotEmpty(t, valid.OwnerLeafScript)
+
+	spendPath, err := valid.EffectiveSpendPath()
+	require.NoError(t, err)
+	require.NotEmpty(t, spendPath.WitnessScript)
+
+	tests := []struct {
+		name    string
+		mutate  func(*TransferInput)
+		wantErr string
+	}{
+		{
+			name: "client key rejected",
+			mutate: func(in *TransferInput) {
+				in.VTXO.ClientKey.PubKey = floatKey.PubKey()
+			},
+			wantErr: "cannot carry a client key",
+		},
+		{
+			name: "missing policy template",
+			mutate: func(in *TransferInput) {
+				in.VTXOPolicyTemplate = nil
+			},
+			wantErr: "requires a policy template",
+		},
+		{
+			name: "missing owner leaf policy",
+			mutate: func(in *TransferInput) {
+				in.OwnerLeafPolicy = nil
+			},
+			wantErr: "requires an owner leaf policy",
+		},
+		{
+			name: "missing operator key",
+			mutate: func(in *TransferInput) {
+				in.VTXO.OperatorKey = nil
+			},
+			wantErr: "requires an operator key",
+		},
+		{
+			name: "custom spend rejected",
+			mutate: func(in *TransferInput) {
+				in.CustomSpend = &arkscript.SpendPath{}
+			},
+			wantErr: "cannot use a custom spend path",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			in := newTestOperatorFundedInput(
+				t, floatKey, operatorKey.PubKey(),
+				wire.OutPoint{
+					Hash:  [32]byte{0x0f},
+					Index: 0,
+				},
+				25_000,
+			)
+			test.mutate(&in)
+			require.ErrorContains(
+				t, in.Validate(), test.wantErr,
+			)
+		})
+	}
+}
+
+// TestOperatorFundedSigningSkipsLocalKey proves both local signing sites skip
+// the leased float input while the operator's checkpoint signature on it is
+// still verified, and an extra float-owner leg is tolerated.
+func TestOperatorFundedSigningSkipsLocalKey(t *testing.T) {
+	t.Parallel()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	floatKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, operatorKey.PubKey(), wire.OutPoint{
+				Hash:  [32]byte{0x01},
+				Index: 0,
+			},
+			10_000,
+		),
+		newTestOperatorFundedInput(
+			t, floatKey, operatorKey.PubKey(), wire.OutPoint{
+				Hash:  [32]byte{0x02},
+				Index: 0,
+			},
+			25_000,
+		),
+	}
+	outputs := []oortx.RecipientOutput{{
+		PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+		Value:    35_000,
+	}}
+
+	arkPSBT, checkpoints, err := BuildSubmitPackage(policy, inputs, outputs)
+	require.NoError(t, err)
+
+	// The operator cosigns every checkpoint and adds the float-owner leg
+	// on its own funded input.
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
+	require.NoError(
+		t, coSignCheckpointPSBTsForTest(
+			operatorSigner, inputs, checkpoints,
+		),
+	)
+	signFloatOwnerLegForTest(t, floatKey, &inputs[1], checkpoints[1])
+
+	// Missing the operator leg must still fail for the float input, so
+	// strip it and confirm before signing for real.
+	stripped, err := psbtutil.Parse(mustSerializePSBT(t, checkpoints[1]))
+	require.NoError(t, err)
+	stripped.Inputs[0].TaprootScriptSpendSig = nil
+	err = SignCheckpointPSBTs(
+		input.NewMockSigner(
+			[]*btcec.PrivateKey{clientKey}, nil,
+		),
+		inputs,
+		[]*psbt.Packet{checkpoints[0], stripped},
+	)
+	require.ErrorContains(t, err, "missing taproot script spend signature")
+
+	clientSigner := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
+	require.NoError(
+		t, SignCheckpointPSBTs(
+			clientSigner, inputs, checkpoints,
+		),
+	)
+
+	// The wallet input gains the client signature; the float input keeps
+	// exactly the operator-provided legs.
+	require.Len(t, checkpoints[0].Inputs[0].TaprootScriptSpendSig, 2)
+	require.Len(t, checkpoints[1].Inputs[0].TaprootScriptSpendSig, 2)
+	clientXOnly := schnorr.SerializePubKey(clientKey.PubKey())
+	for _, sigRec := range checkpoints[1].Inputs[0].TaprootScriptSpendSig {
+		require.NotEqual(t, clientXOnly, sigRec.XOnlyPubKey)
+	}
+
+	// Ark signing skips the float input entirely.
+	require.NoError(
+		t, SignArkPSBT(
+			clientSigner, arkPSBT, checkpoints, inputs,
+		),
+	)
+
+	floatCheckpointTxid := checkpoints[1].UnsignedTx.TxHash()
+	for idx, txIn := range arkPSBT.UnsignedTx.TxIn {
+		sigs := arkPSBT.Inputs[idx].TaprootScriptSpendSig
+		if txIn.PreviousOutPoint.Hash == floatCheckpointTxid {
+			require.Empty(t, sigs)
+
+			continue
+		}
+
+		require.Len(t, sigs, 1)
+	}
+}
+
+// TestNormalizeCheckpointOwnerLeavesSkipsOperatorFunded proves the float
+// input's lease-supplied owner leaf survives owner-leaf normalization under a
+// different session operator key.
+func TestNormalizeCheckpointOwnerLeavesSkipsOperatorFunded(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	sessionOperatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	floatKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	in := newTestOperatorFundedInput(
+		t, floatKey, operatorKey.PubKey(), wire.OutPoint{
+			Hash:  [32]byte{0x0f},
+			Index: 1,
+		},
+		25_000,
+	)
+	require.NoError(t, in.Validate())
+	wantLeafScript := append([]byte(nil), in.OwnerLeafScript...)
+	wantLeafPolicy := append([]byte(nil), in.OwnerLeafPolicy...)
+
+	inputs := []TransferInput{in}
+	require.NoError(
+		t,
+		NormalizeCheckpointOwnerLeaves(
+			arkscript.CheckpointPolicy{
+				OperatorKey: sessionOperatorKey.PubKey(),
+				CSVDelay:    10,
+			},
+			inputs,
+		),
+	)
+
+	require.Equal(t, wantLeafScript, inputs[0].OwnerLeafScript)
+	require.Equal(t, wantLeafPolicy, inputs[0].OwnerLeafPolicy)
+}
+
+// TestOperatorFundedSnapshotRoundTrip proves the marker and the lease-derived
+// signing context survive the durable snapshot encoding.
+func TestOperatorFundedSnapshotRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	floatKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	in := newTestOperatorFundedInput(
+		t, floatKey, operatorKey.PubKey(), wire.OutPoint{
+			Hash:  [32]byte{0x0f},
+			Index: 2,
+		},
+		25_000,
+	)
+	require.NoError(t, in.Validate())
+
+	snap, err := in.ToSnapshot()
+	require.NoError(t, err)
+	require.True(t, snap.OperatorFunded)
+	require.Empty(t, snap.ClientPubKey)
+
+	encoded, err := encodeTransferInputSnapshot(snap)
+	require.NoError(t, err)
+	decoded, err := decodeTransferInputSnapshot(encoded)
+	require.NoError(t, err)
+	require.True(t, decoded.OperatorFunded)
+
+	restored, err := TransferInputFromSnapshot(decoded)
+	require.NoError(t, err)
+	require.True(t, restored.OperatorFunded)
+	require.Nil(t, restored.VTXO.ClientKey.PubKey)
+	require.Equal(t, in.VTXO.PkScript, restored.VTXO.PkScript)
+	require.Equal(t, in.OwnerLeafScript, restored.OwnerLeafScript)
+	require.NoError(t, restored.Validate())
+
+	// The restored input still resolves the float collab spend path for
+	// operator-signature verification.
+	spendPath, err := restored.EffectiveSpendPath()
+	require.NoError(t, err)
+	require.NotEmpty(t, spendPath.WitnessScript)
+
+	// A pkscript-less marked snapshot must fail closed rather than
+	// resurrect an unsignable input.
+	broken := *decoded
+	broken.PkScript = nil
+	_, err = TransferInputFromSnapshot(&broken)
+	require.ErrorContains(t, err, "requires a stored pkscript")
+}
+
+// mustSerializePSBT round-trips a PSBT through its wire encoding so tests can
+// mutate an independent copy.
+func mustSerializePSBT(t *testing.T, packet *psbt.Packet) []byte {
+	t.Helper()
+
+	raw, err := psbtutil.Serialize(packet)
+	require.NoError(t, err)
+
+	return raw
+}

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -149,11 +149,11 @@ func NewOutgoingSnapshot(sessionID SessionID,
 	}
 
 	snap := &OutgoingSnapshot{
-		// Version 7 adds SDK-neutral asset identity and amount within
-		// the recipient and input records. Restore remains
-		// backward-compatible because the appended TLV fields are
-		// optional.
-		Version:   7,
+		// Version 8 adds the operator-funded marker within the input
+		// records so a resumed session never re-attempts local signing
+		// on a leased float input. Restore remains backward-compatible
+		// because the appended TLV field is optional.
+		Version:   8,
 		SessionID: sessionID,
 	}
 

--- a/oor/session_actor_handlers.go
+++ b/oor/session_actor_handlers.go
@@ -236,7 +236,11 @@ func (b *sessionBehavior) recordReservations(ctx context.Context,
 	}
 
 	ownerID := chainHashOf(b.sessionID)
-	outpoints := InputOutpoints(inputs)
+
+	// Reservation rows exist only for wallet VTXOs; an operator-funded
+	// float input has no local row and would fail the store's
+	// wallet-state precondition.
+	outpoints := WalletInputOutpoints(inputs)
 	if assetPrepared {
 		if strings.TrimSpace(assetPreparationRequestID) == "" {
 			return fmt.Errorf("Taproot Asset OOR idempotency key " +
@@ -432,6 +436,12 @@ func (b *sessionBehavior) queueVTXOSent(ctx context.Context,
 
 	var total int64
 	for i := range state.TransferInputs {
+		// The operator's leased float value is not wallet money and
+		// must not inflate the sent amount.
+		if state.TransferInputs[i].OperatorFunded {
+			continue
+		}
+
 		total += int64(state.TransferInputs[i].VTXO.Amount)
 	}
 	if total <= 0 {

--- a/oor/taproot_asset_preparer.go
+++ b/oor/taproot_asset_preparer.go
@@ -53,8 +53,10 @@ type TaprootAssetOORIntent struct {
 	// caller's receiver. Zero preserves the legacy full-send default.
 	RecipientAssetAmount uint64
 
-	// AssetChangeCarrierValueSat is the explicit Bitcoin value assigned to
-	// local asset change. It must be zero for a full asset send.
+	// AssetChangeCarrierValueSat is the Bitcoin value assigned to local
+	// asset change on a partial send. Zero defers to the operator's
+	// minimum VTXO amount; the daemon materializes that default before
+	// preparation. It must be zero for a full asset send.
 	AssetChangeCarrierValueSat uint64
 
 	// ProofFile is the complete confirmed proof for the selected asset.
@@ -108,11 +110,6 @@ func (i *TaprootAssetOORIntent) Validate() error {
 		i.AssetChangeCarrierValueSat != 0 {
 		return fmt.Errorf("taproot asset change carrier must be zero " +
 			"for a full send")
-	}
-	if recipientAmount < i.AssetAmount &&
-		i.AssetChangeCarrierValueSat == 0 {
-		return fmt.Errorf("taproot asset change carrier is required " +
-			"for a partial send")
 	}
 	if i.AssetChangeCarrierValueSat > uint64(btcutil.MaxSatoshi) {
 		return fmt.Errorf("taproot asset change carrier exceeds " +
@@ -255,37 +252,67 @@ func (r *TaprootAssetOORPrepareRequest) Validate() error {
 	}
 
 	assetChange := btcutil.Amount(r.Intent.AssetChangeCarrierValueSat)
+	if r.Intent.EffectiveRecipientAssetAmount() < r.Intent.AssetAmount &&
+		assetChange == 0 {
+		return fmt.Errorf("taproot asset change carrier is required " +
+			"for a partial send")
+	}
 	if assetChange != 0 && assetChange < r.OutputFloor {
 		return fmt.Errorf("taproot asset OOR change carrier is below " +
 			"the output floor")
 	}
 
-	inputTotal, err := taprootAssetInputTotal(r.Inputs)
+	assetChange, bitcoinChange, err := r.CarrierAllocation()
 	if err != nil {
 		return err
 	}
-	required, err := addTaprootAssetCarrier(
-		r.Recipients[0].Value, assetChange,
-	)
-	if err != nil {
-		return err
-	}
-	if required > inputTotal {
-		return fmt.Errorf("taproot asset OOR carrier funding is " +
-			"insufficient")
-	}
-	change := inputTotal - required
-	if change != 0 && change < r.OutputFloor {
-		return fmt.Errorf("taproot asset OOR Bitcoin change is below " +
-			"the output floor")
-	}
-	if (assetChange != 0 || change != 0) &&
+	if (assetChange != 0 || bitcoinChange != 0) &&
 		r.BuildChangeRecipient == nil {
 		return fmt.Errorf("taproot asset OOR change recipient " +
 			"builder is required")
 	}
 
 	return nil
+}
+
+// CarrierAllocation returns the Bitcoin value assigned to the asset-change
+// output and to the sender's plain Bitcoin change output. A remainder below
+// the operator floor cannot become its own output, so a partial send folds it
+// into the asset-change carrier instead of creating a dust output.
+func (r *TaprootAssetOORPrepareRequest) CarrierAllocation() (btcutil.Amount,
+	btcutil.Amount, error) {
+
+	if r == nil || len(r.Recipients) != 1 {
+		return 0, 0, fmt.Errorf("taproot asset OOR requires exactly " +
+			"one recipient")
+	}
+
+	assetChange := btcutil.Amount(r.Intent.AssetChangeCarrierValueSat)
+	inputTotal, err := taprootAssetInputTotal(r.Inputs)
+	if err != nil {
+		return 0, 0, err
+	}
+	required, err := addTaprootAssetCarrier(
+		r.Recipients[0].Value, assetChange,
+	)
+	if err != nil {
+		return 0, 0, err
+	}
+	if required > inputTotal {
+		return 0, 0, fmt.Errorf("taproot asset OOR carrier funding " +
+			"is insufficient")
+	}
+
+	bitcoinChange := inputTotal - required
+	if bitcoinChange == 0 || bitcoinChange >= r.OutputFloor {
+		return assetChange, bitcoinChange, nil
+	}
+	if assetChange == 0 {
+		return 0, 0, fmt.Errorf("taproot asset OOR Bitcoin change is " +
+			"below the output floor")
+	}
+
+	return assetChange + bitcoinChange, 0, nil
 }
 
 // AssetInputIndex returns the unique asset-bearing input. Every other input

--- a/oor/taproot_asset_preparer.go
+++ b/oor/taproot_asset_preparer.go
@@ -326,27 +326,33 @@ func (r *TaprootAssetOORPrepareRequest) validateLeaseBinding(
 
 // TaprootAssetCarrierPlan is the Bitcoin-side output plan of an
 // operator-funded asset send. Every new asset leaf is created at the operator
-// floor out of the leased float, the sender's full input carrier returns as
-// plain Bitcoin change, and the float residual returns to the operator.
+// floor out of the leased float, and a spent leaf's carrier follows its
+// origin: round-created carriers return to the sender as plain Bitcoin
+// change, while OOR-created carriers were operator money and are reclaimed
+// into the operator's change.
 type TaprootAssetCarrierPlan struct {
 	// AssetChange is the asset-change leaf carrier: the operator floor on
 	// a partial send, zero on a full send.
 	AssetChange btcutil.Amount
 
-	// SenderChange is the sender's plain Bitcoin change: the asset
-	// input's full carrier value.
+	// SenderChange is the sender's plain Bitcoin change: the summed
+	// carriers of the round-created asset inputs. Zero means every spent
+	// leaf was OOR-created and no sender change output exists.
 	SenderChange btcutil.Amount
 
-	// OperatorChange is the float residual returned to the lease
-	// pkScript: lease value minus the new asset-leaf floors. Zero means
-	// the lease was consumed exactly and no operator output exists.
+	// OperatorChange is the value returned to the lease pkScript: the
+	// float residual (lease value minus the new asset-leaf floors) plus
+	// the reclaimed carriers of the OOR-created asset inputs. Zero means
+	// the lease was consumed exactly with nothing reclaimed and no
+	// operator output exists.
 	OperatorChange btcutil.Amount
 }
 
 // CarrierAllocation returns the Bitcoin-side output plan funded by the
 // operator's carrier float. The recipient leaf and the asset-change leaf of a
 // partial send are always the operator floor; a lease below the summed floors
-// cannot fund the send.
+// cannot fund the send. The carrier arithmetic sums over every asset input so
+// atomic multi-input sends can reuse it unchanged.
 func (r *TaprootAssetOORPrepareRequest) CarrierAllocation() (
 	TaprootAssetCarrierPlan, error) {
 
@@ -364,8 +370,7 @@ func (r *TaprootAssetOORPrepareRequest) CarrierAllocation() (
 
 	// A light scan suffices here: every caller runs the request's full
 	// Validate (which runs AssetInputIndex) before planning values.
-	assetInputIndex, err := locateTaprootAssetInput(r.Inputs)
-	if err != nil {
+	if _, err := locateTaprootAssetInput(r.Inputs); err != nil {
 		return TaprootAssetCarrierPlan{}, err
 	}
 
@@ -386,15 +391,50 @@ func (r *TaprootAssetOORPrepareRequest) CarrierAllocation() (
 			"new asset-leaf floors", r.Lease.Value, floors)
 	}
 
+	senderCarriers, reclaimedCarriers := splitAssetInputCarriers(r.Inputs)
 	plan := TaprootAssetCarrierPlan{
-		SenderChange:   r.Inputs[assetInputIndex].VTXO.Amount,
-		OperatorChange: r.Lease.Value - floors,
+		SenderChange:   senderCarriers,
+		OperatorChange: r.Lease.Value - floors + reclaimedCarriers,
 	}
 	if leafCount > 1 {
 		plan.AssetChange = r.OutputFloor
 	}
 
 	return plan, nil
+}
+
+// splitAssetInputCarriers sums the asset inputs' Bitcoin carriers by leaf
+// origin: a round-created leaf's carrier is the sender's own money, while an
+// OOR-created leaf's carrier was operator-funded and is reclaimed when the
+// leaf is spent.
+func splitAssetInputCarriers(inputs []TransferInput) (btcutil.Amount,
+	btcutil.Amount) {
+
+	var sender, reclaimed btcutil.Amount
+	for idx := range inputs {
+		input := &inputs[idx]
+		if input.VTXO == nil || !hasTaprootAssetState(input) {
+			continue
+		}
+		if input.TaprootAssetRoundCreated {
+			sender += input.VTXO.Amount
+
+			continue
+		}
+		reclaimed += input.VTXO.Amount
+	}
+
+	return sender, reclaimed
+}
+
+// hasTaprootAssetState reports whether any identity field marks the input as
+// asset-bearing. The transfer-input and descriptor views must agree, which
+// AssetInputIndex enforces separately.
+func hasTaprootAssetState(input *TransferInput) bool {
+	return input.TaprootAssetRoot != nil ||
+		input.VTXO.TaprootAssetRoot != nil ||
+		input.VTXO.TaprootAssetRef != "" ||
+		input.VTXO.TaprootAssetAmount != 0
 }
 
 // locateTaprootAssetInput returns the unique asset-bearing input without the
@@ -408,11 +448,7 @@ func locateTaprootAssetInput(inputs []TransferInput) (int, error) {
 				"has no VTXO", idx)
 		}
 
-		hasAsset := input.TaprootAssetRoot != nil ||
-			input.VTXO.TaprootAssetRoot != nil ||
-			input.VTXO.TaprootAssetRef != "" ||
-			input.VTXO.TaprootAssetAmount != 0
-		if !hasAsset {
+		if !hasTaprootAssetState(input) {
 			continue
 		}
 		if assetIndex >= 0 {
@@ -479,11 +515,7 @@ func (r *TaprootAssetOORPrepareRequest) AssetInputIndex() (int, error) {
 		}
 		seenOutpoints[input.VTXO.Outpoint] = struct{}{}
 
-		hasAsset := input.TaprootAssetRoot != nil ||
-			input.VTXO.TaprootAssetRoot != nil ||
-			input.VTXO.TaprootAssetRef != "" ||
-			input.VTXO.TaprootAssetAmount != 0
-		if !hasAsset {
+		if !hasTaprootAssetState(input) {
 			continue
 		}
 		if input.TaprootAssetRoot == nil ||
@@ -591,9 +623,9 @@ func (p *TaprootAssetOORPreparation) Validate(
 					"recipient %d: %w", idx, err)
 			}
 
-			// A non-asset output is either the operator's float
-			// residual (pays the lease pkScript verbatim) or the
-			// sender's returned carrier.
+			// A non-asset output is either the operator's change
+			// (pays the lease pkScript verbatim) or the sender's
+			// returned carrier.
 			if bytes.Equal(
 				recipient.PkScript, request.Lease.PkScript,
 			) {
@@ -606,6 +638,15 @@ func (p *TaprootAssetOORPreparation) Validate(
 				operatorChangeSeen++
 
 				continue
+			}
+
+			// The sender's carrier returns only when the spent
+			// leaf was round-created; a reclaim-only send must
+			// not pay the sender any plain output.
+			if plan.SenderChange == 0 {
+				return fmt.Errorf("taproot asset OOR sender " +
+					"change must be absent when every " +
+					"carrier is reclaimed")
 			}
 			if recipient.Value != plan.SenderChange {
 				return fmt.Errorf("taproot asset OOR sender " +
@@ -641,7 +682,11 @@ func (p *TaprootAssetOORPreparation) Validate(
 		return fmt.Errorf("taproot asset OOR asset allocation is not " +
 			"conserved")
 	}
-	if senderChangeSeen != 1 {
+	wantSenderChange := 0
+	if plan.SenderChange > 0 {
+		wantSenderChange = 1
+	}
+	if senderChangeSeen != wantSenderChange {
 		return fmt.Errorf("taproot asset OOR sender change is not " +
 			"unique")
 	}

--- a/oor/taproot_asset_preparer.go
+++ b/oor/taproot_asset_preparer.go
@@ -33,20 +33,29 @@ const (
 	// MaxTaprootAssetCourierAddressBytes bounds the optional proof courier
 	// address before the concrete tap-sdk adapter interprets it.
 	MaxTaprootAssetCourierAddressBytes = 2048
+
+	// MaxTaprootAssetInputs bounds the asset-bearing inputs of one atomic
+	// transfer. Each input adds a checkpoint transition plus recursive
+	// co-input evidence on every created leaf, so a send needing more
+	// must consolidate first.
+	MaxTaprootAssetInputs = 8
 )
 
 // TaprootAssetOORIntent is the proof-selected asset movement requested by an
 // OOR caller. AssetAmount is measured in asset units and is deliberately
 // separate from the satoshi value of the containing Ark VTXO.
 type TaprootAssetOORIntent struct {
-	// InputVTXOOutpoint is the wallet-managed asset-bearing VTXO that must
-	// be selected and reserved through the normal VTXO manager path.
-	InputVTXOOutpoint wire.OutPoint
+	// InputVTXOOutpoints are the wallet-managed asset-bearing VTXOs the
+	// transfer spends in one atomic transition, spine first. The daemon
+	// resolves the list before preparation, so an empty list is valid
+	// only on the public RPC surface where it delegates selection.
+	InputVTXOOutpoints []wire.OutPoint
 
 	// AssetRef is the opaque tap-sdk asset or group identifier.
 	AssetRef string
 
-	// AssetAmount is the exact number of asset units selected by ProofFile.
+	// AssetAmount is the exact total number of asset units carried by the
+	// selected inputs.
 	AssetAmount uint64
 
 	// RecipientAssetAmount is the number of asset units delivered to the
@@ -92,9 +101,31 @@ func (i *TaprootAssetOORIntent) Validate() error {
 	if i.AssetAmount == 0 {
 		return fmt.Errorf("taproot asset amount is required")
 	}
+	if len(i.InputVTXOOutpoints) > MaxTaprootAssetInputs {
+		return fmt.Errorf("taproot asset OOR spans %d inputs, more "+
+			"than %d: consolidate first", len(i.InputVTXOOutpoints),
+			MaxTaprootAssetInputs)
+	}
+	seenInputs := make(
+		map[wire.OutPoint]struct{}, len(i.InputVTXOOutpoints),
+	)
+	for _, outpoint := range i.InputVTXOOutpoints {
+		if _, ok := seenInputs[outpoint]; ok {
+			return fmt.Errorf("taproot asset OOR intent input %s "+
+				"is duplicated", outpoint)
+		}
+		seenInputs[outpoint] = struct{}{}
+	}
 	if len(i.ProofFile) > oortx.MaxTaprootAssetPackageBytes {
 		return fmt.Errorf("taproot asset input proof exceeds %d bytes",
 			oortx.MaxTaprootAssetPackageBytes)
+	}
+
+	// A caller-supplied proof file describes exactly one confirmed input;
+	// multi-input sends resolve every input from its sealed local package.
+	if len(i.InputVTXOOutpoints) > 1 && len(i.ProofFile) != 0 {
+		return fmt.Errorf("taproot asset input proof file requires a " +
+			"single pinned input")
 	}
 	if len(i.RecipientScriptKey) != 0 {
 		return fmt.Errorf("taproot asset recipient script key is " +
@@ -232,22 +263,9 @@ func (r *TaprootAssetOORPrepareRequest) Validate() error {
 	if r.OutputFloor <= 0 {
 		return fmt.Errorf("taproot asset OOR output floor is required")
 	}
-	assetInputIndex, err := r.AssetInputIndex()
+	assetInputIndices, err := r.AssetInputIndices()
 	if err != nil {
 		return err
-	}
-	assetInput := r.Inputs[assetInputIndex]
-	if assetInput.VTXO.Outpoint != r.Intent.InputVTXOOutpoint {
-		return fmt.Errorf("taproot asset OOR input outpoint does not " +
-			"match the requested managed VTXO")
-	}
-	if assetInput.VTXO.TaprootAssetRef != r.Intent.AssetRef {
-		return fmt.Errorf("taproot asset OOR input ref does not " +
-			"match the requested asset")
-	}
-	if assetInput.VTXO.TaprootAssetAmount != r.Intent.AssetAmount {
-		return fmt.Errorf("taproot asset OOR input amount does not " +
-			"match the requested asset")
 	}
 	if len(r.Recipients[0].VTXOPolicyTemplate) == 0 {
 		return fmt.Errorf("taproot asset OOR recipient policy is " +
@@ -271,9 +289,11 @@ func (r *TaprootAssetOORPrepareRequest) Validate() error {
 	if err != nil {
 		return err
 	}
-	if floatInputIndex == assetInputIndex {
-		return fmt.Errorf("taproot asset OOR float input cannot " +
-			"carry the asset")
+	for _, assetIndex := range assetInputIndices {
+		if floatInputIndex == assetIndex {
+			return fmt.Errorf("taproot asset OOR float input " +
+				"cannot carry the asset")
+		}
 	}
 	if err := r.validateLeaseBinding(floatInputIndex); err != nil {
 		return err
@@ -369,8 +389,8 @@ func (r *TaprootAssetOORPrepareRequest) CarrierAllocation() (
 	}
 
 	// A light scan suffices here: every caller runs the request's full
-	// Validate (which runs AssetInputIndex) before planning values.
-	if _, err := locateTaprootAssetInput(r.Inputs); err != nil {
+	// Validate (which runs AssetInputIndices) before planning values.
+	if err := requireTaprootAssetInput(r.Inputs); err != nil {
 		return TaprootAssetCarrierPlan{}, err
 	}
 
@@ -437,31 +457,22 @@ func hasTaprootAssetState(input *TransferInput) bool {
 		input.VTXO.TaprootAssetAmount != 0
 }
 
-// locateTaprootAssetInput returns the unique asset-bearing input without the
-// per-input structural validation AssetInputIndex performs.
-func locateTaprootAssetInput(inputs []TransferInput) (int, error) {
-	assetIndex := -1
+// requireTaprootAssetInput checks at least one asset-bearing input exists,
+// without the per-input structural validation AssetInputIndices performs.
+func requireTaprootAssetInput(inputs []TransferInput) error {
 	for idx := range inputs {
 		input := &inputs[idx]
 		if input.VTXO == nil {
-			return 0, fmt.Errorf("taproot asset OOR input %d "+
+			return fmt.Errorf("taproot asset OOR input %d "+
 				"has no VTXO", idx)
 		}
 
-		if !hasTaprootAssetState(input) {
-			continue
+		if hasTaprootAssetState(input) {
+			return nil
 		}
-		if assetIndex >= 0 {
-			return 0, fmt.Errorf("taproot asset OOR requires " +
-				"exactly one asset input")
-		}
-		assetIndex = idx
-	}
-	if assetIndex < 0 {
-		return 0, fmt.Errorf("taproot asset OOR input root is required")
 	}
 
-	return assetIndex, nil
+	return fmt.Errorf("taproot asset OOR input root is required")
 }
 
 // OperatorFundedInputIndex returns the unique operator-funded float input.
@@ -492,31 +503,51 @@ func (r *TaprootAssetOORPrepareRequest) OperatorFundedInputIndex() (int,
 	return floatIndex, nil
 }
 
-// AssetInputIndex returns the unique asset-bearing input. Every other input
-// must be an ordinary Bitcoin VTXO.
-func (r *TaprootAssetOORPrepareRequest) AssetInputIndex() (int, error) {
+// AssetInputIndices returns the asset-bearing inputs resolved against the
+// intent's ordered outpoint list, spine first. The intent order also has to
+// be the inputs' relative order, so the journaled wallet input set and the
+// asset transition input order stay interchangeable across restarts. Every
+// other input must be the operator-funded carrier float.
+func (r *TaprootAssetOORPrepareRequest) AssetInputIndices() ([]int, error) {
 	if r == nil {
-		return 0, fmt.Errorf("taproot asset OOR prepare request is " +
+		return nil, fmt.Errorf("taproot asset OOR prepare request is " +
 			"required")
 	}
+	outpointCount := len(r.Intent.InputVTXOOutpoints)
+	if outpointCount == 0 {
+		return nil, fmt.Errorf("taproot asset OOR intent input " +
+			"outpoints are required")
+	}
 
-	assetIndex := -1
+	byOutpoint := make(map[wire.OutPoint]int, outpointCount)
 	seenOutpoints := make(map[wire.OutPoint]struct{}, len(r.Inputs))
+	assetOrder := make([]wire.OutPoint, 0, outpointCount)
 	for idx := range r.Inputs {
 		input := &r.Inputs[idx]
 		if err := input.Validate(); err != nil {
-			return 0, fmt.Errorf("taproot asset OOR input %d: %w",
+			return nil, fmt.Errorf("taproot asset OOR input %d: %w",
 				idx, err)
 		}
 		if _, ok := seenOutpoints[input.VTXO.Outpoint]; ok {
-			return 0, fmt.Errorf("taproot asset OOR input %d has "+
-				"duplicate outpoint %s", idx,
+			return nil, fmt.Errorf("taproot asset OOR input %d "+
+				"has duplicate outpoint %s", idx,
 				input.VTXO.Outpoint)
 		}
 		seenOutpoints[input.VTXO.Outpoint] = struct{}{}
 
 		if !hasTaprootAssetState(input) {
+			if !input.OperatorFunded {
+				return nil, fmt.Errorf("taproot asset OOR "+
+					"input %d is neither an asset input "+
+					"nor the operator float", idx)
+			}
+
 			continue
+		}
+		if input.OperatorFunded {
+			return nil, fmt.Errorf("taproot asset OOR input %d "+
+				"cannot be both asset-bearing and "+
+				"operator-funded", idx)
 		}
 		if input.TaprootAssetRoot == nil ||
 			input.VTXO.TaprootAssetRoot == nil ||
@@ -524,20 +555,49 @@ func (r *TaprootAssetOORPrepareRequest) AssetInputIndex() (int, error) {
 				*input.VTXO.TaprootAssetRoot ||
 			input.VTXO.TaprootAssetRef == "" ||
 			input.VTXO.TaprootAssetAmount == 0 {
-			return 0, fmt.Errorf("taproot asset OOR input %d has "+
-				"incomplete asset state", idx)
+			return nil, fmt.Errorf("taproot asset OOR input %d "+
+				"has incomplete asset state", idx)
 		}
-		if assetIndex >= 0 {
-			return 0, fmt.Errorf("taproot asset OOR requires " +
-				"exactly one asset input")
-		}
-		assetIndex = idx
+		byOutpoint[input.VTXO.Outpoint] = idx
+		assetOrder = append(assetOrder, input.VTXO.Outpoint)
 	}
-	if assetIndex < 0 {
-		return 0, fmt.Errorf("taproot asset OOR input root is required")
+	if len(byOutpoint) != outpointCount {
+		return nil, fmt.Errorf("taproot asset OOR has %d asset "+
+			"inputs, the intent names %d", len(byOutpoint),
+			outpointCount)
 	}
 
-	return assetIndex, nil
+	indices := make([]int, 0, outpointCount)
+	var total uint64
+	for ordinal, outpoint := range r.Intent.InputVTXOOutpoints {
+		idx, ok := byOutpoint[outpoint]
+		if !ok {
+			return nil, fmt.Errorf("taproot asset OOR input "+
+				"outpoint %s does not match the requested "+
+				"managed VTXOs", outpoint)
+		}
+		if assetOrder[ordinal] != outpoint {
+			return nil, fmt.Errorf("taproot asset OOR asset " +
+				"inputs are not in intent order")
+		}
+		input := &r.Inputs[idx]
+		if input.VTXO.TaprootAssetRef != r.Intent.AssetRef {
+			return nil, fmt.Errorf("taproot asset OOR input ref " +
+				"does not match the requested asset")
+		}
+		if input.VTXO.TaprootAssetAmount > ^uint64(0)-total {
+			return nil, fmt.Errorf("taproot asset OOR input " +
+				"amounts overflow")
+		}
+		total += input.VTXO.TaprootAssetAmount
+		indices = append(indices, idx)
+	}
+	if total != r.Intent.AssetAmount {
+		return nil, fmt.Errorf("taproot asset OOR input amount does " +
+			"not match the requested asset")
+	}
+
+	return indices, nil
 }
 
 // TaprootAssetOORPreparation is the immutable custom-anchor result supplied

--- a/oor/taproot_asset_preparer.go
+++ b/oor/taproot_asset_preparer.go
@@ -449,7 +449,7 @@ func splitAssetInputCarriers(inputs []TransferInput) (btcutil.Amount,
 
 // hasTaprootAssetState reports whether any identity field marks the input as
 // asset-bearing. The transfer-input and descriptor views must agree, which
-// AssetInputIndex enforces separately.
+// AssetInputIndices enforces separately.
 func hasTaprootAssetState(input *TransferInput) bool {
 	return input.TaprootAssetRoot != nil ||
 		input.VTXO.TaprootAssetRoot != nil ||

--- a/oor/taproot_asset_preparer.go
+++ b/oor/taproot_asset_preparer.go
@@ -53,10 +53,9 @@ type TaprootAssetOORIntent struct {
 	// caller's receiver. Zero preserves the legacy full-send default.
 	RecipientAssetAmount uint64
 
-	// AssetChangeCarrierValueSat is the Bitcoin value assigned to local
-	// asset change on a partial send. Zero defers to the operator's
-	// minimum VTXO amount; the daemon materializes that default before
-	// preparation. It must be zero for a full asset send.
+	// AssetChangeCarrierValueSat is a deprecated wire field and must be
+	// zero: new asset-leaf carriers are operator-funded at the operator's
+	// minimum VTXO amount.
 	AssetChangeCarrierValueSat uint64
 
 	// ProofFile is the complete confirmed proof for the selected asset.
@@ -106,14 +105,10 @@ func (i *TaprootAssetOORIntent) Validate() error {
 		return fmt.Errorf("taproot asset recipient amount exceeds " +
 			"input amount")
 	}
-	if recipientAmount == i.AssetAmount &&
-		i.AssetChangeCarrierValueSat != 0 {
-		return fmt.Errorf("taproot asset change carrier must be zero " +
-			"for a full send")
-	}
-	if i.AssetChangeCarrierValueSat > uint64(btcutil.MaxSatoshi) {
-		return fmt.Errorf("taproot asset change carrier exceeds " +
-			"maximum satoshi value")
+	if i.AssetChangeCarrierValueSat != 0 {
+		return fmt.Errorf("taproot asset change carrier must be " +
+			"zero: carriers are operator-funded at the " +
+			"operator's minimum VTXO amount")
 	}
 	if len(i.ProofCourierAddress) >
 		MaxTaprootAssetCourierAddressBytes {
@@ -151,6 +146,20 @@ func (i *TaprootAssetOORIntent) EffectiveRecipientAssetAmount() uint64 {
 	return i.RecipientAssetAmount
 }
 
+// NewAssetLeafCount returns the number of new asset-leaf carriers the send
+// creates: the recipient leaf, plus an asset-change leaf on a partial send.
+func (i *TaprootAssetOORIntent) NewAssetLeafCount() int {
+	if i == nil {
+		return 0
+	}
+
+	if i.EffectiveRecipientAssetAmount() < i.AssetAmount {
+		return 2
+	}
+
+	return 1
+}
+
 // TaprootAssetChangeRecipientBuilder derives a wallet-owned Ark policy output
 // for either asset change or ordinary Bitcoin change.
 type TaprootAssetChangeRecipientBuilder func(context.Context,
@@ -186,6 +195,11 @@ type TaprootAssetOORPrepareRequest struct {
 
 	// Intent identifies the selected asset and its final receiver script.
 	Intent TaprootAssetOORIntent
+
+	// Lease is the operator carrier-float reservation funding the new
+	// asset-leaf carriers. Inputs must contain exactly one matching
+	// operator-funded input.
+	Lease *OORCarrierLease
 }
 
 // Validate checks the first showcase contract before preparation begins.
@@ -246,28 +260,29 @@ func (r *TaprootAssetOORPrepareRequest) Validate() error {
 			"uncomposed")
 	}
 
-	if r.Recipients[0].Value < r.OutputFloor {
-		return fmt.Errorf("taproot asset OOR receiver carrier is " +
-			"below the output floor")
+	// New asset leaves are always created exactly at the operator floor;
+	// anything else the operator rejects at submit.
+	if r.Recipients[0].Value != r.OutputFloor {
+		return fmt.Errorf("taproot asset OOR receiver carrier must " +
+			"equal the operator floor")
 	}
 
-	assetChange := btcutil.Amount(r.Intent.AssetChangeCarrierValueSat)
-	if r.Intent.EffectiveRecipientAssetAmount() < r.Intent.AssetAmount &&
-		assetChange == 0 {
-		return fmt.Errorf("taproot asset change carrier is required " +
-			"for a partial send")
-	}
-	if assetChange != 0 && assetChange < r.OutputFloor {
-		return fmt.Errorf("taproot asset OOR change carrier is below " +
-			"the output floor")
-	}
-
-	assetChange, bitcoinChange, err := r.CarrierAllocation()
+	floatInputIndex, err := r.OperatorFundedInputIndex()
 	if err != nil {
 		return err
 	}
-	if (assetChange != 0 || bitcoinChange != 0) &&
-		r.BuildChangeRecipient == nil {
+	if floatInputIndex == assetInputIndex {
+		return fmt.Errorf("taproot asset OOR float input cannot " +
+			"carry the asset")
+	}
+	if err := r.validateLeaseBinding(floatInputIndex); err != nil {
+		return err
+	}
+
+	if _, err := r.CarrierAllocation(); err != nil {
+		return err
+	}
+	if r.BuildChangeRecipient == nil {
 		return fmt.Errorf("taproot asset OOR change recipient " +
 			"builder is required")
 	}
@@ -275,44 +290,170 @@ func (r *TaprootAssetOORPrepareRequest) Validate() error {
 	return nil
 }
 
-// CarrierAllocation returns the Bitcoin value assigned to the asset-change
-// output and to the sender's plain Bitcoin change output. A remainder below
-// the operator floor cannot become its own output, so a partial send folds it
-// into the asset-change carrier instead of creating a dust output.
-func (r *TaprootAssetOORPrepareRequest) CarrierAllocation() (btcutil.Amount,
-	btcutil.Amount, error) {
+// validateLeaseBinding proves the operator-funded input spends exactly the
+// leased float, so the planned outputs and the signed graph cannot diverge
+// from the reservation the operator granted.
+func (r *TaprootAssetOORPrepareRequest) validateLeaseBinding(
+	floatInputIndex int) error {
+
+	if err := r.Lease.Validate(); err != nil {
+		return err
+	}
+
+	floatInput := &r.Inputs[floatInputIndex]
+	switch {
+	case floatInput.VTXO.Outpoint != r.Lease.Outpoint:
+		return fmt.Errorf("taproot asset OOR float input outpoint " +
+			"does not match the lease")
+
+	case floatInput.VTXO.Amount != r.Lease.Value:
+		return fmt.Errorf("taproot asset OOR float input value does " +
+			"not match the lease")
+
+	case !bytes.Equal(floatInput.VTXO.PkScript, r.Lease.PkScript):
+		return fmt.Errorf("taproot asset OOR float input pkScript " +
+			"does not match the lease")
+
+	case !bytes.Equal(
+		floatInput.VTXOPolicyTemplate, r.Lease.PolicyTemplate,
+	):
+		return fmt.Errorf("taproot asset OOR float input policy does " +
+			"not match the lease")
+	}
+
+	return nil
+}
+
+// TaprootAssetCarrierPlan is the Bitcoin-side output plan of an
+// operator-funded asset send. Every new asset leaf is created at the operator
+// floor out of the leased float, the sender's full input carrier returns as
+// plain Bitcoin change, and the float residual returns to the operator.
+type TaprootAssetCarrierPlan struct {
+	// AssetChange is the asset-change leaf carrier: the operator floor on
+	// a partial send, zero on a full send.
+	AssetChange btcutil.Amount
+
+	// SenderChange is the sender's plain Bitcoin change: the asset
+	// input's full carrier value.
+	SenderChange btcutil.Amount
+
+	// OperatorChange is the float residual returned to the lease
+	// pkScript: lease value minus the new asset-leaf floors. Zero means
+	// the lease was consumed exactly and no operator output exists.
+	OperatorChange btcutil.Amount
+}
+
+// CarrierAllocation returns the Bitcoin-side output plan funded by the
+// operator's carrier float. The recipient leaf and the asset-change leaf of a
+// partial send are always the operator floor; a lease below the summed floors
+// cannot fund the send.
+func (r *TaprootAssetOORPrepareRequest) CarrierAllocation() (
+	TaprootAssetCarrierPlan, error) {
 
 	if r == nil || len(r.Recipients) != 1 {
-		return 0, 0, fmt.Errorf("taproot asset OOR requires exactly " +
-			"one recipient")
+		return TaprootAssetCarrierPlan{}, fmt.Errorf("taproot asset " +
+			"OOR requires exactly one recipient")
+	}
+	if err := r.Lease.Validate(); err != nil {
+		return TaprootAssetCarrierPlan{}, err
+	}
+	if r.OutputFloor <= 0 {
+		return TaprootAssetCarrierPlan{}, fmt.Errorf("taproot asset " +
+			"OOR output floor is required")
 	}
 
-	assetChange := btcutil.Amount(r.Intent.AssetChangeCarrierValueSat)
-	inputTotal, err := taprootAssetInputTotal(r.Inputs)
+	// A light scan suffices here: every caller runs the request's full
+	// Validate (which runs AssetInputIndex) before planning values.
+	assetInputIndex, err := locateTaprootAssetInput(r.Inputs)
 	if err != nil {
-		return 0, 0, err
-	}
-	required, err := addTaprootAssetCarrier(
-		r.Recipients[0].Value, assetChange,
-	)
-	if err != nil {
-		return 0, 0, err
-	}
-	if required > inputTotal {
-		return 0, 0, fmt.Errorf("taproot asset OOR carrier funding " +
-			"is insufficient")
+		return TaprootAssetCarrierPlan{}, err
 	}
 
-	bitcoinChange := inputTotal - required
-	if bitcoinChange == 0 || bitcoinChange >= r.OutputFloor {
-		return assetChange, bitcoinChange, nil
+	leafCount := r.Intent.NewAssetLeafCount()
+	if leafCount <= 0 {
+		return TaprootAssetCarrierPlan{}, fmt.Errorf("taproot asset " +
+			"OOR requires at least one new asset leaf")
 	}
-	if assetChange == 0 {
-		return 0, 0, fmt.Errorf("taproot asset OOR Bitcoin change is " +
-			"below the output floor")
+	if r.OutputFloor > btcutil.MaxSatoshi/btcutil.Amount(leafCount) {
+		return TaprootAssetCarrierPlan{}, fmt.Errorf("taproot asset " +
+			"OOR carrier sum overflows")
 	}
 
-	return assetChange + bitcoinChange, 0, nil
+	floors := r.OutputFloor * btcutil.Amount(leafCount)
+	if r.Lease.Value < floors {
+		return TaprootAssetCarrierPlan{}, fmt.Errorf("taproot asset "+
+			"OOR float lease value %d sat is below the %d sat of "+
+			"new asset-leaf floors", r.Lease.Value, floors)
+	}
+
+	plan := TaprootAssetCarrierPlan{
+		SenderChange:   r.Inputs[assetInputIndex].VTXO.Amount,
+		OperatorChange: r.Lease.Value - floors,
+	}
+	if leafCount > 1 {
+		plan.AssetChange = r.OutputFloor
+	}
+
+	return plan, nil
+}
+
+// locateTaprootAssetInput returns the unique asset-bearing input without the
+// per-input structural validation AssetInputIndex performs.
+func locateTaprootAssetInput(inputs []TransferInput) (int, error) {
+	assetIndex := -1
+	for idx := range inputs {
+		input := &inputs[idx]
+		if input.VTXO == nil {
+			return 0, fmt.Errorf("taproot asset OOR input %d "+
+				"has no VTXO", idx)
+		}
+
+		hasAsset := input.TaprootAssetRoot != nil ||
+			input.VTXO.TaprootAssetRoot != nil ||
+			input.VTXO.TaprootAssetRef != "" ||
+			input.VTXO.TaprootAssetAmount != 0
+		if !hasAsset {
+			continue
+		}
+		if assetIndex >= 0 {
+			return 0, fmt.Errorf("taproot asset OOR requires " +
+				"exactly one asset input")
+		}
+		assetIndex = idx
+	}
+	if assetIndex < 0 {
+		return 0, fmt.Errorf("taproot asset OOR input root is required")
+	}
+
+	return assetIndex, nil
+}
+
+// OperatorFundedInputIndex returns the unique operator-funded float input.
+func (r *TaprootAssetOORPrepareRequest) OperatorFundedInputIndex() (int,
+	error) {
+
+	if r == nil {
+		return 0, fmt.Errorf("taproot asset OOR prepare request is " +
+			"required")
+	}
+
+	floatIndex := -1
+	for idx := range r.Inputs {
+		if !r.Inputs[idx].OperatorFunded {
+			continue
+		}
+		if floatIndex >= 0 {
+			return 0, fmt.Errorf("taproot asset OOR requires " +
+				"exactly one operator-funded input")
+		}
+		floatIndex = idx
+	}
+	if floatIndex < 0 {
+		return 0, fmt.Errorf("taproot asset OOR requires an " +
+			"operator-funded float input")
+	}
+
+	return floatIndex, nil
 }
 
 // AssetInputIndex returns the unique asset-bearing input. Every other input
@@ -365,30 +506,6 @@ func (r *TaprootAssetOORPrepareRequest) AssetInputIndex() (int, error) {
 	}
 
 	return assetIndex, nil
-}
-
-func taprootAssetInputTotal(inputs []TransferInput) (btcutil.Amount, error) {
-	var total btcutil.Amount
-	for idx := range inputs {
-		amount := inputs[idx].VTXO.Amount
-		if amount <= 0 || total > btcutil.MaxSatoshi-amount {
-			return 0, fmt.Errorf("taproot asset OOR input " +
-				"carrier sum overflows")
-		}
-		total += amount
-	}
-
-	return total, nil
-}
-
-func addTaprootAssetCarrier(left, right btcutil.Amount) (btcutil.Amount,
-	error) {
-
-	if left < 0 || right < 0 || left > btcutil.MaxSatoshi-right {
-		return 0, fmt.Errorf("taproot asset OOR carrier sum overflows")
-	}
-
-	return left + right, nil
 }
 
 // TaprootAssetOORPreparation is the immutable custom-anchor result supplied
@@ -449,9 +566,16 @@ func (p *TaprootAssetOORPreparation) Validate(
 			"changed")
 	}
 
+	plan, err := request.CarrierAllocation()
+	if err != nil {
+		return err
+	}
+
 	var (
-		assetTotal    uint64
-		matchingCount int
+		assetTotal         uint64
+		matchingCount      int
+		operatorChangeSeen int
+		senderChangeSeen   int
 	)
 	for idx := range p.Recipients {
 		recipient := p.Recipients[idx]
@@ -467,7 +591,36 @@ func (p *TaprootAssetOORPreparation) Validate(
 					"recipient %d: %w", idx, err)
 			}
 
+			// A non-asset output is either the operator's float
+			// residual (pays the lease pkScript verbatim) or the
+			// sender's returned carrier.
+			if bytes.Equal(
+				recipient.PkScript, request.Lease.PkScript,
+			) {
+
+				if recipient.Value != plan.OperatorChange {
+					return fmt.Errorf("taproot asset OOR " +
+						"operator change value " +
+						"mismatch")
+				}
+				operatorChangeSeen++
+
+				continue
+			}
+			if recipient.Value != plan.SenderChange {
+				return fmt.Errorf("taproot asset OOR sender " +
+					"change value mismatch")
+			}
+			senderChangeSeen++
+
 			continue
+		}
+
+		// Every new asset leaf is operator-funded at exactly the
+		// floor, mirroring the operator's submit validation.
+		if recipient.Value != request.OutputFloor {
+			return fmt.Errorf("taproot asset OOR asset carrier " +
+				"is not the operator floor")
 		}
 		err := recipient.ValidateTaprootAssetCommitment()
 		if err != nil {
@@ -488,6 +641,20 @@ func (p *TaprootAssetOORPreparation) Validate(
 		return fmt.Errorf("taproot asset OOR asset allocation is not " +
 			"conserved")
 	}
+	if senderChangeSeen != 1 {
+		return fmt.Errorf("taproot asset OOR sender change is not " +
+			"unique")
+	}
+
+	wantOperatorChange := 0
+	if plan.OperatorChange > 0 {
+		wantOperatorChange = 1
+	}
+	if operatorChangeSeen != wantOperatorChange {
+		return fmt.Errorf("taproot asset OOR operator change is not " +
+			"unique")
+	}
+
 	if err := p.PreparedSubmit.Validate(
 		request.Inputs, p.Recipients,
 	); err != nil {
@@ -521,10 +688,13 @@ type TaprootAssetOORResumeRequest struct {
 	Intent      TaprootAssetOORIntent
 }
 
-// TaprootAssetOORResume contains the exact input outpoints journaled before
-// the first external asset commit.
+// TaprootAssetOORResume contains the exact wallet input outpoints and the
+// carrier lease journaled before the first external asset commit. The float
+// input is not a wallet VTXO, so it is carried as the lease rather than an
+// outpoint the wallet could re-select.
 type TaprootAssetOORResume struct {
 	InputOutpoints []wire.OutPoint
+	Lease          *OORCarrierLease
 }
 
 // TaprootAssetOORPreparationResumer is an optional restart bridge implemented

--- a/oor/taproot_asset_preparer_test.go
+++ b/oor/taproot_asset_preparer_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
+	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -73,6 +75,89 @@ func TestTaprootAssetOORIntentValidate(t *testing.T) {
 			require.ErrorContains(
 				t, intent.Validate(), test.wantErr,
 			)
+		})
+	}
+}
+
+// TestTaprootAssetOORCarrierAllocation pins the split between the asset
+// change carrier and plain Bitcoin change, including the fold of a sub-floor
+// remainder into the asset change carrier.
+func TestTaprootAssetOORCarrierAllocation(t *testing.T) {
+	t.Parallel()
+
+	newRequest := func(carrier uint64,
+		inputAmounts ...btcutil.Amount) *TaprootAssetOORPrepareRequest {
+
+		inputs := make([]TransferInput, len(inputAmounts))
+		for idx := range inputAmounts {
+			inputs[idx] = TransferInput{
+				VTXO: &vtxo.Descriptor{
+					Amount: inputAmounts[idx],
+				},
+			}
+		}
+
+		return &TaprootAssetOORPrepareRequest{
+			Inputs: inputs,
+			Recipients: []oortx.RecipientOutput{{
+				Value: 10_000,
+			}},
+			OutputFloor: 1_000,
+			Intent: TaprootAssetOORIntent{
+				AssetChangeCarrierValueSat: carrier,
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		request           *TaprootAssetOORPrepareRequest
+		wantAssetChange   btcutil.Amount
+		wantBitcoinChange btcutil.Amount
+		wantErr           string
+	}{
+		{
+			name:    "exact full send",
+			request: newRequest(0, 10_000),
+		},
+		{
+			name:              "partial send returns the remainder",
+			request:           newRequest(1_000, 10_000, 90_000),
+			wantAssetChange:   1_000,
+			wantBitcoinChange: 89_000,
+		},
+		{
+			name:            "sub-floor remainder folds in",
+			request:         newRequest(1_000, 10_000, 1_500),
+			wantAssetChange: 1_500,
+		},
+		{
+			name:    "sub-floor full-send remainder is refused",
+			request: newRequest(0, 10_500),
+			wantErr: "Bitcoin change is below the output floor",
+		},
+		{
+			name:    "insufficient carrier funding",
+			request: newRequest(1_000, 10_000),
+			wantErr: "carrier funding is insufficient",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assetChange, bitcoinChange, err := test.request.
+				CarrierAllocation()
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.wantAssetChange, assetChange)
+			require.Equal(t, test.wantBitcoinChange, bitcoinChange)
 		})
 	}
 }

--- a/oor/taproot_asset_preparer_test.go
+++ b/oor/taproot_asset_preparer_test.go
@@ -95,13 +95,15 @@ func TestTaprootAssetOORIntentValidate(t *testing.T) {
 
 // TestTaprootAssetOORCarrierAllocation pins the operator-funded carrier
 // arithmetic: every new asset leaf is the operator floor out of the leased
-// float, the sender's carrier returns whole, and the float residual returns
-// to the operator.
+// float, a round-created input's carrier returns to the sender, and an
+// OOR-created input's carrier is reclaimed into the operator change on top
+// of the float residual.
 func TestTaprootAssetOORCarrierAllocation(t *testing.T) {
 	t.Parallel()
 
 	newRequest := func(leaseValue, inputCarrier btcutil.Amount,
-		recipientUnits uint64) *TaprootAssetOORPrepareRequest {
+		recipientUnits uint64,
+		roundCreated bool) *TaprootAssetOORPrepareRequest {
 
 		return &TaprootAssetOORPrepareRequest{
 			Inputs: []TransferInput{
@@ -112,6 +114,7 @@ func TestTaprootAssetOORCarrierAllocation(t *testing.T) {
 							"asset",
 						TaprootAssetAmount: 21,
 					},
+					TaprootAssetRoundCreated: roundCreated,
 				},
 				{
 					VTXO: &vtxo.Descriptor{
@@ -154,16 +157,16 @@ func TestTaprootAssetOORCarrierAllocation(t *testing.T) {
 		wantErr  string
 	}{
 		{
-			name:    "full send",
-			request: newRequest(25_000, 5_000, 0),
+			name:    "full send of a round-created leaf",
+			request: newRequest(25_000, 5_000, 0, true),
 			wantPlan: TaprootAssetCarrierPlan{
 				SenderChange:   5_000,
 				OperatorChange: 24_000,
 			},
 		},
 		{
-			name:    "partial send",
-			request: newRequest(25_000, 5_000, 13),
+			name:    "partial send of a round-created leaf",
+			request: newRequest(25_000, 5_000, 13, true),
 			wantPlan: TaprootAssetCarrierPlan{
 				AssetChange:    1_000,
 				SenderChange:   5_000,
@@ -171,8 +174,23 @@ func TestTaprootAssetOORCarrierAllocation(t *testing.T) {
 			},
 		},
 		{
+			name:    "full send reclaims an OOR-created carrier",
+			request: newRequest(25_000, 5_000, 0, false),
+			wantPlan: TaprootAssetCarrierPlan{
+				OperatorChange: 29_000,
+			},
+		},
+		{
+			name:    "partial send reclaims an OOR-created carrier",
+			request: newRequest(25_000, 5_000, 13, false),
+			wantPlan: TaprootAssetCarrierPlan{
+				AssetChange:    1_000,
+				OperatorChange: 28_000,
+			},
+		},
+		{
 			name:    "lease consumed exactly",
-			request: newRequest(2_000, 5_000, 13),
+			request: newRequest(2_000, 5_000, 13, true),
 			wantPlan: TaprootAssetCarrierPlan{
 				AssetChange:  1_000,
 				SenderChange: 5_000,
@@ -180,13 +198,13 @@ func TestTaprootAssetOORCarrierAllocation(t *testing.T) {
 		},
 		{
 			name:    "lease below the floors",
-			request: newRequest(1_500, 5_000, 13),
+			request: newRequest(1_500, 5_000, 13, true),
 			wantErr: "below the 2000 sat of new asset-leaf floors",
 		},
 		{
 			name: "missing lease",
 			request: func() *TaprootAssetOORPrepareRequest {
-				request := newRequest(25_000, 5_000, 0)
+				request := newRequest(25_000, 5_000, 0, true)
 				request.Lease = nil
 
 				return request
@@ -214,9 +232,12 @@ func TestTaprootAssetOORCarrierAllocation(t *testing.T) {
 
 // testOperatorFundedPreparation builds a complete operator-funded full-send
 // preparation: an asset input, a leased float input, a floor-valued composed
-// receiver, the sender's returned carrier, and the operator's float residual.
-func testOperatorFundedPreparation(t *testing.T) (
-	*TaprootAssetOORPrepareRequest, *TaprootAssetOORPreparation) {
+// receiver, and the operator's change. A round-created input adds the
+// sender's returned carrier; an OOR-created input reclaims it into the
+// operator change instead.
+func testOperatorFundedPreparation(t *testing.T,
+	roundCreated bool) (*TaprootAssetOORPrepareRequest,
+	*TaprootAssetOORPreparation) {
 
 	t.Helper()
 
@@ -285,8 +306,9 @@ func testOperatorFundedPreparation(t *testing.T) (
 			TaprootAssetRef:    "asset-id:010203",
 			TaprootAssetAmount: 21,
 		},
-		VTXOPolicyTemplate: inputPolicyRaw,
-		TaprootAssetRoot:   &inputAssetRoot,
+		VTXOPolicyTemplate:       inputPolicyRaw,
+		TaprootAssetRoot:         &inputAssetRoot,
+		TaprootAssetRoundCreated: roundCreated,
 	}
 
 	floatInput := newTestOperatorFundedInput(
@@ -348,19 +370,23 @@ func testOperatorFundedPreparation(t *testing.T) (
 		)
 	require.NoError(t, err)
 
-	recipients := []oortx.RecipientOutput{
-		receiver,
-		{
+	operatorChange := leaseValue - outputFloor
+	if !roundCreated {
+		operatorChange += assetCarrier
+	}
+	recipients := []oortx.RecipientOutput{receiver}
+	if roundCreated {
+		recipients = append(recipients, oortx.RecipientOutput{
 			PkScript:           senderChangePkScript,
 			Value:              assetCarrier,
 			VTXOPolicyTemplate: senderChangePolicy,
-		},
-		{
-			PkScript:           bytes.Clone(lease.PkScript),
-			Value:              leaseValue - outputFloor,
-			VTXOPolicyTemplate: bytes.Clone(lease.PolicyTemplate),
-		},
+		})
 	}
+	recipients = append(recipients, oortx.RecipientOutput{
+		PkScript:           bytes.Clone(lease.PkScript),
+		Value:              operatorChange,
+		VTXOPolicyTemplate: bytes.Clone(lease.PolicyTemplate),
+	})
 
 	ark, checkpoints, err := BuildSubmitPackage(policy, inputs, recipients)
 	require.NoError(t, err)
@@ -416,7 +442,7 @@ func testOperatorFundedPreparation(t *testing.T) (
 func TestTaprootAssetOORPreparationBindsRequest(t *testing.T) {
 	t.Parallel()
 
-	request, preparation := testOperatorFundedPreparation(t)
+	request, preparation := testOperatorFundedPreparation(t, true)
 	require.NoError(t, request.Validate())
 	require.NoError(t, preparation.Validate(request))
 
@@ -523,5 +549,74 @@ func TestTaprootAssetOORPreparationBindsRequest(t *testing.T) {
 	require.ErrorContains(
 		t, missingOperatorChange.Validate(request),
 		"operator change is not unique",
+	)
+
+	missingSenderChange := *preparation
+	missingSenderChange.Recipients = cloneRecipientOutputs(
+		[]oortx.RecipientOutput{
+			preparation.Recipients[0],
+			preparation.Recipients[2],
+		},
+	)
+	require.ErrorContains(
+		t, missingSenderChange.Validate(request),
+		"sender change is not unique",
+	)
+
+	markedFloat := *request
+	markedFloat.Inputs = append([]TransferInput(nil), request.Inputs...)
+	markedFloat.Inputs[1].TaprootAssetRoundCreated = true
+	require.ErrorContains(
+		t, markedFloat.Validate(),
+		"round-created marker requires an asset-bearing vtxo",
+	)
+}
+
+// TestTaprootAssetOORPreparationReclaimsOORCarrier proves an OOR-created
+// leaf's operator-funded carrier is reclaimed into the operator change, and
+// that drift in either direction (wrong reclaimed value, or a sender output
+// that must not exist) is rejected.
+func TestTaprootAssetOORPreparationReclaimsOORCarrier(t *testing.T) {
+	t.Parallel()
+
+	request, preparation := testOperatorFundedPreparation(t, false)
+	require.NoError(t, request.Validate())
+	require.NoError(t, preparation.Validate(request))
+
+	// The fixture's lease is 3_000 sat, one floor of 1_000 sat funds the
+	// receiver leaf, and the 5_000 sat carrier is reclaimed.
+	plan, err := request.CarrierAllocation()
+	require.NoError(t, err)
+	require.Zero(t, plan.SenderChange)
+	require.Equal(t, btcutil.Amount(7_000), plan.OperatorChange)
+	require.Len(t, preparation.Recipients, 2)
+	require.Equal(
+		t, plan.OperatorChange, preparation.Recipients[1].Value,
+	)
+
+	reclaimDrift := *preparation
+	reclaimDrift.Recipients = cloneRecipientOutputs(
+		preparation.Recipients,
+	)
+	reclaimDrift.Recipients[1].Value--
+	require.ErrorContains(
+		t, reclaimDrift.Validate(request),
+		"operator change value mismatch",
+	)
+
+	straySenderChange := *preparation
+	straySenderChange.Recipients = cloneRecipientOutputs(
+		preparation.Recipients,
+	)
+	stray, err := request.BuildChangeRecipient(
+		t.Context(), btcutil.Amount(5_000),
+	)
+	require.NoError(t, err)
+	straySenderChange.Recipients = append(
+		straySenderChange.Recipients, stray,
+	)
+	require.ErrorContains(
+		t, straySenderChange.Validate(request),
+		"sender change must be absent",
 	)
 }

--- a/oor/taproot_asset_preparer_test.go
+++ b/oor/taproot_asset_preparer_test.go
@@ -230,6 +230,169 @@ func TestTaprootAssetOORCarrierAllocation(t *testing.T) {
 	}
 }
 
+// TestTaprootAssetOORCarrierAllocationMultiInput proves the carrier plan sums
+// per-input origins across an atomic multi-input send: round-created carriers
+// return to the sender, OOR-created carriers are reclaimed by the operator.
+func TestTaprootAssetOORCarrierAllocationMultiInput(t *testing.T) {
+	t.Parallel()
+
+	request := &TaprootAssetOORPrepareRequest{
+		Inputs: []TransferInput{
+			{
+				VTXO: &vtxo.Descriptor{
+					Amount:             5_000,
+					TaprootAssetRef:    "tapr1asset",
+					TaprootAssetAmount: 200,
+				},
+				TaprootAssetRoundCreated: true,
+			},
+			{
+				VTXO: &vtxo.Descriptor{
+					Amount:             4_000,
+					TaprootAssetRef:    "tapr1asset",
+					TaprootAssetAmount: 50,
+				},
+			},
+			{
+				VTXO: &vtxo.Descriptor{
+					Amount: 25_000,
+				},
+				OperatorFunded: true,
+			},
+		},
+		Recipients: []oortx.RecipientOutput{{
+			Value: 1_000,
+		}},
+		OutputFloor: 1_000,
+		Intent: TaprootAssetOORIntent{
+			AssetRef:             "tapr1asset",
+			AssetAmount:          250,
+			RecipientAssetAmount: 240,
+		},
+		Lease: &OORCarrierLease{
+			Outpoint: wire.OutPoint{
+				Hash: [32]byte{
+					0xf0,
+				},
+			},
+			Value: 25_000,
+			PolicyTemplate: []byte{
+				0x01,
+			},
+			PkScript: []byte{
+				0x02,
+			},
+		},
+	}
+
+	plan, err := request.CarrierAllocation()
+	require.NoError(t, err)
+	require.Equal(t, TaprootAssetCarrierPlan{
+		AssetChange:    1_000,
+		SenderChange:   5_000,
+		OperatorChange: 25_000 - 2_000 + 4_000,
+	}, plan)
+}
+
+// TestTaprootAssetOORAssetInputIndices pins the ordered multi-input contract:
+// the intent's outpoint list names every asset input, spine first, in the
+// inputs' own relative order, and the per-input amounts sum to the total.
+func TestTaprootAssetOORAssetInputIndices(t *testing.T) {
+	t.Parallel()
+
+	request, _ := testOperatorFundedPreparation(t, true)
+	second := request.Inputs[0]
+	secondVTXO := *second.VTXO
+	secondVTXO.Outpoint.Index++
+	secondVTXO.TaprootAssetAmount = 13
+	second.VTXO = &secondVTXO
+	second.TaprootAssetRoundCreated = false
+
+	// Inputs are [spine, co, float]; the fixture's float stays last.
+	request.Inputs = []TransferInput{
+		request.Inputs[0], second, request.Inputs[1],
+	}
+	request.Intent.InputVTXOOutpoints = []wire.OutPoint{
+		request.Inputs[0].VTXO.Outpoint,
+		second.VTXO.Outpoint,
+	}
+	request.Intent.AssetAmount = 21 + 13
+
+	// Multi-input sends resolve every input from its sealed local package;
+	// the caller-supplied proof file stays a single-input affordance.
+	request.Intent.ProofFile = nil
+	require.NoError(t, request.Validate())
+
+	indices, err := request.AssetInputIndices()
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1}, indices)
+
+	reversed := *request
+	reversed.Intent.InputVTXOOutpoints = []wire.OutPoint{
+		second.VTXO.Outpoint,
+		request.Inputs[0].VTXO.Outpoint,
+	}
+	_, err = reversed.AssetInputIndices()
+	require.ErrorContains(t, err, "not in intent order")
+
+	missing := *request
+	missing.Intent.InputVTXOOutpoints = []wire.OutPoint{
+		request.Inputs[0].VTXO.Outpoint,
+	}
+	_, err = missing.AssetInputIndices()
+	require.ErrorContains(t, err, "asset inputs, the intent names")
+
+	sumDrift := *request
+	sumDrift.Intent.AssetAmount++
+	_, err = sumDrift.AssetInputIndices()
+	require.ErrorContains(t, err, "input amount does not match")
+
+	proofFile := *request
+	proofFile.Intent.ProofFile = []byte("confirmed-proof")
+	require.ErrorContains(
+		t, proofFile.Validate(),
+		"requires a single pinned input",
+	)
+
+	duplicated := *request
+	duplicated.Intent.InputVTXOOutpoints = []wire.OutPoint{
+		request.Inputs[0].VTXO.Outpoint,
+		request.Inputs[0].VTXO.Outpoint,
+	}
+	require.ErrorContains(t, duplicated.Validate(), "is duplicated")
+
+	overCap := *request
+	overCap.Intent.InputVTXOOutpoints = make(
+		[]wire.OutPoint, MaxTaprootAssetInputs+1,
+	)
+	for idx := range overCap.Intent.InputVTXOOutpoints {
+		overCap.Intent.InputVTXOOutpoints[idx] = wire.OutPoint{
+			Index: uint32(idx),
+		}
+	}
+	require.ErrorContains(t, overCap.Validate(), "consolidate first")
+
+	bitcoinInput := *request
+	plainVTXO := *second.VTXO
+	plainVTXO.Outpoint.Index += 10
+	plainVTXO.TaprootAssetRef = ""
+	plainVTXO.TaprootAssetAmount = 0
+	plainVTXO.TaprootAssetRoot = nil
+	plain := second
+	plain.VTXO = &plainVTXO
+	plain.TaprootAssetRoot = nil
+	bitcoinInput.Inputs = append(
+		append(
+			[]TransferInput(nil), request.Inputs...,
+		),
+		plain,
+	)
+	_, err = bitcoinInput.AssetInputIndices()
+	require.ErrorContains(
+		t, err, "neither an asset input nor the operator float",
+	)
+}
+
 // testOperatorFundedPreparation builds a complete operator-funded full-send
 // preparation: an asset input, a leased float input, a floor-valued composed
 // receiver, and the operator's change. A round-created input adds the
@@ -420,10 +583,12 @@ func testOperatorFundedPreparation(t *testing.T,
 			}, nil
 		},
 		Intent: TaprootAssetOORIntent{
-			InputVTXOOutpoint: assetInput.VTXO.Outpoint,
-			AssetRef:          "asset-id:010203",
-			AssetAmount:       21,
-			ProofFile:         []byte("confirmed-proof"),
+			InputVTXOOutpoints: []wire.OutPoint{
+				assetInput.VTXO.Outpoint,
+			},
+			AssetRef:    "asset-id:010203",
+			AssetAmount: 21,
+			ProofFile:   []byte("confirmed-proof"),
 		},
 		Lease: lease,
 	}
@@ -471,7 +636,11 @@ func TestTaprootAssetOORPreparationBindsRequest(t *testing.T) {
 	)
 
 	mismatchedInput := *request
-	mismatchedInput.Intent.InputVTXOOutpoint.Index++
+	mismatchedOutpoint := request.Inputs[0].VTXO.Outpoint
+	mismatchedOutpoint.Index++
+	mismatchedInput.Intent.InputVTXOOutpoints = []wire.OutPoint{
+		mismatchedOutpoint,
+	}
 	require.ErrorContains(
 		t, mismatchedInput.Validate(),
 		"does not match",

--- a/oor/taproot_asset_preparer_test.go
+++ b/oor/taproot_asset_preparer_test.go
@@ -2,12 +2,18 @@ package oor
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
 	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,6 +58,14 @@ func TestTaprootAssetOORIntentValidate(t *testing.T) {
 			wantErr: "deprecated and must be empty",
 		},
 		{
+			name: "nonzero change carrier",
+			mutate: func(intent *TaprootAssetOORIntent) {
+				intent.RecipientAssetAmount = 1
+				intent.AssetChangeCarrierValueSat = 1_000
+			},
+			wantErr: "carriers are operator-funded",
+		},
+		{
 			name: "malformed proof courier",
 			mutate: func(intent *TaprootAssetOORIntent) {
 				intent.ProofCourierAddress = "://missing-scheme"
@@ -79,67 +93,105 @@ func TestTaprootAssetOORIntentValidate(t *testing.T) {
 	}
 }
 
-// TestTaprootAssetOORCarrierAllocation pins the split between the asset
-// change carrier and plain Bitcoin change, including the fold of a sub-floor
-// remainder into the asset change carrier.
+// TestTaprootAssetOORCarrierAllocation pins the operator-funded carrier
+// arithmetic: every new asset leaf is the operator floor out of the leased
+// float, the sender's carrier returns whole, and the float residual returns
+// to the operator.
 func TestTaprootAssetOORCarrierAllocation(t *testing.T) {
 	t.Parallel()
 
-	newRequest := func(carrier uint64,
-		inputAmounts ...btcutil.Amount) *TaprootAssetOORPrepareRequest {
-
-		inputs := make([]TransferInput, len(inputAmounts))
-		for idx := range inputAmounts {
-			inputs[idx] = TransferInput{
-				VTXO: &vtxo.Descriptor{
-					Amount: inputAmounts[idx],
-				},
-			}
-		}
+	newRequest := func(leaseValue, inputCarrier btcutil.Amount,
+		recipientUnits uint64) *TaprootAssetOORPrepareRequest {
 
 		return &TaprootAssetOORPrepareRequest{
-			Inputs: inputs,
+			Inputs: []TransferInput{
+				{
+					VTXO: &vtxo.Descriptor{
+						Amount: inputCarrier,
+						TaprootAssetRef: "tapr1" +
+							"asset",
+						TaprootAssetAmount: 21,
+					},
+				},
+				{
+					VTXO: &vtxo.Descriptor{
+						Amount: leaseValue,
+					},
+					OperatorFunded: true,
+				},
+			},
 			Recipients: []oortx.RecipientOutput{{
-				Value: 10_000,
+				Value: 1_000,
 			}},
 			OutputFloor: 1_000,
 			Intent: TaprootAssetOORIntent{
-				AssetChangeCarrierValueSat: carrier,
+				AssetRef:             "tapr1asset",
+				AssetAmount:          21,
+				RecipientAssetAmount: recipientUnits,
+			},
+			Lease: &OORCarrierLease{
+				Outpoint: wire.OutPoint{
+					Hash: [32]byte{
+						0xf0,
+					},
+					Index: 0,
+				},
+				Value: leaseValue,
+				PolicyTemplate: []byte{
+					0x01,
+				},
+				PkScript: []byte{
+					0x02,
+				},
 			},
 		}
 	}
 
 	tests := []struct {
-		name              string
-		request           *TaprootAssetOORPrepareRequest
-		wantAssetChange   btcutil.Amount
-		wantBitcoinChange btcutil.Amount
-		wantErr           string
+		name     string
+		request  *TaprootAssetOORPrepareRequest
+		wantPlan TaprootAssetCarrierPlan
+		wantErr  string
 	}{
 		{
-			name:    "exact full send",
-			request: newRequest(0, 10_000),
+			name:    "full send",
+			request: newRequest(25_000, 5_000, 0),
+			wantPlan: TaprootAssetCarrierPlan{
+				SenderChange:   5_000,
+				OperatorChange: 24_000,
+			},
 		},
 		{
-			name:              "partial send returns the remainder",
-			request:           newRequest(1_000, 10_000, 90_000),
-			wantAssetChange:   1_000,
-			wantBitcoinChange: 89_000,
+			name:    "partial send",
+			request: newRequest(25_000, 5_000, 13),
+			wantPlan: TaprootAssetCarrierPlan{
+				AssetChange:    1_000,
+				SenderChange:   5_000,
+				OperatorChange: 23_000,
+			},
 		},
 		{
-			name:            "sub-floor remainder folds in",
-			request:         newRequest(1_000, 10_000, 1_500),
-			wantAssetChange: 1_500,
+			name:    "lease consumed exactly",
+			request: newRequest(2_000, 5_000, 13),
+			wantPlan: TaprootAssetCarrierPlan{
+				AssetChange:  1_000,
+				SenderChange: 5_000,
+			},
 		},
 		{
-			name:    "sub-floor full-send remainder is refused",
-			request: newRequest(0, 10_500),
-			wantErr: "Bitcoin change is below the output floor",
+			name:    "lease below the floors",
+			request: newRequest(1_500, 5_000, 13),
+			wantErr: "below the 2000 sat of new asset-leaf floors",
 		},
 		{
-			name:    "insufficient carrier funding",
-			request: newRequest(1_000, 10_000),
-			wantErr: "carrier funding is insufficient",
+			name: "missing lease",
+			request: func() *TaprootAssetOORPrepareRequest {
+				request := newRequest(25_000, 5_000, 0)
+				request.Lease = nil
+
+				return request
+			}(),
+			wantErr: "carrier lease must be provided",
 		},
 	}
 
@@ -148,56 +200,224 @@ func TestTaprootAssetOORCarrierAllocation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			assetChange, bitcoinChange, err := test.request.
-				CarrierAllocation()
+			plan, err := test.request.CarrierAllocation()
 			if test.wantErr != "" {
 				require.ErrorContains(t, err, test.wantErr)
 
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, test.wantAssetChange, assetChange)
-			require.Equal(t, test.wantBitcoinChange, bitcoinChange)
+			require.Equal(t, test.wantPlan, plan)
 		})
 	}
 }
 
-// TestTaprootAssetOORPreparationBindsRequest proves an adapter cannot change
-// BTC value or Ark policy while inserting Taproot Asset roots.
-func TestTaprootAssetOORPreparationBindsRequest(t *testing.T) {
-	t.Parallel()
+// testOperatorFundedPreparation builds a complete operator-funded full-send
+// preparation: an asset input, a leased float input, a floor-valued composed
+// receiver, the sender's returned carrier, and the operator's float residual.
+func testOperatorFundedPreparation(t *testing.T) (
+	*TaprootAssetOORPrepareRequest, *TaprootAssetOORPreparation) {
 
-	policy, inputs, preparedRecipients, prepared :=
-		testPreparedSubmitPackage(t)
-	requestRecipients := cloneRecipientOutputs(preparedRecipients)
-	requestRecipients[0].TaprootAssetRoot = nil
-	requestRecipients[0].TaprootAssetRef = ""
-	requestRecipients[0].TaprootAssetAmount = 0
-	template, err := arkscript.DecodePolicyTemplate(
-		requestRecipients[0].VTXOPolicyTemplate,
+	t.Helper()
+
+	ownerKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	floatKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	const (
+		outputFloor  = btcutil.Amount(1_000)
+		assetCarrier = btcutil.Amount(5_000)
+		leaseValue   = btcutil.Amount(3_000)
+	)
+
+	// The asset input mirrors the wallet-managed descriptor shape.
+	inputPolicy, err := arkscript.NewVTXOPolicy(
+		ownerKey.PubKey(), operatorKey.PubKey(), 10,
 	)
 	require.NoError(t, err)
-	requestRecipients[0].PkScript, err = template.PkScript()
+	inputPolicyRaw, err := inputPolicy.Template.Encode()
+	require.NoError(t, err)
+	inputAssetRoot := chainhash.Hash{1, 2, 3}
+	inputComposed, err := arkscript.ComposeWithSiblingRoot(
+		inputPolicy.CompiledPolicy, inputAssetRoot,
+	)
+	require.NoError(t, err)
+	inputPkScript, err := txscript.PayToTaprootScript(
+		inputComposed.OutputKey(),
+	)
+	require.NoError(t, err)
+	inputTapScript, err := arkscript.VTXOTapScript(
+		ownerKey.PubKey(), operatorKey.PubKey(), 10,
+	)
 	require.NoError(t, err)
 
+	assetInput := TransferInput{
+		VTXO: &vtxo.Descriptor{
+			Outpoint: wire.OutPoint{
+				Hash: chainhash.Hash{
+					9,
+					8,
+					7,
+				},
+				Index: 1,
+			},
+			Amount:   assetCarrier,
+			PkScript: inputPkScript,
+			ClientKey: keychain.KeyDescriptor{
+				KeyLocator: keychain.KeyLocator{
+					Family: 1,
+					Index:  2,
+				},
+				PubKey: ownerKey.PubKey(),
+			},
+			OperatorKey:        operatorKey.PubKey(),
+			TapScript:          inputTapScript,
+			RelativeExpiry:     10,
+			Status:             vtxo.VTXOStatusLive,
+			TaprootAssetRoot:   &inputAssetRoot,
+			TaprootAssetRef:    "asset-id:010203",
+			TaprootAssetAmount: 21,
+		},
+		VTXOPolicyTemplate: inputPolicyRaw,
+		TaprootAssetRoot:   &inputAssetRoot,
+	}
+
+	floatInput := newTestOperatorFundedInput(
+		t, floatKey, operatorKey.PubKey(), wire.OutPoint{
+			Hash:  chainhash.Hash{0xf0},
+			Index: 0,
+		},
+		leaseValue,
+	)
+	lease := &OORCarrierLease{
+		Outpoint:       floatInput.VTXO.Outpoint,
+		Value:          leaseValue,
+		PolicyTemplate: bytes.Clone(floatInput.VTXOPolicyTemplate),
+		PkScript:       bytes.Clone(floatInput.VTXO.PkScript),
+	}
+
+	inputs := []TransferInput{assetInput, floatInput}
+	require.NoError(t, NormalizeCheckpointOwnerLeaves(policy, inputs))
+
+	// The receiver is a floor-valued asset leaf; the request carries its
+	// uncomposed shape and the preparation its composed one.
+	recipientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	recipientPolicy, err := arkscript.NewVTXOPolicy(
+		recipientKey.PubKey(), operatorKey.PubKey(), 10,
+	)
+	require.NoError(t, err)
+	recipientPolicyRaw, err := recipientPolicy.Template.Encode()
+	require.NoError(t, err)
+	recipientAssetRoot := chainhash.Hash{4, 5, 6}
+	recipientComposed, err := arkscript.ComposeWithSiblingRoot(
+		recipientPolicy.CompiledPolicy, recipientAssetRoot,
+	)
+	require.NoError(t, err)
+	recipientPkScript, err := txscript.PayToTaprootScript(
+		recipientComposed.OutputKey(),
+	)
+	require.NoError(t, err)
+	receiver := oortx.RecipientOutput{
+		PkScript:           recipientPkScript,
+		Value:              outputFloor,
+		VTXOPolicyTemplate: recipientPolicyRaw,
+		TaprootAssetRoot:   &recipientAssetRoot,
+		TaprootAssetRef:    "asset-id:010203",
+		TaprootAssetAmount: 21,
+	}
+	requestReceiver := receiver
+	requestReceiver.TaprootAssetRoot = nil
+	requestReceiver.TaprootAssetRef = ""
+	requestReceiver.TaprootAssetAmount = 0
+	requestReceiver.PkScript, err = recipientPolicy.Template.PkScript()
+	require.NoError(t, err)
+
+	senderChangeKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	senderChangePolicy, senderChangePkScript, err := arkscript.
+		EncodeStandardVTXOArtifacts(
+			senderChangeKey.PubKey(), operatorKey.PubKey(), 10,
+		)
+	require.NoError(t, err)
+
+	recipients := []oortx.RecipientOutput{
+		receiver,
+		{
+			PkScript:           senderChangePkScript,
+			Value:              assetCarrier,
+			VTXOPolicyTemplate: senderChangePolicy,
+		},
+		{
+			PkScript:           bytes.Clone(lease.PkScript),
+			Value:              leaseValue - outputFloor,
+			VTXOPolicyTemplate: bytes.Clone(lease.PolicyTemplate),
+		},
+	}
+
+	ark, checkpoints, err := BuildSubmitPackage(policy, inputs, recipients)
+	require.NoError(t, err)
+	checkpointPackages := make([][]byte, len(inputs))
+	checkpointPackages[0] = []byte("checkpoint-package")
+	prepared := &PreparedSubmitPackage{
+		ArkPSBT:         ark,
+		CheckpointPSBTs: checkpoints,
+		TaprootAssetTransfer: &oortx.TaprootAssetTransfer{
+			Version:            oortx.TaprootAssetTransferVersion,
+			CheckpointPackages: checkpointPackages,
+			ArkPackage:         []byte("ark-package"),
+		},
+	}
+
 	request := &TaprootAssetOORPrepareRequest{
-		RequestID:   "asset-request-1",
-		Policy:      policy,
-		Inputs:      inputs,
-		Recipients:  requestRecipients,
-		OutputFloor: 1_000,
+		RequestID: "asset-request-1",
+		Policy:    policy,
+		Inputs:    inputs,
+		Recipients: []oortx.RecipientOutput{
+			requestReceiver,
+		},
+		OutputFloor: outputFloor,
+		BuildChangeRecipient: func(_ context.Context,
+			change btcutil.Amount) (oortx.RecipientOutput, error) {
+
+			return oortx.RecipientOutput{
+				PkScript:           senderChangePkScript,
+				Value:              change,
+				VTXOPolicyTemplate: senderChangePolicy,
+			}, nil
+		},
 		Intent: TaprootAssetOORIntent{
-			InputVTXOOutpoint: inputs[0].VTXO.Outpoint,
+			InputVTXOOutpoint: assetInput.VTXO.Outpoint,
 			AssetRef:          "asset-id:010203",
 			AssetAmount:       21,
 			ProofFile:         []byte("confirmed-proof"),
 		},
+		Lease: lease,
 	}
 	preparation := &TaprootAssetOORPreparation{
 		PreparedSubmit: prepared,
-		Recipients:     preparedRecipients,
-		Receiver:       preparedRecipients[0],
+		Recipients:     recipients,
+		Receiver:       recipients[0],
 	}
+
+	return request, preparation
+}
+
+// TestTaprootAssetOORPreparationBindsRequest proves an adapter cannot change
+// carrier values, the operator's float residual, or Ark policy while
+// inserting Taproot Asset roots.
+func TestTaprootAssetOORPreparationBindsRequest(t *testing.T) {
+	t.Parallel()
+
+	request, preparation := testOperatorFundedPreparation(t)
+	require.NoError(t, request.Validate())
 	require.NoError(t, preparation.Validate(request))
 
 	tooManyInputs := *request
@@ -231,6 +451,31 @@ func TestTaprootAssetOORPreparationBindsRequest(t *testing.T) {
 		"does not match",
 	)
 
+	receiverAboveFloor := *request
+	receiverAboveFloor.Recipients = cloneRecipientOutputs(
+		request.Recipients,
+	)
+	receiverAboveFloor.Recipients[0].Value++
+	require.ErrorContains(
+		t, receiverAboveFloor.Validate(),
+		"must equal the operator floor",
+	)
+
+	missingFloat := *request
+	missingFloat.Inputs = request.Inputs[:1]
+	require.ErrorContains(
+		t, missingFloat.Validate(),
+		"requires an operator-funded float input",
+	)
+
+	leaseValueDrift := *request
+	leaseValueDrift.Lease = request.Lease.Clone()
+	leaseValueDrift.Lease.Value++
+	require.ErrorContains(
+		t, leaseValueDrift.Validate(),
+		"float input value does not match the lease",
+	)
+
 	valueChanged := *preparation
 	valueChanged.Recipients = cloneRecipientOutputs(
 		preparation.Recipients,
@@ -249,5 +494,34 @@ func TestTaprootAssetOORPreparationBindsRequest(t *testing.T) {
 	require.ErrorContains(
 		t, policyChanged.Validate(request),
 		"recipient 0 policy changed",
+	)
+
+	operatorChangeDrift := *preparation
+	operatorChangeDrift.Recipients = cloneRecipientOutputs(
+		preparation.Recipients,
+	)
+	operatorChangeDrift.Recipients[2].Value--
+	require.ErrorContains(
+		t, operatorChangeDrift.Validate(request),
+		"operator change value mismatch",
+	)
+
+	senderChangeDrift := *preparation
+	senderChangeDrift.Recipients = cloneRecipientOutputs(
+		preparation.Recipients,
+	)
+	senderChangeDrift.Recipients[1].Value--
+	require.ErrorContains(
+		t, senderChangeDrift.Validate(request),
+		"sender change value mismatch",
+	)
+
+	missingOperatorChange := *preparation
+	missingOperatorChange.Recipients = cloneRecipientOutputs(
+		preparation.Recipients[:2],
+	)
+	require.ErrorContains(
+		t, missingOperatorChange.Validate(request),
+		"operator change is not unique",
 	)
 }

--- a/oor/transfer_input_snapshot.go
+++ b/oor/transfer_input_snapshot.go
@@ -92,6 +92,11 @@ type TransferInputSnapshot struct {
 	// ExternalSignatures are pre-collected tapscript signatures needed to
 	// resume custom OOR spends after restart.
 	ExternalSignatures []ExternalTaprootScriptSignature
+
+	// OperatorFunded marks an input the local wallet cannot sign (an
+	// operator carrier-float VTXO). It must survive snapshots so a
+	// resumed session never re-attempts local signing on the input.
+	OperatorFunded bool
 }
 
 // ToSnapshot converts the transfer input into a portable snapshot.
@@ -122,6 +127,7 @@ func (i *TransferInput) ToSnapshot() (*TransferInputSnapshot, error) {
 		OwnerLeafPolicy:    i.OwnerLeafPolicy,
 		VTXOPolicyTemplate: i.VTXOPolicyTemplate,
 		PkScript:           i.VTXO.PkScript,
+		OperatorFunded:     i.OperatorFunded,
 	}
 	if i.TaprootAssetRoot != nil {
 		root := *i.TaprootAssetRoot
@@ -165,8 +171,19 @@ func TransferInputFromSnapshot(snap *TransferInputSnapshot) (TransferInput,
 		return TransferInput{}, fmt.Errorf("amount must be positive")
 	}
 
-	if len(snap.ClientPubKey) == 0 || len(snap.OperatorPubKey) == 0 {
-		return TransferInput{}, fmt.Errorf("pubkeys must be provided")
+	if len(snap.OperatorPubKey) == 0 {
+		return TransferInput{}, fmt.Errorf("operator pubkey must be " +
+			"provided")
+	}
+
+	if len(snap.ClientPubKey) == 0 && !snap.OperatorFunded {
+		return TransferInput{}, fmt.Errorf("client pubkey must be " +
+			"provided")
+	}
+
+	if snap.OperatorFunded && len(snap.PkScript) == 0 {
+		return TransferInput{}, fmt.Errorf("operator-funded input " +
+			"requires a stored pkscript")
 	}
 
 	if snap.ExitDelay == 0 {
@@ -179,46 +196,59 @@ func TransferInputFromSnapshot(snap *TransferInputSnapshot) (TransferInput,
 			"policy must be provided")
 	}
 
-	clientPub, err := btcec.ParsePubKey(snap.ClientPubKey)
-	if err != nil {
-		return TransferInput{}, fmt.Errorf("parse client pubkey: %w",
-			err)
-	}
-
 	operatorPub, err := btcec.ParsePubKey(snap.OperatorPubKey)
 	if err != nil {
 		return TransferInput{}, fmt.Errorf("parse operator pubkey: %w",
 			err)
 	}
 
-	tapScript, err := arkscript.VTXOTapScript(
-		clientPub, operatorPub, snap.ExitDelay,
-	)
-	if err != nil {
-		return TransferInput{}, fmt.Errorf("rebuild vtxo tapscript: %w",
-			err)
-	}
-
-	tapKey, err := arkscript.VTXOTapKey(
-		clientPub, operatorPub, snap.ExitDelay,
-	)
-	if err != nil {
-		return TransferInput{}, fmt.Errorf("rebuild vtxo tapkey: %w",
-			err)
-	}
-
-	pkScript, err := txscript.PayToTaprootScript(tapKey)
-	if err != nil {
-		return TransferInput{}, fmt.Errorf("build vtxo pkscript: %w",
-			err)
-	}
-
 	desc := &vtxo.Descriptor{
-		Outpoint:       snap.Outpoint,
-		Amount:         btcutil.Amount(snap.AmountSat),
-		PolicyTemplate: bytes.Clone(snap.VTXOPolicyTemplate),
-		PkScript:       pkScript,
-		ClientKey: keychain.KeyDescriptor{
+		Outpoint:           snap.Outpoint,
+		Amount:             btcutil.Amount(snap.AmountSat),
+		PolicyTemplate:     bytes.Clone(snap.VTXOPolicyTemplate),
+		TaprootAssetRoot:   snap.TaprootAssetRoot,
+		TaprootAssetRef:    snap.TaprootAssetRef,
+		TaprootAssetAmount: snap.TaprootAssetAmount,
+		OperatorKey:        operatorPub,
+		RelativeExpiry:     snap.ExitDelay,
+		Status:             vtxo.VTXOStatusLive,
+	}
+
+	// An operator-funded float input has no local key material, so the
+	// stored pkScript and lease-supplied policy are authoritative; no
+	// tapscript can or needs to be rebuilt for local signing.
+	if !snap.OperatorFunded {
+		clientPub, err := btcec.ParsePubKey(snap.ClientPubKey)
+		if err != nil {
+			return TransferInput{}, fmt.Errorf("parse client "+
+				"pubkey: %w", err)
+		}
+
+		tapScript, err := arkscript.VTXOTapScript(
+			clientPub, operatorPub, snap.ExitDelay,
+		)
+		if err != nil {
+			return TransferInput{}, fmt.Errorf("rebuild vtxo "+
+				"tapscript: %w", err)
+		}
+
+		tapKey, err := arkscript.VTXOTapKey(
+			clientPub, operatorPub, snap.ExitDelay,
+		)
+		if err != nil {
+			return TransferInput{}, fmt.Errorf("rebuild vtxo "+
+				"tapkey: %w", err)
+		}
+
+		pkScript, err := txscript.PayToTaprootScript(tapKey)
+		if err != nil {
+			return TransferInput{}, fmt.Errorf("build vtxo "+
+				"pkscript: %w", err)
+		}
+
+		desc.PkScript = pkScript
+		desc.TapScript = tapScript
+		desc.ClientKey = keychain.KeyDescriptor{
 			KeyLocator: keychain.KeyLocator{
 				Family: keychain.KeyFamily(
 					snap.ClientKeyFamily,
@@ -226,14 +256,7 @@ func TransferInputFromSnapshot(snap *TransferInputSnapshot) (TransferInput,
 				Index: snap.ClientKeyIndex,
 			},
 			PubKey: clientPub,
-		},
-		TaprootAssetRoot:   snap.TaprootAssetRoot,
-		TaprootAssetRef:    snap.TaprootAssetRef,
-		TaprootAssetAmount: snap.TaprootAssetAmount,
-		OperatorKey:        operatorPub,
-		TapScript:          tapScript,
-		RelativeExpiry:     snap.ExitDelay,
-		Status:             vtxo.VTXOStatusLive,
+		}
 	}
 
 	result := TransferInput{
@@ -242,6 +265,7 @@ func TransferInputFromSnapshot(snap *TransferInputSnapshot) (TransferInput,
 		OwnerLeafPolicy:    snap.OwnerLeafPolicy,
 		VTXOPolicyTemplate: snap.VTXOPolicyTemplate,
 		TaprootAssetRoot:   snap.TaprootAssetRoot,
+		OperatorFunded:     snap.OperatorFunded,
 	}
 
 	if len(snap.SpendWitnessScript) > 0 {

--- a/oor/transfer_inputs.go
+++ b/oor/transfer_inputs.go
@@ -59,6 +59,14 @@ type TransferInput struct {
 	// ExternalSignatures are tapscript signatures produced by additional
 	// custom-spend participants before the local daemon adds its signature.
 	ExternalSignatures []ExternalTaprootScriptSignature
+
+	// OperatorFunded marks an input the local wallet cannot sign: an
+	// operator carrier-float VTXO leased for the transfer. The operator
+	// signs both legs of its checkpoint and Ark spends, so every local
+	// signing site skips the input while still verifying the operator's
+	// signatures. The input carries no ClientKey; its policy template and
+	// owner leaf come from the lease.
+	OperatorFunded bool
 }
 
 // ExternalTaprootScriptSignature carries one externally produced tapscript
@@ -88,6 +96,23 @@ func InputOutpoints(inputs []TransferInput) []wire.OutPoint {
 	return outpoints
 }
 
+// WalletInputOutpoints returns the outpoints of the inputs the local wallet
+// funds and signs. Operator-funded float inputs are excluded because they are
+// not wallet VTXOs: reservation stores and spend accounting reject or
+// misattribute outpoints that have no local VTXO row.
+func WalletInputOutpoints(inputs []TransferInput) []wire.OutPoint {
+	outpoints := make([]wire.OutPoint, 0, len(inputs))
+	for i := range inputs {
+		if inputs[i].OperatorFunded {
+			continue
+		}
+
+		outpoints = append(outpoints, inputs[i].VTXO.Outpoint)
+	}
+
+	return outpoints
+}
+
 // Validate performs basic structural validation. For custom spend
 // paths, the TapScript and ClientKey requirements are relaxed since
 // the spend path carries its own signing context.
@@ -105,11 +130,40 @@ func (i *TransferInput) Validate() error {
 	case len(i.VTXO.PkScript) == 0:
 		return fmt.Errorf("vtxo pkScript must be provided")
 
-	case !i.IsCustomSpend() && i.VTXO.TapScript == nil:
+	case !i.IsCustomSpend() && !i.OperatorFunded &&
+		i.VTXO.TapScript == nil:
 		return fmt.Errorf("vtxo tapscript must be provided")
 
-	case !i.IsCustomSpend() && i.VTXO.ClientKey.PubKey == nil:
+	case !i.IsCustomSpend() && !i.OperatorFunded &&
+		i.VTXO.ClientKey.PubKey == nil:
 		return fmt.Errorf("vtxo client key must be provided")
+	}
+
+	// An operator-funded input carries no local key material, so nothing
+	// can be auto-derived: the lease must have supplied the policy, the
+	// owner leaf, and the operator key explicitly.
+	if i.OperatorFunded {
+		switch {
+		case i.IsCustomSpend():
+			return fmt.Errorf("operator-funded input cannot use " +
+				"a custom spend path")
+
+		case i.VTXO.ClientKey.PubKey != nil:
+			return fmt.Errorf("operator-funded input cannot " +
+				"carry a client key")
+
+		case len(i.VTXOPolicyTemplate) == 0:
+			return fmt.Errorf("operator-funded input requires a " +
+				"policy template")
+
+		case len(i.OwnerLeafPolicy) == 0:
+			return fmt.Errorf("operator-funded input requires an " +
+				"owner leaf policy")
+
+		case i.VTXO.OperatorKey == nil:
+			return fmt.Errorf("operator-funded input requires an " +
+				"operator key")
+		}
 	}
 	if (i.VTXO.TaprootAssetRef == "") !=
 		(i.VTXO.TaprootAssetAmount == 0) {

--- a/oor/transfer_inputs.go
+++ b/oor/transfer_inputs.go
@@ -67,6 +67,13 @@ type TransferInput struct {
 	// signatures. The input carries no ClientKey; its policy template and
 	// owner leaf come from the lease.
 	OperatorFunded bool
+
+	// TaprootAssetRoundCreated marks an asset input whose leaf was
+	// created by a round (boarded or refreshed), so its Bitcoin carrier
+	// is the sender's own money and returns as plain change. An
+	// OOR-created leaf rides an operator-funded carrier instead, which
+	// is reclaimed into the operator's change when the leaf is spent.
+	TaprootAssetRoundCreated bool
 }
 
 // ExternalTaprootScriptSignature carries one externally produced tapscript
@@ -169,6 +176,10 @@ func (i *TransferInput) Validate() error {
 		(i.VTXO.TaprootAssetAmount == 0) {
 		return fmt.Errorf("vtxo asset ref and amount must both be " +
 			"provided")
+	}
+	if i.TaprootAssetRoundCreated && i.VTXO.TaprootAssetRef == "" {
+		return fmt.Errorf("round-created marker requires an " +
+			"asset-bearing vtxo")
 	}
 	if len(i.VTXO.TaprootAssetRef) > MaxTaprootAssetRefBytes {
 		return fmt.Errorf("vtxo asset ref exceeds %d bytes",

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -752,6 +752,13 @@ func NormalizeCheckpointOwnerLeaves(policy arkscript.CheckpointPolicy,
 			continue
 		}
 
+		// An operator-funded float input keeps the owner leaf carried
+		// by its own lease policy; the wallet holds no float owner key
+		// to derive a replacement from.
+		if input.OperatorFunded {
+			continue
+		}
+
 		if input.VTXO == nil || input.VTXO.ClientKey.PubKey == nil {
 			continue
 		}

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -86,6 +86,17 @@ func (c *ArkServiceClient) EstimateFee(ctx context.Context,
 	return out, err
 }
 
+// LeaseOORCarrier reserves one of the operator's carrier float VTXOs.
+func (c *ArkServiceClient) LeaseOORCarrier(ctx context.Context,
+	in *arkrpc.LeaseOORCarrierRequest, _ ...grpc.CallOption) (
+	*arkrpc.LeaseOORCarrierResponse, error) {
+
+	out := new(arkrpc.LeaseOORCarrierResponse)
+	err := c.client.Post(ctx, "/v1/ark/lease-oor-carrier", in, out)
+
+	return out, err
+}
+
 // NewMailboxServiceClient creates a MailboxService REST client.
 func NewMailboxServiceClient(addr string,
 	opts ...Option) mailboxpb.MailboxServiceClient {

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -534,6 +534,32 @@ func (c *DaemonServiceClient) OnboardTaprootAsset(ctx context.Context,
 	return out, err
 }
 
+// BoardTaprootAsset boards a confirmed onboarded output into a round.
+func (c *DaemonServiceClient) BoardTaprootAsset(ctx context.Context,
+	in *waverpc.BoardTaprootAssetRequest, _ ...grpc.CallOption) (
+	*waverpc.BoardTaprootAssetResponse, error) {
+
+	out := new(waverpc.BoardTaprootAssetResponse)
+	err := c.client.Post(
+		ctx, "/v1/daemon/board-taproot-asset", in, out,
+	)
+
+	return out, err
+}
+
+// ClaimTaprootAssetVTXO claims an exited asset VTXO into the tapd wallet.
+func (c *DaemonServiceClient) ClaimTaprootAssetVTXO(ctx context.Context,
+	in *waverpc.ClaimTaprootAssetVTXORequest, _ ...grpc.CallOption) (
+	*waverpc.ClaimTaprootAssetVTXOResponse, error) {
+
+	out := new(waverpc.ClaimTaprootAssetVTXOResponse)
+	err := c.client.Post(
+		ctx, "/v1/daemon/claim-taproot-asset-vtxo", in, out,
+	)
+
+	return out, err
+}
+
 // PrepareOOR builds an out-of-round transfer package without submitting it.
 func (c *DaemonServiceClient) PrepareOOR(ctx context.Context,
 	in *waverpc.PrepareOORRequest, _ ...grpc.CallOption) (

--- a/tapassets/batch_anchor.go
+++ b/tapassets/batch_anchor.go
@@ -46,19 +46,98 @@ type BatchAnchorSource struct {
 	AnchorInternalKey *btcec.PublicKey
 }
 
+// Logical output identifiers naming the transition's outputs across
+// derivation, commit, and the sealed package.
+const (
+	batchAnchorOutputID = "batch-anchor-output"
+	batchAnchorChangeID = "batch-anchor-change"
+)
+
+// BatchAnchorChange returns a funding surplus to the operator's own tapd
+// wallet: the batch output consumes the request's amount and the
+// remainder re-anchors under wallet-owned keys on its own BIP-86 anchor
+// output, becoming ordinary spendable inventory once the anchor
+// confirms. Both keys are derived once and pinned on the request: the
+// split commitment binds the change script key, so derivation and
+// commit must see the same key to reproduce the same batch script.
+type BatchAnchorChange struct {
+	// Amount is the change output's asset amount.
+	Amount uint64
+
+	// OutputIndex is the change anchor output's position in the anchor
+	// transaction.
+	OutputIndex uint32
+
+	// OutputValueSat is the change anchor output's Bitcoin value.
+	OutputValueSat int64
+
+	// ScriptKey is the tapd wallet script key that owns the change.
+	ScriptKey tapsdk.ScriptKey
+
+	// AnchorInternalKey is the tapd wallet internal key of the change
+	// anchor output.
+	AnchorInternalKey tapsdk.InternalKey
+}
+
+// DeriveBatchAnchorChange derives and pins the wallet keys owning a batch
+// transition's asset change. The output index is assigned by the planner
+// when the anchor transaction's output positions are final.
+func DeriveBatchAnchorChange(ctx context.Context, wallet *tapsdk.Wallet,
+	amount uint64, outputValueSat int64) (*BatchAnchorChange, error) {
+
+	if wallet == nil {
+		return nil, fmt.Errorf("tap-sdk wallet is required")
+	}
+	if amount == 0 || outputValueSat <= 0 {
+		return nil, fmt.Errorf("change amount and value are required")
+	}
+
+	scriptKey, err := wallet.Client().DeriveScriptKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("derive change script key: %w", err)
+	}
+	internalKey, err := wallet.Client().DeriveInternalKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("derive change anchor internal key: %w",
+			err)
+	}
+
+	return &BatchAnchorChange{
+		Amount:            amount,
+		OutputValueSat:    outputValueSat,
+		ScriptKey:         *scriptKey,
+		AnchorInternalKey: *internalKey,
+	}, nil
+}
+
+// internalPubKey parses the change anchor internal key.
+func (c *BatchAnchorChange) internalPubKey() (*btcec.PublicKey, error) {
+	key, err := btcec.ParsePubKey(c.AnchorInternalKey.PubKey[:])
+	if err != nil {
+		return nil, fmt.Errorf("change anchor internal key: %w", err)
+	}
+
+	return key, nil
+}
+
 // BatchAnchorRequest describes one asset batch output on a caller-funded
-// anchor transaction: the whole funding UTXO moves into a single output whose
+// anchor transaction: the funding UTXOs move into a single output whose
 // taproot key is the cosigner aggregate tweaked with the combined tapscript
-// root. Full-value transitions produce no split commitment, so the derived
-// roots are independent of output reordering by the funding wallet.
+// root. Without change the transition is full-value and produces no split
+// commitment, so the derived roots are independent of output positions.
+// With change the split commitment binds every asset output's anchor
+// index, so both output positions must be final before derivation.
 type BatchAnchorRequest struct {
 	// AssetRef identifies the asset carried by the batch output.
 	AssetRef tapsdk.AssetRef
 
-	// Amount is the batch output's total asset amount: the sum of the
-	// funding sources' amounts, all of which move beneath the batch
-	// output.
+	// Amount is the batch output's total asset amount. The funding
+	// sources must carry exactly this amount plus any change.
 	Amount uint64
+
+	// Change optionally returns the funding surplus to the operator's
+	// tapd wallet on its own anchor output.
+	Change *BatchAnchorChange
 
 	// Sources identify the funding UTXOs the transition spends. Every
 	// source anchors one input of the anchor transaction.
@@ -102,6 +181,10 @@ type BatchAnchorScript struct {
 
 	// AssetRoot is the batch output's Taproot Asset commitment root.
 	AssetRoot tapsdk.Hash
+
+	// ChangePkScript is the composed change anchor output script, set
+	// only when the request carries change.
+	ChangePkScript []byte
 }
 
 // BatchAnchorCommit is the sealed commitment transition: the persistence
@@ -174,8 +257,9 @@ func (c *BatchAnchorCommitter) DeriveScript(ctx context.Context,
 		return nil, fmt.Errorf("preview batch anchor: %w", err)
 	}
 
+	var derived *BatchAnchorScript
 	for _, preview := range previews {
-		if preview.anchorOutputIndex != req.OutputIndex {
+		if preview.logicalOutputID != batchAnchorOutputID {
 			continue
 		}
 
@@ -186,16 +270,52 @@ func (c *BatchAnchorCommitter) DeriveScript(ctx context.Context,
 			return nil, err
 		}
 
-		return &BatchAnchorScript{
+		derived = &BatchAnchorScript{
 			PkScript:     pkScript,
 			InternalKey:  internalKey,
 			SigningTweak: preview.merkleRoot[:],
 			AssetRoot:    preview.assetRoot,
-		}, nil
+		}
+
+		break
+	}
+	if derived == nil {
+		return nil, fmt.Errorf("preview misses batch output %d",
+			req.OutputIndex)
+	}
+	if req.Change == nil {
+		return derived, nil
 	}
 
-	return nil, fmt.Errorf("preview misses batch output %d",
-		req.OutputIndex)
+	changeScript, err := changePreviewScript(req.Change, previews)
+	if err != nil {
+		return nil, err
+	}
+	derived.ChangePkScript = changeScript
+
+	return derived, nil
+}
+
+// changePreviewScript composes the change anchor output script from its
+// previewed roots.
+func changePreviewScript(change *BatchAnchorChange,
+	previews []commitmentPreview) ([]byte, error) {
+
+	changeKey, err := change.internalPubKey()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, preview := range previews {
+		if preview.logicalOutputID != batchAnchorChangeID {
+			continue
+		}
+
+		return composedScript(changeKey, preview.merkleRoot)
+	}
+
+	return nil, fmt.Errorf("preview misses change output %d",
+		change.OutputIndex)
 }
 
 // Commit seals the commitment transition against the final funded anchor
@@ -220,6 +340,9 @@ func (c *BatchAnchorCommitter) Commit(ctx context.Context,
 		return nil, fmt.Errorf("funded anchor output %d does not "+
 			"carry the derived batch script", req.OutputIndex)
 	}
+	if err := checkFundedChange(req.Change, derived, finalTx); err != nil {
+		return nil, err
+	}
 
 	request, internalKey, err := c.buildRequest(req, funded)
 	if err != nil {
@@ -233,11 +356,23 @@ func (c *BatchAnchorCommitter) Commit(ctx context.Context,
 		return nil, fmt.Errorf("commit batch anchor: %w", err)
 	}
 
-	if len(committed.outputs) != 1 {
-		return nil, fmt.Errorf("batch anchor committed %d "+
-			"outputs, want 1", len(committed.outputs))
+	wantOutputs := 1
+	if req.Change != nil {
+		wantOutputs = 2
 	}
-	out := committed.outputs[0]
+	if len(committed.outputs) != wantOutputs {
+		return nil, fmt.Errorf("batch anchor committed %d "+
+			"outputs, want %d", len(committed.outputs), wantOutputs)
+	}
+	out, err := committedOutput(committed, batchAnchorOutputID)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkCommittedChange(
+		req.Change, derived, committed,
+	); err != nil {
+		return nil, err
+	}
 	if out.anchorOutputIndex != req.OutputIndex {
 		return nil, fmt.Errorf("batch anchor committed output index "+
 			"%d, want %d", out.anchorOutputIndex, req.OutputIndex)
@@ -296,6 +431,89 @@ func (c *BatchAnchorCommitter) Commit(ctx context.Context,
 	}, nil
 }
 
+// committedOutput locates one committed output by its logical identifier.
+func committedOutput(committed *commitResult,
+	logicalID string) (commitOutput, error) {
+
+	for i := range committed.outputs {
+		if committed.outputs[i].logicalOutputID == logicalID {
+			return committed.outputs[i], nil
+		}
+	}
+
+	return commitOutput{}, fmt.Errorf("batch anchor commit misses "+
+		"output %q", logicalID)
+}
+
+// checkFundedChange verifies the funded transaction carries the derived
+// change script at the change position. Nil change passes.
+func checkFundedChange(change *BatchAnchorChange, derived *BatchAnchorScript,
+	finalTx *wire.MsgTx) error {
+
+	if change == nil {
+		return nil
+	}
+	if len(derived.ChangePkScript) == 0 {
+		return fmt.Errorf("derived change script is required")
+	}
+	if int(change.OutputIndex) >= len(finalTx.TxOut) {
+		return fmt.Errorf("change output %d exceeds anchor outputs",
+			change.OutputIndex)
+	}
+	if !bytes.Equal(
+		finalTx.TxOut[change.OutputIndex].PkScript,
+		derived.ChangePkScript,
+	) {
+		return fmt.Errorf("funded anchor output %d does not carry the "+
+			"derived change script", change.OutputIndex)
+	}
+
+	return nil
+}
+
+// checkCommittedChange verifies fail-closed that the committed change
+// output matches the request and reproduces the derived change script.
+// Nil change passes.
+func checkCommittedChange(change *BatchAnchorChange, derived *BatchAnchorScript,
+	committed *commitResult) error {
+
+	if change == nil {
+		return nil
+	}
+
+	out, err := committedOutput(committed, batchAnchorChangeID)
+	if err != nil {
+		return err
+	}
+	if out.anchorOutputIndex != change.OutputIndex {
+		return fmt.Errorf("committed change output index %d, want %d",
+			out.anchorOutputIndex, change.OutputIndex)
+	}
+	if out.amount != change.Amount {
+		return fmt.Errorf("committed change amount %d, want %d",
+			out.amount, change.Amount)
+	}
+	if out.anchorValueSat != change.OutputValueSat {
+		return fmt.Errorf("committed change value %d, want %d",
+			out.anchorValueSat, change.OutputValueSat)
+	}
+
+	changeKey, err := change.internalPubKey()
+	if err != nil {
+		return err
+	}
+	pkScript, err := composedScript(changeKey, out.taprootMerkleRoot)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(pkScript, derived.ChangePkScript) {
+		return fmt.Errorf("committed change output script does not " +
+			"reproduce the derived script")
+	}
+
+	return nil
+}
+
 // buildRequest assembles the caller-funded custom-anchor request shared by
 // derivation and commit.
 func (c *BatchAnchorCommitter) buildRequest(req *BatchAnchorRequest,
@@ -343,9 +561,22 @@ func (c *BatchAnchorCommitter) buildRequest(req *BatchAnchorRequest,
 				source.AnchorOutpoint)
 		}
 	}
-	if sourceTotal != req.Amount {
+	wantTotal := req.Amount
+	if req.Change != nil {
+		change := req.Change
+		if change.Amount == 0 || change.OutputValueSat <= 0 {
+			return nil, nil, fmt.Errorf("change amount and value " +
+				"are required")
+		}
+		if change.OutputIndex == req.OutputIndex {
+			return nil, nil, fmt.Errorf("change and batch outputs "+
+				"share anchor index %d", change.OutputIndex)
+		}
+		wantTotal += change.Amount
+	}
+	if sourceTotal != wantTotal {
 		return nil, nil, fmt.Errorf("funding sources carry %d units, "+
-			"the batch carries %d", sourceTotal, req.Amount)
+			"the batch and change carry %d", sourceTotal, wantTotal)
 	}
 	if len(req.SweepLeaf.Script) == 0 {
 		return nil, nil, fmt.Errorf("sweep leaf is required")
@@ -415,29 +646,55 @@ func (c *BatchAnchorCommitter) buildRequest(req *BatchAnchorRequest,
 		return nil, nil, err
 	}
 
-	request := &tapsdk.CustomAnchorRequest{
-		Inputs: inputs,
-		Outputs: []tapsdk.CustomAssetOutput{{
-			ID:                "batch-anchor-output",
-			AssetRef:          req.AssetRef,
-			Amount:            req.Amount,
-			AnchorOutputIndex: req.OutputIndex,
-			AnchorValueSat:    uint64(req.OutputValueSat),
-			Script: tapsdk.CustomAssetScriptPlan{
-				Mode: tapsdk.CustomAssetScriptOPTrue,
-				OPTrue: &tapsdk.CustomAssetOPTrueScriptPlan{
-					InternalKey: tapsdk.KeyDescriptor{
-						RawKeyBytes: deterministicKey(
-							req.Digest,
-							"batch-anchor",
-						),
-					},
+	outputs := []tapsdk.CustomAssetOutput{{
+		ID:                batchAnchorOutputID,
+		AssetRef:          req.AssetRef,
+		Amount:            req.Amount,
+		AnchorOutputIndex: req.OutputIndex,
+		AnchorValueSat:    uint64(req.OutputValueSat),
+		Script: tapsdk.CustomAssetScriptPlan{
+			Mode: tapsdk.CustomAssetScriptOPTrue,
+			OPTrue: &tapsdk.CustomAssetOPTrueScriptPlan{
+				InternalKey: tapsdk.KeyDescriptor{
+					RawKeyBytes: deterministicKey(
+						req.Digest, "batch-anchor",
+					),
 				},
 			},
-			Anchor: anchorPlan(
-				internalKey, []txscript.TapLeaf{req.SweepLeaf},
+		},
+		Anchor: anchorPlan(
+			internalKey, []txscript.TapLeaf{req.SweepLeaf},
+		),
+	}}
+	if req.Change != nil {
+		outputs = append(outputs, tapsdk.CustomAssetOutput{
+			ID:                batchAnchorChangeID,
+			AssetRef:          req.AssetRef,
+			Amount:            req.Change.Amount,
+			AnchorOutputIndex: req.Change.OutputIndex,
+			AnchorValueSat: uint64(
+				req.Change.OutputValueSat,
 			),
-		}},
+			// The pinned wallet script key rides as an external
+			// key: the wallet script mode would derive a fresh
+			// key on every build, and derivation and commit must
+			// build identical transitions.
+			Script: tapsdk.CustomAssetScriptPlan{
+				Mode: scriptExternal,
+				External: &tapsdk.
+					CustomAssetExternalScriptPlan{
+					ScriptKey: req.Change.ScriptKey,
+				},
+			},
+			Anchor: tapsdk.CustomAnchorOutputPlan{
+				InternalKey: req.Change.AnchorInternalKey,
+			},
+		})
+	}
+
+	request := &tapsdk.CustomAnchorRequest{
+		Inputs:     inputs,
+		Outputs:    outputs,
 		AnchorPSBT: anchorBytes,
 		Funding: tapsdk.CustomAnchorFundingPlan{
 			Mode: tapsdk.CustomAnchorFundingCallerFundedExact,

--- a/tapassets/batch_anchor.go
+++ b/tapassets/batch_anchor.go
@@ -885,7 +885,6 @@ func batchRootSource(req *BatchAnchorRequest, out commitOutput,
 	}
 
 	expected := &expectedUnconfirmedAnchor{
-		stepIndex:        0,
 		previousOutpoint: previousOutpoint,
 		anchorOutpoint:   out.anchorOutpoint,
 		transaction:      serializeTx(finalTx),

--- a/tapassets/batch_anchor_test.go
+++ b/tapassets/batch_anchor_test.go
@@ -86,6 +86,7 @@ func (f *fakeBatchDriver) Commit(_ context.Context,
 	}
 	for _, out := range request.Outputs {
 		result.outputs = append(result.outputs, commitOutput{
+			logicalOutputID:   out.ID,
 			anchorOutputIndex: out.AnchorOutputIndex,
 			anchorOutpoint: sdkOutpoint(wire.OutPoint{
 				Hash:  template.TxHash(),
@@ -400,6 +401,181 @@ func TestBatchAnchorCommitFailClosed(t *testing.T) {
 
 			funded := fundedFromTemplate(t, template, derived)
 			test.corrupt(req, funded, derived, fake)
+
+			_, err = committer.Commit(ctx, req, funded, derived)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+// addBatchAnchorChange rewires the fixture so 600 of the 1500 funded
+// units return as wallet-owned change on a second anchor output, and
+// returns the rebuilt two-output template.
+func addBatchAnchorChange(t *testing.T, req *BatchAnchorRequest,
+	template *psbt.Packet) *psbt.Packet {
+
+	t.Helper()
+
+	scriptPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	scriptPub, err := tapsdk.ParsePubKey(
+		scriptPriv.PubKey().SerializeCompressed(),
+	)
+	require.NoError(t, err)
+	internalPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	internalPub, err := tapsdk.ParsePubKey(
+		internalPriv.PubKey().SerializeCompressed(),
+	)
+	require.NoError(t, err)
+
+	req.Amount = 900
+	req.Change = &BatchAnchorChange{
+		Amount:         600,
+		OutputIndex:    1,
+		OutputValueSat: 1_000,
+		ScriptKey: tapsdk.ScriptKey{
+			PubKey: scriptPub,
+		},
+		AnchorInternalKey: tapsdk.InternalKey{
+			PubKey: internalPub,
+		},
+	}
+
+	tx := template.UnsignedTx.Copy()
+	tx.AddTxOut(&wire.TxOut{
+		Value:    req.Change.OutputValueSat,
+		PkScript: []byte{0x51},
+	})
+	rebuilt, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	return rebuilt
+}
+
+// TestBatchAnchorChangeDeriveAndCommit proves a batch transition with
+// asset change derives both output scripts and seals only when the funded
+// transaction and the committed result carry them byte-for-byte.
+func TestBatchAnchorChangeDeriveAndCommit(t *testing.T) {
+	t.Parallel()
+
+	committer, req, template := newBatchAnchorFixture(t)
+	template = addBatchAnchorChange(t, req, template)
+	ctx := context.Background()
+
+	derived, err := committer.DeriveScript(ctx, req, template)
+	require.NoError(t, err)
+	require.NotEmpty(t, derived.ChangePkScript)
+
+	// The change script is the pinned wallet internal key tweaked with
+	// the change output's previewed root.
+	input := template.UnsignedTx.TxIn[0].PreviousOutPoint
+	changeInternal, err := btcec.ParsePubKey(
+		req.Change.AnchorInternalKey.PubKey[:],
+	)
+	require.NoError(t, err)
+	wantScript, err := composedScript(
+		changeInternal, batchMerkleRoot(input, req.Change.OutputIndex),
+	)
+	require.NoError(t, err)
+	require.Equal(t, wantScript, derived.ChangePkScript)
+
+	funded := fundedFromTemplate(t, template, derived)
+	funded.UnsignedTx.TxOut[1].PkScript = append(
+		[]byte(nil), derived.ChangePkScript...,
+	)
+
+	commit, err := committer.Commit(ctx, req, funded, derived)
+	require.NoError(t, err)
+	require.Equal(t, derived.ChangePkScript, commit.Script.ChangePkScript)
+}
+
+// TestBatchAnchorChangeFailClosed proves change divergences between the
+// request, the funded transaction, and the committed result are rejected.
+func TestBatchAnchorChangeFailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		corrupt func(req *BatchAnchorRequest, funded *psbt.Packet,
+			fake *fakeBatchDriver)
+		wantErr string
+	}{
+		{
+			name: "sources do not cover batch and change",
+			corrupt: func(req *BatchAnchorRequest, _ *psbt.Packet,
+				_ *fakeBatchDriver) {
+
+				req.Change.Amount--
+			},
+			wantErr: "funding sources carry",
+		},
+		{
+			name: "funded output misses change script",
+			corrupt: func(_ *BatchAnchorRequest,
+				funded *psbt.Packet, _ *fakeBatchDriver) {
+
+				funded.UnsignedTx.TxOut[1].PkScript = []byte{
+					0x53,
+				}
+			},
+			wantErr: "does not carry the derived change script",
+		},
+		{
+			name: "committed change amount diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[1].amount--
+				}
+			},
+			wantErr: "committed change amount",
+		},
+		{
+			name: "committed change root diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[1].taprootMerkleRoot[0] ^= 1
+				}
+			},
+			wantErr: "does not reproduce the derived script",
+		},
+		{
+			name: "committed change output missing",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs = r.outputs[:1]
+				}
+			},
+			wantErr: "want 2",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			committer, req, template := newBatchAnchorFixture(t)
+			template = addBatchAnchorChange(t, req, template)
+			fake, ok := committer.driver.(*fakeBatchDriver)
+			require.True(t, ok)
+			ctx := context.Background()
+
+			derived, err := committer.DeriveScript(
+				ctx, req, template,
+			)
+			require.NoError(t, err)
+
+			funded := fundedFromTemplate(t, template, derived)
+			funded.UnsignedTx.TxOut[1].PkScript = append(
+				[]byte(nil), derived.ChangePkScript...,
+			)
+			test.corrupt(req, funded, fake)
 
 			_, err = committer.Commit(ctx, req, funded, derived)
 			require.ErrorContains(t, err, test.wantErr)

--- a/tapassets/boarded_proof.go
+++ b/tapassets/boarded_proof.go
@@ -1,0 +1,71 @@
+package tapassets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+)
+
+// ExportBoardedProof exports the confirmed proof file of an onboarded
+// composed output from the owner's own tapd. The output is not part of
+// tapd's wallet inventory (its script key is the round-scoped OP_TRUE
+// spec), so the proof is located through the transfer that created it.
+// A transfer that has not confirmed yet returns ErrBoardedProofPending.
+func ExportBoardedProof(ctx context.Context, wallet *tapsdk.Wallet,
+	outpoint wire.OutPoint) ([]byte, error) {
+
+	if wallet == nil {
+		return nil, fmt.Errorf("tap-sdk wallet is required")
+	}
+
+	client := wallet.Client()
+	transfers, err := client.ListTransfers(
+		ctx, &tapsdk.ListTransfersRequest{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list Taproot Asset transfers: %w", err)
+	}
+
+	target := sdkOutpoint(outpoint)
+	anchorTxid := outpoint.Hash.String()
+	for _, transfer := range transfers {
+		if transfer == nil || transfer.AnchorTxid != anchorTxid {
+			continue
+		}
+		if transfer.AnchorTxBlockHash == ([32]byte{}) {
+			return nil, ErrBoardedProofPending
+		}
+
+		for i := range transfer.Outputs {
+			out := &transfer.Outputs[i]
+			if out.AnchorOutpoint != target {
+				continue
+			}
+
+			exported, err := client.ExportProof(
+				ctx, tapsdk.AssetRefFromAssetID(out.IssuanceID),
+				out.ScriptKey, &out.AnchorOutpoint,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("export boarded "+
+					"proof: %w", err)
+			}
+			if exported == nil ||
+				len(exported.RawProofFile) == 0 {
+				return nil, fmt.Errorf("exported boarded " +
+					"proof is empty")
+			}
+
+			return exported.RawProofFile, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no transfer creates outpoint %v", outpoint)
+}
+
+// ErrBoardedProofPending reports an onboarding transfer that tapd has not
+// seen confirm yet, so its proof file cannot be exported.
+var ErrBoardedProofPending = fmt.Errorf("boarded asset proof is not " +
+	"confirmed yet")

--- a/tapassets/onboarding.go
+++ b/tapassets/onboarding.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"sync"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -30,21 +31,66 @@ const (
 	onboardingStorePrefix   = "onboarding/"
 	onboardingLockIDDomain  = "wavelength/taproot-assets/onboarding-lock/v1"
 	onboardingDustFloorSat  = uint64(330)
+
+	// onboardingChangeValueSat is the Bitcoin value carried by the asset
+	// change anchor output. The change is ordinary tapd wallet inventory,
+	// so it takes tapd's own asset-anchor value rather than the
+	// operator-mandated carrier value of the boarded output.
+	onboardingChangeValueSat = int64(1_000)
 )
 
-// OnboardingRequest selects one complete Taproot Asset proof and the standard
-// Wavelength policy that will own its new on-chain anchor.
+// Logical identifiers naming the transition's asset outputs across the
+// commit and the sealed package. The boarding identifier is part of the
+// single-output transition's committed shape and must not change.
+const (
+	onboardingOutputID = "wavelength-onboarding-output-0"
+	onboardingChangeID = "wavelength-onboarding-change"
+)
+
+// onboardingChangeOutputIndex is the asset change anchor output's position.
+// The boarded output holds index 0 and wallet funding appends its Bitcoin
+// change after both asset outputs, so the position is fixed at build time.
+const onboardingChangeOutputIndex = uint32(1)
+
+// OnboardingRequest selects the complete Taproot Asset proofs funding one
+// boarding and the standard Wavelength policy that will own its new
+// on-chain anchor. The selected proofs must cover AssetAmount; any surplus
+// returns to the daemon's own tapd wallet as asset change.
 type OnboardingRequest struct {
-	RequestID          string
-	AssetRef           string
-	AssetAmount        uint64
-	ProofFile          []byte
+	RequestID   string
+	AssetRef    string
+	AssetAmount uint64
+
+	// ProofFile is one complete confirmed proof file. Exactly one of
+	// ProofFile and ProofFiles must be set.
+	ProofFile []byte
+
+	// ProofFiles are the complete confirmed proof files of every funding
+	// UTXO the transition spends.
+	ProofFiles [][]byte
+
 	CarrierValueSat    uint64
 	FeeRateSatPerVByte uint64
 	TargetConf         uint32
 	MaxFeeSat          uint64
 	OperatorKey        *btcec.PublicKey
 	ExitDelay          uint32
+}
+
+// onboardingProofFiles returns the request's funding proofs with the
+// singular field folded in, so every caller sees one shape.
+func onboardingProofFiles(request *OnboardingRequest) [][]byte {
+	if request == nil {
+		return nil
+	}
+	if len(request.ProofFiles) != 0 {
+		return request.ProofFiles
+	}
+	if len(request.ProofFile) != 0 {
+		return [][]byte{request.ProofFile}
+	}
+
+	return nil
 }
 
 // OnboardingKeyDeriver returns the next wallet-owned standard VTXO key.
@@ -102,23 +148,44 @@ type OnboarderConfig struct {
 type Onboarder struct {
 	driver         onboardingDriver
 	inventory      proofInventoryClient
+	keys           onboardingKeyClient
 	store          Store
 	signer         tapsdk.AnchorSigner
 	deriveOwnerKey OnboardingKeyDeriver
 	mu             sync.Mutex
 }
 
+// onboardingKeyClient derives the tapd wallet keys owning asset change.
+type onboardingKeyClient interface {
+	DeriveScriptKey(context.Context) (*tapsdk.ScriptKey, error)
+
+	DeriveInternalKey(context.Context) (*tapsdk.InternalKey, error)
+}
+
+// onboardingChange is the pinned asset change of one onboarding: the units
+// the selected funding UTXOs carry beyond the boarded amount, returned to
+// the daemon's own tapd wallet on its own anchor output. Both keys are
+// derived once and persisted, because the split commitment binds the change
+// script key and a replay must rebuild the identical transition.
+type onboardingChange struct {
+	Amount            uint64             `json:"amount"`
+	OutputValueSat    int64              `json:"output_value_sat"`
+	ScriptKey         tapsdk.ScriptKey   `json:"script_key"`
+	AnchorInternalKey tapsdk.InternalKey `json:"anchor_internal_key"`
+}
+
 type onboardingState struct {
-	Version         uint16      `json:"version"`
-	RequestDigest   tapsdk.Hash `json:"request_digest"`
-	Attempt         string      `json:"attempt,omitempty"`
-	OwnerPubKey     []byte      `json:"owner_pub_key"`
-	OwnerKeyFamily  int32       `json:"owner_key_family"`
-	OwnerKeyIndex   uint32      `json:"owner_key_index"`
-	PolicyTemplate  []byte      `json:"policy_template"`
-	TransferPackage []byte      `json:"transfer_package,omitempty"`
-	FinalAnchorPSBT []byte      `json:"final_anchor_psbt,omitempty"`
-	Published       bool        `json:"published"`
+	Version         uint16            `json:"version"`
+	RequestDigest   tapsdk.Hash       `json:"request_digest"`
+	Attempt         string            `json:"attempt,omitempty"`
+	OwnerPubKey     []byte            `json:"owner_pub_key"`
+	OwnerKeyFamily  int32             `json:"owner_key_family"`
+	OwnerKeyIndex   uint32            `json:"owner_key_index"`
+	PolicyTemplate  []byte            `json:"policy_template"`
+	Change          *onboardingChange `json:"change,omitempty"`
+	TransferPackage []byte            `json:"transfer_package,omitempty"`
+	FinalAnchorPSBT []byte            `json:"final_anchor_psbt,omitempty"`
+	Published       bool              `json:"published"`
 }
 
 // NewOnboarder constructs the tap-sdk-backed onboarding workflow.
@@ -144,6 +211,7 @@ func NewOnboarder(cfg OnboarderConfig) (*Onboarder, error) {
 			wallet: cfg.Wallet,
 		},
 		inventory:      cfg.Wallet.Client(),
+		keys:           cfg.Wallet.Client(),
 		store:          cfg.Store,
 		signer:         cfg.Signer,
 		deriveOwnerKey: cfg.DeriveOwnerKey,
@@ -155,7 +223,7 @@ func NewOnboarder(cfg OnboarderConfig) (*Onboarder, error) {
 func (o *Onboarder) Onboard(ctx context.Context, request *OnboardingRequest) (
 	*OnboardingResult, error) {
 
-	if o == nil || o.driver == nil || o.inventory == nil ||
+	if o == nil || o.driver == nil || o.inventory == nil || o.keys == nil ||
 		o.store == nil ||
 		o.signer == nil || o.deriveOwnerKey == nil {
 		return nil, fmt.Errorf("taproot asset onboarder is not " +
@@ -275,7 +343,7 @@ func (o *Onboarder) commit(ctx context.Context, request *OnboardingRequest,
 		return committed, nil
 	}
 
-	assetRef, anchor, verifier, err := o.verifyInput(ctx, request)
+	assetRef, assetInputs, verifier, err := o.verifyInputs(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -289,45 +357,98 @@ func (o *Onboarder) commit(ctx context.Context, request *OnboardingRequest,
 			"the Taproot dust floor", outputValue)
 	}
 
-	anchorPSBT, err := onboardingAnchorPSBT(anchor.OutPoint, outputValue)
-	if err != nil {
+	// The funding surplus is whatever the selected anchors carry beyond
+	// the boarded amount. Its keys are derived once and pinned, because
+	// the split commitment binds the change script key and every later
+	// rebuild must reproduce the same transition.
+	if err := o.pinChange(
+		ctx, request, state, assetInputs,
+	); err != nil {
 		return nil, err
 	}
-	anchorInternalKey, err := btcec.ParsePubKey(anchor.InternalKey[:])
-	if err != nil {
-		return nil, fmt.Errorf("parse onboarding anchor "+
-			"internal key: %w", err)
-	}
-	anchorSigner, err := tapsdk.ParseXOnlyPubKey(
-		schnorr.SerializePubKey(anchorInternalKey),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("parse onboarding anchor signer: %w",
-			err)
-	}
 
-	requestDigest := onboardingRequestDigest(request)
-	requestDTO := &tapsdk.CustomAnchorRequest{
-		Inputs: []tapsdk.CustomAssetInput{{
-			ID:        "wavelength-onboarding-input-0",
+	inputs := make([]tapsdk.CustomAssetInput, 0, len(assetInputs))
+	plans := make(
+		[]tapsdk.CustomAnchorInputSigningPlan, 0, len(assetInputs),
+	)
+	anchorInputs := make([]tapsdk.Outpoint, 0, len(assetInputs))
+	for idx := range assetInputs {
+		input := &assetInputs[idx]
+		inputs = append(inputs, tapsdk.CustomAssetInput{
+			ID: fmt.Sprintf(
+				"wavelength-onboarding-input-%d", idx,
+			),
 			AssetRef:  assetRef,
-			Amount:    request.AssetAmount,
-			ProofFile: append([]byte(nil), request.ProofFile...),
+			Amount:    input.amount,
+			ProofFile: append([]byte(nil), input.proofFile...),
 			Witness: tapsdk.CustomAssetWitnessPlan{
 				Mode: tapsdk.CustomAssetWitnessBackendSigner,
 			},
-		}},
-		Outputs: []tapsdk.CustomAssetOutput{{
-			ID:                "wavelength-onboarding-output-0",
+		})
+
+		// Each funding anchor is a tapd key spend under its own
+		// internal key; wallet funding appends its own inputs after
+		// these and the backend manages them itself.
+		signer, err := onboardingAnchorSigner(input.anchor)
+		if err != nil {
+			return nil, err
+		}
+		plans = append(plans, tapsdk.CustomAnchorInputSigningPlan{
+			InputIndex: uint32(idx),
+			KeyPath: &tapsdk.CustomAnchorKeyPathSigningPlan{
+				Signer: signer,
+			},
+		})
+		anchorInputs = append(anchorInputs, input.anchor.OutPoint)
+	}
+
+	requestDigest := onboardingRequestDigest(request)
+	outputs := []tapsdk.CustomAssetOutput{{
+		ID:                onboardingOutputID,
+		AssetRef:          assetRef,
+		Amount:            request.AssetAmount,
+		AnchorOutputIndex: 0,
+		AnchorValueSat:    uint64(outputValue),
+		Script:            boardingScriptPlan(requestDigest),
+		Anchor: anchorPlan(
+			policy.InternalKey, policyTapLeaves(policy),
+		),
+	}}
+	anchorValues := []int64{outputValue}
+	if change := state.Change; change != nil {
+		outputs = append(outputs, tapsdk.CustomAssetOutput{
+			ID:                onboardingChangeID,
 			AssetRef:          assetRef,
-			Amount:            request.AssetAmount,
-			AnchorOutputIndex: 0,
-			AnchorValueSat:    uint64(outputValue),
-			Script:            boardingScriptPlan(requestDigest),
-			Anchor: anchorPlan(
-				policy.InternalKey, policyTapLeaves(policy),
-			),
-		}},
+			Amount:            change.Amount,
+			AnchorOutputIndex: onboardingChangeOutputIndex,
+			AnchorValueSat:    uint64(change.OutputValueSat),
+
+			// The pinned wallet script key rides as an external
+			// key: the wallet script mode would derive a fresh
+			// key on every build, and a rebuild must reproduce
+			// the identical transition.
+			Script: tapsdk.CustomAssetScriptPlan{
+				Mode: scriptExternal,
+				External: &tapsdk.
+					CustomAssetExternalScriptPlan{
+					ScriptKey: change.ScriptKey,
+				},
+			},
+			Anchor: tapsdk.CustomAnchorOutputPlan{
+				InternalKey: change.AnchorInternalKey,
+			},
+		})
+		anchorValues = append(anchorValues, change.OutputValueSat)
+	}
+
+	anchorPSBT, err := onboardingAnchorPSBT(anchorInputs, anchorValues)
+	if err != nil {
+		return nil, err
+	}
+
+	requestDTO := &tapsdk.CustomAnchorRequest{
+		Inputs:     inputs,
+		Outputs:    outputs,
 		AnchorPSBT: anchorPSBT,
 		Funding: tapsdk.CustomAnchorFundingPlan{
 			Mode: tapsdk.CustomAnchorFundingWalletFunded,
@@ -348,12 +469,7 @@ func (o *Onboarder) commit(ctx context.Context, request *OnboardingRequest,
 		LossPolicy: tapsdk.CustomAnchorLossPolicy{
 			Mode: tapsdk.CustomAnchorLossReject,
 		},
-		SigningPlans: []tapsdk.CustomAnchorInputSigningPlan{{
-			InputIndex: 0,
-			KeyPath: &tapsdk.CustomAnchorKeyPathSigningPlan{
-				Signer: anchorSigner,
-			},
-		}},
+		SigningPlans: plans,
 	}
 
 	state.Attempt = onboardingAttemptCommit
@@ -389,30 +505,27 @@ func (o *Onboarder) commit(ctx context.Context, request *OnboardingRequest,
 	return committed, nil
 }
 
-func (o *Onboarder) verifyInput(ctx context.Context,
-	request *OnboardingRequest) (tapsdk.AssetRef, *tapsdk.ManagedUtxo,
+// onboardingAssetInput is one verified funding UTXO of an onboarding: the
+// proof selecting it, the tapd-managed anchor holding it, and the exact
+// amount its proof tip carries.
+type onboardingAssetInput struct {
+	proofFile []byte
+	anchor    *tapsdk.ManagedUtxo
+	amount    uint64
+}
+
+// verifyInputs binds every funding proof to tapd's own managed inventory
+// and returns the verifier the builder revalidates them with. The proofs
+// select whole anchors, so their amounts are whatever the anchors hold; the
+// caller reconciles the total against the requested amount.
+func (o *Onboarder) verifyInputs(ctx context.Context,
+	request *OnboardingRequest) (tapsdk.AssetRef, []onboardingAssetInput,
 	tapsdk.ConfirmedProofVerifier, error) {
 
 	assetRef, err := tapsdk.ParseAssetRef(request.AssetRef)
 	if err != nil {
 		return "", nil, nil,
 			fmt.Errorf("parse Taproot Asset ref: %w", err)
-	}
-	verified, err := o.inventory.VerifyProof(ctx, request.ProofFile)
-	if err != nil {
-		return "", nil, nil,
-			fmt.Errorf("verify onboarding proof with tapd: %w", err)
-	}
-	if verified == nil || !verified.Valid || verified.DecodedProof == nil {
-		return "", nil, nil,
-			fmt.Errorf("tapd rejected onboarding proof")
-	}
-	tip := verified.DecodedProof
-	if !tip.AssetRef.Equivalent(assetRef) ||
-		tip.Amount != request.AssetAmount {
-		return "", nil, nil,
-			fmt.Errorf("onboarding proof tip does not match " +
-				"request")
 	}
 
 	utxos, err := o.inventory.ListUtxos(ctx, &tapsdk.ListUtxosRequest{
@@ -422,41 +535,177 @@ func (o *Onboarder) verifyInput(ctx context.Context,
 		return "", nil, nil,
 			fmt.Errorf("list tapd onboarding inventory: %w", err)
 	}
-	var anchor *tapsdk.ManagedUtxo
-	for _, candidate := range utxos {
-		if candidate != nil && candidate.OutPoint == tip.Outpoint {
-			anchor = candidate
-			break
+
+	proofs := onboardingProofFiles(request)
+	if len(proofs) == 0 {
+		return "", nil, nil,
+			fmt.Errorf("onboarding funding proof is required")
+	}
+	var (
+		inputs    = make([]onboardingAssetInput, 0, len(proofs))
+		verifiers = make(
+			[]tapsdk.ConfirmedProofVerifier, 0, len(proofs),
+		)
+		selected = make(map[tapsdk.Outpoint]struct{}, len(proofs))
+	)
+	for idx, proofFile := range proofs {
+		verified, err := o.inventory.VerifyProof(ctx, proofFile)
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("verify onboarding "+
+				"proof %d with tapd: %w", idx, err)
 		}
-	}
-	if anchor == nil {
-		return "", nil, nil,
-			fmt.Errorf("onboarding proof anchor is not managed " +
-				"by tapd")
-	}
-	if len(anchor.Assets) != 1 {
-		return "", nil, nil, fmt.Errorf("Taproot Asset onboarding PoC "+
-			"requires one isolated asset, found %d",
-			len(anchor.Assets))
-	}
-	asset := anchor.Assets[0]
-	if asset == nil || asset.Genesis.IssuanceID != tip.IssuanceID ||
-		asset.Amount != tip.Amount ||
-		asset.ScriptKey.PubKey != tip.ScriptKey {
-		return "", nil, nil,
-			fmt.Errorf("tapd onboarding inventory does not match " +
-				"proof")
+		if verified == nil || !verified.Valid ||
+			verified.DecodedProof == nil {
+			return "", nil, nil, fmt.Errorf("tapd rejected "+
+				"onboarding proof %d", idx)
+		}
+		tip := verified.DecodedProof
+		if !tip.AssetRef.Equivalent(assetRef) || tip.Amount == 0 {
+			return "", nil, nil, fmt.Errorf("onboarding proof %d "+
+				"tip does not match request", idx)
+		}
+
+		// Two proofs selecting one anchor would double-count the units
+		// it holds against the requested amount.
+		if _, ok := selected[tip.Outpoint]; ok {
+			return "", nil, nil, fmt.Errorf("onboarding proof %d "+
+				"selects anchor %v twice", idx, tip.Outpoint)
+		}
+		selected[tip.Outpoint] = struct{}{}
+
+		var anchor *tapsdk.ManagedUtxo
+		for _, candidate := range utxos {
+			if candidate != nil &&
+				candidate.OutPoint == tip.Outpoint {
+
+				anchor = candidate
+
+				break
+			}
+		}
+		if anchor == nil {
+			return "", nil, nil, fmt.Errorf("onboarding proof %d "+
+				"anchor is not managed by tapd", idx)
+		}
+		if len(anchor.Assets) != 1 {
+			return "", nil, nil, fmt.Errorf("Taproot Asset "+
+				"onboarding PoC requires one isolated asset, "+
+				"found %d", len(anchor.Assets))
+		}
+		asset := anchor.Assets[0]
+		if asset == nil ||
+			asset.Genesis.IssuanceID != tip.IssuanceID ||
+			asset.Amount != tip.Amount ||
+			asset.ScriptKey.PubKey != tip.ScriptKey {
+			return "", nil, nil, fmt.Errorf("tapd onboarding "+
+				"inventory does not match proof %d", idx)
+		}
+
+		inputs = append(inputs, onboardingAssetInput{
+			proofFile: proofFile,
+			anchor:    anchor,
+			amount:    tip.Amount,
+		})
+		verifiers = append(verifiers, &proofInventoryVerifier{
+			client:    o.inventory,
+			assetRef:  assetRef,
+			amount:    tip.Amount,
+			anchor:    tip.Outpoint,
+			assetRoot: anchor.TaprootAssetRoot,
+		})
 	}
 
-	verifier := &proofInventoryVerifier{
-		client:    o.inventory,
-		assetRef:  assetRef,
-		amount:    request.AssetAmount,
-		anchor:    tip.Outpoint,
-		assetRoot: anchor.TaprootAssetRoot,
+	// Every verifier pins its own tip claim, so one proof can only ever
+	// satisfy the input it belongs to.
+	verifier := verifiers[0]
+	if len(verifiers) > 1 {
+		verifier = &multiSourceVerifier{verifiers: verifiers}
 	}
 
-	return assetRef, anchor, verifier, nil
+	return assetRef, inputs, verifier, nil
+}
+
+// pinChange resolves the funding surplus and, the first time an onboarding
+// needs one, derives and persists the tapd wallet keys owning it. An exact
+// funding total pins no change and keeps the single-output transition.
+func (o *Onboarder) pinChange(ctx context.Context, request *OnboardingRequest,
+	state *onboardingState, inputs []onboardingAssetInput) error {
+
+	var total uint64
+	for idx := range inputs {
+		if total > math.MaxUint64-inputs[idx].amount {
+			return fmt.Errorf("onboarding funding amounts overflow")
+		}
+		total += inputs[idx].amount
+	}
+	if total < request.AssetAmount {
+		return fmt.Errorf("onboarding funding proofs carry %d units, "+
+			"the request boards %d", total, request.AssetAmount)
+	}
+
+	amount := total - request.AssetAmount
+	switch {
+	case amount == 0 && state.Change != nil:
+		return fmt.Errorf("onboarding funding no longer needs the " +
+			"pinned asset change")
+
+	case amount == 0:
+		return nil
+
+	case state.Change != nil:
+		if state.Change.Amount != amount {
+			return fmt.Errorf("onboarding funding needs %d units "+
+				"of change, %d are pinned", amount,
+				state.Change.Amount)
+		}
+
+		return nil
+	}
+
+	scriptKey, err := o.keys.DeriveScriptKey(ctx)
+	if err != nil {
+		return fmt.Errorf("derive onboarding change script key: %w",
+			err)
+	}
+	internalKey, err := o.keys.DeriveInternalKey(ctx)
+	if err != nil {
+		return fmt.Errorf("derive onboarding change anchor "+
+			"internal key: %w", err)
+	}
+	if scriptKey == nil || internalKey == nil {
+		return fmt.Errorf("tapd returned an empty onboarding change " +
+			"key")
+	}
+
+	state.Change = &onboardingChange{
+		Amount:            amount,
+		OutputValueSat:    onboardingChangeValueSat,
+		ScriptKey:         *scriptKey,
+		AnchorInternalKey: *internalKey,
+	}
+
+	return o.storeState(ctx, request.RequestID, state)
+}
+
+// onboardingAnchorSigner returns the tapd key-path signer of one funding
+// anchor's Bitcoin input.
+func onboardingAnchorSigner(anchor *tapsdk.ManagedUtxo) (tapsdk.XOnlyPubKey,
+	error) {
+
+	internalKey, err := btcec.ParsePubKey(anchor.InternalKey[:])
+	if err != nil {
+		return tapsdk.XOnlyPubKey{}, fmt.Errorf("parse onboarding "+
+			"anchor internal key: %w", err)
+	}
+	signer, err := tapsdk.ParseXOnlyPubKey(
+		schnorr.SerializePubKey(internalKey),
+	)
+	if err != nil {
+		return tapsdk.XOnlyPubKey{}, fmt.Errorf("parse onboarding "+
+			"anchor signer: %w", err)
+	}
+
+	return signer, nil
 }
 
 func onboardingResultFromCommit(request *OnboardingRequest,
@@ -464,10 +713,15 @@ func onboardingResultFromCommit(request *OnboardingRequest,
 	policy *arkscript.VTXOPolicy, digest tapsdk.Hash,
 	committed *commitResult) (*OnboardingResult, error) {
 
-	if committed == nil || len(committed.inputs) != 1 ||
-		len(committed.outputs) != 1 {
-		return nil, fmt.Errorf("onboarding package must contain one " +
-			"input and one output")
+	wantInputs := len(onboardingProofFiles(request))
+	wantOutputs := 1
+	if state.Change != nil {
+		wantOutputs = 2
+	}
+	if committed == nil || len(committed.inputs) != wantInputs ||
+		len(committed.outputs) != wantOutputs {
+		return nil, fmt.Errorf("onboarding package must contain %d "+
+			"inputs and %d outputs", wantInputs, wantOutputs)
 	}
 	if committed.fundingMode != tapsdk.CustomAnchorFundingWalletFunded {
 		return nil, fmt.Errorf("onboarding package is not wallet " +
@@ -487,11 +741,36 @@ func onboardingResultFromCommit(request *OnboardingRequest,
 	if err != nil {
 		return nil, err
 	}
-	input := committed.inputs[0]
-	output := committed.outputs[0]
-	if !input.assetRef.Equivalent(assetRef) ||
-		!output.assetRef.Equivalent(assetRef) ||
-		input.amount != request.AssetAmount ||
+	output, err := committedOutput(committed, onboardingOutputID)
+	if err != nil {
+		return nil, err
+	}
+
+	// The transition conserves the asset exactly: everything the funding
+	// anchors carry either boards or returns as pinned change.
+	wantTotal := request.AssetAmount
+	if state.Change != nil {
+		wantTotal += state.Change.Amount
+	}
+	var inputTotal uint64
+	for idx := range committed.inputs {
+		input := committed.inputs[idx]
+		if !input.assetRef.Equivalent(assetRef) {
+			return nil, fmt.Errorf("onboarding package input %d "+
+				"carries another asset", idx)
+		}
+		if inputTotal > math.MaxUint64-input.amount {
+			return nil, fmt.Errorf("onboarding package input " +
+				"amounts overflow")
+		}
+		inputTotal += input.amount
+	}
+	if inputTotal != wantTotal {
+		return nil, fmt.Errorf("onboarding package spends %d units, "+
+			"the boarding and change carry %d", inputTotal,
+			wantTotal)
+	}
+	if !output.assetRef.Equivalent(assetRef) ||
 		output.amount != request.AssetAmount {
 		return nil, fmt.Errorf("onboarding package asset selection " +
 			"mismatch")
@@ -555,6 +834,11 @@ func onboardingResultFromCommit(request *OnboardingRequest,
 	if packet.UnsignedTx.TxHash() != outpoint.Hash {
 		return nil, fmt.Errorf("onboarding package outpoint mismatch")
 	}
+	if err := checkOnboardingChange(
+		state.Change, committed, packet.UnsignedTx,
+	); err != nil {
+		return nil, fmt.Errorf("committed onboarding change: %w", err)
+	}
 
 	return &OnboardingResult{
 		Outpoint:         outpoint,
@@ -572,6 +856,76 @@ func onboardingResultFromCommit(request *OnboardingRequest,
 		Digest:           digest,
 		OPTrueWitness:    cloneByteSlices(output.opTrueWitness),
 	}, nil
+}
+
+// checkOnboardingChange verifies fail-closed that the committed asset change
+// is the one that was pinned: the same units on the same anchor position,
+// keyed to the pinned wallet script key, under a BIP-86 output of the pinned
+// anchor internal key. Nil change passes.
+func checkOnboardingChange(change *onboardingChange, committed *commitResult,
+	anchorTx *wire.MsgTx) error {
+
+	if change == nil {
+		return nil
+	}
+
+	out, err := committedOutput(committed, onboardingChangeID)
+	if err != nil {
+		return err
+	}
+	if out.anchorOutputIndex != onboardingChangeOutputIndex {
+		return fmt.Errorf("output index %d, want %d",
+			out.anchorOutputIndex, onboardingChangeOutputIndex)
+	}
+	if out.anchorOutpoint.Index != out.anchorOutputIndex {
+		return fmt.Errorf("outpoint index mismatch")
+	}
+	if out.amount != change.Amount {
+		return fmt.Errorf("amount %d, want %d", out.amount,
+			change.Amount)
+	}
+	if out.anchorValueSat != change.OutputValueSat {
+		return fmt.Errorf("value %d, want %d", out.anchorValueSat,
+			change.OutputValueSat)
+	}
+	if out.scriptMode != scriptExternal {
+		return fmt.Errorf("script mode %d is not the pinned external "+
+			"wallet key", out.scriptMode)
+	}
+	if out.scriptKey != change.ScriptKey.PubKey {
+		return fmt.Errorf("script key does not reproduce the pinned " +
+			"wallet key")
+	}
+	if out.taprootAssetRoot == (tapsdk.Hash{}) ||
+		out.taprootMerkleRoot == (tapsdk.Hash{}) {
+		return fmt.Errorf("root hints are missing")
+	}
+
+	internalKey, err := btcec.ParsePubKey(
+		change.AnchorInternalKey.PubKey[:],
+	)
+	if err != nil {
+		return fmt.Errorf("pinned anchor internal key: %w", err)
+	}
+	pkScript, err := composedScript(internalKey, out.taprootMerkleRoot)
+	if err != nil {
+		return err
+	}
+	if int(out.anchorOutputIndex) >= len(anchorTx.TxOut) {
+		return fmt.Errorf("output index %d is out of range",
+			out.anchorOutputIndex)
+	}
+	anchorOutput := anchorTx.TxOut[out.anchorOutputIndex]
+	if anchorOutput.Value != change.OutputValueSat {
+		return fmt.Errorf("anchor value %d, want %d",
+			anchorOutput.Value, change.OutputValueSat)
+	}
+	if !bytes.Equal(anchorOutput.PkScript, pkScript) {
+		return fmt.Errorf("anchor output does not reproduce the " +
+			"pinned wallet script")
+	}
+
+	return nil
 }
 
 func (o *Onboarder) loadState(ctx context.Context, request *OnboardingRequest,
@@ -644,10 +998,23 @@ func validateOnboardingRequest(request *OnboardingRequest) error {
 		return fmt.Errorf("taproot asset onboarding idempotency key " +
 			"is required")
 	}
-	if request.AssetRef == "" || request.AssetAmount == 0 ||
-		len(request.ProofFile) == 0 {
+	if request.AssetRef == "" || request.AssetAmount == 0 {
+		return fmt.Errorf("taproot asset ref and amount are required")
+	}
+	if len(request.ProofFile) != 0 && len(request.ProofFiles) != 0 {
+		return fmt.Errorf("taproot asset onboarding takes either one " +
+			"proof file or a proof file set")
+	}
+	proofs := onboardingProofFiles(request)
+	if len(proofs) == 0 {
 		return fmt.Errorf("taproot asset ref, amount, and proof are " +
 			"required")
+	}
+	for idx := range proofs {
+		if len(proofs[idx]) == 0 {
+			return fmt.Errorf("taproot asset onboarding proof %d "+
+				"is empty", idx)
+		}
 	}
 	if len(request.AssetRef) > vtxo.MaxTaprootAssetRefBytes {
 		return fmt.Errorf("taproot asset ref exceeds %d bytes",
@@ -681,12 +1048,17 @@ func validateOnboardingRequest(request *OnboardingRequest) error {
 	return nil
 }
 
+// onboardingRequestDigest binds one onboarding's retry identity. The funding
+// proofs enter in content order, so the digest is independent of the order
+// the selection or the durable replay slice hands them over in.
 func onboardingRequestDigest(request *OnboardingRequest) tapsdk.Hash {
 	var value bytes.Buffer
 	writeDigestBytes(&value, []byte(request.RequestID))
 	writeDigestBytes(&value, []byte(request.AssetRef))
 	_ = binary.Write(&value, binary.BigEndian, request.AssetAmount)
-	writeDigestBytes(&value, request.ProofFile)
+	for _, proofFile := range sortedProofFiles(request) {
+		writeDigestBytes(&value, proofFile)
+	}
 	_ = binary.Write(&value, binary.BigEndian, request.CarrierValueSat)
 	_ = binary.Write(
 		&value, binary.BigEndian, request.FeeRateSatPerVByte,
@@ -733,6 +1105,18 @@ func onboardingAnchorFee(request *OnboardingRequest) (tapsdk.AnchorFee, error) {
 	}, nil
 }
 
+// sortedProofFiles returns the request's funding proofs ordered by content,
+// without disturbing the caller's slice.
+func sortedProofFiles(request *OnboardingRequest) [][]byte {
+	proofs := onboardingProofFiles(request)
+	sorted := append([][]byte(nil), proofs...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return bytes.Compare(sorted[i], sorted[j]) < 0
+	})
+
+	return sorted
+}
+
 func onboardingCustomLockID(requestDigest tapsdk.Hash) []byte {
 	var value bytes.Buffer
 	writeDigestBytes(&value, []byte(onboardingLockIDDomain))
@@ -762,7 +1146,18 @@ func ownerKeyFromState(state *onboardingState) (keychain.KeyDescriptor, error) {
 	}, nil
 }
 
-func onboardingAnchorPSBT(input tapsdk.Outpoint, value int64) ([]byte, error) {
+// onboardingAnchorPSBT builds the unfunded anchor template: one input per
+// funding anchor and one placeholder output per asset output, in index
+// order. Wallet funding adds the Bitcoin inputs and appends its change after
+// them, so tapd rewrites the placeholder scripts with the real composed
+// ones and every asset output keeps the position derived here.
+func onboardingAnchorPSBT(inputs []tapsdk.Outpoint,
+	values []int64) ([]byte, error) {
+
+	if len(inputs) == 0 || len(values) == 0 {
+		return nil, fmt.Errorf("onboarding anchor template needs an " +
+			"input and an output")
+	}
 	placeholderKey := txscript.ComputeTaprootKeyNoScript(
 		&arkscript.ARKNUMSKey,
 	)
@@ -772,20 +1167,24 @@ func onboardingAnchorPSBT(input tapsdk.Outpoint, value int64) ([]byte, error) {
 	}
 
 	tx := wire.NewMsgTx(2)
-	tx.AddTxIn(
-		wire.NewTxIn(
-			&wire.OutPoint{
-				Hash:  chainhash.Hash(input.Txid),
-				Index: input.Index,
-			},
-			nil,
-			nil,
-		),
-	)
-	tx.AddTxOut(&wire.TxOut{
-		Value:    value,
-		PkScript: placeholderScript,
-	})
+	for _, input := range inputs {
+		tx.AddTxIn(
+			wire.NewTxIn(
+				&wire.OutPoint{
+					Hash:  chainhash.Hash(input.Txid),
+					Index: input.Index,
+				},
+				nil,
+				nil,
+			),
+		)
+	}
+	for _, value := range values {
+		tx.AddTxOut(&wire.TxOut{
+			Value:    value,
+			PkScript: placeholderScript,
+		})
+	}
 	packet, err := psbt.NewFromUnsignedTx(tx)
 	if err != nil {
 		return nil, fmt.Errorf("build onboarding anchor PSBT: %w", err)

--- a/tapassets/onboarding_test.go
+++ b/tapassets/onboarding_test.go
@@ -34,6 +34,7 @@ func TestOnboarderResumesWithoutRebuilding(t *testing.T) {
 		return &Onboarder{
 			driver:    driver,
 			inventory: inventory,
+			keys:      inventory,
 			store:     store,
 			signer: func(_ context.Context, anchor []byte) ([]byte,
 				error) {
@@ -410,6 +411,304 @@ func TestOnboarderStopsAfterAmbiguousCommit(t *testing.T) {
 	require.Equal(t, 1, driver.commits)
 }
 
+// TestOnboarderFundsFromSeveralUtxos proves an onboarding that boards less
+// than its funding anchors carry spends one asset input per anchor and
+// returns the surplus on its own change output, owned by keys derived from
+// the daemon's own tapd exactly once and pinned across every rebuild.
+func TestOnboarderFundsFromSeveralUtxos(t *testing.T) {
+	t.Parallel()
+
+	const boarded = uint64(40)
+	request, inventory, owner := testMultiUtxoOnboardingRequest(t, boarded)
+	driver := newFakeOnboardingDriver()
+	store, err := NewFileStore(t.TempDir())
+	require.NoError(t, err)
+	onboarder := testOnboarder(driver, inventory, store, owner)
+
+	result, err := onboarder.Onboard(t.Context(), request)
+	require.NoError(t, err)
+	require.Equal(t, boarded, result.AssetAmount)
+
+	// One script key plus one anchor internal key, derived once and never
+	// again on a replay.
+	require.Equal(t, 2, inventory.derived)
+
+	dto := driver.requests[0]
+	require.Len(t, dto.Inputs, 2)
+	require.Equal(
+		t, "wavelength-onboarding-input-0", dto.Inputs[0].ID,
+	)
+	require.Equal(
+		t, "wavelength-onboarding-input-1", dto.Inputs[1].ID,
+	)
+	require.Equal(
+		t, testOnboardingFirstAmount, dto.Inputs[0].Amount,
+	)
+	require.Equal(
+		t, testOnboardingSecondAmount, dto.Inputs[1].Amount,
+	)
+	require.Equal(t, request.ProofFiles[0], dto.Inputs[0].ProofFile)
+	require.Equal(t, request.ProofFiles[1], dto.Inputs[1].ProofFile)
+
+	// Every funding anchor is a tapd key spend under its own internal
+	// key; wallet funding manages the inputs it adds after them.
+	require.Len(t, dto.SigningPlans, 2)
+	for idx := range dto.SigningPlans {
+		plan := dto.SigningPlans[idx]
+		require.EqualValues(t, idx, plan.InputIndex)
+		require.NotNil(t, plan.KeyPath)
+	}
+	template, err := psbtutil.Parse(dto.AnchorPSBT)
+	require.NoError(t, err)
+	require.Len(t, template.UnsignedTx.TxIn, 2)
+	require.Len(t, template.UnsignedTx.TxOut, 2)
+
+	// The boarded output keeps index 0 and the change takes index 1, so
+	// wallet funding can only append its Bitcoin change after both.
+	require.Len(t, dto.Outputs, 2)
+	require.Equal(t, onboardingOutputID, dto.Outputs[0].ID)
+	require.Equal(t, boarded, dto.Outputs[0].Amount)
+	require.EqualValues(t, 0, dto.Outputs[0].AnchorOutputIndex)
+	require.Equal(
+		t, tapsdk.CustomAssetScriptOPTrue, dto.Outputs[0].Script.Mode,
+	)
+
+	change := dto.Outputs[1]
+	require.Equal(t, onboardingChangeID, change.ID)
+	require.Equal(t, testOnboardingTotalAmount-boarded, change.Amount)
+	require.Equal(
+		t, onboardingChangeOutputIndex, change.AnchorOutputIndex,
+	)
+	require.EqualValues(
+		t, onboardingChangeValueSat, change.AnchorValueSat,
+	)
+	require.Equal(t, scriptExternal, change.Script.Mode)
+	require.NotNil(t, change.Script.External)
+	require.Empty(t, change.Anchor.Tapscript.TapLeaves)
+
+	// A replay must rebuild nothing and reuse the pinned change keys.
+	replayed, err := onboarder.Onboard(t.Context(), request)
+	require.NoError(t, err)
+	require.Equal(t, result.Outpoint, replayed.Outpoint)
+	require.Equal(t, 1, driver.commits)
+	require.Equal(t, 2, inventory.derived)
+}
+
+// TestOnboarderExactFundingKeepsOneOutput proves funding that matches the
+// boarded amount exactly still commits the single-output transition, so the
+// change path never touches a full-value onboarding.
+func TestOnboarderExactFundingKeepsOneOutput(t *testing.T) {
+	t.Parallel()
+
+	request, inventory, owner := testMultiUtxoOnboardingRequest(
+		t, testOnboardingTotalAmount,
+	)
+	driver := newFakeOnboardingDriver()
+	store, err := NewFileStore(t.TempDir())
+	require.NoError(t, err)
+	onboarder := testOnboarder(driver, inventory, store, owner)
+
+	result, err := onboarder.Onboard(t.Context(), request)
+	require.NoError(t, err)
+	require.Equal(t, testOnboardingTotalAmount, result.AssetAmount)
+	require.Zero(t, inventory.derived)
+
+	dto := driver.requests[0]
+	require.Len(t, dto.Inputs, 2)
+	require.Len(t, dto.Outputs, 1)
+	require.Equal(t, onboardingOutputID, dto.Outputs[0].ID)
+	template, err := psbtutil.Parse(dto.AnchorPSBT)
+	require.NoError(t, err)
+	require.Len(t, template.UnsignedTx.TxOut, 1)
+}
+
+// TestOnboarderRejectsInsufficientFunding keeps an onboarding that its
+// funding proofs cannot cover from ever reaching tapd.
+func TestOnboarderRejectsInsufficientFunding(t *testing.T) {
+	t.Parallel()
+
+	request, inventory, owner := testMultiUtxoOnboardingRequest(
+		t, testOnboardingTotalAmount+1,
+	)
+	driver := newFakeOnboardingDriver()
+	store, err := NewFileStore(t.TempDir())
+	require.NoError(t, err)
+	onboarder := testOnboarder(driver, inventory, store, owner)
+
+	_, err = onboarder.Onboard(t.Context(), request)
+	require.ErrorContains(t, err, "carry 55 units, the request boards 56")
+	require.Zero(t, driver.commits)
+}
+
+// TestOnboarderRejectsDuplicateFundingProof keeps two proofs selecting one
+// anchor from double-counting the units it holds.
+func TestOnboarderRejectsDuplicateFundingProof(t *testing.T) {
+	t.Parallel()
+
+	request, inventory, owner := testMultiUtxoOnboardingRequest(t, 40)
+	request.ProofFiles = [][]byte{
+		request.ProofFiles[0], request.ProofFiles[0],
+	}
+	driver := newFakeOnboardingDriver()
+	store, err := NewFileStore(t.TempDir())
+	require.NoError(t, err)
+	onboarder := testOnboarder(driver, inventory, store, owner)
+
+	_, err = onboarder.Onboard(t.Context(), request)
+	require.ErrorContains(t, err, "selects anchor")
+	require.Zero(t, driver.commits)
+}
+
+// TestOnboardingProofSetDigestIsOrderIndependent proves the retry identity
+// depends on which funding proofs an onboarding selects, not on the order
+// the selection or the durable replay slice hands them over in.
+func TestOnboardingProofSetDigestIsOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	request, _, _ := testMultiUtxoOnboardingRequest(t, 40)
+	digest := onboardingRequestDigest(request)
+
+	swapped := *request
+	swapped.ProofFiles = [][]byte{
+		request.ProofFiles[1], request.ProofFiles[0],
+	}
+	require.Equal(t, digest, onboardingRequestDigest(&swapped))
+
+	// A different funding set is a different request.
+	dropped := *request
+	dropped.ProofFiles = request.ProofFiles[:1]
+	require.NotEqual(t, digest, onboardingRequestDigest(&dropped))
+
+	// One proof reaches the same identity through either field.
+	single, _, _ := testOnboardingRequest(t)
+	folded := *single
+	folded.ProofFile = nil
+	folded.ProofFiles = [][]byte{single.ProofFile}
+	require.Equal(
+		t, onboardingRequestDigest(single),
+		onboardingRequestDigest(&folded),
+	)
+}
+
+// TestOnboardingChangeFailsClosed proves every divergence between the
+// pinned asset change and what tapd committed is refused.
+func TestOnboardingChangeFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		mutate      func(*commitResult, *onboardingChange)
+		errContains string
+	}{{
+		name: "missing change output",
+		mutate: func(result *commitResult, _ *onboardingChange) {
+			result.outputs = result.outputs[:1]
+		},
+		errContains: "misses output",
+	}, {
+		name: "wrong anchor position",
+		mutate: func(result *commitResult, _ *onboardingChange) {
+			result.outputs[1].anchorOutputIndex = 7
+		},
+		errContains: "output index 7",
+	}, {
+		name: "wrong amount",
+		mutate: func(result *commitResult, _ *onboardingChange) {
+			result.outputs[1].amount++
+		},
+		errContains: "amount 16, want 15",
+	}, {
+		name: "wrong carrier value",
+		mutate: func(result *commitResult, _ *onboardingChange) {
+			result.outputs[1].anchorValueSat--
+		},
+		errContains: "value 999, want 1000",
+	}, {
+		name: "wallet script mode substituted",
+		mutate: func(result *commitResult, _ *onboardingChange) {
+			result.outputs[1].scriptMode =
+				tapsdk.CustomAssetScriptOPTrue
+		},
+		errContains: "is not the pinned external wallet key",
+	}, {
+		name: "another script key",
+		mutate: func(result *commitResult, _ *onboardingChange) {
+			result.outputs[1].scriptKey[1] ^= 1
+		},
+		errContains: "script key does not reproduce",
+	}, {
+		name: "another anchor internal key",
+		mutate: func(_ *commitResult, change *onboardingChange) {
+			change.AnchorInternalKey.PubKey =
+				deterministicKey(
+					tapsdk.Hash{1}, "onboarding-test",
+				)
+		},
+		errContains: "does not reproduce the pinned wallet script",
+	}, {
+		name: "missing roots",
+		mutate: func(result *commitResult, _ *onboardingChange) {
+			result.outputs[1].taprootMerkleRoot = tapsdk.Hash{}
+		},
+		errContains: "root hints are missing",
+	}}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			committed, change, anchorTx := onboardingChangeFixture(
+				t,
+			)
+			test.mutate(committed, change)
+
+			err := checkOnboardingChange(
+				change, committed, anchorTx,
+			)
+			require.ErrorContains(t, err, test.errContains)
+		})
+	}
+}
+
+// onboardingChangeFixture commits one onboarding with change and returns the
+// sealed material its verification runs over.
+func onboardingChangeFixture(t *testing.T) (*commitResult, *onboardingChange,
+	*wire.MsgTx) {
+
+	t.Helper()
+	request, inventory, owner := testMultiUtxoOnboardingRequest(t, 40)
+	driver := newFakeOnboardingDriver()
+	store, err := NewFileStore(t.TempDir())
+	require.NoError(t, err)
+	onboarder := testOnboarder(driver, inventory, store, owner)
+
+	_, err = onboarder.Onboard(t.Context(), request)
+	require.NoError(t, err)
+
+	committed := cloneCommitResult(driver.result)
+	packet, err := psbtutil.Parse(committed.anchorPSBT)
+	require.NoError(t, err)
+
+	state, err := onboarder.loadState(
+		t.Context(), request, onboardingRequestDigest(request),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, state.Change)
+	require.EqualValues(t, 15, state.Change.Amount)
+
+	// The unmutated material must pass, so every case below fails on its
+	// own mutation alone.
+	change := *state.Change
+	require.NoError(
+		t, checkOnboardingChange(
+			&change, committed, packet.UnsignedTx,
+		),
+	)
+
+	return committed, &change, packet.UnsignedTx
+}
+
 type fakeOnboardingDriver struct {
 	mu            sync.Mutex
 	base          *fakeDriver
@@ -450,6 +749,25 @@ func (d *fakeOnboardingDriver) CommitOnboarding(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+
+	// Onboarding spends one anchor input per selected funding UTXO, in
+	// the template's own input order.
+	template, err := psbtutil.Parse(result.anchorPSBT)
+	if err != nil {
+		return nil, err
+	}
+	result.inputs = make([]commitInput, len(request.Inputs))
+	for idx := range request.Inputs {
+		result.inputs[idx] = commitInput{
+			logicalInputID:   request.Inputs[idx].ID,
+			anchorInputIndex: uint32(idx),
+			anchorOutpoint: sdkOutpoint(
+				template.UnsignedTx.TxIn[idx].PreviousOutPoint,
+			),
+			assetRef: request.Inputs[idx].AssetRef,
+			amount:   request.Inputs[idx].Amount,
+		}
+	}
 	result.fundingMode = request.Funding.Mode
 	result.actualFeeSat = d.actualFeeSat
 	if request.Funding.WalletFunded != nil {
@@ -467,11 +785,15 @@ func (d *fakeOnboardingDriver) CommitOnboarding(ctx context.Context,
 			return nil, parseErr
 		}
 		walletInputValue := int64(2_000)
-		packet.Inputs[0].WitnessUtxo = &wire.TxOut{
-			Value: int64(request.Outputs[0].AnchorValueSat),
-			PkScript: []byte{
-				txscript.OP_TRUE,
-			},
+		for idx := range request.Inputs {
+			packet.Inputs[idx].WitnessUtxo = &wire.TxOut{
+				Value: int64(
+					request.Outputs[0].AnchorValueSat,
+				),
+				PkScript: []byte{
+					txscript.OP_TRUE,
+				},
+			}
 		}
 		walletInputHash := sha256Bytes(
 			[]byte("onboarding-wallet-input"),
@@ -592,13 +914,84 @@ func testOnboardingRequest(t *testing.T) (*OnboardingRequest, *fakeInventory,
 	}, inventory, ownerDescriptor
 }
 
-func testOnboarder(driver onboardingDriver, inventory proofInventoryClient,
+// Amounts of the two-anchor onboarding fixture: the base fixture's anchor
+// holds 21 units and a second one holds 34.
+const (
+	testOnboardingFirstAmount  = uint64(21)
+	testOnboardingSecondAmount = uint64(34)
+	testOnboardingTotalAmount  = testOnboardingFirstAmount +
+		testOnboardingSecondAmount
+)
+
+// testMultiUtxoOnboardingRequest funds one onboarding from two anchors of
+// the same asset. Boarding less than they carry returns the surplus to the
+// daemon's own tapd wallet as asset change.
+func testMultiUtxoOnboardingRequest(t *testing.T, boarded uint64) (
+	*OnboardingRequest, *fakeInventory, keychain.KeyDescriptor) {
+
+	t.Helper()
+	request, inventory, owner := testOnboardingRequest(t)
+	first := inventory.onlyAnchor()
+	require.Equal(t, testOnboardingFirstAmount, first.Assets[0].Amount)
+	firstProof := append([]byte(nil), request.ProofFile...)
+
+	scriptKey, err := tapsdk.ParsePubKey(
+		testPrivateKey(t, 24).PubKey().SerializeCompressed(),
+	)
+	require.NoError(t, err)
+	second := &tapsdk.ManagedUtxo{
+		OutPoint: tapsdk.Outpoint{
+			Txid:  sha256Bytes([]byte("second-onboarding-anchor")),
+			Index: 3,
+		},
+		AmtSat:      first.AmtSat,
+		InternalKey: first.InternalKey,
+		TaprootAssetRoot: tapsdk.Hash(
+			sha256Bytes(
+				[]byte("second-onboarding-root"),
+			),
+		),
+		Assets: []*tapsdk.AssetRecord{{
+			AssetRef: first.Assets[0].AssetRef,
+			Genesis:  first.Assets[0].Genesis,
+			Amount:   testOnboardingSecondAmount,
+			ScriptKey: tapsdk.ScriptKey{
+				PubKey: scriptKey,
+			},
+		}},
+	}
+	inventory.utxos[second.OutPoint.String()] = second
+
+	secondProof := []byte("second-confirmed-proof")
+	inventory.verifications = map[string]*tapsdk.VerifyProofResponse{
+		string(firstProof): inventory.verification,
+		string(secondProof): {
+			Valid: true,
+			DecodedProof: &tapsdk.DecodedProof{
+				AssetRef:   second.Assets[0].AssetRef,
+				IssuanceID: second.Assets[0].Genesis.IssuanceID,
+				ScriptKey:  scriptKey,
+				Amount:     second.Assets[0].Amount,
+				Outpoint:   second.OutPoint,
+			},
+		},
+	}
+
+	request.ProofFile = nil
+	request.ProofFiles = [][]byte{firstProof, secondProof}
+	request.AssetAmount = boarded
+
+	return request, inventory, owner
+}
+
+func testOnboarder(driver onboardingDriver, inventory *fakeInventory,
 	store Store, owner keychain.KeyDescriptor,
 ) *Onboarder {
 
 	return &Onboarder{
 		driver:    driver,
 		inventory: inventory,
+		keys:      inventory,
 		store:     store,
 		signer: func(_ context.Context, anchor []byte) ([]byte, error) {
 			return append([]byte(nil), anchor...), nil

--- a/tapassets/owned_proof.go
+++ b/tapassets/owned_proof.go
@@ -1,0 +1,72 @@
+package tapassets
+
+import (
+	"context"
+	"fmt"
+
+	tapsdk "github.com/lightninglabs/tap-sdk"
+)
+
+// ResolveOwnedAssetProof exports the proof file of the wallet-owned UTXO
+// holding exactly the requested amount of the given asset. Onboarding
+// consumes one complete anchor, so the wallet must hold the amount in
+// exactly one UTXO; zero or multiple candidates are an error.
+func ResolveOwnedAssetProof(ctx context.Context, wallet *tapsdk.Wallet,
+	assetRef string, amount uint64) ([]byte, error) {
+
+	if wallet == nil {
+		return nil, fmt.Errorf("tap-sdk wallet is required")
+	}
+
+	ref, err := tapsdk.ParseAssetRef(assetRef)
+	if err != nil {
+		return nil, fmt.Errorf("parse asset ref: %w", err)
+	}
+
+	client := wallet.Client()
+	utxos, err := client.ListUtxos(ctx, &tapsdk.ListUtxosRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("list Taproot Asset UTXOs: %w", err)
+	}
+
+	var (
+		matched    *tapsdk.ManagedUtxo
+		candidates int
+	)
+	for _, utxo := range utxos {
+		if utxo == nil || len(utxo.Assets) != 1 ||
+			utxo.Assets[0] == nil {
+
+			continue
+		}
+		asset := utxo.Assets[0]
+		if !asset.AssetRef.Equivalent(ref) || asset.Amount != amount {
+			continue
+		}
+
+		candidates++
+		matched = utxo
+	}
+	if candidates != 1 {
+		return nil, fmt.Errorf("expected exactly one owned UTXO "+
+			"holding %d units of %s, found %d; onboarding "+
+			"consumes one complete anchor, so hold exactly the "+
+			"amount in one UTXO", amount, assetRef, candidates)
+	}
+
+	// Proofs are exported per tranche, so the issuance ID is the only
+	// ref the archive accepts here.
+	asset := matched.Assets[0]
+	exported, err := client.ExportProof(
+		ctx, tapsdk.AssetRefFromAssetID(asset.Genesis.IssuanceID),
+		asset.ScriptKey.PubKey, &matched.OutPoint,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("export owned asset proof: %w", err)
+	}
+	if exported == nil || len(exported.RawProofFile) == 0 {
+		return nil, fmt.Errorf("exported owned asset proof is empty")
+	}
+
+	return exported.RawProofFile, nil
+}

--- a/tapassets/owned_proof.go
+++ b/tapassets/owned_proof.go
@@ -1,18 +1,35 @@
 package tapassets
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"math"
+	"sort"
 
 	tapsdk "github.com/lightninglabs/tap-sdk"
 )
 
-// ResolveOwnedAssetProof exports the proof file of the wallet-owned UTXO
-// holding exactly the requested amount of the given asset. Onboarding
-// consumes one complete anchor, so the wallet must hold the amount in
-// exactly one UTXO; zero or multiple candidates are an error.
-func ResolveOwnedAssetProof(ctx context.Context, wallet *tapsdk.Wallet,
-	assetRef string, amount uint64) ([]byte, error) {
+// ownedAssetUtxo is one candidate funding UTXO of the daemon's own tapd
+// wallet: the anchor holding it plus the tranche coordinates the proof
+// archive exports its proof file under.
+type ownedAssetUtxo struct {
+	outpoint   tapsdk.Outpoint
+	issuanceID tapsdk.AssetID
+	scriptKey  tapsdk.PubKey
+	amount     uint64
+}
+
+// ResolveOwnedAssetProofs exports the proof files of the wallet-owned UTXOs
+// funding one onboarding of the requested amount. Onboarding consumes whole
+// anchors, so the selected UTXOs must cover the amount and any surplus
+// re-anchors as asset change on the same transition.
+//
+// Only unleased UTXOs holding the asset in isolation are candidates.
+// Confirmation is enforced by the export itself: the archive has no proof
+// file for an anchor that has not confirmed.
+func ResolveOwnedAssetProofs(ctx context.Context, wallet *tapsdk.Wallet,
+	assetRef string, amount uint64) ([][]byte, error) {
 
 	if wallet == nil {
 		return nil, fmt.Errorf("tap-sdk wallet is required")
@@ -29,44 +46,123 @@ func ResolveOwnedAssetProof(ctx context.Context, wallet *tapsdk.Wallet,
 		return nil, fmt.Errorf("list Taproot Asset UTXOs: %w", err)
 	}
 
-	var (
-		matched    *tapsdk.ManagedUtxo
-		candidates int
-	)
+	candidates := make([]ownedAssetUtxo, 0, len(utxos))
 	for _, utxo := range utxos {
-		if utxo == nil || len(utxo.Assets) != 1 ||
-			utxo.Assets[0] == nil {
+		if utxo == nil || len(utxo.LeaseOwner) != 0 ||
+			len(utxo.Assets) != 1 || utxo.Assets[0] == nil {
 
 			continue
 		}
 		asset := utxo.Assets[0]
-		if !asset.AssetRef.Equivalent(ref) || asset.Amount != amount {
+		if !asset.AssetRef.Equivalent(ref) || asset.Amount == 0 {
 			continue
 		}
 
-		candidates++
-		matched = utxo
-	}
-	if candidates != 1 {
-		return nil, fmt.Errorf("expected exactly one owned UTXO "+
-			"holding %d units of %s, found %d; onboarding "+
-			"consumes one complete anchor, so hold exactly the "+
-			"amount in one UTXO", amount, assetRef, candidates)
+		candidates = append(candidates, ownedAssetUtxo{
+			outpoint:   utxo.OutPoint,
+			issuanceID: asset.Genesis.IssuanceID,
+			scriptKey:  asset.ScriptKey.PubKey,
+			amount:     asset.Amount,
+		})
 	}
 
-	// Proofs are exported per tranche, so the issuance ID is the only
-	// ref the archive accepts here.
-	asset := matched.Assets[0]
-	exported, err := client.ExportProof(
-		ctx, tapsdk.AssetRefFromAssetID(asset.Genesis.IssuanceID),
-		asset.ScriptKey.PubKey, &matched.OutPoint,
-	)
+	selected, err := selectOwnedAssetUtxos(candidates, amount)
 	if err != nil {
-		return nil, fmt.Errorf("export owned asset proof: %w", err)
-	}
-	if exported == nil || len(exported.RawProofFile) == 0 {
-		return nil, fmt.Errorf("exported owned asset proof is empty")
+		return nil, fmt.Errorf("select owned UTXOs holding %d units "+
+			"of %s: %w", amount, assetRef, err)
 	}
 
-	return exported.RawProofFile, nil
+	proofs := make([][]byte, 0, len(selected))
+	for idx := range selected {
+		utxo := &selected[idx]
+
+		// Proofs are exported per tranche, so the issuance ID is the
+		// only ref the archive accepts here.
+		exported, err := client.ExportProof(
+			ctx, tapsdk.AssetRefFromAssetID(utxo.issuanceID),
+			utxo.scriptKey, &utxo.outpoint,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("export owned asset proof "+
+				"%v: %w", utxo.outpoint, err)
+		}
+		if exported == nil || len(exported.RawProofFile) == 0 {
+			return nil, fmt.Errorf("exported owned asset proof %v "+
+				"is empty", utxo.outpoint)
+		}
+
+		proofs = append(proofs, exported.RawProofFile)
+	}
+
+	return proofs, nil
+}
+
+// selectOwnedAssetUtxos picks the funding set for one onboarding of the
+// given amount: an exact single UTXO when the wallet holds one, otherwise
+// the smallest single UTXO that covers the amount, otherwise the smallest
+// UTXOs accumulated until they do. Candidates are ordered by amount and
+// then by outpoint, so one wallet state always selects the same inputs and
+// a replay rebuilds the same transition.
+func selectOwnedAssetUtxos(candidates []ownedAssetUtxo,
+	amount uint64) ([]ownedAssetUtxo, error) {
+
+	if amount == 0 {
+		return nil, fmt.Errorf("onboarding amount is required")
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no owned UTXO holds the asset")
+	}
+
+	ordered := append([]ownedAssetUtxo(nil), candidates...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].amount != ordered[j].amount {
+			return ordered[i].amount < ordered[j].amount
+		}
+
+		return outpointBefore(ordered[i].outpoint, ordered[j].outpoint)
+	})
+
+	// One anchor holding exactly the amount needs no change output at
+	// all, so it always wins over any accumulation that would.
+	for idx := range ordered {
+		if ordered[idx].amount == amount {
+			return ordered[idx : idx+1 : idx+1], nil
+		}
+	}
+
+	// The smallest single anchor above the amount wastes the least: it
+	// spends one input and leaves the least change behind.
+	for idx := range ordered {
+		if ordered[idx].amount > amount {
+			return ordered[idx : idx+1 : idx+1], nil
+		}
+	}
+
+	var (
+		selected = make([]ownedAssetUtxo, 0, len(ordered))
+		total    uint64
+	)
+	for idx := range ordered {
+		if total > math.MaxUint64-ordered[idx].amount {
+			return nil, fmt.Errorf("owned asset amounts overflow")
+		}
+		selected = append(selected, ordered[idx])
+		total += ordered[idx].amount
+		if total >= amount {
+			return selected, nil
+		}
+	}
+
+	return nil, fmt.Errorf("owned UTXOs hold %d units, need %d", total,
+		amount)
+}
+
+// outpointBefore orders two outpoints, breaking amount ties in the funding
+// selection with a total order.
+func outpointBefore(left, right tapsdk.Outpoint) bool {
+	if cmp := bytes.Compare(left.Txid[:], right.Txid[:]); cmp != 0 {
+		return cmp < 0
+	}
+
+	return left.Index < right.Index
 }

--- a/tapassets/owned_proof_test.go
+++ b/tapassets/owned_proof_test.go
@@ -1,0 +1,197 @@
+package tapassets
+
+import (
+	"fmt"
+	"testing"
+
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/stretchr/testify/require"
+)
+
+// testOwnedUtxo builds one candidate funding UTXO whose outpoint is derived
+// from its label, so a fixture can name the UTXO a selection must pick.
+func testOwnedUtxo(label string, amount uint64) ownedAssetUtxo {
+	return ownedAssetUtxo{
+		outpoint: tapsdk.Outpoint{
+			Txid:  sha256Bytes([]byte(label)),
+			Index: 0,
+		},
+		amount: amount,
+	}
+}
+
+// selectedAmounts projects a selection onto its amounts in order.
+func selectedAmounts(selected []ownedAssetUtxo) []uint64 {
+	amounts := make([]uint64, len(selected))
+	for idx := range selected {
+		amounts[idx] = selected[idx].amount
+	}
+
+	return amounts
+}
+
+// TestOwnedAssetSelection pins the funding order onboarding selects its own
+// tapd UTXOs in: an exact anchor first, then the smallest single anchor that
+// covers the amount, then the smallest anchors accumulated until they do.
+func TestOwnedAssetSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		candidates  []ownedAssetUtxo
+		amount      uint64
+		want        []uint64
+		errContains string
+	}{{
+		// An exact anchor needs no change output, so it wins even
+		// when a smaller accumulation would also cover the amount.
+		name: "exact single anchor",
+		candidates: []ownedAssetUtxo{
+			testOwnedUtxo("a", 300),
+			testOwnedUtxo("b", 500),
+			testOwnedUtxo("c", 800),
+		},
+		amount: 500,
+		want: []uint64{
+			500,
+		},
+	}, {
+		name: "smallest sufficient single anchor",
+		candidates: []ownedAssetUtxo{
+			testOwnedUtxo("a", 1_200),
+			testOwnedUtxo("b", 800),
+			testOwnedUtxo("c", 400),
+		},
+		amount: 500,
+		want: []uint64{
+			800,
+		},
+	}, {
+		// No single anchor covers the amount, so the smallest ones
+		// accumulate until they do and stop there.
+		name: "accumulate smallest first",
+		candidates: []ownedAssetUtxo{
+			testOwnedUtxo("a", 400),
+			testOwnedUtxo("b", 300),
+			testOwnedUtxo("c", 200),
+		},
+		amount: 500,
+		want: []uint64{
+			200,
+			300,
+		},
+	}, {
+		name: "accumulate every anchor",
+		candidates: []ownedAssetUtxo{
+			testOwnedUtxo("a", 400),
+			testOwnedUtxo("b", 300),
+		},
+		amount: 700,
+		want: []uint64{
+			300,
+			400,
+		},
+	}, {
+		name: "insufficient total",
+		candidates: []ownedAssetUtxo{
+			testOwnedUtxo("a", 400),
+			testOwnedUtxo("b", 300),
+		},
+		amount:      900,
+		errContains: "hold 700 units, need 900",
+	}, {
+		name:        "no candidate",
+		amount:      100,
+		errContains: "no owned UTXO holds the asset",
+	}, {
+		name: "amount required",
+		candidates: []ownedAssetUtxo{
+			testOwnedUtxo("a", 400),
+		},
+		errContains: "amount is required",
+	}}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			selected, err := selectOwnedAssetUtxos(
+				test.candidates, test.amount,
+			)
+			if test.errContains != "" {
+				require.ErrorContains(t, err, test.errContains)
+				require.Nil(t, selected)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(
+				t, test.want, selectedAmounts(selected),
+			)
+		})
+	}
+}
+
+// TestOwnedAssetSelectionIsDeterministic proves one wallet state always
+// selects the same anchors regardless of the order tapd lists them, so a
+// replay that has to re-resolve rebuilds the same transition.
+func TestOwnedAssetSelectionIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	candidates := []ownedAssetUtxo{
+		testOwnedUtxo("d", 200),
+		testOwnedUtxo("c", 300),
+		testOwnedUtxo("b", 200),
+		testOwnedUtxo("a", 400),
+	}
+	selected, err := selectOwnedAssetUtxos(candidates, 500)
+	require.NoError(t, err)
+
+	// Ties on amount break on the outpoint, so the pair of 200s is fixed
+	// rather than whichever one tapd happened to list first.
+	require.Equal(t, []uint64{200, 200, 300}, selectedAmounts(selected))
+	require.True(
+		t, outpointBefore(selected[0].outpoint, selected[1].outpoint),
+	)
+
+	for shift := range candidates {
+		rotated := make([]ownedAssetUtxo, 0, len(candidates))
+		for idx := range candidates {
+			rotated = append(
+				rotated,
+				candidates[(idx+shift)%len(candidates)],
+			)
+		}
+
+		other, err := selectOwnedAssetUtxos(rotated, 500)
+		require.NoError(t, err, "rotation %d", shift)
+		require.Equal(t, selected, other, "rotation %d", shift)
+	}
+}
+
+// TestOwnedAssetSelectionSpansEveryAnchor proves accumulation covers an
+// amount no subset of the smaller anchors reaches on its own.
+func TestOwnedAssetSelectionSpansEveryAnchor(t *testing.T) {
+	t.Parallel()
+
+	candidates := make([]ownedAssetUtxo, 0, 5)
+	var total uint64
+	for idx := range 5 {
+		amount := uint64(100 * (idx + 1))
+		total += amount
+		candidates = append(
+			candidates,
+			testOwnedUtxo(
+				fmt.Sprintf("utxo-%d", idx), amount,
+			),
+		)
+	}
+
+	selected, err := selectOwnedAssetUtxos(candidates, total)
+	require.NoError(t, err)
+	require.Len(t, selected, len(candidates))
+	require.Equal(
+		t, []uint64{100, 200, 300, 400, 500}, selectedAmounts(selected),
+	)
+}

--- a/tapassets/partial_preparer.go
+++ b/tapassets/partial_preparer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -151,35 +152,50 @@ func (p *Preparer) plannedRecipients(ctx context.Context,
 	}
 
 	recipients := cloneRecipients(request.Recipients)
-	assetChange, bitcoinChange, err := request.CarrierAllocation()
+	plan, err := request.CarrierAllocation()
 	if err != nil {
 		return nil, err
 	}
-	if assetChange > 0 {
-		change, err := request.BuildChangeRecipient(ctx, assetChange)
+	if plan.AssetChange > 0 {
+		change, err := request.BuildChangeRecipient(
+			ctx, plan.AssetChange,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("derive Taproot Asset "+
 				"change: %w", err)
 		}
 		if err := validateUncomposedChange(
-			change, assetChange,
+			change, plan.AssetChange,
 		); err != nil {
 			return nil, fmt.Errorf("Taproot Asset change: %w", err)
 		}
 		recipients = append(recipients, change)
 	}
 
-	if bitcoinChange > 0 {
-		change, err := request.BuildChangeRecipient(ctx, bitcoinChange)
-		if err != nil {
-			return nil, fmt.Errorf("derive Bitcoin change: %w", err)
-		}
-		if err := validateUncomposedChange(
-			change, bitcoinChange,
-		); err != nil {
-			return nil, fmt.Errorf("Bitcoin change: %w", err)
-		}
-		recipients = append(recipients, change)
+	change, err := request.BuildChangeRecipient(ctx, plan.SenderChange)
+	if err != nil {
+		return nil, fmt.Errorf("derive Bitcoin change: %w", err)
+	}
+	if err := validateUncomposedChange(
+		change, plan.SenderChange,
+	); err != nil {
+		return nil, fmt.Errorf("Bitcoin change: %w", err)
+	}
+	recipients = append(recipients, change)
+
+	// The float residual returns to the lease pkScript verbatim: a plain
+	// recipient output under the float's own policy, so BIP-371 output
+	// metadata and VTXO registration derive from the lease template.
+	if plan.OperatorChange > 0 {
+		recipients = append(recipients, oortx.RecipientOutput{
+			PkScript: append(
+				[]byte(nil), request.Lease.PkScript...,
+			),
+			Value: plan.OperatorChange,
+			VTXOPolicyTemplate: append(
+				[]byte(nil), request.Lease.PolicyTemplate...,
+			),
+		})
 	}
 	if err := validatePlannedRecipients(request, recipients); err != nil {
 		return nil, err
@@ -200,15 +216,15 @@ func validatePlannedRecipients(request *oor.TaprootAssetOORPrepareRequest,
 	if request == nil || len(request.Recipients) != 1 {
 		return fmt.Errorf("caller receiver is required")
 	}
-	assetChange, bitcoinChange, err := request.CarrierAllocation()
+	plan, err := request.CarrierAllocation()
 	if err != nil {
 		return err
 	}
-	expectedCount := 1
-	if assetChange != 0 {
+	expectedCount := 2
+	if plan.AssetChange != 0 {
 		expectedCount++
 	}
-	if bitcoinChange != 0 {
+	if plan.OperatorChange != 0 {
 		expectedCount++
 	}
 	if len(recipients) != expectedCount {
@@ -231,19 +247,36 @@ func validatePlannedRecipients(request *oor.TaprootAssetOORPrepareRequest,
 	}
 
 	next := 1
-	if assetChange != 0 {
+	if plan.AssetChange != 0 {
 		if err := validateUncomposedChange(
-			recipients[next], assetChange,
+			recipients[next], plan.AssetChange,
 		); err != nil {
 			return fmt.Errorf("Taproot Asset change: %w", err)
 		}
 		next++
 	}
-	if bitcoinChange != 0 {
-		if err := validateUncomposedChange(
-			recipients[next], bitcoinChange,
-		); err != nil {
-			return fmt.Errorf("Bitcoin change: %w", err)
+	if err := validateUncomposedChange(
+		recipients[next], plan.SenderChange,
+	); err != nil {
+		return fmt.Errorf("Bitcoin change: %w", err)
+	}
+	next++
+	if plan.OperatorChange != 0 {
+		operatorChange := recipients[next]
+		if operatorChange.Value != plan.OperatorChange ||
+			!bytes.Equal(
+				operatorChange.PkScript, request.Lease.PkScript,
+			) ||
+			!bytes.Equal(
+				operatorChange.VTXOPolicyTemplate,
+				request.Lease.PolicyTemplate,
+			) {
+			return fmt.Errorf("operator change does not pay the " +
+				"leased float script")
+		}
+		err := validateUncomposedRecipient(operatorChange)
+		if err != nil {
+			return fmt.Errorf("operator change: %w", err)
 		}
 	}
 
@@ -873,10 +906,12 @@ func buildArkRequest(request *oor.TaprootAssetOORPrepareRequest,
 		}
 		ark.Inputs[arkIndex].TaprootLeafScript =
 			[]*psbt.TaprootTapLeafScript{leaf}
-		input := &request.Inputs[idx]
+		signers, err := ownerLeafSigners(&request.Inputs[idx])
+		if err != nil {
+			return nil, fmt.Errorf("input %d signers: %w", idx, err)
+		}
 		signingPlans[idx] = scriptSigningPlan(
-			arkIndex, artifacts[idx].OwnerLeafScript,
-			input.VTXO.ClientKey.PubKey, input.VTXO.OperatorKey,
+			arkIndex, artifacts[idx].OwnerLeafScript, signers...,
 		)
 	}
 
@@ -965,6 +1000,30 @@ func buildArkRequest(request *oor.TaprootAssetOORPrepareRequest,
 		},
 		verifier: verifier,
 	}, nil
+}
+
+// ownerLeafSigners returns the keys that must sign an input's checkpoint
+// owner leaf in the Ark transaction. An operator-funded float input has no
+// local client key; its signers are the lease policy's own collab pair.
+func ownerLeafSigners(input *oor.TransferInput) ([]*btcec.PublicKey, error) {
+	if !input.OperatorFunded {
+		return []*btcec.PublicKey{
+			input.VTXO.ClientKey.PubKey,
+			input.VTXO.OperatorKey,
+		}, nil
+	}
+
+	leaf, err := arkscript.DecodeLeafTemplate(input.OwnerLeafPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("decode float owner leaf: %w", err)
+	}
+
+	multisig, ok := leaf.Node.(*arkscript.Multisig)
+	if !ok || len(multisig.Keys) == 0 {
+		return nil, fmt.Errorf("float owner leaf is not a multisig")
+	}
+
+	return append([]*btcec.PublicKey(nil), multisig.Keys...), nil
 }
 
 // addNonAssetArkOutputMetadata attaches the complete standard PSBT Taproot

--- a/tapassets/partial_preparer.go
+++ b/tapassets/partial_preparer.go
@@ -450,13 +450,12 @@ func (s *assetSpendSource) customInput(id string, assetRef tapsdk.AssetRef,
 	return input, nil
 }
 
-func (s *assetSpendSource) appendTransition(proofBlob []byte, witness [][]byte,
-	expected *expectedUnconfirmedAnchor) (tapsdk.CustomAssetInput,
-	tapsdk.ConfirmedProofVerifier, error) {
+func (s *assetSpendSource) appendTransition(proofBlob []byte,
+	witness [][]byte) (tapsdk.CustomAssetInput, error) {
 
 	if s == nil || len(proofBlob) == 0 {
-		return tapsdk.CustomAssetInput{}, nil, fmt.Errorf(
-			"checkpoint transition proof is required")
+		return tapsdk.CustomAssetInput{}, fmt.Errorf("checkpoint " +
+			"transition proof is required")
 	}
 	var path *tapsdk.AssetProofPath
 	if s.proofPath != nil {
@@ -470,15 +469,12 @@ func (s *assetSpendSource) appendTransition(proofBlob []byte, witness [][]byte,
 		}
 	}
 	if len(path.Steps) >= tapsdk.AssetProofPathMaxDepth {
-		return tapsdk.CustomAssetInput{}, nil, fmt.Errorf("Taproot " +
-			"Asset proof path has no remaining transition slot")
+		return tapsdk.CustomAssetInput{}, fmt.Errorf("Taproot Asset " +
+			"proof path has no remaining transition slot")
 	}
 	path.Steps = append(path.Steps, tapsdk.AssetProofPathStep{
 		TransitionProof: append([]byte(nil), proofBlob...),
 	})
-	expected.stepIndex = uint16(len(path.Steps) - 1)
-
-	verifier := verifierWithExpectedLast(s.verifier, expected)
 
 	return tapsdk.CustomAssetInput{
 		ProofPath: path,
@@ -486,28 +482,7 @@ func (s *assetSpendSource) appendTransition(proofBlob []byte, witness [][]byte,
 			Mode:  witnessCallerProvided,
 			Stack: cloneByteSlices(witness),
 		},
-	}, verifier, nil
-}
-
-func verifierWithExpectedLast(verifier tapsdk.ConfirmedProofVerifier,
-	expected *expectedUnconfirmedAnchor) tapsdk.ConfirmedProofVerifier {
-
-	switch typed := verifier.(type) {
-	case *proofInventoryVerifier:
-		clone := *typed
-		clone.unconfirmed = expected
-
-		return &clone
-
-	case *proofLineageVerifier:
-		clone := *typed
-		clone.expectedLast = expected
-
-		return &clone
-
-	default:
-		return verifier
-	}
+	}, nil
 }
 
 // prepareCheckpoints builds every Bitcoin checkpoint and commits only the
@@ -926,17 +901,8 @@ func buildArkRequest(request *oor.TaprootAssetOORPrepareRequest,
 		)
 	}
 
-	transitionInput, verifier, err := source.appendTransition(
+	transitionInput, err := source.appendTransition(
 		assetCheckpoint.proofBlob, assetCheckpoint.opTrueWitness,
-		&expectedUnconfirmedAnchor{
-			previousOutpoint: sdkOutpoint(
-				request.Inputs[assetInputIndex].VTXO.Outpoint,
-			),
-			anchorOutpoint: assetCheckpoint.anchorOutpoint,
-			transaction: append(
-				[]byte(nil), assetCheckpointTx...,
-			),
-		},
 	)
 	if err != nil {
 		return nil, err
@@ -944,6 +910,22 @@ func buildArkRequest(request *oor.TaprootAssetOORPrepareRequest,
 	transitionInput.ID = "wavelength-checkpoint"
 	transitionInput.AssetRef = assetRef
 	transitionInput.Amount = request.Intent.AssetAmount
+
+	verifier, err := newAssetTransitionVerifier(
+		[]*assetSpendSource{source},
+		[]*expectedUnconfirmedAnchor{{
+			previousOutpoint: sdkOutpoint(
+				request.Inputs[assetInputIndex].VTXO.Outpoint,
+			),
+			anchorOutpoint: assetCheckpoint.anchorOutpoint,
+			transaction: append(
+				[]byte(nil), assetCheckpointTx...,
+			),
+		}},
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	specs := assetRecipientSpecs(request)
 	outputs := make([]tapsdk.CustomAssetOutput, len(specs))

--- a/tapassets/partial_preparer.go
+++ b/tapassets/partial_preparer.go
@@ -151,11 +151,11 @@ func (p *Preparer) plannedRecipients(ctx context.Context,
 	}
 
 	recipients := cloneRecipients(request.Recipients)
-	recipientAssetAmount := request.Intent.EffectiveRecipientAssetAmount()
-	if recipientAssetAmount < request.Intent.AssetAmount {
-		assetChange := btcutil.Amount(
-			request.Intent.AssetChangeCarrierValueSat,
-		)
+	assetChange, bitcoinChange, err := request.CarrierAllocation()
+	if err != nil {
+		return nil, err
+	}
+	if assetChange > 0 {
 		change, err := request.BuildChangeRecipient(ctx, assetChange)
 		if err != nil {
 			return nil, fmt.Errorf("derive Taproot Asset "+
@@ -169,14 +169,6 @@ func (p *Preparer) plannedRecipients(ctx context.Context,
 		recipients = append(recipients, change)
 	}
 
-	inputTotal, err := taprootAssetInputTotalLocal(request.Inputs)
-	if err != nil {
-		return nil, err
-	}
-	required := request.Recipients[0].Value + btcutil.Amount(
-		request.Intent.AssetChangeCarrierValueSat,
-	)
-	bitcoinChange := inputTotal - required
 	if bitcoinChange > 0 {
 		change, err := request.BuildChangeRecipient(ctx, bitcoinChange)
 		if err != nil {
@@ -208,15 +200,10 @@ func validatePlannedRecipients(request *oor.TaprootAssetOORPrepareRequest,
 	if request == nil || len(request.Recipients) != 1 {
 		return fmt.Errorf("caller receiver is required")
 	}
-	inputTotal, err := taprootAssetInputTotalLocal(request.Inputs)
+	assetChange, bitcoinChange, err := request.CarrierAllocation()
 	if err != nil {
 		return err
 	}
-	assetChange := btcutil.Amount(
-		request.Intent.AssetChangeCarrierValueSat,
-	)
-	required := request.Recipients[0].Value + assetChange
-	bitcoinChange := inputTotal - required
 	expectedCount := 1
 	if assetChange != 0 {
 		expectedCount++
@@ -319,22 +306,6 @@ func validateUncomposedChange(recipient oortx.RecipientOutput,
 	}
 
 	return nil
-}
-
-func taprootAssetInputTotalLocal(inputs []oor.TransferInput) (btcutil.Amount,
-	error) {
-
-	var total btcutil.Amount
-	for idx := range inputs {
-		amount := inputs[idx].VTXO.Amount
-		if amount <= 0 || total > btcutil.MaxSatoshi-amount {
-			return 0, fmt.Errorf("Taproot Asset input carrier " +
-				"sum overflows")
-		}
-		total += amount
-	}
-
-	return total, nil
 }
 
 // resolveAssetSpendSource chooses either the initial managed proof or the

--- a/tapassets/partial_preparer.go
+++ b/tapassets/partial_preparer.go
@@ -80,21 +80,24 @@ func (s *assetSpendSource) validateTransitionCapacity() error {
 	return nil
 }
 
-// verify performs the complete proof/path validation before the atomic input
-// reservation set is acquired. The SDK repeats this during build, but doing it
-// here keeps deterministic proof, passive-asset, and lineage failures on the
-// safe side of Wavelength's reservation point of no return.
-func (s *assetSpendSource) verify(ctx context.Context) error {
-	if s == nil || s.verifier == nil {
+// verifySpendSource performs the complete proof/path validation before the
+// atomic input reservation set is acquired. The SDK repeats this during
+// build, but doing it here keeps deterministic proof, passive-asset, and
+// lineage failures on the safe side of Wavelength's reservation point of no
+// return.
+func (p *Preparer) verifySpendSource(ctx context.Context,
+	source *assetSpendSource) error {
+
+	if source == nil || source.verifier == nil {
 		return fmt.Errorf("Taproot Asset proof source verifier is " +
 			"required")
 	}
 
-	if s.proofPath == nil {
-		verification, err := s.verifier.VerifyConfirmedProof(
+	if source.proofPath == nil {
+		verification, err := source.verifier.VerifyConfirmedProof(
 			ctx,
 			append(
-				[]byte(nil), s.proofFile...,
+				[]byte(nil), source.proofFile...,
 			),
 		)
 		if err != nil {
@@ -115,7 +118,13 @@ func (s *assetSpendSource) verify(ctx context.Context) error {
 		return nil
 	}
 
-	if _, err := s.proofPath.Clone().Verify(ctx, s.verifier); err != nil {
+	verify := p.verifyProofPath
+	if verify == nil {
+		verify = verifyAssetProofPath
+	}
+	if err := verify(
+		ctx, source.proofPath.Clone(), source.verifier,
+	); err != nil {
 		return fmt.Errorf("preflight Taproot Asset proof path: %w", err)
 	}
 
@@ -388,10 +397,20 @@ func (p *Preparer) resolveAssetSpendSource(ctx context.Context,
 		return nil, fmt.Errorf("load created Taproot Asset package: %w",
 			err)
 	}
-	resolved, err := ResolveCreatedAssetProofSource(
-		packageBytes, input.VTXO.Outpoint, int64(input.VTXO.Amount),
-		input.VTXO.TaprootAssetRef, input.VTXO.TaprootAssetAmount,
-		*input.TaprootAssetRoot,
+	inputRef, err := tapsdk.ParseAssetRef(input.VTXO.TaprootAssetRef)
+	if err != nil {
+		return nil, fmt.Errorf("parse Taproot Asset input ref: %w", err)
+	}
+	committed, err := p.driver.DecodePackage(packageBytes)
+	if err != nil {
+		return nil, fmt.Errorf("decode created Taproot Asset "+
+			"package: %w", err)
+	}
+	resolved, err := resolveCreatedAssetProofSource(
+		committed, sdkOutpoint(input.VTXO.Outpoint),
+		int64(input.VTXO.Amount), inputRef,
+		input.VTXO.TaprootAssetAmount,
+		tapsdk.Hash(*input.TaprootAssetRoot),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("resolve created Taproot Asset "+
@@ -485,13 +504,13 @@ func (s *assetSpendSource) appendTransition(proofBlob []byte,
 	}, nil
 }
 
-// prepareCheckpoints builds every Bitcoin checkpoint and commits only the
-// unique asset-bearing checkpoint through tap-sdk.
+// prepareCheckpoints builds every Bitcoin checkpoint and commits one
+// asset-bearing checkpoint per asset input through tap-sdk, spine first.
 func (p *Preparer) prepareCheckpoints(ctx context.Context,
-	request *oor.TaprootAssetOORPrepareRequest, assetInputIndex int,
-	assetRef tapsdk.AssetRef, digest tapsdk.Hash, source *assetSpendSource,
-	state *preparationState) ([]*psbt.Packet, []*oortx.CheckpointArtifact,
-	*commitResult, error) {
+	request *oor.TaprootAssetOORPrepareRequest, assetInputIndices []int,
+	assetRef tapsdk.AssetRef, digest tapsdk.Hash,
+	sources []*assetSpendSource, state *preparationState) ([]*psbt.Packet,
+	[]*oortx.CheckpointArtifact, []*commitResult, error) {
 
 	checkpoints := make([]*psbt.Packet, len(request.Inputs))
 	artifacts := make([]*oortx.CheckpointArtifact, len(request.Inputs))
@@ -520,47 +539,68 @@ func (p *Preparer) prepareCheckpoints(ctx context.Context,
 		checkpoints[idx] = artifact.PSBT
 	}
 
-	committed, err := p.commitAssetCheckpoint(
-		ctx, request, assetInputIndex, assetRef, digest, source,
-		artifacts[assetInputIndex], state,
-	)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	checkpoint, err := psbtutil.Parse(committed.anchorPSBT)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	checkpoints[assetInputIndex] = checkpoint
-	if err := validateCheckpointResult(
-		request, assetInputIndex, assetRef, checkpoint, committed,
-	); err != nil {
-		return nil, nil, nil, err
+	results := make([]*commitResult, len(assetInputIndices))
+	for ordinal, inputIndex := range assetInputIndices {
+		var source *assetSpendSource
+		if sources != nil {
+			source = sources[ordinal]
+		}
+		committed, err := p.commitAssetCheckpoint(
+			ctx, request, ordinal, inputIndex,
+			len(assetInputIndices), assetRef, digest, source,
+			artifacts[inputIndex], state,
+		)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		checkpoint, err := psbtutil.Parse(committed.anchorPSBT)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		checkpoints[inputIndex] = checkpoint
+		if err := validateCheckpointResult(
+			request, inputIndex, assetRef, checkpoint, committed,
+		); err != nil {
+			return nil, nil, nil, err
+		}
+		results[ordinal] = committed
 	}
 
-	return checkpoints, artifacts, committed, nil
+	return checkpoints, artifacts, results, nil
 }
 
 func (p *Preparer) commitAssetCheckpoint(ctx context.Context,
-	request *oor.TaprootAssetOORPrepareRequest, assetInputIndex int,
-	assetRef tapsdk.AssetRef, digest tapsdk.Hash, source *assetSpendSource,
-	artifact *oortx.CheckpointArtifact, state *preparationState) (
-	*commitResult, error) {
+	request *oor.TaprootAssetOORPrepareRequest, ordinal, inputIndex,
+	assetInputCount int, assetRef tapsdk.AssetRef, digest tapsdk.Hash,
+	source *assetSpendSource, artifact *oortx.CheckpointArtifact,
+	state *preparationState) (*commitResult, error) {
 
-	if len(state.CheckpointPackage) != 0 {
+	if len(state.CheckpointPackages) == 0 {
+		state.CheckpointPackages = make([][]byte, assetInputCount)
+	}
+	if len(state.CheckpointPackages) != assetInputCount {
+		return nil, fmt.Errorf("checkpoint package journal holds %d "+
+			"slots, want %d", len(state.CheckpointPackages),
+			assetInputCount)
+	}
+	if len(state.CheckpointPackages[ordinal]) != 0 {
 		committed, err := p.driver.DecodePackage(
-			state.CheckpointPackage,
+			state.CheckpointPackages[ordinal],
 		)
 		if err != nil {
-			return nil, fmt.Errorf("restore checkpoint package: %w",
-				err)
+			return nil, fmt.Errorf("restore checkpoint package "+
+				"%d: %w", ordinal, err)
 		}
 
 		return committed, nil
 	}
-	input := &request.Inputs[assetInputIndex]
+	if source == nil {
+		return nil, fmt.Errorf("checkpoint %d spend source is required",
+			ordinal)
+	}
+	input := &request.Inputs[inputIndex]
 	assetInput, err := source.customInput(
-		"wavelength-input", assetRef, request.Intent.AssetAmount,
+		"wavelength-input", assetRef, input.VTXO.TaprootAssetAmount,
 	)
 	if err != nil {
 		return nil, err
@@ -579,7 +619,11 @@ func (p *Preparer) commitAssetCheckpoint(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	opTrueKey := deterministicKey(digest, attemptCheckpoint)
+
+	// The attempt marker doubles as the deterministic key domain, so
+	// every asset input's checkpoint derives a distinct OP_TRUE key.
+	attempt := checkpointAttempt(ordinal)
+	opTrueKey := deterministicKey(digest, attempt)
 	sdkRequest := &tapsdk.CustomAnchorRequest{
 		Inputs: []tapsdk.CustomAssetInput{
 			assetInput,
@@ -587,7 +631,7 @@ func (p *Preparer) commitAssetCheckpoint(ctx context.Context,
 		Outputs: []tapsdk.CustomAssetOutput{{
 			ID:                "wavelength-checkpoint",
 			AssetRef:          assetRef,
-			Amount:            request.Intent.AssetAmount,
+			Amount:            input.VTXO.TaprootAssetAmount,
 			AnchorOutputIndex: 0,
 			AnchorValueSat:    uint64(input.VTXO.Amount),
 			Script: tapsdk.CustomAssetScriptPlan{
@@ -618,18 +662,18 @@ func (p *Preparer) commitAssetCheckpoint(ctx context.Context,
 	}
 
 	committed, err := p.commit(
-		ctx, request.RequestID, state, attemptCheckpoint, sdkRequest,
+		ctx, request.RequestID, state, attempt, sdkRequest,
 		source.verifier,
 	)
 	if err != nil {
 		return nil, err
 	}
-	state.CheckpointPackage = append(
+	state.CheckpointPackages[ordinal] = append(
 		[]byte(nil), committed.packageBytes...,
 	)
 	state.Attempt = ""
 	if err := p.storeState(ctx, request.RequestID, state); err != nil {
-		state.Attempt = attemptCheckpoint
+		state.Attempt = attempt
 
 		return nil, fmt.Errorf("persist checkpoint package: %w", err)
 	}
@@ -639,12 +683,13 @@ func (p *Preparer) commitAssetCheckpoint(ctx context.Context,
 
 // prepareMixedArk restores or commits the checkpoint-to-recipient transition.
 func (p *Preparer) prepareMixedArk(ctx context.Context,
-	request *oor.TaprootAssetOORPrepareRequest, assetInputIndex int,
+	request *oor.TaprootAssetOORPrepareRequest, assetInputIndices []int,
 	assetRef tapsdk.AssetRef, checkpoints []*psbt.Packet,
-	artifacts []*oortx.CheckpointArtifact, checkpointResult *commitResult,
-	planned []oortx.RecipientOutput, digest tapsdk.Hash,
-	source *assetSpendSource, state *preparationState) (*psbt.Packet,
-	*commitResult, []oortx.RecipientOutput, error) {
+	artifacts []*oortx.CheckpointArtifact,
+	checkpointResults []*commitResult, planned []oortx.RecipientOutput,
+	digest tapsdk.Hash, sources []*assetSpendSource,
+	state *preparationState) (*psbt.Packet, *commitResult,
+	[]oortx.RecipientOutput, error) {
 
 	checkpointOutputs, err := checkpointOutputs(checkpoints, artifacts)
 	if err != nil {
@@ -661,19 +706,24 @@ func (p *Preparer) prepareMixedArk(ctx context.Context,
 			return nil, nil, nil, err
 		}
 		recipients, err := validateMixedArkResult(
-			request, assetInputIndex, assetRef, ark,
-			checkpointOutputs, checkpointResult, planned, committed,
-			nil,
+			request, assetInputIndices, assetRef, ark,
+			checkpointOutputs, checkpointResults, planned,
+			committed, nil,
 		)
 
 		return ark, committed, recipients, err
 	}
 
+	assetCheckpointTxs := make([][]byte, len(assetInputIndices))
+	for ordinal, inputIndex := range assetInputIndices {
+		assetCheckpointTxs[ordinal] = serializeTx(
+			checkpoints[inputIndex].UnsignedTx,
+		)
+	}
 	build, previews, _, nonce, err := p.stableArkBuild(
-		ctx, request, assetInputIndex, assetRef, checkpointOutputs,
-		artifacts, checkpointResult, planned, digest, source,
-		serializeTx(checkpoints[assetInputIndex].UnsignedTx),
-		state.OrderingNonce,
+		ctx, request, assetInputIndices, assetRef, checkpointOutputs,
+		artifacts, checkpointResults, planned, digest, sources,
+		assetCheckpointTxs, state.OrderingNonce,
 	)
 	if err != nil {
 		return nil, nil, nil, err
@@ -707,8 +757,8 @@ func (p *Preparer) prepareMixedArk(ctx context.Context,
 		return nil, nil, nil, err
 	}
 	recipients, err := validateMixedArkResult(
-		request, assetInputIndex, assetRef, ark, checkpointOutputs,
-		checkpointResult, planned, committed, previews,
+		request, assetInputIndices, assetRef, ark, checkpointOutputs,
+		checkpointResults, planned, committed, previews,
 	)
 	if err != nil {
 		return nil, nil, nil, err
@@ -746,13 +796,13 @@ func checkpointOutputs(checkpoints []*psbt.Packet,
 }
 
 func (p *Preparer) stableArkBuild(ctx context.Context,
-	request *oor.TaprootAssetOORPrepareRequest, assetInputIndex int,
+	request *oor.TaprootAssetOORPrepareRequest, assetInputIndices []int,
 	assetRef tapsdk.AssetRef, checkpoints []oortx.CheckpointOutput,
-	artifacts []*oortx.CheckpointArtifact, checkpointResult *commitResult,
-	planned []oortx.RecipientOutput, digest tapsdk.Hash,
-	source *assetSpendSource, assetCheckpointTx []byte, firstNonce uint32) (
-	*arkBuild, []commitmentPreview, []oortx.RecipientOutput, uint32,
-	error) {
+	artifacts []*oortx.CheckpointArtifact,
+	checkpointResults []*commitResult, planned []oortx.RecipientOutput,
+	digest tapsdk.Hash, sources []*assetSpendSource,
+	assetCheckpointTxs [][]byte, firstNonce uint32) (*arkBuild,
+	[]commitmentPreview, []oortx.RecipientOutput, uint32, error) {
 
 	if firstNonce >= maxOrderingNonces {
 		return nil, nil, nil, 0, fmt.Errorf("Taproot Asset output " +
@@ -765,9 +815,10 @@ func (p *Preparer) stableArkBuild(ctx context.Context,
 			maxOrderingIterations; iteration++ {
 
 			build, err := buildArkRequest(
-				request, assetInputIndex, assetRef, checkpoints,
-				artifacts, checkpointResult, planned, current,
-				digest, source, assetCheckpointTx, nonce,
+				request, assetInputIndices, assetRef,
+				checkpoints, artifacts, checkpointResults,
+				planned, current, digest, sources,
+				assetCheckpointTxs, nonce,
 			)
 			if err != nil {
 				return nil, nil, nil, 0, err
@@ -793,10 +844,10 @@ func (p *Preparer) stableArkBuild(ctx context.Context,
 			}
 			if stable {
 				finalBuild, err := buildArkRequest(
-					request, assetInputIndex, assetRef,
+					request, assetInputIndices, assetRef,
 					checkpoints, artifacts,
-					checkpointResult, planned, composed,
-					digest, source, assetCheckpointTx,
+					checkpointResults, planned, composed,
+					digest, sources, assetCheckpointTxs,
 					nonce,
 				)
 				if err != nil {
@@ -843,13 +894,24 @@ func (p *Preparer) stableArkBuild(ctx context.Context,
 		"ordering did not converge")
 }
 
+// assetTransitionInputID names one Ark transition input. The spine keeps the
+// historical single-input identifier so single-input packages stay stable.
+func assetTransitionInputID(ordinal int) string {
+	if ordinal == 0 {
+		return "wavelength-checkpoint"
+	}
+
+	return fmt.Sprintf("wavelength-checkpoint/%d", ordinal)
+}
+
 func buildArkRequest(request *oor.TaprootAssetOORPrepareRequest,
-	assetInputIndex int, assetRef tapsdk.AssetRef,
+	assetInputIndices []int, assetRef tapsdk.AssetRef,
 	checkpoints []oortx.CheckpointOutput,
-	artifacts []*oortx.CheckpointArtifact, checkpointResult *commitResult,
+	artifacts []*oortx.CheckpointArtifact,
+	checkpointResults []*commitResult,
 	planned, current []oortx.RecipientOutput, digest tapsdk.Hash,
-	source *assetSpendSource, assetCheckpointTx []byte, nonce uint32) (
-	*arkBuild, error) {
+	sources []*assetSpendSource, assetCheckpointTxs [][]byte,
+	nonce uint32) (*arkBuild, error) {
 
 	ark, err := oortx.BuildArkPSBT(checkpoints, current)
 	if err != nil {
@@ -862,7 +924,10 @@ func buildArkRequest(request *oor.TaprootAssetOORPrepareRequest,
 		inputPositions[ark.UnsignedTx.TxIn[idx].PreviousOutPoint] =
 			uint32(idx)
 	}
-	assetCheckpoint := checkpointResult.outputs[0]
+	ordinalByInput := make(map[int]int, len(assetInputIndices))
+	for ordinal, inputIndex := range assetInputIndices {
+		ordinalByInput[inputIndex] = ordinal
+	}
 	signingPlans := make(
 		[]tapsdk.CustomAnchorInputSigningPlan, len(checkpoints),
 	)
@@ -882,9 +947,10 @@ func buildArkRequest(request *oor.TaprootAssetOORPrepareRequest,
 		if err != nil {
 			return nil, err
 		}
-		if idx == assetInputIndex {
+		if ordinal, ok := ordinalByInput[idx]; ok {
 			leaf, err = composeTapLeaf(
-				leaf, assetCheckpoint.taprootAssetRoot,
+				leaf, checkpointResults[ordinal].
+					outputs[0].taprootAssetRoot,
 			)
 			if err != nil {
 				return nil, err
@@ -901,28 +967,41 @@ func buildArkRequest(request *oor.TaprootAssetOORPrepareRequest,
 		)
 	}
 
-	transitionInput, err := source.appendTransition(
-		assetCheckpoint.proofBlob, assetCheckpoint.opTrueWitness,
+	// The spine must stay Ark request input 0: the emitted transition
+	// proof's predecessor is vPacket input 0, and every created output's
+	// respend evidence keys its spine off that predecessor.
+	transitionInputs := make(
+		[]tapsdk.CustomAssetInput, len(assetInputIndices),
 	)
-	if err != nil {
-		return nil, err
-	}
-	transitionInput.ID = "wavelength-checkpoint"
-	transitionInput.AssetRef = assetRef
-	transitionInput.Amount = request.Intent.AssetAmount
-
-	verifier, err := newAssetTransitionVerifier(
-		[]*assetSpendSource{source},
-		[]*expectedUnconfirmedAnchor{{
+	expected := make(
+		[]*expectedUnconfirmedAnchor, len(assetInputIndices),
+	)
+	for ordinal, inputIndex := range assetInputIndices {
+		assetCheckpoint := checkpointResults[ordinal].outputs[0]
+		transitionInput, err := sources[ordinal].appendTransition(
+			assetCheckpoint.proofBlob,
+			assetCheckpoint.opTrueWitness,
+		)
+		if err != nil {
+			return nil, err
+		}
+		transitionInput.ID = assetTransitionInputID(ordinal)
+		transitionInput.AssetRef = assetRef
+		transitionInput.Amount =
+			request.Inputs[inputIndex].VTXO.TaprootAssetAmount
+		transitionInputs[ordinal] = transitionInput
+		expected[ordinal] = &expectedUnconfirmedAnchor{
 			previousOutpoint: sdkOutpoint(
-				request.Inputs[assetInputIndex].VTXO.Outpoint,
+				request.Inputs[inputIndex].VTXO.Outpoint,
 			),
 			anchorOutpoint: assetCheckpoint.anchorOutpoint,
 			transaction: append(
-				[]byte(nil), assetCheckpointTx...,
+				[]byte(nil), assetCheckpointTxs[ordinal]...,
 			),
-		}},
-	)
+		}
+	}
+
+	verifier, err := newAssetTransitionVerifier(sources, expected)
 	if err != nil {
 		return nil, err
 	}
@@ -977,9 +1056,7 @@ func buildArkRequest(request *oor.TaprootAssetOORPrepareRequest,
 
 	return &arkBuild{
 		request: &tapsdk.CustomAnchorRequest{
-			Inputs: []tapsdk.CustomAssetInput{
-				transitionInput,
-			},
+			Inputs:     transitionInputs,
 			Outputs:    outputs,
 			AnchorPSBT: anchorBytes,
 			Funding:    callerFundedExact(),
@@ -1252,8 +1329,8 @@ func previewIndicesStable(recipients []oortx.RecipientOutput,
 // validateMixedArkResult binds the sealed tap-sdk package to every Ark input
 // and recipient while preserving Bitcoin-only change as an unrooted output.
 func validateMixedArkResult(request *oor.TaprootAssetOORPrepareRequest,
-	assetInputIndex int, assetRef tapsdk.AssetRef, ark *psbt.Packet,
-	checkpoints []oortx.CheckpointOutput, checkpoint *commitResult,
+	assetInputIndices []int, assetRef tapsdk.AssetRef, ark *psbt.Packet,
+	checkpoints []oortx.CheckpointOutput, checkpointResults []*commitResult,
 	planned []oortx.RecipientOutput, result *commitResult,
 	expectedPreviews []commitmentPreview) ([]oortx.RecipientOutput, error) {
 
@@ -1261,7 +1338,7 @@ func validateMixedArkResult(request *oor.TaprootAssetOORPrepareRequest,
 		return nil, fmt.Errorf("committed Ark PSBT is required")
 	}
 	specs := assetRecipientSpecs(request)
-	if result == nil || len(result.inputs) != 1 ||
+	if result == nil || len(result.inputs) != len(assetInputIndices) ||
 		len(result.outputs) != len(specs) {
 		return nil, fmt.Errorf("Ark package asset cardinality mismatch")
 	}
@@ -1270,22 +1347,38 @@ func validateMixedArkResult(request *oor.TaprootAssetOORPrepareRequest,
 		return nil, fmt.Errorf("Ark package funding mode mismatch")
 	}
 
-	assetCheckpoint := checkpoint.outputs[0]
-	assetArkInput, err := findArkInputIndex(
-		ark, wire.OutPoint{
-			Hash:  checkpoints[assetInputIndex].Txid,
-			Index: 0,
-		},
+	// Every asset input binds 1:1 to its committed checkpoint output,
+	// with the per-input unit amount preserved through the checkpoint.
+	inputsByOutpoint := make(
+		map[tapsdk.Outpoint]*commitInput, len(result.inputs),
 	)
-	if err != nil {
-		return nil, err
+	for idx := range result.inputs {
+		input := &result.inputs[idx]
+		if _, ok := inputsByOutpoint[input.anchorOutpoint]; ok {
+			return nil, fmt.Errorf("Ark package input %v is "+
+				"duplicated", input.anchorOutpoint)
+		}
+		inputsByOutpoint[input.anchorOutpoint] = input
 	}
-	input := result.inputs[0]
-	if input.anchorOutpoint != assetCheckpoint.anchorOutpoint ||
-		input.anchorInputIndex != assetArkInput ||
-		!input.assetRef.Equivalent(assetRef) ||
-		input.amount != request.Intent.AssetAmount {
-		return nil, fmt.Errorf("Ark package asset input mismatch")
+	for ordinal, inputIndex := range assetInputIndices {
+		assetCheckpoint := checkpointResults[ordinal].outputs[0]
+		assetArkInput, err := findArkInputIndex(
+			ark, wire.OutPoint{
+				Hash:  checkpoints[inputIndex].Txid,
+				Index: 0,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		input, ok := inputsByOutpoint[assetCheckpoint.anchorOutpoint]
+		if !ok || input.anchorInputIndex != assetArkInput ||
+			!input.assetRef.Equivalent(assetRef) ||
+			input.amount != request.Inputs[inputIndex].
+				VTXO.TaprootAssetAmount {
+			return nil, fmt.Errorf("Ark package asset input %d "+
+				"mismatch", ordinal)
+		}
 	}
 
 	previewByID := make(map[string]commitmentPreview, len(expectedPreviews))

--- a/tapassets/partial_preparer.go
+++ b/tapassets/partial_preparer.go
@@ -172,16 +172,22 @@ func (p *Preparer) plannedRecipients(ctx context.Context,
 		recipients = append(recipients, change)
 	}
 
-	change, err := request.BuildChangeRecipient(ctx, plan.SenderChange)
-	if err != nil {
-		return nil, fmt.Errorf("derive Bitcoin change: %w", err)
+	// The sender's carrier returns only when the spent leaf was
+	// round-created; a reclaim-only send derives no wallet change at all.
+	if plan.SenderChange > 0 {
+		change, err := request.BuildChangeRecipient(
+			ctx, plan.SenderChange,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("derive Bitcoin change: %w", err)
+		}
+		if err := validateUncomposedChange(
+			change, plan.SenderChange,
+		); err != nil {
+			return nil, fmt.Errorf("Bitcoin change: %w", err)
+		}
+		recipients = append(recipients, change)
 	}
-	if err := validateUncomposedChange(
-		change, plan.SenderChange,
-	); err != nil {
-		return nil, fmt.Errorf("Bitcoin change: %w", err)
-	}
-	recipients = append(recipients, change)
 
 	// The float residual returns to the lease pkScript verbatim: a plain
 	// recipient output under the float's own policy, so BIP-371 output
@@ -220,8 +226,11 @@ func validatePlannedRecipients(request *oor.TaprootAssetOORPrepareRequest,
 	if err != nil {
 		return err
 	}
-	expectedCount := 2
+	expectedCount := 1
 	if plan.AssetChange != 0 {
+		expectedCount++
+	}
+	if plan.SenderChange != 0 {
 		expectedCount++
 	}
 	if plan.OperatorChange != 0 {
@@ -255,12 +264,14 @@ func validatePlannedRecipients(request *oor.TaprootAssetOORPrepareRequest,
 		}
 		next++
 	}
-	if err := validateUncomposedChange(
-		recipients[next], plan.SenderChange,
-	); err != nil {
-		return fmt.Errorf("Bitcoin change: %w", err)
+	if plan.SenderChange != 0 {
+		if err := validateUncomposedChange(
+			recipients[next], plan.SenderChange,
+		); err != nil {
+			return fmt.Errorf("Bitcoin change: %w", err)
+		}
+		next++
 	}
-	next++
 	if plan.OperatorChange != 0 {
 		operatorChange := recipients[next]
 		if operatorChange.Value != plan.OperatorChange ||

--- a/tapassets/partial_preparer_multi_test.go
+++ b/tapassets/partial_preparer_multi_test.go
@@ -1,0 +1,535 @@
+package tapassets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
+	"github.com/lightninglabs/wavelength/oor"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// multiInputFixture carries one prepared two-asset-input request together
+// with the fake driver seeded with each input's creating package.
+type multiInputFixture struct {
+	request   *oor.TaprootAssetOORPrepareRequest
+	inventory *fakeInventory
+	driver    *fakeDriver
+	loader    CreatedPackageLoader
+}
+
+// chainedAssetLeaf is one asset VTXO backed by a real base proof file and a
+// real creating transition, seeded into the fake driver as a sealed package.
+type chainedAssetLeaf struct {
+	outpoint     wire.OutPoint
+	root         chainhash.Hash
+	summary      *tapsdk.AssetProofPathStepSummary
+	packageBytes []byte
+}
+
+// seedChainedAssetLeaf registers one created-package projection for a leaf
+// whose creating transition really spends the shared confirmed base.
+func seedChainedAssetLeaf(t *testing.T, driver *fakeDriver, baseFile []byte,
+	transitionBytes []byte, rootSeed string) *chainedAssetLeaf {
+
+	t.Helper()
+
+	step := tapsdk.AssetProofPathStep{
+		TransitionProof: append([]byte(nil), transitionBytes...),
+	}
+	summary, err := step.Summary()
+	require.NoError(t, err)
+
+	root := chainhash.HashH([]byte(rootSeed))
+	packageBytes := []byte("created-package/" + rootSeed)
+	driver.results[string(packageBytes)] = &commitResult{
+		packageBytes: packageBytes,
+		inputs: []commitInput{{
+			logicalInputID: "input-0",
+			anchorOutpoint: summary.PreviousAnchorOutpoint,
+			assetRef:       summary.AssetRef,
+			issuanceID:     summary.IssuanceID,
+			amount:         summary.Amount,
+			proofSource: commitProofSource{
+				kind: tapsdk.
+					CustomAnchorProofSourceConfirmedFile,
+				blob: append([]byte(nil), baseFile...),
+			},
+		}},
+		outputs: []commitOutput{{
+			logicalOutputID:   "output-0",
+			anchorOutputIndex: summary.AnchorOutpoint.Index,
+			anchorOutpoint:    summary.AnchorOutpoint,
+			anchorValueSat:    summary.AnchorValueSat,
+			assetRef:          summary.AssetRef,
+			issuanceID:        summary.IssuanceID,
+			amount:            summary.Amount,
+			taprootAssetRoot:  tapsdk.Hash(root),
+			scriptKey:         summary.ScriptKey,
+			scriptMode:        tapsdk.CustomAssetScriptOPTrue,
+			opTrueWitness: [][]byte{
+				{
+					txscript.OP_TRUE,
+				}, {
+					9,
+					9,
+					9,
+				},
+			},
+			proofBlob: append([]byte(nil), transitionBytes...),
+		}},
+	}
+
+	return &chainedAssetLeaf{
+		outpoint: wire.OutPoint{
+			Hash:  summary.AnchorOutpoint.Txid,
+			Index: summary.AnchorOutpoint.Index,
+		},
+		root:         root,
+		summary:      summary,
+		packageBytes: packageBytes,
+	}
+}
+
+// chainedTransferInput builds the wallet-descriptor view of one chained
+// asset leaf.
+func chainedTransferInput(t *testing.T, leaf *chainedAssetLeaf, ownerByte byte,
+	operatorKey *keychain.KeyDescriptor,
+	roundCreated bool) oor.TransferInput {
+
+	t.Helper()
+
+	owner := testPrivateKey(t, ownerByte)
+	policy, err := arkscript.NewVTXOPolicy(
+		owner.PubKey(), operatorKey.PubKey, 10,
+	)
+	require.NoError(t, err)
+	policyBytes, err := policy.Template.Encode()
+	require.NoError(t, err)
+	composed, err := arkscript.ComposeWithSiblingRoot(
+		policy.CompiledPolicy, leaf.root,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToTaprootScript(composed.OutputKey())
+	require.NoError(t, err)
+	tapScript, err := arkscript.VTXOTapScript(
+		owner.PubKey(), operatorKey.PubKey, 10,
+	)
+	require.NoError(t, err)
+	root := leaf.root
+
+	return oor.TransferInput{
+		VTXO: &vtxo.Descriptor{
+			Outpoint: leaf.outpoint,
+			Amount:   btcutil.Amount(leaf.summary.AnchorValueSat),
+			PkScript: pkScript,
+			ClientKey: keychain.KeyDescriptor{
+				KeyLocator: keychain.KeyLocator{
+					Family: 1,
+					Index:  uint32(ownerByte),
+				},
+				PubKey: owner.PubKey(),
+			},
+			OperatorKey:        operatorKey.PubKey,
+			TapScript:          tapScript,
+			RelativeExpiry:     10,
+			Status:             vtxo.VTXOStatusLive,
+			TaprootAssetRoot:   &root,
+			TaprootAssetRef:    leaf.summary.AssetRef.String(),
+			TaprootAssetAmount: leaf.summary.Amount,
+		},
+		VTXOPolicyTemplate:       policyBytes,
+		TaprootAssetRoot:         &root,
+		TaprootAssetRoundCreated: roundCreated,
+	}
+}
+
+// testMultiInputPreparationRequest builds a two-asset-input partial send: a
+// round-created spine, an OOR-created co-input, one leased float, and real
+// per-input creating transitions behind the fake package loader.
+func testMultiInputPreparationRequest(t *testing.T) *multiInputFixture {
+	t.Helper()
+
+	driver := newFakeDriver()
+	baseFile, baseProof, senderKey := proofSourceBase(t)
+	transitionA, err := proofSourceTransition(
+		t, baseProof, senderKey, testPrivateKey(t, 51),
+	).Bytes()
+	require.NoError(t, err)
+	transitionB, err := proofSourceTransition(
+		t, baseProof, senderKey, testPrivateKey(t, 52),
+	).Bytes()
+	require.NoError(t, err)
+	spineLeaf := seedChainedAssetLeaf(
+		t, driver, baseFile, transitionA, "spine",
+	)
+	coLeaf := seedChainedAssetLeaf(t, driver, baseFile, transitionB, "co")
+
+	operator := testPrivateKey(t, 2)
+	operatorDesc := &keychain.KeyDescriptor{PubKey: operator.PubKey()}
+	spineInput := chainedTransferInput(t, spineLeaf, 11, operatorDesc, true)
+	coInput := chainedTransferInput(t, coLeaf, 12, operatorDesc, false)
+	floatInput, lease := testFloatInput(t, operator.PubKey(), 30_000)
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operator.PubKey(),
+		CSVDelay:    10,
+	}
+	inputs := []oor.TransferInput{spineInput, coInput, floatInput}
+	require.NoError(t, oor.NormalizeCheckpointOwnerLeaves(policy, inputs))
+
+	recipient := testPrivateKey(t, 3)
+	recipientPolicy, err := arkscript.NewVTXOPolicy(
+		recipient.PubKey(), operator.PubKey(), 10,
+	)
+	require.NoError(t, err)
+	recipientPolicyBytes, err := recipientPolicy.Template.Encode()
+	require.NoError(t, err)
+	recipientScript, err := recipientPolicy.Template.PkScript()
+	require.NoError(t, err)
+
+	totalUnits := spineLeaf.summary.Amount + coLeaf.summary.Amount
+	assetRef := spineLeaf.summary.AssetRef.String()
+	request := &oor.TaprootAssetOORPrepareRequest{
+		RequestID:   "taproot-asset-multi-request",
+		Policy:      policy,
+		OutputFloor: 1_000,
+		Inputs:      inputs,
+		Recipients: []oortx.RecipientOutput{{
+			PkScript:           recipientScript,
+			Value:              1_000,
+			VTXOPolicyTemplate: recipientPolicyBytes,
+		}},
+		BuildChangeRecipient: testChangeRecipientBuilder(
+			t, operator.PubKey(), 40,
+		),
+		Intent: oor.TaprootAssetOORIntent{
+			InputVTXOOutpoints: []wire.OutPoint{
+				spineLeaf.outpoint,
+				coLeaf.outpoint,
+			},
+			AssetRef:             assetRef,
+			AssetAmount:          totalUnits,
+			RecipientAssetAmount: totalUnits - 50,
+		},
+		Lease: lease,
+	}
+	require.NoError(t, request.Validate())
+
+	inventory := &fakeInventory{
+		verifications: map[string]*tapsdk.VerifyProofResponse{
+			string(baseFile): {
+				Valid:        true,
+				DecodedProof: &tapsdk.DecodedProof{},
+			},
+		},
+	}
+	loader := func(_ context.Context, outpoint wire.OutPoint) ([]byte,
+		error) {
+
+		switch outpoint {
+		case spineLeaf.outpoint:
+			return spineLeaf.packageBytes, nil
+
+		case coLeaf.outpoint:
+			return coLeaf.packageBytes, nil
+
+		default:
+			return nil, fmt.Errorf("unknown created package for %s",
+				outpoint)
+		}
+	}
+
+	return &multiInputFixture{
+		request:   request,
+		inventory: inventory,
+		driver:    driver,
+		loader:    loader,
+	}
+}
+
+// newMultiInputPreparer wires one preparer over the fixture's fake driver
+// and package loader.
+func newMultiInputPreparer(fixture *multiInputFixture, store Store,
+	reservations oor.ReservationSetStore) *Preparer {
+
+	preparer := newTestPreparer(
+		fixture.driver, fixture.inventory, store, reservations,
+	)
+	preparer.loadCreatedPackage = fixture.loader
+
+	return preparer
+}
+
+// TestPreparerMergesMultipleAssetInputs proves one atomic transfer commits
+// one checkpoint per asset input, merges every checkpoint into a single Ark
+// transition (spine first), splits recipient and change units, and sums the
+// carrier plan across mixed leaf origins.
+func TestPreparerMergesMultipleAssetInputs(t *testing.T) {
+	t.Parallel()
+
+	fixture := testMultiInputPreparationRequest(t)
+	request := fixture.request
+	store, err := NewFileStore(t.TempDir())
+	require.NoError(t, err)
+	reservations := &fakeReservationStore{}
+	preparer := newMultiInputPreparer(fixture, store, reservations)
+
+	prepared, err := preparer.PrepareTaprootAssetOOR(t.Context(), request)
+	require.NoError(t, err)
+	require.NoError(t, prepared.Validate(request))
+
+	// Two checkpoint commits and one Ark commit.
+	require.Len(t, fixture.driver.requests, 3)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		checkpointRequest := fixture.driver.requests[ordinal]
+		require.Len(t, checkpointRequest.Inputs, 1)
+		require.Len(t, checkpointRequest.Outputs, 1)
+		require.Equal(
+			t, "wavelength-checkpoint",
+			checkpointRequest.Outputs[0].ID,
+		)
+		require.Equal(
+			t, request.Inputs[ordinal].VTXO.TaprootAssetAmount,
+			checkpointRequest.Outputs[0].Amount,
+		)
+		require.Equal(
+			t, uint64(request.Inputs[ordinal].VTXO.Amount),
+			checkpointRequest.Outputs[0].AnchorValueSat,
+		)
+	}
+
+	// Distinct deterministic OP_TRUE key domains per checkpoint ordinal.
+	require.NotEqual(
+		t,
+		fixture.driver.requests[0].Outputs[0].Script.OPTrue.InternalKey,
+		fixture.driver.requests[1].Outputs[0].Script.OPTrue.InternalKey,
+	)
+
+	// One Ark transition: the spine is input 0, the co-input follows in
+	// intent order, each carrying its own per-input amount and appended
+	// checkpoint step.
+	arkRequest := fixture.driver.requests[2]
+	require.Len(t, arkRequest.Inputs, 2)
+	require.Equal(t, "wavelength-checkpoint", arkRequest.Inputs[0].ID)
+	require.Equal(t, "wavelength-checkpoint/1", arkRequest.Inputs[1].ID)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		transitionInput := arkRequest.Inputs[ordinal]
+		require.Equal(
+			t, request.Inputs[ordinal].VTXO.TaprootAssetAmount,
+			transitionInput.Amount,
+		)
+		require.NotNil(t, transitionInput.ProofPath)
+		require.Len(t, transitionInput.ProofPath.Steps, 2)
+	}
+
+	// Merge-and-split: 150 units to the receiver, 50 units change, both
+	// on operator-floor carriers.
+	require.Len(t, arkRequest.Outputs, 2)
+	require.Equal(t, receiverOutputID, arkRequest.Outputs[0].ID)
+	require.Equal(t, uint64(150), arkRequest.Outputs[0].Amount)
+	require.Equal(t, changeOutputID, arkRequest.Outputs[1].ID)
+	require.Equal(t, uint64(50), arkRequest.Outputs[1].Amount)
+
+	// Reclaim interplay: the round-created spine's carrier returns to the
+	// sender; the OOR-created co-input's carrier joins the operator
+	// change on top of the float residual.
+	require.Len(t, prepared.Recipients, 4)
+	require.Equal(t, btcutil.Amount(1_000), prepared.Recipients[0].Value)
+	require.Equal(
+		t, uint64(150), prepared.Recipients[0].TaprootAssetAmount,
+	)
+	require.Equal(t, btcutil.Amount(1_000), prepared.Recipients[1].Value)
+	require.Equal(
+		t, uint64(50), prepared.Recipients[1].TaprootAssetAmount,
+	)
+	require.Equal(
+		t, request.Inputs[0].VTXO.Amount, prepared.Recipients[2].Value,
+	)
+	require.Nil(t, prepared.Recipients[2].TaprootAssetRoot)
+	require.Equal(
+		t, btcutil.Amount(30_000)-2_000+request.Inputs[1].VTXO.Amount,
+		prepared.Recipients[3].Value,
+	)
+	require.Equal(
+		t, request.Lease.PkScript, prepared.Recipients[3].PkScript,
+	)
+
+	// The sealed container fills one checkpoint package slot per asset
+	// input, at the transfer-input positions.
+	require.Equal(
+		t, [][]byte{
+			fakeCheckpointPackageName(
+				request.Inputs[0].
+					VTXO.Outpoint,
+			),
+			fakeCheckpointPackageName(
+				request.Inputs[1].
+					VTXO.Outpoint,
+			),
+			nil,
+		},
+		prepared.PreparedSubmit.TaprootAssetTransfer.CheckpointPackages,
+	)
+
+	// Both wallet inputs are quarantined under the preparation owner.
+	records := reservations.records()
+	require.Len(t, records, 2)
+	require.Equal(t, request.Inputs[0].VTXO.Outpoint, records[0].outpoint)
+	require.Equal(t, request.Inputs[1].VTXO.Outpoint, records[1].outpoint)
+
+	// Restart restores every sealed package without new tapd commits.
+	restarted := newMultiInputPreparer(fixture, store, reservations)
+	restored, err := restarted.PrepareTaprootAssetOOR(t.Context(), request)
+	require.NoError(t, err)
+	require.Len(t, fixture.driver.requests, 3)
+	require.Equal(
+		t, prepared.PreparedSubmit.TaprootAssetTransfer,
+		restored.PreparedSubmit.TaprootAssetTransfer,
+	)
+	require.Equal(t, prepared.Recipients, restored.Recipients)
+
+	resume, err := restarted.ResumeTaprootAssetOOR(
+		t.Context(), testResumeRequest(request),
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, request.Intent.InputVTXOOutpoints, resume.InputOutpoints,
+	)
+}
+
+// TestPreparerResumesPartialCheckpointCommits proves a known-negative
+// failure between two checkpoint commits retries only the missing
+// checkpoint and the Ark transition, reusing the journaled first package.
+func TestPreparerResumesPartialCheckpointCommits(t *testing.T) {
+	t.Parallel()
+
+	fixture := testMultiInputPreparationRequest(t)
+	request := fixture.request
+	store, err := NewFileStore(t.TempDir())
+	require.NoError(t, err)
+	reservations := &fakeReservationStore{}
+	preparer := newMultiInputPreparer(fixture, store, reservations)
+
+	fixture.driver.commitErrs = []error{
+		nil, errors.New("second checkpoint rejected"),
+	}
+	_, err = preparer.PrepareTaprootAssetOOR(t.Context(), request)
+	require.ErrorContains(t, err, "second checkpoint rejected")
+	require.ErrorIs(t, err, ErrReconciliationRequired)
+	require.Len(t, fixture.driver.requests, 2)
+
+	restarted := newMultiInputPreparer(fixture, store, reservations)
+	prepared, err := restarted.PrepareTaprootAssetOOR(t.Context(), request)
+	require.NoError(t, err)
+	require.NoError(t, prepared.Validate(request))
+	require.Len(t, fixture.driver.requests, 4)
+	require.Equal(
+		t, "wavelength-checkpoint",
+		fixture.driver.requests[2].Outputs[0].ID,
+	)
+	require.Equal(
+		t, request.Inputs[1].VTXO.TaprootAssetAmount,
+		fixture.driver.requests[2].Outputs[0].Amount,
+	)
+}
+
+// TestPreparationIntentDigestIgnoresSelection proves the intent digest stays
+// stable across different resolutions of the same logical send, so a
+// daemon-selected retry resolves the journal its earlier attempt wrote.
+func TestPreparationIntentDigestIgnoresSelection(t *testing.T) {
+	t.Parallel()
+
+	operator := testPrivateKey(t, 2)
+	newResume := func(outpoints []wire.OutPoint, total,
+		recipientUnits uint64) *oor.TaprootAssetOORResumeRequest {
+
+		return &oor.TaprootAssetOORResumeRequest{
+			RequestID: "digest-request",
+			Policy: arkscript.CheckpointPolicy{
+				OperatorKey: operator.PubKey(),
+				CSVDelay:    10,
+			},
+			Recipients: []oortx.RecipientOutput{{
+				PkScript: []byte{
+					0x51,
+				},
+				Value: 1_000,
+				VTXOPolicyTemplate: []byte{
+					0x01,
+				},
+			}},
+			OutputFloor: 1_000,
+			Intent: oor.TaprootAssetOORIntent{
+				InputVTXOOutpoints:   outpoints,
+				AssetRef:             "tapr1asset",
+				AssetAmount:          total,
+				RecipientAssetAmount: recipientUnits,
+			},
+		}
+	}
+
+	unresolved := newResume(nil, 100, 0)
+	singleInput := newResume(
+		[]wire.OutPoint{{Index: 1}}, 100, 0,
+	)
+	multiInput := newResume(
+		[]wire.OutPoint{
+			{Index: 1},
+			{Index: 2},
+		},
+		150,
+		100,
+	)
+
+	unresolvedDigest, err := preparationIntentDigest(unresolved)
+	require.NoError(t, err)
+	singleDigest, err := preparationIntentDigest(singleInput)
+	require.NoError(t, err)
+	multiDigest, err := preparationIntentDigest(multiInput)
+	require.NoError(t, err)
+	require.Equal(t, unresolvedDigest, singleDigest)
+	require.Equal(t, unresolvedDigest, multiDigest)
+
+	otherSend := newResume(nil, 99, 0)
+	otherDigest, err := preparationIntentDigest(otherSend)
+	require.NoError(t, err)
+	require.NotEqual(t, unresolvedDigest, otherDigest)
+}
+
+// TestPreparationRequestDigestBindsInputOrder proves the request digest pins
+// the ordered asset input set, so a journaled preparation can never be
+// replayed against a reordered or substituted selection.
+func TestPreparationRequestDigestBindsInputOrder(t *testing.T) {
+	t.Parallel()
+
+	fixture := testMultiInputPreparationRequest(t)
+	request := fixture.request
+	first, err := preparationRequestDigest(request)
+	require.NoError(t, err)
+	repeat, err := preparationRequestDigest(request)
+	require.NoError(t, err)
+	require.Equal(t, first, repeat)
+
+	reordered := *request
+	reordered.Inputs = []oor.TransferInput{
+		request.Inputs[1], request.Inputs[0], request.Inputs[2],
+	}
+	reordered.Intent.InputVTXOOutpoints = []wire.OutPoint{
+		request.Intent.InputVTXOOutpoints[1],
+		request.Intent.InputVTXOOutpoints[0],
+	}
+	swapped, err := preparationRequestDigest(&reordered)
+	require.NoError(t, err)
+	require.NotEqual(t, first, swapped)
+}

--- a/tapassets/partial_preparer_test.go
+++ b/tapassets/partial_preparer_test.go
@@ -100,7 +100,12 @@ func TestPreparerBuildsPartialAssetTransferFromOperatorFloat(t *testing.T) {
 	// position rather than the canonically sorted Ark-input position.
 	require.Len(t, prepared.PreparedSubmit.CheckpointPSBTs, 2)
 	require.Equal(
-		t, [][]byte{[]byte("checkpoint-package"), nil},
+		t, [][]byte{
+			fakeCheckpointPackageName(
+				request.Inputs[0].VTXO.Outpoint,
+			),
+			nil,
+		},
 		prepared.PreparedSubmit.TaprootAssetTransfer.CheckpointPackages,
 	)
 	require.Len(t, driver.requests, 2)

--- a/tapassets/partial_preparer_test.go
+++ b/tapassets/partial_preparer_test.go
@@ -212,6 +212,48 @@ func TestPreparerBuildsPartialAssetTransferFromOperatorFloat(t *testing.T) {
 	require.Len(t, reservations.records(), 2)
 }
 
+// TestPreparerReclaimsOORCreatedCarrier proves a full send of an OOR-created
+// leaf derives no wallet change at all and pays the reclaimed carrier to the
+// lease script on top of the float residual.
+func TestPreparerReclaimsOORCreatedCarrier(t *testing.T) {
+	t.Parallel()
+
+	request, inventory := testPreparationRequest(t)
+	request.Inputs[0].TaprootAssetRoundCreated = false
+
+	var changeCalls int
+	builder := testChangeRecipientBuilder(t, request.Policy.OperatorKey, 10)
+	request.BuildChangeRecipient = func(ctx context.Context,
+		value btcutil.Amount) (oortx.RecipientOutput, error) {
+
+		changeCalls++
+
+		return builder(ctx, value)
+	}
+	require.NoError(t, request.Validate())
+
+	driver := newFakeDriver()
+	store, err := NewFileStore(t.TempDir())
+	require.NoError(t, err)
+	preparer := newTestPreparer(driver, inventory, store)
+	prepared, err := preparer.PrepareTaprootAssetOOR(t.Context(), request)
+	require.NoError(t, err)
+	require.NoError(t, prepared.Validate(request))
+
+	// 30_000 sat lease, one 1_000 sat floor for the receiver leaf, and
+	// the 5_000 sat OOR-created carrier reclaimed on top of the residual.
+	require.Zero(t, changeCalls)
+	require.Len(t, prepared.Recipients, 2)
+	require.Equal(t, btcutil.Amount(1_000), prepared.Recipients[0].Value)
+	require.NotNil(t, prepared.Recipients[0].TaprootAssetRoot)
+	require.Equal(t, btcutil.Amount(34_000), prepared.Recipients[1].Value)
+	require.Equal(
+		t, request.Lease.PkScript, prepared.Recipients[1].PkScript,
+	)
+	require.Nil(t, prepared.Recipients[1].TaprootAssetRoot)
+	require.Equal(t, prepared.Recipients[0], prepared.Receiver)
+}
+
 // TestEncodeBIP371TapTreePreservesArkShape proves the standard depth-first
 // tuples reconstruct the exact Ark root for balanced and non-power-of-two
 // policy shapes.

--- a/tapassets/partial_preparer_test.go
+++ b/tapassets/partial_preparer_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -17,70 +16,40 @@ import (
 	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
 	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
 	"github.com/lightninglabs/wavelength/oor"
-	"github.com/lightninglabs/wavelength/vtxo"
-	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
 
-// TestPreparerBuildsPartialAssetTransferWithCarrierTopUp proves an asset input
-// can be supplemented by a Bitcoin-only VTXO while the asset allocation and
-// all three carrier outputs remain explicit and independently conserved.
-func TestPreparerBuildsPartialAssetTransferWithCarrierTopUp(t *testing.T) {
+// TestPreparerBuildsPartialAssetTransferFromOperatorFloat proves a partial
+// send funds both new asset leaves at the operator floor out of the leased
+// float, returns the sender's full carrier, and pays the float residual back
+// to the lease script.
+func TestPreparerBuildsPartialAssetTransferFromOperatorFloat(t *testing.T) {
 	t.Parallel()
 
 	request, inventory := testPreparationRequest(t)
-	assetInput := request.Inputs[0]
+	assetInput := &request.Inputs[0]
 	assetInput.VTXO.Amount = 500
 	assetInput.VTXO.TaprootAssetAmount = 1_000
 	request.Intent.AssetAmount = 1_000
 	request.Intent.RecipientAssetAmount = 800
-	request.Intent.AssetChangeCarrierValueSat = 500
-	request.Recipients[0].Value = 700
+	request.Intent.InputVTXOOutpoint = assetInput.VTXO.Outpoint
+	request.Recipients[0].Value = 300
 	request.OutputFloor = 300
 	inventory.onlyAnchor().Assets[0].Amount = 1_000
 	inventory.verification.DecodedProof.Amount = 1_000
-
-	bitcoinInput := testBitcoinInput(
-		t, request.Policy.OperatorKey, 1_000,
-	)
-	request.Inputs = []oor.TransferInput{bitcoinInput, assetInput}
-	require.NoError(
-		t, oor.NormalizeCheckpointOwnerLeaves(
-			request.Policy, request.Inputs,
-		),
-	)
 
 	var (
 		changeCalls  int
 		changeValues []btcutil.Amount
 	)
-	request.BuildChangeRecipient = func(_ context.Context,
+	builder := testChangeRecipientBuilder(t, request.Policy.OperatorKey, 10)
+	request.BuildChangeRecipient = func(ctx context.Context,
 		value btcutil.Amount) (oortx.RecipientOutput, error) {
 
 		changeCalls++
 		changeValues = append(changeValues, value)
-		owner := testPrivateKey(t, byte(10+changeCalls))
-		policy, err := arkscript.NewVTXOPolicy(
-			owner.PubKey(), request.Policy.OperatorKey,
-			request.Policy.CSVDelay,
-		)
-		if err != nil {
-			return oortx.RecipientOutput{}, err
-		}
-		template, err := policy.Template.Encode()
-		if err != nil {
-			return oortx.RecipientOutput{}, err
-		}
-		pkScript, err := policy.Template.PkScript()
-		if err != nil {
-			return oortx.RecipientOutput{}, err
-		}
 
-		return oortx.RecipientOutput{
-			PkScript:           pkScript,
-			Value:              value,
-			VTXOPolicyTemplate: template,
-		}, nil
+		return builder(ctx, value)
 	}
 	require.NoError(t, request.Validate())
 
@@ -97,24 +66,30 @@ func TestPreparerBuildsPartialAssetTransferWithCarrierTopUp(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, prepared.Validate(request))
 
-	// The input's 500 carrier sats cannot fund the 700-sat receiver and
-	// 500-sat asset change alone. The Bitcoin-only input tops up the graph,
-	// leaving an ordinary 300-sat Bitcoin change VTXO.
+	// The wallet derives the asset-change and sender-change scripts; the
+	// operator change reuses the lease script verbatim.
 	require.Equal(t, 2, changeCalls)
 	require.Equal(
-		t, []btcutil.Amount{500, 300}, changeValues,
+		t, []btcutil.Amount{300, 500}, changeValues,
 	)
-	require.Len(t, prepared.Recipients, 3)
-	require.Equal(t, btcutil.Amount(700), prepared.Recipients[0].Value)
+	require.Len(t, prepared.Recipients, 4)
+	require.Equal(t, btcutil.Amount(300), prepared.Recipients[0].Value)
 	require.Equal(t, uint64(800), prepared.Recipients[0].TaprootAssetAmount)
 	require.NotNil(t, prepared.Recipients[0].TaprootAssetRoot)
-	require.Equal(t, btcutil.Amount(500), prepared.Recipients[1].Value)
+	require.Equal(t, btcutil.Amount(300), prepared.Recipients[1].Value)
 	require.Equal(t, uint64(200), prepared.Recipients[1].TaprootAssetAmount)
 	require.NotNil(t, prepared.Recipients[1].TaprootAssetRoot)
-	require.Equal(t, btcutil.Amount(300), prepared.Recipients[2].Value)
+	require.Equal(t, btcutil.Amount(500), prepared.Recipients[2].Value)
 	require.Nil(t, prepared.Recipients[2].TaprootAssetRoot)
 	require.Empty(t, prepared.Recipients[2].TaprootAssetRef)
 	require.Zero(t, prepared.Recipients[2].TaprootAssetAmount)
+	require.Equal(
+		t, btcutil.Amount(29_400), prepared.Recipients[3].Value,
+	)
+	require.Equal(
+		t, request.Lease.PkScript, prepared.Recipients[3].PkScript,
+	)
+	require.Nil(t, prepared.Recipients[3].TaprootAssetRoot)
 	require.Equal(t, prepared.Recipients[0], prepared.Receiver)
 	require.NotEqual(t, prepared.Recipients[1], prepared.Receiver)
 
@@ -123,7 +98,7 @@ func TestPreparerBuildsPartialAssetTransferWithCarrierTopUp(t *testing.T) {
 	// position rather than the canonically sorted Ark-input position.
 	require.Len(t, prepared.PreparedSubmit.CheckpointPSBTs, 2)
 	require.Equal(
-		t, [][]byte{nil, []byte("checkpoint-package")},
+		t, [][]byte{[]byte("checkpoint-package"), nil},
 		prepared.PreparedSubmit.TaprootAssetTransfer.CheckpointPackages,
 	)
 	require.Len(t, driver.requests, 2)
@@ -135,10 +110,10 @@ func TestPreparerBuildsPartialAssetTransferWithCarrierTopUp(t *testing.T) {
 	require.Len(t, arkRequest.Outputs, 2)
 	require.Equal(t, receiverOutputID, arkRequest.Outputs[0].ID)
 	require.Equal(t, uint64(800), arkRequest.Outputs[0].Amount)
-	require.Equal(t, uint64(700), arkRequest.Outputs[0].AnchorValueSat)
+	require.Equal(t, uint64(300), arkRequest.Outputs[0].AnchorValueSat)
 	require.Equal(t, changeOutputID, arkRequest.Outputs[1].ID)
 	require.Equal(t, uint64(200), arkRequest.Outputs[1].Amount)
-	require.Equal(t, uint64(500), arkRequest.Outputs[1].AnchorValueSat)
+	require.Equal(t, uint64(300), arkRequest.Outputs[1].AnchorValueSat)
 	for idx := range arkRequest.Outputs {
 		require.Equal(
 			t, tapsdk.CustomAssetScriptOPTrue,
@@ -147,40 +122,36 @@ func TestPreparerBuildsPartialAssetTransferWithCarrierTopUp(t *testing.T) {
 		require.NotNil(t, arkRequest.Outputs[idx].Script.OPTrue)
 	}
 
-	// Each signing plan points at the actual BIP-69-sorted Ark input for
-	// the corresponding transfer checkpoint, not its caller-side index.
+	// Both non-asset outputs carry complete BIP-371 metadata: the sender's
+	// change from its wallet policy, the operator's change from the lease
+	// policy.
 	ark, err := psbtutil.Parse(arkRequest.AnchorPSBT)
 	require.NoError(t, err)
-	bitcoinChangeIndex, err := oortx.RecipientOutputIndex(
-		prepared.Recipients, prepared.Recipients[2],
-	)
-	require.NoError(t, err)
-	require.Zero(
-		t, bitcoinChangeIndex, "the 300-sat Bitcoin change must "+
-			"move from caller position 2 to canonical position 0",
-	)
-	bitcoinChangeOutput := ark.Outputs[bitcoinChangeIndex]
-	_, bitcoinChangePolicy, err := recipientAnchorPlan(
-		prepared.Recipients[2],
-	)
-	require.NoError(t, err)
-	require.Equal(
-		t, schnorr.SerializePubKey(bitcoinChangePolicy.InternalKey),
-		bitcoinChangeOutput.TaprootInternalKey,
-	)
-	bitcoinChangeRoot := assertBIP371TapTree(
-		t, bitcoinChangeOutput.TaprootTapTree, bitcoinChangePolicy,
-	)
-	require.Equal(
-		t, bitcoinChangePolicy.RootHash, bitcoinChangeRoot[:],
-	)
-	privateTapTree, err := arkscript.EncodeTapTree(bitcoinChangePolicy)
-	require.NoError(t, err)
-	require.NotEqual(
-		t, privateTapTree, bitcoinChangeOutput.TaprootTapTree, "Wave"+
-			"length's count-prefixed checkpoint encoding is "+
-			"not BIP-371",
-	)
+	for _, recipientIndex := range []int{2, 3} {
+		recipient := prepared.Recipients[recipientIndex]
+		outputIndex, err := oortx.RecipientOutputIndex(
+			prepared.Recipients, recipient,
+		)
+		require.NoError(t, err)
+		output := ark.Outputs[outputIndex]
+		_, policy, err := recipientAnchorPlan(recipient)
+		require.NoError(t, err)
+		require.Equal(
+			t, schnorr.SerializePubKey(policy.InternalKey),
+			output.TaprootInternalKey,
+		)
+		root := assertBIP371TapTree(
+			t, output.TaprootTapTree, policy,
+		)
+		require.Equal(t, policy.RootHash, root[:])
+		privateTapTree, err := arkscript.EncodeTapTree(policy)
+		require.NoError(t, err)
+		require.NotEqual(
+			t, privateTapTree, output.TaprootTapTree, "Wavelengt"+
+				"h's count-prefixed checkpoint encoding is "+
+				"not BIP-371",
+		)
+	}
 	for idx := range arkRequest.Outputs {
 		anchorIndex := arkRequest.Outputs[idx].AnchorOutputIndex
 		assetOutput := ark.Outputs[anchorIndex]
@@ -190,6 +161,11 @@ func TestPreparerBuildsPartialAssetTransferWithCarrierTopUp(t *testing.T) {
 	p2aOutput := ark.Outputs[len(ark.Outputs)-1]
 	require.Empty(t, p2aOutput.TaprootInternalKey)
 	require.Empty(t, p2aOutput.TaprootTapTree)
+
+	// Each signing plan points at the actual BIP-69-sorted Ark input for
+	// the corresponding transfer checkpoint, not its caller-side index.
+	// The float input's plan requires the lease policy's own collab pair
+	// instead of a wallet client key.
 	require.Len(t, arkRequest.SigningPlans, 2)
 	for idx := range request.Inputs {
 		checkpoint := prepared.PreparedSubmit.CheckpointPSBTs[idx]
@@ -203,9 +179,25 @@ func TestPreparerBuildsPartialAssetTransferWithCarrierTopUp(t *testing.T) {
 			t, want, arkRequest.SigningPlans[idx].InputIndex,
 		)
 	}
+	floatSigners, err := ownerLeafSigners(&request.Inputs[1])
+	require.NoError(t, err)
+	require.Len(t, floatSigners, 2)
+	wantFloatSigners := make([]tapsdk.XOnlyPubKey, 0, len(floatSigners))
+	for _, signer := range floatSigners {
+		key, err := tapsdk.ParseXOnlyPubKey(
+			schnorr.SerializePubKey(signer),
+		)
+		require.NoError(t, err)
+		wantFloatSigners = append(wantFloatSigners, key)
+	}
+	require.Equal(
+		t, wantFloatSigners,
+		arkRequest.SigningPlans[1].ScriptPath.RequiredSigners,
+	)
 
-	// Restart uses the persisted change policies and sealed packages. It
-	// neither derives new addresses nor repeats a tapd commit.
+	// Restart uses the persisted change policies, lease journal, and
+	// sealed packages. It neither derives new addresses nor repeats a
+	// tapd commit.
 	restarted := newTestPreparer(
 		driver, inventory, store, reservations,
 	)
@@ -217,7 +209,7 @@ func TestPreparerBuildsPartialAssetTransferWithCarrierTopUp(t *testing.T) {
 	require.Len(t, driver.requests, 2)
 	require.Equal(t, prepared.Recipients, restored.Recipients)
 	require.Equal(t, prepared.Receiver, restored.Receiver)
-	require.Len(t, reservations.records(), 4)
+	require.Len(t, reservations.records(), 2)
 }
 
 // TestEncodeBIP371TapTreePreservesArkShape proves the standard depth-first
@@ -357,7 +349,6 @@ func TestPreparerRejectsInvalidRecipientPlansBeforeReservation(t *testing.T) {
 				request.Recipients[0].Value = 500
 				request.OutputFloor = 500
 				request.Intent.RecipientAssetAmount = 10
-				request.Intent.AssetChangeCarrierValueSat = 500
 				request.BuildChangeRecipient = func(
 					_ context.Context,
 					value btcutil.Amount) (
@@ -460,7 +451,6 @@ func TestPreparerBoundsCanonicalOrderingCycles(t *testing.T) {
 	request.Recipients[0].Value = 500
 	request.OutputFloor = 500
 	request.Intent.RecipientAssetAmount = 10
-	request.Intent.AssetChangeCarrierValueSat = 500
 	request.BuildChangeRecipient = func(_ context.Context,
 		value btcutil.Amount) (oortx.RecipientOutput, error) {
 
@@ -615,50 +605,4 @@ func previewForRoot(output tapsdk.CustomAssetOutput, assetRoot tapsdk.Hash) (
 		assetRoot:         assetRoot,
 		merkleRoot:        tapsdk.Hash(combined),
 	}, pkScript, nil
-}
-
-// testBitcoinInput returns one standard, asset-free VTXO suitable for carrier
-// top-ups in mixed Taproot Asset preparation tests.
-func testBitcoinInput(t *testing.T, operator *btcec.PublicKey,
-	amount btcutil.Amount) oor.TransferInput {
-
-	t.Helper()
-	owner := testPrivateKey(t, 9)
-	policy, err := arkscript.NewVTXOPolicy(owner.PubKey(), operator, 10)
-	require.NoError(t, err)
-	template, err := policy.Template.Encode()
-	require.NoError(t, err)
-	pkScript, err := policy.Template.PkScript()
-	require.NoError(t, err)
-	legacyTapScript, err := arkscript.VTXOTapScript(
-		owner.PubKey(), operator, 10,
-	)
-	require.NoError(t, err)
-
-	return oor.TransferInput{
-		VTXO: &vtxo.Descriptor{
-			Outpoint: wire.OutPoint{
-				Hash: chainhash.Hash(
-					sha256Bytes(
-						[]byte("bitcoin-input"),
-					),
-				),
-				Index: 2,
-			},
-			Amount:   amount,
-			PkScript: pkScript,
-			ClientKey: keychain.KeyDescriptor{
-				KeyLocator: keychain.KeyLocator{
-					Family: 1,
-					Index:  9,
-				},
-				PubKey: owner.PubKey(),
-			},
-			OperatorKey:    operator,
-			TapScript:      legacyTapScript,
-			RelativeExpiry: 10,
-			Status:         vtxo.VTXOStatusLive,
-		},
-		VTXOPolicyTemplate: template,
-	}
 }

--- a/tapassets/partial_preparer_test.go
+++ b/tapassets/partial_preparer_test.go
@@ -32,7 +32,9 @@ func TestPreparerBuildsPartialAssetTransferFromOperatorFloat(t *testing.T) {
 	assetInput.VTXO.TaprootAssetAmount = 1_000
 	request.Intent.AssetAmount = 1_000
 	request.Intent.RecipientAssetAmount = 800
-	request.Intent.InputVTXOOutpoint = assetInput.VTXO.Outpoint
+	request.Intent.InputVTXOOutpoints = []wire.OutPoint{
+		assetInput.VTXO.Outpoint,
+	}
 	request.Recipients[0].Value = 300
 	request.OutputFloor = 300
 	inventory.onlyAnchor().Assets[0].Amount = 1_000

--- a/tapassets/preparer.go
+++ b/tapassets/preparer.go
@@ -121,10 +121,16 @@ func (p *Preparer) PrepareTaprootAssetOOR(ctx context.Context,
 	if err := request.Validate(); err != nil {
 		return nil, err
 	}
-	assetInputIndex, err := request.AssetInputIndex()
+	assetInputIndices, err := request.AssetInputIndices()
 	if err != nil {
 		return nil, err
 	}
+	if len(assetInputIndices) != 1 {
+		return nil, fmt.Errorf("taproot asset preparer supports "+
+			"exactly one asset input, got %d",
+			len(assetInputIndices))
+	}
+	assetInputIndex := assetInputIndices[0]
 	for idx := range request.Inputs {
 		if request.Inputs[idx].CustomSpend != nil ||
 			len(request.Inputs[idx].ExternalSignatures) != 0 {
@@ -999,11 +1005,13 @@ func preparationIntentDigest(request *oor.TaprootAssetOORResumeRequest) (
 	_ = binary.Write(
 		&value, binary.BigEndian, uint64(request.OutputFloor),
 	)
-	writeDigestBytes(&value, request.Intent.InputVTXOOutpoint.Hash[:])
-	_ = binary.Write(
-		&value, binary.BigEndian,
-		request.Intent.InputVTXOOutpoint.Index,
-	)
+	if len(request.Intent.InputVTXOOutpoints) != 1 {
+		return tapsdk.Hash{}, fmt.Errorf("Taproot Asset OOR intent " +
+			"requires exactly one input outpoint")
+	}
+	spineOutpoint := request.Intent.InputVTXOOutpoints[0]
+	writeDigestBytes(&value, spineOutpoint.Hash[:])
+	_ = binary.Write(&value, binary.BigEndian, spineOutpoint.Index)
 	writeDigestBytes(&value, []byte(request.Intent.AssetRef))
 	_ = binary.Write(&value, binary.BigEndian, request.Intent.AssetAmount)
 	_ = binary.Write(

--- a/tapassets/preparer.go
+++ b/tapassets/preparer.go
@@ -77,6 +77,7 @@ type preparationState struct {
 	ArkPackage        []byte                  `json:"ark_package,omitempty"`
 	PlannedRecipients []oortx.RecipientOutput `json:"planned_recipients,omitempty"` //nolint:ll
 	OrderingNonce     uint32                  `json:"ordering_nonce,omitempty"`     //nolint:ll
+	CarrierLease      *oor.OORCarrierLease    `json:"carrier_lease,omitempty"`      //nolint:ll
 }
 
 // NewPreparer constructs a production tap-sdk-backed OOR preparer.
@@ -151,9 +152,12 @@ func (p *Preparer) PrepareTaprootAssetOOR(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	// The float input is not a wallet VTXO: it must never enter the
+	// wallet-side reservation journal, which precondition-checks every
+	// outpoint against a local Spending row.
 	state, err := p.loadState(
 		ctx, request.RequestID, digest, intentDigest,
-		oor.InputOutpoints(request.Inputs),
+		oor.WalletInputOutpoints(request.Inputs),
 	)
 	if err != nil {
 		return nil, err
@@ -162,6 +166,9 @@ func (p *Preparer) PrepareTaprootAssetOOR(ctx context.Context,
 		return nil, fmt.Errorf("%w: %s commit for request %q",
 			ErrReconciliationRequired, state.Attempt,
 			request.RequestID)
+	}
+	if err := p.journalCarrierLease(ctx, request, state); err != nil {
+		return nil, err
 	}
 	recipients, err := p.plannedRecipients(ctx, request, state)
 	if err != nil {
@@ -236,6 +243,42 @@ func (p *Preparer) PrepareTaprootAssetOOR(ctx context.Context,
 	}
 
 	return prepared, nil
+}
+
+// journalCarrierLease adopts the request's carrier lease into the durable
+// state on first sight and afterwards holds the journal authoritative: an
+// idempotent replay must reuse the exact float funding the graph committed
+// to, never a fresh lease.
+func (p *Preparer) journalCarrierLease(ctx context.Context,
+	request *oor.TaprootAssetOORPrepareRequest,
+	state *preparationState) error {
+
+	if state.CarrierLease != nil {
+		if !state.CarrierLease.FundingEquals(request.Lease) {
+			return fmt.Errorf("Taproot Asset OOR idempotency key " +
+				"reused with a different carrier lease")
+		}
+
+		return nil
+	}
+
+	// A committed journal without a lease predates carrier funding and
+	// cannot be adopted safely.
+	if len(state.CheckpointPackage) != 0 || len(state.ArkPackage) != 0 {
+		return fmt.Errorf("%w: committed request %q has no journaled "+
+			"carrier lease", ErrReconciliationRequired,
+			request.RequestID)
+	}
+
+	state.CarrierLease = request.Lease.Clone()
+	if err := p.storeState(ctx, request.RequestID, state); err != nil {
+		state.CarrierLease = nil
+
+		return fmt.Errorf("persist Taproot Asset carrier lease: %w",
+			err)
+	}
+
+	return nil
 }
 
 // ensureReservationSet either atomically acquires/revalidates preparation
@@ -421,6 +464,7 @@ func (p *Preparer) ResumeTaprootAssetOOR(ctx context.Context,
 
 	return &oor.TaprootAssetOORResume{
 		InputOutpoints: cloneOutpoints(state.InputOutpoints),
+		Lease:          state.CarrierLease.Clone(),
 	}, nil
 }
 
@@ -500,6 +544,7 @@ func (p *Preparer) loadState(ctx context.Context, requestID string,
 		state.InputOutpoints = cloneOutpoints(inputOutpoints)
 		state.PlannedRecipients = nil
 		state.OrderingNonce = 0
+		state.CarrierLease = nil
 		if err := p.storeState(ctx, requestID, state); err != nil {
 			return nil, fmt.Errorf("rebind Taproot Asset carrier "+
 				"selection: %w", err)

--- a/tapassets/preparer.go
+++ b/tapassets/preparer.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -26,7 +27,7 @@ import (
 )
 
 const (
-	preparationStateVersion = uint16(2)
+	preparationStateVersion = uint16(3)
 	attemptCheckpoint       = "checkpoint"
 	attemptArk              = "ark"
 	opTrueKeyDomain         = "wavelength/taproot-assets-oor/optrue/v0/"
@@ -56,6 +57,12 @@ type PreparerConfig struct {
 	LoadCreatedPackage CreatedPackageLoader
 }
 
+// proofPathVerifier is the preflight seam running tap-sdk's complete path
+// verification. It exists as a function value so graph-orchestration tests
+// can fake the SDK boundary without real proof material.
+type proofPathVerifier func(context.Context, *tapsdk.AssetProofPath,
+	tapsdk.ConfirmedProofVerifier) error
+
 // Preparer commits the checkpoint and Ark asset transitions before handing a
 // sealed, immutable package to Wavelength's outgoing OOR actor.
 type Preparer struct {
@@ -64,20 +71,45 @@ type Preparer struct {
 	store              Store
 	reservations       oor.ReservationSetStore
 	loadCreatedPackage CreatedPackageLoader
+	verifyProofPath    proofPathVerifier
 	mu                 sync.Mutex
 }
 
 type preparationState struct {
-	Version           uint16                  `json:"version"`
-	IntentDigest      tapsdk.Hash             `json:"intent_digest"`
-	RequestDigest     tapsdk.Hash             `json:"request_digest"`
-	InputOutpoints    []wire.OutPoint         `json:"input_outpoints"`
-	Attempt           string                  `json:"attempt,omitempty"`
-	CheckpointPackage []byte                  `json:"checkpoint_package,omitempty"` //nolint:ll
+	Version        uint16          `json:"version"`
+	IntentDigest   tapsdk.Hash     `json:"intent_digest"`
+	RequestDigest  tapsdk.Hash     `json:"request_digest"`
+	InputOutpoints []wire.OutPoint `json:"input_outpoints"`
+	Attempt        string          `json:"attempt,omitempty"`
+
+	// CheckpointPackages holds one sealed checkpoint package per asset
+	// input, indexed by the intent's spine-first input order.
+	CheckpointPackages [][]byte `json:"checkpoint_packages,omitempty"` //nolint:ll
+
 	ArkPackage        []byte                  `json:"ark_package,omitempty"`
 	PlannedRecipients []oortx.RecipientOutput `json:"planned_recipients,omitempty"` //nolint:ll
 	OrderingNonce     uint32                  `json:"ordering_nonce,omitempty"`     //nolint:ll
 	CarrierLease      *oor.OORCarrierLease    `json:"carrier_lease,omitempty"`      //nolint:ll
+}
+
+// hasCommittedPackages reports whether any external tapd commit is journaled.
+func (s *preparationState) hasCommittedPackages() bool {
+	if len(s.ArkPackage) != 0 {
+		return true
+	}
+	for _, checkpointPackage := range s.CheckpointPackages {
+		if len(checkpointPackage) != 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// checkpointAttempt returns the journal marker and deterministic key domain
+// of one asset input's checkpoint commit.
+func checkpointAttempt(ordinal int) string {
+	return fmt.Sprintf("%s/%d", attemptCheckpoint, ordinal)
 }
 
 // NewPreparer constructs a production tap-sdk-backed OOR preparer.
@@ -102,7 +134,17 @@ func NewPreparer(cfg PreparerConfig) (*Preparer, error) {
 		store:              cfg.Store,
 		reservations:       cfg.ReservationStore,
 		loadCreatedPackage: cfg.LoadCreatedPackage,
+		verifyProofPath:    verifyAssetProofPath,
 	}, nil
+}
+
+// verifyAssetProofPath runs tap-sdk's complete compact-path verification.
+func verifyAssetProofPath(ctx context.Context, path *tapsdk.AssetProofPath,
+	verifier tapsdk.ConfirmedProofVerifier) error {
+
+	_, err := path.Verify(ctx, verifier)
+
+	return err
 }
 
 // PrepareTaprootAssetOOR implements oor.TaprootAssetOORPreparer. It commits one
@@ -125,12 +167,6 @@ func (p *Preparer) PrepareTaprootAssetOOR(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if len(assetInputIndices) != 1 {
-		return nil, fmt.Errorf("taproot asset preparer supports "+
-			"exactly one asset input, got %d",
-			len(assetInputIndices))
-	}
-	assetInputIndex := assetInputIndices[0]
 	for idx := range request.Inputs {
 		if request.Inputs[idx].CustomSpend != nil ||
 			len(request.Inputs[idx].ExternalSignatures) != 0 {
@@ -184,19 +220,27 @@ func (p *Preparer) PrepareTaprootAssetOOR(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("parse Taproot Asset ref: %w", err)
 	}
-	var source *assetSpendSource
-	if len(state.CheckpointPackage) == 0 || len(state.ArkPackage) == 0 {
-		source, err = p.resolveAssetSpendSource(
-			ctx, request, assetInputIndex, assetRef,
-		)
-		if err != nil {
-			return nil, err
-		}
-		if err := source.validateTransitionCapacity(); err != nil {
-			return nil, err
-		}
-		if err := source.verify(ctx); err != nil {
-			return nil, err
+
+	// A journaled Ark package implies every checkpoint package exists, so
+	// nothing needs the spend sources on a pure restore.
+	var sources []*assetSpendSource
+	if len(state.ArkPackage) == 0 {
+		sources = make([]*assetSpendSource, len(assetInputIndices))
+		for ordinal, inputIndex := range assetInputIndices {
+			source, err := p.resolveAssetSpendSource(
+				ctx, request, inputIndex, assetRef,
+			)
+			if err != nil {
+				return nil, err
+			}
+			err = source.validateTransitionCapacity()
+			if err != nil {
+				return nil, err
+			}
+			if err := p.verifySpendSource(ctx, source); err != nil {
+				return nil, err
+			}
+			sources[ordinal] = source
 		}
 	}
 
@@ -206,25 +250,29 @@ func (p *Preparer) PrepareTaprootAssetOOR(ctx context.Context,
 		return nil, err
 	}
 
-	checkpoints, artifacts, checkpointResult, err := p.prepareCheckpoints(
-		ctx, request, assetInputIndex, assetRef, digest, source, state,
+	checkpoints, artifacts, checkpointResults, err := p.prepareCheckpoints(
+		ctx, request, assetInputIndices, assetRef, digest, sources,
+		state,
 	)
 	if err != nil {
 		return nil, retainedPreparationError(request.RequestID, err)
 	}
 
 	ark, arkResult, recipients, err := p.prepareMixedArk(
-		ctx, request, assetInputIndex, assetRef, checkpoints, artifacts,
-		checkpointResult, recipients, digest, source, state,
+		ctx, request, assetInputIndices, assetRef, checkpoints,
+		artifacts, checkpointResults, recipients, digest, sources,
+		state,
 	)
 	if err != nil {
 		return nil, retainedPreparationError(request.RequestID, err)
 	}
 
 	checkpointPackages := make([][]byte, len(checkpoints))
-	checkpointPackages[assetInputIndex] = append(
-		[]byte(nil), checkpointResult.packageBytes...,
-	)
+	for ordinal, inputIndex := range assetInputIndices {
+		checkpointPackages[inputIndex] = append(
+			[]byte(nil), checkpointResults[ordinal].packageBytes...,
+		)
+	}
 	assetTransfer := &oortx.TaprootAssetTransfer{
 		Version:            oortx.TaprootAssetTransferVersion,
 		CheckpointPackages: checkpointPackages,
@@ -270,7 +318,7 @@ func (p *Preparer) journalCarrierLease(ctx context.Context,
 
 	// A committed journal without a lease predates carrier funding and
 	// cannot be adopted safely.
-	if len(state.CheckpointPackage) != 0 || len(state.ArkPackage) != 0 {
+	if state.hasCommittedPackages() {
 		return fmt.Errorf("%w: committed request %q has no journaled "+
 			"carrier lease", ErrReconciliationRequired,
 			request.RequestID)
@@ -458,8 +506,7 @@ func (p *Preparer) ResumeTaprootAssetOOR(ctx context.Context,
 			request.RequestID)
 	}
 	if reservationState == oor.ReservationSetAbsent {
-		if len(state.CheckpointPackage) != 0 ||
-			len(state.ArkPackage) != 0 {
+		if state.hasCommittedPackages() {
 			return nil, fmt.Errorf("%w: committed request %q has "+
 				"no owned input reservations",
 				ErrReconciliationRequired, request.RequestID)
@@ -539,8 +586,7 @@ func (p *Preparer) loadState(ctx context.Context, requestID string,
 			"reused with different request")
 	}
 	if state.RequestDigest != digest {
-		if state.Attempt != "" || len(state.CheckpointPackage) != 0 ||
-			len(state.ArkPackage) != 0 {
+		if state.Attempt != "" || state.hasCommittedPackages() {
 			return nil, fmt.Errorf("Taproot Asset OOR " +
 				"idempotency key reused with different " +
 				"carrier inputs")
@@ -578,16 +624,25 @@ func decodePreparationState(encoded []byte) (*preparationState, error) {
 		return nil, fmt.Errorf("unsupported taproot asset preparation "+
 			"state version %d", state.Version)
 	}
-	if state.Attempt != "" && state.Attempt != attemptCheckpoint &&
-		state.Attempt != attemptArk {
+	if state.Attempt != "" && state.Attempt != attemptArk &&
+		!strings.HasPrefix(state.Attempt, attemptCheckpoint+"/") {
 		return nil, fmt.Errorf("invalid taproot asset commit "+
 			"attempt %q", state.Attempt)
 	}
-	if len(state.ArkPackage) != 0 && len(state.CheckpointPackage) == 0 {
-		return nil, fmt.Errorf("Taproot Asset Ark package has no " +
-			"checkpoint package")
+	if len(state.ArkPackage) != 0 {
+		if len(state.CheckpointPackages) == 0 {
+			return nil, fmt.Errorf("Taproot Asset Ark package " +
+				"has no checkpoint packages")
+		}
+		for _, checkpointPackage := range state.CheckpointPackages {
+			if len(checkpointPackage) == 0 {
+				return nil, fmt.Errorf("Taproot Asset Ark " +
+					"package has an uncommitted " +
+					"checkpoint slot")
+			}
+		}
 	}
-	if (state.Attempt != "" || len(state.CheckpointPackage) != 0) &&
+	if (state.Attempt != "" || state.hasCommittedPackages()) &&
 		len(state.InputOutpoints) == 0 {
 		return nil, fmt.Errorf("Taproot Asset preparation has no " +
 			"input journal")
@@ -821,14 +876,14 @@ func validateCheckpointResult(request *oor.TaprootAssetOORPrepareRequest,
 	expectedInput := sdkOutpoint(assetInput.VTXO.Outpoint)
 	if input.anchorOutpoint != expectedInput ||
 		!input.assetRef.Equivalent(assetRef) ||
-		input.amount != request.Intent.AssetAmount {
+		input.amount != assetInput.VTXO.TaprootAssetAmount {
 		return fmt.Errorf("checkpoint package asset input mismatch")
 	}
 	if output.anchorOutputIndex != 0 ||
 		output.anchorOutpoint != sdkOutpoint(wire.OutPoint{
 			Hash: checkpoint.UnsignedTx.TxHash(), Index: 0,
 		}) || !output.assetRef.Equivalent(assetRef) ||
-		output.amount != request.Intent.AssetAmount ||
+		output.amount != assetInput.VTXO.TaprootAssetAmount ||
 		output.anchorValueSat != int64(assetInput.VTXO.Amount) ||
 		len(output.opTrueWitness) == 0 || len(output.proofBlob) == 0 {
 		return fmt.Errorf("checkpoint package asset output mismatch")
@@ -899,8 +954,26 @@ func preparationRequestDigest(request *oor.TaprootAssetOORPrepareRequest) (
 	}
 
 	var value bytes.Buffer
-	writeDigestBytes(&value, []byte("wavelength-asset-prepare-v2"))
+	writeDigestBytes(&value, []byte("wavelength-asset-prepare-v3"))
 	writeDigestBytes(&value, intentDigest[:])
+
+	// The resolved selection binds here: the ordered asset outpoint set
+	// and the exact unit split are immutable once a commit could exist,
+	// while the intent digest above stays selection-independent.
+	_ = binary.Write(
+		&value, binary.BigEndian,
+		uint32(
+			len(request.Intent.InputVTXOOutpoints),
+		),
+	)
+	for _, outpoint := range request.Intent.InputVTXOOutpoints {
+		writeDigestBytes(&value, outpoint.Hash[:])
+		_ = binary.Write(&value, binary.BigEndian, outpoint.Index)
+	}
+	_ = binary.Write(&value, binary.BigEndian, request.Intent.AssetAmount)
+	_ = binary.Write(
+		&value, binary.BigEndian, request.Intent.RecipientAssetAmount,
+	)
 	_ = binary.Write(&value, binary.BigEndian, uint32(len(request.Inputs)))
 	for idx := range request.Inputs {
 		input := request.Inputs[idx]
@@ -991,8 +1064,13 @@ func preparationIntentDigest(request *oor.TaprootAssetOORResumeRequest) (
 		return tapsdk.Hash{}, err
 	}
 
+	// Selection-dependent values are deliberately absent: a retry of a
+	// daemon-selected send must resolve the same journal even though a
+	// fresh selection could pick other inputs or a different unit split.
+	// The receiver's effective units are the same under every split of
+	// one logical send, so they anchor the public intent instead.
 	var value bytes.Buffer
-	writeDigestBytes(&value, []byte("wavelength-asset-intent-v2"))
+	writeDigestBytes(&value, []byte("wavelength-asset-intent-v3"))
 	writeDigestBytes(&value, []byte(request.RequestID))
 	writeDigestBytes(
 		&value, request.Policy.OperatorKey.SerializeCompressed(),
@@ -1005,24 +1083,12 @@ func preparationIntentDigest(request *oor.TaprootAssetOORResumeRequest) (
 	_ = binary.Write(
 		&value, binary.BigEndian, uint64(request.OutputFloor),
 	)
-	if len(request.Intent.InputVTXOOutpoints) != 1 {
-		return tapsdk.Hash{}, fmt.Errorf("Taproot Asset OOR intent " +
-			"requires exactly one input outpoint")
-	}
-	spineOutpoint := request.Intent.InputVTXOOutpoints[0]
-	writeDigestBytes(&value, spineOutpoint.Hash[:])
-	_ = binary.Write(&value, binary.BigEndian, spineOutpoint.Index)
 	writeDigestBytes(&value, []byte(request.Intent.AssetRef))
-	_ = binary.Write(&value, binary.BigEndian, request.Intent.AssetAmount)
-	_ = binary.Write(
-		&value, binary.BigEndian, request.Intent.RecipientAssetAmount,
-	)
 	_ = binary.Write(
 		&value, binary.BigEndian,
-		request.Intent.AssetChangeCarrierValueSat,
+		request.Intent.EffectiveRecipientAssetAmount(),
 	)
 	writeDigestBytes(&value, request.Intent.ProofFile)
-	writeDigestBytes(&value, request.Intent.RecipientScriptKey)
 	writeDigestBytes(&value, []byte(request.Intent.ProofCourierAddress))
 	writeDigestBytes(&value, request.Intent.ProofDeliveryMetadata)
 	digest := sha256.Sum256(value.Bytes())

--- a/tapassets/preparer_test.go
+++ b/tapassets/preparer_test.go
@@ -614,7 +614,6 @@ type fakeDriver struct {
 	commitPreviewMutator func(
 		*tapsdk.CustomAnchorRequest, []commitmentPreview,
 	)
-	forcedAssetInputIndex *uint32
 
 	// lineages holds one entry per committed checkpoint in commit order,
 	// which equals the Ark request's transition-input order.
@@ -789,9 +788,6 @@ func (d *fakeDriver) Commit(ctx context.Context,
 					break
 				}
 			}
-		}
-		if d.forcedAssetInputIndex != nil {
-			anchorInputIndex = *d.forcedAssetInputIndex
 		}
 		inputs[idx] = commitInput{
 			logicalInputIndex: uint32(idx),

--- a/tapassets/preparer_test.go
+++ b/tapassets/preparer_test.go
@@ -52,16 +52,35 @@ func TestPreparerBuildsTwoTransitionGraph(t *testing.T) {
 		driver.requests[1].Inputs[0].Witness.Stack,
 	)
 	require.NoError(t, prepared.Validate(request))
-	require.Len(t, prepared.PreparedSubmit.CheckpointPSBTs, 1)
+	require.Len(t, prepared.PreparedSubmit.CheckpointPSBTs, 2)
 	require.NotNil(t, prepared.Recipients[0].TaprootAssetRoot)
+
+	// The full send pays out the receiver at the floor, the sender's
+	// returned carrier, and the operator's float residual.
+	require.Len(t, prepared.Recipients, 3)
+	require.Equal(t, btcutil.Amount(1_000), prepared.Recipients[0].Value)
+	require.Equal(t, btcutil.Amount(5_000), prepared.Recipients[1].Value)
+	require.Nil(t, prepared.Recipients[1].TaprootAssetRoot)
+	require.Equal(t, btcutil.Amount(29_000), prepared.Recipients[2].Value)
 	require.Equal(
-		t, prepared.PreparedSubmit.CheckpointPSBTs[0].
-			UnsignedTx.TxHash(),
-		prepared.PreparedSubmit.ArkPSBT.UnsignedTx.
-			TxIn[0].PreviousOutPoint.Hash,
+		t, request.Lease.PkScript, prepared.Recipients[2].PkScript,
 	)
+	require.Nil(t, prepared.Recipients[2].TaprootAssetRoot)
+
+	// Both checkpoints feed the Ark transaction; only the asset input's
+	// checkpoint carries a sealed tap-sdk package.
+	assetCheckpointHash := prepared.PreparedSubmit.CheckpointPSBTs[0].
+		UnsignedTx.TxHash()
+	assetArkInput, err := findArkInputIndex(
+		prepared.PreparedSubmit.ArkPSBT, wire.OutPoint{
+			Hash:  assetCheckpointHash,
+			Index: 0,
+		},
+	)
+	require.NoError(t, err)
+	require.LessOrEqual(t, assetArkInput, uint32(1))
 	require.Equal(
-		t, [][]byte{[]byte("checkpoint-package")},
+		t, [][]byte{[]byte("checkpoint-package"), nil},
 		prepared.PreparedSubmit.TaprootAssetTransfer.CheckpointPackages,
 	)
 	require.Equal(
@@ -92,7 +111,8 @@ func TestPreparerRestoresCommittedPackages(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(
-		t, oor.InputOutpoints(request.Inputs), resume.InputOutpoints,
+		t, oor.WalletInputOutpoints(request.Inputs),
+		resume.InputOutpoints,
 	)
 
 	changed := testResumeRequest(request)
@@ -165,7 +185,8 @@ func TestPreparerRestoresAfterOORReservationHandoff(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(
-		t, oor.InputOutpoints(request.Inputs), resume.InputOutpoints,
+		t, oor.WalletInputOutpoints(request.Inputs),
+		resume.InputOutpoints,
 	)
 	restored, err := restarted.PrepareTaprootAssetOOR(
 		t.Context(), request,
@@ -295,7 +316,7 @@ func TestPreparerResumeBeforeCommitAndRejectsCorruptVersion(t *testing.T) {
 	require.NoError(t, err)
 	state, err := preparer.loadState(
 		t.Context(), request.RequestID, requestDigest, intentDigest,
-		oor.InputOutpoints(request.Inputs),
+		oor.WalletInputOutpoints(request.Inputs),
 	)
 	require.NoError(t, err)
 
@@ -367,11 +388,25 @@ func TestPreparerRejectsCorruptPlannedRecipientsBeforeCommit(t *testing.T) {
 	require.NoError(t, err)
 	state, err := preparer.loadState(
 		t.Context(), request.RequestID, requestDigest, intentDigest,
-		oor.InputOutpoints(request.Inputs),
+		oor.WalletInputOutpoints(request.Inputs),
 	)
 	require.NoError(t, err)
-	state.PlannedRecipients = cloneRecipients(request.Recipients)
-	state.PlannedRecipients[0].Value++
+
+	// Journal a complete plan whose receiver was tampered with.
+	plan, err := request.CarrierAllocation()
+	require.NoError(t, err)
+	senderChange, err := request.BuildChangeRecipient(
+		t.Context(), plan.SenderChange,
+	)
+	require.NoError(t, err)
+	planned := cloneRecipients(request.Recipients)
+	planned = append(planned, senderChange, oortx.RecipientOutput{
+		PkScript:           request.Lease.PkScript,
+		Value:              plan.OperatorChange,
+		VTXOPolicyTemplate: request.Lease.PolicyTemplate,
+	})
+	planned[0].Value++
+	state.PlannedRecipients = planned
 	require.NoError(
 		t,
 		preparer.storeState(
@@ -413,7 +448,8 @@ func TestPreparerRetriesKnownCommitFailure(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(
-		t, oor.InputOutpoints(request.Inputs), resume.InputOutpoints,
+		t, oor.WalletInputOutpoints(request.Inputs),
+		resume.InputOutpoints,
 	)
 	_, err = restarted.PrepareTaprootAssetOOR(t.Context(), request)
 	require.NoError(t, err)
@@ -1215,8 +1251,92 @@ func newTestPreparer(driver customAnchorDriver, inventory proofInventoryClient,
 	}
 }
 
-// testPreparationRequest constructs one asset-bearing standard VTXO and one
-// Bitcoin-only recipient policy template.
+// testFloatInput builds the leased operator carrier-float input and its
+// lease, mirroring the daemon's BuildOperatorFundedTransferInput output.
+func testFloatInput(t *testing.T, operatorKey *btcec.PublicKey,
+	value btcutil.Amount) (oor.TransferInput, *oor.OORCarrierLease) {
+
+	t.Helper()
+
+	floatKey := testPrivateKey(t, 5)
+	policyTemplate, pkScript, err := arkscript.EncodeStandardVTXOArtifacts(
+		floatKey.PubKey(), operatorKey, 10,
+	)
+	require.NoError(t, err)
+
+	ownerLeafPolicy, err := arkscript.LeafTemplate{
+		Node: &arkscript.Multisig{
+			Keys: []*btcec.PublicKey{
+				floatKey.PubKey(),
+				operatorKey,
+			},
+		},
+	}.Encode()
+	require.NoError(t, err)
+
+	input := oor.TransferInput{
+		VTXO: &vtxo.Descriptor{
+			Outpoint: wire.OutPoint{
+				Hash: chainhash.Hash(
+					sha256Bytes(
+						[]byte("float-outpoint"),
+					),
+				),
+				Index: 0,
+			},
+			Amount:         value,
+			PkScript:       pkScript,
+			PolicyTemplate: policyTemplate,
+			OperatorKey:    operatorKey,
+			RelativeExpiry: 10,
+		},
+		VTXOPolicyTemplate: policyTemplate,
+		OwnerLeafPolicy:    ownerLeafPolicy,
+		OperatorFunded:     true,
+	}
+	lease := &oor.OORCarrierLease{
+		Outpoint:       input.VTXO.Outpoint,
+		Value:          value,
+		PolicyTemplate: policyTemplate,
+		PkScript:       pkScript,
+	}
+
+	return input, lease
+}
+
+// testChangeRecipientBuilder returns a deterministic wallet-owned change
+// builder that derives a fresh policy per call.
+func testChangeRecipientBuilder(t *testing.T, operatorKey *btcec.PublicKey,
+	firstKeyByte byte) oor.TaprootAssetChangeRecipientBuilder {
+
+	t.Helper()
+
+	calls := byte(0)
+
+	return func(_ context.Context, value btcutil.Amount) (
+		oortx.RecipientOutput, error) {
+
+		calls++
+		owner := testPrivateKey(t, firstKeyByte+calls)
+		policyTemplate, pkScript, err := arkscript.
+			EncodeStandardVTXOArtifacts(
+				owner.PubKey(), operatorKey, 10,
+			)
+		if err != nil {
+			return oortx.RecipientOutput{}, err
+		}
+
+		return oortx.RecipientOutput{
+			PkScript:           pkScript,
+			Value:              value,
+			VTXOPolicyTemplate: policyTemplate,
+		}, nil
+	}
+}
+
+// testPreparationRequest constructs one asset-bearing standard VTXO, one
+// leased operator float input, and one floor-valued Bitcoin-only recipient
+// policy template.
 func testPreparationRequest(t *testing.T) (*oor.TaprootAssetOORPrepareRequest,
 	*fakeInventory) {
 
@@ -1280,9 +1400,9 @@ func testPreparationRequest(t *testing.T) (*oor.TaprootAssetOORPrepareRequest,
 		OperatorKey: operator.PubKey(),
 		CSVDelay:    10,
 	}
-	inputs := []oor.TransferInput{input}
+	floatInput, lease := testFloatInput(t, operator.PubKey(), 30_000)
+	inputs := []oor.TransferInput{input, floatInput}
 	require.NoError(t, oor.NormalizeCheckpointOwnerLeaves(policy, inputs))
-	input = inputs[0]
 	recipientPolicy, err := arkscript.NewVTXOPolicy(
 		recipient.PubKey(), operator.PubKey(), 10,
 	)
@@ -1296,20 +1416,22 @@ func testPreparationRequest(t *testing.T) (*oor.TaprootAssetOORPrepareRequest,
 		RequestID:   "taproot-asset-request",
 		Policy:      policy,
 		OutputFloor: 1_000,
-		Inputs: []oor.TransferInput{
-			input,
-		},
+		Inputs:      inputs,
 		Recipients: []oortx.RecipientOutput{{
 			PkScript:           recipientScript,
-			Value:              5_000,
+			Value:              1_000,
 			VTXOPolicyTemplate: recipientPolicyBytes,
 		}},
+		BuildChangeRecipient: testChangeRecipientBuilder(
+			t, operator.PubKey(), 40,
+		),
 		Intent: oor.TaprootAssetOORIntent{
-			InputVTXOOutpoint: input.VTXO.Outpoint,
+			InputVTXOOutpoint: inputs[0].VTXO.Outpoint,
 			AssetRef:          assetRef.String(),
 			AssetAmount:       21,
 			ProofFile:         []byte("confirmed-proof"),
 		},
+		Lease: lease,
 	}
 	require.NoError(t, request.Validate())
 	scriptKey, err := tapsdk.ParsePubKey(

--- a/tapassets/preparer_test.go
+++ b/tapassets/preparer_test.go
@@ -591,41 +591,6 @@ func TestProofInventoryVerifierFailsClosed(t *testing.T) {
 	require.Equal(t, uint32(1), result.PassiveAssetCount)
 }
 
-// TestProofInventoryVerifierBindsUnconfirmedAnchor proves compact proof steps
-// cannot substitute a different transaction at the checkpoint boundary.
-func TestProofInventoryVerifierBindsUnconfirmedAnchor(t *testing.T) {
-	t.Parallel()
-
-	expected := &expectedUnconfirmedAnchor{
-		previousOutpoint: tapsdk.Outpoint{
-			Index: 1,
-		},
-		anchorOutpoint: tapsdk.Outpoint{
-			Index: 2,
-		},
-		transaction: []byte("checkpoint"),
-	}
-	verifier := &proofInventoryVerifier{unconfirmed: expected}
-	transition := tapsdk.UnconfirmedAnchorVerification{
-		StepIndex:              0,
-		PreviousAnchorOutpoint: expected.previousOutpoint,
-		AnchorOutpoint:         expected.anchorOutpoint,
-		AnchorTransaction: append(
-			[]byte(nil), expected.transaction...,
-		),
-	}
-	require.NoError(
-		t,
-		verifier.VerifyUnconfirmedAnchor(
-			t.Context(), transition,
-		),
-	)
-
-	transition.AnchorTransaction[0] ^= 1
-	err := verifier.VerifyUnconfirmedAnchor(t.Context(), transition)
-	require.ErrorContains(t, err, "transaction mismatch")
-}
-
 type fakeDriver struct {
 	mu                   sync.Mutex
 	requests             []*tapsdk.CustomAnchorRequest
@@ -910,6 +875,9 @@ func (d *fakeDriver) verifyFakeSource(ctx context.Context,
 			AnchorTransaction: append(
 				[]byte(nil), d.assetCheckpointTx...,
 			),
+			PreviousAnchorOutpoints: []tapsdk.Outpoint{
+				sdkOutpoint(*d.assetPreviousOutpoint),
+			},
 		}
 		if err := unconfirmedVerifier.VerifyUnconfirmedAnchor(
 			ctx, verification,

--- a/tapassets/preparer_test.go
+++ b/tapassets/preparer_test.go
@@ -1393,8 +1393,9 @@ func testPreparationRequest(t *testing.T) (*oor.TaprootAssetOORPrepareRequest,
 			TaprootAssetRef:    assetRef.String(),
 			TaprootAssetAmount: 21,
 		},
-		VTXOPolicyTemplate: inputPolicyBytes,
-		TaprootAssetRoot:   &inputRoot,
+		VTXOPolicyTemplate:       inputPolicyBytes,
+		TaprootAssetRoot:         &inputRoot,
+		TaprootAssetRoundCreated: true,
 	}
 	policy := arkscript.CheckpointPolicy{
 		OperatorKey: operator.PubKey(),

--- a/tapassets/preparer_test.go
+++ b/tapassets/preparer_test.go
@@ -1427,10 +1427,12 @@ func testPreparationRequest(t *testing.T) (*oor.TaprootAssetOORPrepareRequest,
 			t, operator.PubKey(), 40,
 		),
 		Intent: oor.TaprootAssetOORIntent{
-			InputVTXOOutpoint: inputs[0].VTXO.Outpoint,
-			AssetRef:          assetRef.String(),
-			AssetAmount:       21,
-			ProofFile:         []byte("confirmed-proof"),
+			InputVTXOOutpoints: []wire.OutPoint{
+				inputs[0].VTXO.Outpoint,
+			},
+			AssetRef:    assetRef.String(),
+			AssetAmount: 21,
+			ProofFile:   []byte("confirmed-proof"),
 		},
 		Lease: lease,
 	}

--- a/tapassets/preparer_test.go
+++ b/tapassets/preparer_test.go
@@ -672,9 +672,7 @@ func (d *fakeDriver) Commit(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		combined := tapBranchHash(
-			policyRoot[:], preview.assetRoot[:],
-		)
+		combined := requestMerkleRoot(policyRoot, preview.assetRoot)
 		outputKey := txscript.ComputeTaprootOutputKey(
 			internalKey, combined[:],
 		)
@@ -686,6 +684,28 @@ func (d *fakeDriver) Commit(ctx context.Context,
 		}
 		packet.UnsignedTx.TxOut[outputRequest.AnchorOutputIndex].
 			PkScript = pkScript
+
+		// An external script plan commits the caller's own key and has
+		// no OP_TRUE spend; every other plan is anyone-can-spend at
+		// the asset layer.
+		var (
+			scriptKey tapsdk.PubKey
+			witness   [][]byte
+		)
+		if outputRequest.Script.Mode == scriptExternal {
+			scriptKey = outputRequest.
+				Script.External.ScriptKey.PubKey
+		} else {
+			witness = [][]byte{
+				{
+					txscript.OP_TRUE,
+				}, {
+					byte(idx + 1),
+					2,
+					3,
+				},
+			}
+		}
 		outputs[idx] = commitOutput{
 			logicalOutputID:   outputRequest.ID,
 			anchorOutputIndex: outputRequest.AnchorOutputIndex,
@@ -694,16 +714,9 @@ func (d *fakeDriver) Commit(ctx context.Context,
 			amount:            outputRequest.Amount,
 			taprootAssetRoot:  preview.assetRoot,
 			taprootMerkleRoot: preview.merkleRoot,
-			scriptMode:        tapsdk.CustomAssetScriptOPTrue,
-			opTrueWitness: [][]byte{
-				{
-					txscript.OP_TRUE,
-				}, {
-					byte(idx + 1),
-					2,
-					3,
-				},
-			},
+			scriptMode:        outputRequest.Script.Mode,
+			scriptKey:         scriptKey,
+			opTrueWitness:     witness,
 			proofBlob: []byte(
 				fmt.Sprintf("%s-proof", outputRequest.ID),
 			),
@@ -799,12 +812,13 @@ func fakeCommitmentPreviews(request *tapsdk.CustomAnchorRequest) (
 		if err != nil {
 			return nil, err
 		}
-		combined := tapBranchHash(policyRoot[:], assetRoot[:])
 		previews[idx] = commitmentPreview{
 			logicalOutputID:   output.ID,
 			anchorOutputIndex: output.AnchorOutputIndex,
 			assetRoot:         assetRoot,
-			merkleRoot:        tapsdk.Hash(combined),
+			merkleRoot: requestMerkleRoot(
+				policyRoot, assetRoot,
+			),
 		}
 	}
 
@@ -910,8 +924,18 @@ func cloneCommitResult(result *commitResult) *commitResult {
 
 type fakeInventory struct {
 	verification *tapsdk.VerifyProofResponse
-	utxos        map[string]*tapsdk.ManagedUtxo
-	err          error
+
+	// verifications resolves a proof file to its tip by content, for
+	// fixtures holding the asset across more than one anchor. It wins
+	// over verification whenever it has an entry.
+	verifications map[string]*tapsdk.VerifyProofResponse
+
+	utxos map[string]*tapsdk.ManagedUtxo
+	err   error
+
+	// derived counts key derivations, so a test can prove a pinned key is
+	// derived exactly once.
+	derived int
 }
 
 type reservationRecord struct {
@@ -1065,14 +1089,70 @@ func (f *fakeReservationStore) records() []reservationRecord {
 }
 
 // VerifyProof returns the configured tapd proof result.
-func (f *fakeInventory) VerifyProof(context.Context, []byte) (
+func (f *fakeInventory) VerifyProof(_ context.Context, proofFile []byte) (
 	*tapsdk.VerifyProofResponse, error) {
 
 	if f.err != nil {
 		return nil, f.err
 	}
+	if verification, ok := f.verifications[string(proofFile)]; ok {
+		return verification, nil
+	}
 
 	return f.verification, nil
+}
+
+// DeriveScriptKey returns a deterministic wallet script key, distinct on
+// every call so a test can tell a pinned key from a re-derived one.
+func (f *fakeInventory) DeriveScriptKey(context.Context) (*tapsdk.ScriptKey,
+	error) {
+
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.derived++
+	seed := sha256Bytes([]byte(fmt.Sprintf("script-key-%d", f.derived)))
+	_, pubKey := btcec.PrivKeyFromBytes(seed[:])
+	key, err := tapsdk.ParsePubKey(pubKey.SerializeCompressed())
+	if err != nil {
+		return nil, err
+	}
+
+	return &tapsdk.ScriptKey{
+		PubKey: key,
+		KeyDesc: tapsdk.KeyDescriptor{
+			RawKeyBytes: key,
+			KeyLocator: tapsdk.KeyLocator{
+				Family: 212,
+				Index:  uint32(f.derived),
+			},
+		},
+	}, nil
+}
+
+// DeriveInternalKey returns a deterministic wallet anchor internal key,
+// distinct on every call.
+func (f *fakeInventory) DeriveInternalKey(context.Context) (*tapsdk.InternalKey,
+	error) {
+
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.derived++
+	seed := sha256Bytes([]byte(fmt.Sprintf("internal-key-%d", f.derived)))
+	_, pubKey := btcec.PrivKeyFromBytes(seed[:])
+	key, err := tapsdk.ParsePubKey(pubKey.SerializeCompressed())
+	if err != nil {
+		return nil, err
+	}
+
+	return &tapsdk.InternalKey{
+		PubKey: key,
+		KeyLocator: tapsdk.KeyLocator{
+			Family: 213,
+			Index:  uint32(f.derived),
+		},
+	}, nil
 }
 
 // UnpackProofFile returns one synthetic issuance proof for chained-path tests.
@@ -1298,13 +1378,27 @@ func requestPolicyRoot(plan tapsdk.CustomAnchorOutputPlan) (chainhash.Hash,
 			plan.Tapscript.TapLeaves[idx].Script,
 		)
 	}
+
+	// A leafless plan is a BIP-86 wallet anchor: no sibling branches the
+	// asset commitment, so its root is the taproot root outright.
 	if len(leaves) == 0 {
-		return chainhash.Hash{}, nil, fmt.Errorf("fake policy has no " +
-			"leaves")
+		return chainhash.Hash{}, internalKey, nil
 	}
 	tree := txscript.AssembleTaprootScriptTree(leaves...)
 
 	return tree.RootNode.TapHash(), internalKey, nil
+}
+
+// requestMerkleRoot composes one fake output's taproot root from its host
+// policy root and asset commitment root.
+func requestMerkleRoot(policyRoot chainhash.Hash,
+	assetRoot tapsdk.Hash) tapsdk.Hash {
+
+	if policyRoot == (chainhash.Hash{}) {
+		return assetRoot
+	}
+
+	return tapsdk.Hash(tapBranchHash(policyRoot[:], assetRoot[:]))
 }
 
 // testPrivateKey deterministically derives a test-only private key.

--- a/tapassets/preparer_test.go
+++ b/tapassets/preparer_test.go
@@ -80,7 +80,12 @@ func TestPreparerBuildsTwoTransitionGraph(t *testing.T) {
 	require.NoError(t, err)
 	require.LessOrEqual(t, assetArkInput, uint32(1))
 	require.Equal(
-		t, [][]byte{[]byte("checkpoint-package"), nil},
+		t, [][]byte{
+			fakeCheckpointPackageName(
+				request.Inputs[0].VTXO.Outpoint,
+			),
+			nil,
+		},
 		prepared.PreparedSubmit.TaprootAssetTransfer.CheckpointPackages,
 	)
 	require.Equal(
@@ -281,7 +286,7 @@ func TestPreparerRebindsCarrierSelectionBeforeCommit(t *testing.T) {
 	require.Equal(t, secondInputs, rebound.InputOutpoints)
 	require.Empty(t, rebound.PlannedRecipients)
 
-	rebound.CheckpointPackage = []byte("committed")
+	rebound.CheckpointPackages = [][]byte{[]byte("committed")}
 	require.NoError(
 		t,
 		preparer.storeState(
@@ -591,6 +596,14 @@ func TestProofInventoryVerifierFailsClosed(t *testing.T) {
 	require.Equal(t, uint32(1), result.PassiveAssetCount)
 }
 
+// fakeCheckpointLineage records one committed fake checkpoint so later Ark
+// builds can bind their transition inputs the way the real SDK would.
+type fakeCheckpointLineage struct {
+	previous           wire.OutPoint
+	checkpointOutpoint wire.OutPoint
+	tx                 []byte
+}
+
 type fakeDriver struct {
 	mu                   sync.Mutex
 	requests             []*tapsdk.CustomAnchorRequest
@@ -601,10 +614,30 @@ type fakeDriver struct {
 	commitPreviewMutator func(
 		*tapsdk.CustomAnchorRequest, []commitmentPreview,
 	)
-	forcedAssetInputIndex   *uint32
-	assetCheckpointOutpoint *wire.OutPoint
-	assetPreviousOutpoint   *wire.OutPoint
-	assetCheckpointTx       []byte
+	forcedAssetInputIndex *uint32
+
+	// lineages holds one entry per committed checkpoint in commit order,
+	// which equals the Ark request's transition-input order.
+	lineages []fakeCheckpointLineage
+}
+
+// recordLineage stores one committed checkpoint, replacing an earlier entry
+// for the same spent outpoint so retries keep a stable ordinal order.
+func (d *fakeDriver) recordLineage(lineage fakeCheckpointLineage) {
+	for idx := range d.lineages {
+		if d.lineages[idx].previous == lineage.previous {
+			d.lineages[idx] = lineage
+
+			return
+		}
+	}
+	d.lineages = append(d.lineages, lineage)
+}
+
+// fakeCheckpointPackageName mirrors the fake driver's per-input checkpoint
+// package naming.
+func fakeCheckpointPackageName(outpoint wire.OutPoint) []byte {
+	return []byte("checkpoint-package/" + outpoint.String())
 }
 
 // newFakeDriver constructs a deterministic SDK commit boundary for graph
@@ -727,40 +760,53 @@ func (d *fakeDriver) Commit(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	input := request.Inputs[0]
 	isCheckpoint := request.Outputs[0].ID == "wavelength-checkpoint"
-	packageBytes := []byte("checkpoint-package")
-	if !isCheckpoint {
-		packageBytes = []byte("ark-package")
+	packageBytes := []byte("ark-package")
+	if isCheckpoint {
+		packageBytes = fakeCheckpointPackageName(
+			packet.UnsignedTx.TxIn[0].PreviousOutPoint,
+		)
 	}
-	anchorInputIndex := uint32(0)
-	if !isCheckpoint && d.assetCheckpointOutpoint != nil {
-		for idx := range packet.UnsignedTx.TxIn {
-			if packet.UnsignedTx.TxIn[idx].PreviousOutPoint ==
-				*d.assetCheckpointOutpoint {
-
-				anchorInputIndex = uint32(idx)
-				break
+	inputs := make([]commitInput, len(request.Inputs))
+	for idx := range request.Inputs {
+		requestInput := request.Inputs[idx]
+		anchorInputIndex := uint32(0)
+		anchorOutpoint := sdkOutpoint(
+			packet.UnsignedTx.TxIn[0].PreviousOutPoint,
+		)
+		// Non-checkpoint requests without recorded lineages come from
+		// flows that overwrite the inputs themselves (onboarding).
+		if !isCheckpoint && idx < len(d.lineages) {
+			lineage := d.lineages[idx]
+			anchorOutpoint = sdkOutpoint(
+				lineage.checkpointOutpoint,
+			)
+			for txIdx := range packet.UnsignedTx.TxIn {
+				previous := packet.UnsignedTx.
+					TxIn[txIdx].PreviousOutPoint
+				if previous == lineage.checkpointOutpoint {
+					anchorInputIndex = uint32(txIdx)
+					break
+				}
 			}
 		}
+		if d.forcedAssetInputIndex != nil {
+			anchorInputIndex = *d.forcedAssetInputIndex
+		}
+		inputs[idx] = commitInput{
+			logicalInputIndex: uint32(idx),
+			anchorInputIndex:  anchorInputIndex,
+			anchorOutpoint:    anchorOutpoint,
+			assetRef:          requestInput.AssetRef,
+			amount:            requestInput.Amount,
+		}
 	}
-	if d.forcedAssetInputIndex != nil {
-		anchorInputIndex = *d.forcedAssetInputIndex
-	}
-	assetAnchorOutpoint := sdkOutpoint(
-		packet.UnsignedTx.TxIn[anchorInputIndex].PreviousOutPoint,
-	)
 	result := &commitResult{
 		packageBytes: packageBytes,
 		anchorPSBT:   encoded,
 		fundingMode:  tapsdk.CustomAnchorFundingCallerFundedExact,
-		inputs: []commitInput{{
-			anchorInputIndex: anchorInputIndex,
-			anchorOutpoint:   assetAnchorOutpoint,
-			assetRef:         input.AssetRef,
-			amount:           input.Amount,
-		}},
-		outputs: outputs,
+		inputs:       inputs,
+		outputs:      outputs,
 	}
 	for idx := range result.outputs {
 		result.outputs[idx].anchorOutpoint = sdkOutpoint(
@@ -771,14 +817,15 @@ func (d *fakeDriver) Commit(ctx context.Context,
 		)
 	}
 	if isCheckpoint {
-		outpoint := wire.OutPoint{
-			Hash:  packet.UnsignedTx.TxHash(),
-			Index: result.outputs[0].anchorOutputIndex,
-		}
-		d.assetCheckpointOutpoint = &outpoint
-		previous := packet.UnsignedTx.TxIn[0].PreviousOutPoint
-		d.assetPreviousOutpoint = &previous
-		d.assetCheckpointTx = serializeTx(packet.UnsignedTx)
+		d.recordLineage(fakeCheckpointLineage{
+			previous: packet.UnsignedTx.TxIn[0].PreviousOutPoint,
+			checkpointOutpoint: wire.OutPoint{
+				Hash: packet.UnsignedTx.TxHash(),
+				Index: result.outputs[0].
+					anchorOutputIndex,
+			},
+			tx: serializeTx(packet.UnsignedTx),
+		})
 	}
 	d.results[string(packageBytes)] = result
 
@@ -833,12 +880,79 @@ func (d *fakeDriver) verifyFakeSource(ctx context.Context,
 	if verifier == nil || len(request.Inputs) == 0 {
 		return nil
 	}
-	proofFile := request.Inputs[0].ProofFile
-	if request.Inputs[0].ProofPath != nil {
-		proofFile = request.Inputs[0].ProofPath.ConfirmedBaseProof
+	isCheckpoint := len(request.Outputs) != 0 &&
+		request.Outputs[0].ID == "wavelength-checkpoint"
+	for idx := range request.Inputs {
+		requestInput := request.Inputs[idx]
+		proofFile := requestInput.ProofFile
+		if requestInput.ProofPath != nil {
+			proofFile = requestInput.ProofPath.ConfirmedBaseProof
+		}
+		verification, err := verifier.VerifyConfirmedProof(
+			ctx, proofFile,
+		)
+		if err != nil {
+			return err
+		}
+		if verification == nil ||
+			!verification.AnchorAssetInventoryComplete ||
+			verification.PassiveAssetCount != 0 {
+			return fmt.Errorf("fake verifier rejected passive " +
+				"inventory")
+		}
+
+		// Checkpoint commits carry no appended step to bind; only the
+		// Ark build presents each input's newest checkpoint step.
+		if isCheckpoint || requestInput.ProofPath == nil ||
+			len(requestInput.ProofPath.Steps) == 0 {
+
+			continue
+		}
+		if idx >= len(d.lineages) {
+			return fmt.Errorf("fake checkpoint lineage is " +
+				"incomplete")
+		}
+		lineage := d.lineages[idx]
+		stepIndex := len(requestInput.ProofPath.Steps) - 1
+		unconfirmedVerifier, ok :=
+			verifier.(tapsdk.UnconfirmedAnchorVerifier)
+		if !ok {
+			return fmt.Errorf("fake verifier has no unconfirmed " +
+				"anchor verifier")
+		}
+		stepVerification := tapsdk.UnconfirmedAnchorVerification{
+			StepIndex: uint16(stepIndex),
+			PreviousAnchorOutpoint: sdkOutpoint(
+				lineage.previous,
+			),
+			AnchorOutpoint: sdkOutpoint(
+				lineage.checkpointOutpoint,
+			),
+			AnchorTransaction: append(
+				[]byte(nil), lineage.tx...,
+			),
+			PreviousAnchorOutpoints: []tapsdk.Outpoint{
+				sdkOutpoint(lineage.previous),
+			},
+		}
+		if err := unconfirmedVerifier.VerifyUnconfirmedAnchor(
+			ctx, stepVerification,
+		); err != nil {
+			return err
+		}
 	}
+
+	return nil
+}
+
+// fakeVerifyProofPath fakes tap-sdk's preflight compact-path verification:
+// every confirmed base in the co-input tree is checked through the host
+// verifier while the cryptographic step checks stay with the real SDK.
+func fakeVerifyProofPath(ctx context.Context, path *tapsdk.AssetProofPath,
+	verifier tapsdk.ConfirmedProofVerifier) error {
+
 	verification, err := verifier.VerifyConfirmedProof(
-		ctx, proofFile,
+		ctx, path.ConfirmedBaseProof,
 	)
 	if err != nil {
 		return err
@@ -848,41 +962,12 @@ func (d *fakeDriver) verifyFakeSource(ctx context.Context,
 		verification.PassiveAssetCount != 0 {
 		return fmt.Errorf("fake verifier rejected passive inventory")
 	}
-	if request.Inputs[0].ProofPath != nil &&
-		len(request.Inputs[0].ProofPath.Steps) != 0 {
-
-		if d.assetPreviousOutpoint == nil ||
-			d.assetCheckpointOutpoint == nil ||
-			len(d.assetCheckpointTx) == 0 {
-			return fmt.Errorf("fake checkpoint lineage is " +
-				"incomplete")
-		}
-		stepIndex := len(request.Inputs[0].ProofPath.Steps) - 1
-		unconfirmedVerifier, ok :=
-			verifier.(tapsdk.UnconfirmedAnchorVerifier)
-		if !ok {
-			return fmt.Errorf("fake verifier has no unconfirmed " +
-				"anchor verifier")
-		}
-		verification := tapsdk.UnconfirmedAnchorVerification{
-			StepIndex: uint16(stepIndex),
-			PreviousAnchorOutpoint: sdkOutpoint(
-				*d.assetPreviousOutpoint,
-			),
-			AnchorOutpoint: sdkOutpoint(
-				*d.assetCheckpointOutpoint,
-			),
-			AnchorTransaction: append(
-				[]byte(nil), d.assetCheckpointTx...,
-			),
-			PreviousAnchorOutpoints: []tapsdk.Outpoint{
-				sdkOutpoint(*d.assetPreviousOutpoint),
-			},
-		}
-		if err := unconfirmedVerifier.VerifyUnconfirmedAnchor(
-			ctx, verification,
-		); err != nil {
-			return err
+	for i := range path.Steps {
+		for _, coPath := range path.Steps[i].CoInputPaths {
+			err := fakeVerifyProofPath(ctx, coPath, verifier)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1212,10 +1297,11 @@ func newTestPreparer(driver customAnchorDriver, inventory proofInventoryClient,
 	}
 
 	return &Preparer{
-		driver:       driver,
-		inventory:    inventory,
-		store:        store,
-		reservations: reservationStore,
+		driver:          driver,
+		inventory:       inventory,
+		store:           store,
+		reservations:    reservationStore,
+		verifyProofPath: fakeVerifyProofPath,
 	}
 }
 

--- a/tapassets/proof_source.go
+++ b/tapassets/proof_source.go
@@ -2,6 +2,7 @@ package tapassets
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -151,13 +152,24 @@ func resolveCreatedAssetProofSource(committed *commitResult,
 			"package output")
 	}
 
-	var input *commitInput
+	// The emitted transition's predecessor is vPacket input 0: the spine.
+	// Every other same-asset input of the package is a co-input whose
+	// prior state the transition consumed alongside the spine tip.
+	var (
+		input    *commitInput
+		coInputs []*commitInput
+	)
 	for idx := range committed.inputs {
 		candidate := &committed.inputs[idx]
-		if candidate.anchorOutpoint !=
-			stepSummary.PreviousAnchorOutpoint ||
-			!candidate.assetRef.Equivalent(stepSummary.AssetRef) ||
+		if !candidate.assetRef.Equivalent(stepSummary.AssetRef) ||
 			candidate.issuanceID != stepSummary.IssuanceID {
+			return nil, fmt.Errorf("sealed package carries a " +
+				"foreign asset input")
+		}
+		if candidate.anchorOutpoint !=
+			stepSummary.PreviousAnchorOutpoint {
+
+			coInputs = append(coInputs, candidate)
 
 			continue
 		}
@@ -171,11 +183,38 @@ func resolveCreatedAssetProofSource(committed *commitResult,
 		return nil, fmt.Errorf("created asset proof predecessor is " +
 			"not present in the sealed package")
 	}
+	if len(coInputs) > tapsdk.AssetProofPathMaxStepCoPaths {
+		return nil, fmt.Errorf("created asset proof merges %d "+
+			"co-inputs, more than %d", len(coInputs),
+			tapsdk.AssetProofPathMaxStepCoPaths)
+	}
+
+	// Co-tips are declared in the package's own input order, matching the
+	// order the Ark request presented them in.
+	sort.SliceStable(coInputs, func(i, j int) bool {
+		return coInputs[i].logicalInputIndex <
+			coInputs[j].logicalInputIndex
+	})
+	for _, coInput := range coInputs {
+		coPath := &tapsdk.AssetProofPath{}
+		if _, err := proofPathFromSource(
+			coInput.proofSource, coPath,
+		); err != nil {
+			return nil, fmt.Errorf("co-input %d: %w",
+				coInput.logicalInputIndex, err)
+		}
+		step.CoInputPaths = append(step.CoInputPaths, coPath)
+	}
 
 	path := &tapsdk.AssetProofPath{}
 	sourceKind, err := proofPathFromSource(input.proofSource, path)
 	if err != nil {
 		return nil, err
+	}
+	if len(step.CoInputPaths) != 0 {
+		if err := promoteAssetProofPathV2(path); err != nil {
+			return nil, err
+		}
 	}
 	path.Steps = append(path.Steps, step)
 	compactPath, err := path.MarshalBinary()
@@ -213,6 +252,90 @@ func resolveCreatedAssetProofSource(committed *commitResult,
 			cloneByteSlices(selected.opTrueWitness),
 		),
 	}, nil
+}
+
+// promoteAssetProofPathV2 re-expresses a path at version 2 so a merging step
+// can carry co-input paths. V1 additional bases become first-step co-input
+// paths of stepless confirmed files, the SDK's own internal model, because a
+// V2 path must leave AdditionalBaseProofs empty.
+func promoteAssetProofPathV2(path *tapsdk.AssetProofPath) error {
+	if path.Version == tapsdk.AssetProofPathVersionV2 {
+		return nil
+	}
+	if len(path.AdditionalBaseProofs) != 0 {
+		if len(path.Steps) == 0 {
+			return fmt.Errorf("spine path carries additional " +
+				"bases without their merging step")
+		}
+		for _, base := range path.AdditionalBaseProofs {
+			path.Steps[0].CoInputPaths = append(
+				path.Steps[0].CoInputPaths,
+				&tapsdk.AssetProofPath{
+					Version: tapsdk.
+						AssetProofPathVersionV0,
+					ConfirmedBaseProof: base,
+				},
+			)
+		}
+		path.AdditionalBaseProofs = nil
+	}
+	path.Version = tapsdk.AssetProofPathVersionV2
+
+	return nil
+}
+
+// AssetProofPathAnchor identifies one unconfirmed anchor transaction of a
+// compact path's transfer DAG. OutputIndex selects the transition's
+// asset-bearing output within that transaction.
+type AssetProofPathAnchor struct {
+	Txid        chainhash.Hash
+	OutputIndex uint32
+}
+
+// CollectAssetProofPathAnchors returns every unconfirmed anchor across the
+// path's transfer DAG: the spine steps plus, recursively, every step's
+// co-input paths. Anchors are deduplicated by txid so a shared ancestor
+// resolves once.
+func CollectAssetProofPathAnchors(path *tapsdk.AssetProofPath) (
+	[]AssetProofPathAnchor, error) {
+
+	if path == nil {
+		return nil, fmt.Errorf("asset proof path is required")
+	}
+
+	seen := make(map[chainhash.Hash]struct{})
+	var anchors []AssetProofPathAnchor
+	var walk func(*tapsdk.AssetProofPath) error
+	walk = func(current *tapsdk.AssetProofPath) error {
+		for i := range current.Steps {
+			summary, err := current.Steps[i].Summary()
+			if err != nil {
+				return fmt.Errorf("summarize lineage step "+
+					"%d: %w", i, err)
+			}
+			txid := chainhash.Hash(summary.AnchorOutpoint.Txid)
+			if _, ok := seen[txid]; !ok {
+				seen[txid] = struct{}{}
+				anchors = append(anchors, AssetProofPathAnchor{
+					Txid: txid,
+					OutputIndex: summary.
+						AnchorOutpoint.Index,
+				})
+			}
+			for _, coPath := range current.Steps[i].CoInputPaths {
+				if err := walk(coPath); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}
+	if err := walk(path); err != nil {
+		return nil, err
+	}
+
+	return anchors, nil
 }
 
 func proofPathFromSource(source commitProofSource,

--- a/tapassets/proof_source_test.go
+++ b/tapassets/proof_source_test.go
@@ -2,6 +2,7 @@ package tapassets
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btcd/blockchain"
@@ -282,6 +283,315 @@ func TestResolveCreatedAssetProofSourceRejectsDepthExhaustion(t *testing.T) {
 		committed.outputs[0].amount, tapsdk.Hash(root),
 	)
 	require.ErrorContains(t, err, "path depth")
+}
+
+// TestResolveCreatedAssetProofSourceAssemblesCoInputPaths proves resolving a
+// merged output rebuilds V2 evidence: the spine keeps the transition
+// predecessor's path, and every other package input's full path rides along
+// as a co-input path of the merging step, in declared input order.
+func TestResolveCreatedAssetProofSourceAssemblesCoInputPaths(t *testing.T) {
+	t.Parallel()
+
+	committed, ref, root, coPathBytes := proofSourceMergeCommitResult(t)
+	resolved, err := resolveCreatedAssetProofSource(
+		committed, committed.outputs[0].anchorOutpoint,
+		committed.outputs[0].anchorValueSat, ref,
+		committed.outputs[0].amount, tapsdk.Hash(root),
+	)
+	require.NoError(t, err)
+
+	var path tapsdk.AssetProofPath
+	require.NoError(t, path.UnmarshalBinary(resolved.CompactProofPath))
+	require.NoError(t, path.Validate())
+	require.Equal(t, tapsdk.AssetProofPathVersionV2, path.Version)
+	require.Empty(t, path.AdditionalBaseProofs)
+
+	// Spine: the predecessor's own creating step, then the merge step
+	// carrying the co-input's complete path.
+	require.Len(t, path.Steps, 2)
+	require.Empty(t, path.Steps[0].CoInputPaths)
+	require.Len(t, path.Steps[1].CoInputPaths, 1)
+	require.Equal(
+		t, committed.outputs[0].proofBlob,
+		path.Steps[1].TransitionProof,
+	)
+	coPath := path.Steps[1].CoInputPaths[0]
+	encodedCoPath, err := coPath.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, coPathBytes, encodedCoPath)
+
+	// The claim walk visits the spine anchors and the co-input's anchor.
+	anchors, err := CollectAssetProofPathAnchors(&path)
+	require.NoError(t, err)
+	require.Len(t, anchors, 3)
+	spineSummary, err := path.Steps[0].Summary()
+	require.NoError(t, err)
+	mergeSummary, err := path.Steps[1].Summary()
+	require.NoError(t, err)
+	coSummary, err := coPath.Steps[0].Summary()
+	require.NoError(t, err)
+	require.Equal(
+		t, chainhash.Hash(spineSummary.AnchorOutpoint.Txid),
+		anchors[0].Txid,
+	)
+	require.Equal(
+		t, chainhash.Hash(mergeSummary.AnchorOutpoint.Txid),
+		anchors[1].Txid,
+	)
+	require.Equal(
+		t, chainhash.Hash(coSummary.AnchorOutpoint.Txid),
+		anchors[2].Txid,
+	)
+}
+
+// TestResolveCreatedAssetProofSourceRejectsForeignAssetInput proves a sealed
+// package whose input set carries another asset can never contribute silent
+// co-input evidence.
+func TestResolveCreatedAssetProofSourceRejectsForeignAssetInput(t *testing.T) {
+	t.Parallel()
+
+	committed, ref, root, _ := proofSourceMergeCommitResult(t)
+	committed.inputs[1].issuanceID[0] ^= 1
+
+	_, err := resolveCreatedAssetProofSource(
+		committed, committed.outputs[0].anchorOutpoint,
+		committed.outputs[0].anchorValueSat, ref,
+		committed.outputs[0].amount, tapsdk.Hash(root),
+	)
+	require.ErrorContains(t, err, "foreign asset input")
+}
+
+// proofSourceMergeCommitResult builds the sealed-package projection of one
+// atomic two-input send: both inputs chain off the shared confirmed base via
+// their own real transitions, and the created output's transition really
+// merges both tips. It returns the co-input's expected compact path bytes.
+func proofSourceMergeCommitResult(t *testing.T) (*commitResult, tapsdk.AssetRef,
+	chainhash.Hash, []byte) {
+
+	t.Helper()
+	baseFile, baseProof, senderKey := proofSourceBase(t)
+	spineKey := testPrivateKey(t, 41)
+	coKey := testPrivateKey(t, 42)
+	spineTip := proofSourceTransition(t, baseProof, senderKey, spineKey)
+	coTip := proofSourceTransition(t, baseProof, senderKey, coKey)
+	merged := proofSourceMergeTransition(
+		t, spineTip, coTip, spineKey, coKey, testPrivateKey(t, 43),
+	)
+	mergedBytes, err := merged.Bytes()
+	require.NoError(t, err)
+	mergedStep := tapsdk.AssetProofPathStep{
+		TransitionProof: mergedBytes,
+	}
+	mergedSummary, err := mergedStep.Summary()
+	require.NoError(t, err)
+
+	pathFor := func(tip *proof.Proof) ([]byte,
+		*tapsdk.AssetProofPathStepSummary) {
+
+		tipBytes, err := tip.Bytes()
+		require.NoError(t, err)
+		step := tapsdk.AssetProofPathStep{TransitionProof: tipBytes}
+		summary, err := step.Summary()
+		require.NoError(t, err)
+		path := &tapsdk.AssetProofPath{
+			Version: tapsdk.AssetProofPathVersionV0,
+			ConfirmedBaseProof: append(
+				[]byte(nil), baseFile...,
+			),
+			Steps: []tapsdk.AssetProofPathStep{
+				step,
+			},
+		}
+		encoded, err := path.MarshalBinary()
+		require.NoError(t, err)
+
+		return encoded, summary
+	}
+	spinePathBytes, spineSummary := pathFor(spineTip)
+	coPathBytes, coSummary := pathFor(coTip)
+	root := chainhash.Hash{7, 7, 7}
+
+	newInput := func(index uint32,
+		summary *tapsdk.AssetProofPathStepSummary,
+		blob []byte) commitInput {
+
+		return commitInput{
+			logicalInputID:    fmt.Sprintf("input-%d", index),
+			logicalInputIndex: index,
+			anchorOutpoint:    summary.AnchorOutpoint,
+			assetRef:          summary.AssetRef,
+			issuanceID:        summary.IssuanceID,
+			amount:            summary.Amount,
+			proofSource: commitProofSource{
+				kind: tapsdk.
+					CustomAnchorProofSourceCompactPath,
+				blob: append([]byte(nil), blob...),
+			},
+		}
+	}
+
+	return &commitResult{
+		inputs: []commitInput{
+			newInput(0, spineSummary, spinePathBytes),
+			newInput(1, coSummary, coPathBytes),
+		},
+		outputs: []commitOutput{{
+			logicalOutputID:   "output-0",
+			anchorOutputIndex: mergedSummary.AnchorOutpoint.Index,
+			anchorOutpoint:    mergedSummary.AnchorOutpoint,
+			anchorValueSat:    mergedSummary.AnchorValueSat,
+			assetRef:          mergedSummary.AssetRef,
+			issuanceID:        mergedSummary.IssuanceID,
+			amount:            mergedSummary.Amount,
+			taprootAssetRoot:  tapsdk.Hash(root),
+			scriptKey:         mergedSummary.ScriptKey,
+			scriptMode:        tapsdk.CustomAssetScriptOPTrue,
+			opTrueWitness: [][]byte{
+				{
+					txscript.OP_TRUE,
+				}, {
+					1,
+					2,
+					3,
+				},
+			},
+			proofBlob: mergedBytes,
+		}},
+	}, mergedSummary.AssetRef, root, coPathBytes
+}
+
+// proofSourceMergeTransition builds a real two-input merging transition:
+// the new asset carries one complete witness per consumed tip and its anchor
+// transaction spends both tips, with the spine as the proof predecessor.
+func proofSourceMergeTransition(t *testing.T, spine, co *proof.Proof, spineKey,
+	coKey, recipientKey *btcec.PrivateKey) *proof.Proof {
+
+	t.Helper()
+	newAsset := spine.Asset.Copy()
+	newAsset.Amount = spine.Asset.Amount + co.Asset.Amount
+	newAsset.ScriptKey = asset.NewScriptKeyBip86(keychain.KeyDescriptor{
+		PubKey: recipientKey.PubKey(),
+	})
+	spinePrev := &asset.PrevID{
+		OutPoint: spine.OutPoint(),
+		ID:       spine.Asset.ID(),
+		ScriptKey: asset.ToSerialized(
+			spine.Asset.ScriptKey.PubKey,
+		),
+	}
+	coPrev := &asset.PrevID{
+		OutPoint: co.OutPoint(),
+		ID:       co.Asset.ID(),
+		ScriptKey: asset.ToSerialized(
+			co.Asset.ScriptKey.PubKey,
+		),
+	}
+	newAsset.PrevWitnesses = []asset.Witness{
+		{
+			PrevID: spinePrev,
+		},
+		{
+			PrevID: coPrev,
+		},
+	}
+	inputs := commitment.InputSet{
+		*spinePrev: &spine.Asset,
+		*coPrev:    &co.Asset,
+	}
+	virtualTx, _, err := tapscript.VirtualTx(newAsset, inputs)
+	require.NoError(t, err)
+	for idx, spent := range []*proof.Proof{spine, co} {
+		signingKey := spineKey
+		if idx == 1 {
+			signingKey = coKey
+		}
+		inputTx := asset.VirtualTxWithInput(
+			virtualTx, 0, 0, uint32(idx), nil,
+		)
+		sigHash, err := tapscript.InputKeySpendSigHash(
+			inputTx, &spent.Asset, newAsset, uint32(idx),
+			txscript.SigHashDefault,
+		)
+		require.NoError(t, err)
+		tweaked := txscript.TweakTaprootPrivKey(*signingKey, nil)
+		signature, err := schnorr.Sign(tweaked, sigHash)
+		require.NoError(t, err)
+		newAsset.PrevWitnesses[idx].TxWitness = wire.TxWitness{
+			signature.Serialize(),
+		}
+	}
+
+	assetCommitment, err := commitment.NewAssetCommitment(newAsset)
+	require.NoError(t, err)
+	version := commitment.TapCommitmentV2
+	tapCommitment, err := commitment.NewTapCommitment(
+		&version, assetCommitment,
+	)
+	require.NoError(t, err)
+	for idx := range newAsset.PrevWitnesses {
+		spentAsset, err := asset.MakeSpentAsset(
+			newAsset.PrevWitnesses[idx],
+		)
+		require.NoError(t, err)
+		require.NoError(
+			t,
+			tapCommitment.MergeAltLeaves(
+				asset.ToAltLeaves(
+					[]*asset.Asset{spentAsset},
+				),
+			),
+		)
+	}
+
+	anchorTx := proofSourceMergeAnchorTx(
+		t, spine.OutPoint(), co.OutPoint(), recipientKey.PubKey(),
+		tapCommitment,
+	)
+	transition, err := proof.CreateTransitionProof(
+		spine.OutPoint(), &proof.TransitionParams{
+			BaseProofParams: proof.BaseProofParams{
+				Block:            proofSourceBlock(anchorTx),
+				Tx:               anchorTx,
+				TxIndex:          0,
+				OutputIndex:      0,
+				InternalKey:      recipientKey.PubKey(),
+				TaprootAssetRoot: tapCommitment,
+			},
+			NewAsset: newAsset,
+		}, proof.WithVersion(proof.TransitionV1),
+	)
+	require.NoError(t, err)
+
+	return transition
+}
+
+// proofSourceMergeAnchorTx anchors a merged commitment while spending both
+// consumed tips.
+func proofSourceMergeAnchorTx(t *testing.T, spine, co wire.OutPoint,
+	internalKey *btcec.PublicKey,
+	tapCommitment *commitment.TapCommitment) *wire.MsgTx {
+
+	t.Helper()
+	root := tapCommitment.TapscriptRoot(nil)
+	outputKey := txscript.ComputeTaprootOutputKey(internalKey, root[:])
+	pkScript, err := txscript.PayToTaprootScript(outputKey)
+	require.NoError(t, err)
+
+	return &wire.MsgTx{
+		Version: 3,
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: spine,
+			},
+			{
+				PreviousOutPoint: co,
+			},
+		},
+		TxOut: []*wire.TxOut{{
+			Value:    660,
+			PkScript: pkScript,
+		}},
+	}
 }
 
 func proofSourceCommitResult(t *testing.T) (*commitResult, tapsdk.AssetRef,

--- a/tapassets/tree_materializer.go
+++ b/tapassets/tree_materializer.go
@@ -675,8 +675,8 @@ func (m *TreeMaterializer) prepareChildren(node *tree.Node, input wire.OutPoint,
 			anchorOutpoint:   out.anchorOutpoint,
 			transaction:      append([]byte(nil), serializedTx...),
 		}
-		transitionInput, _, err := source.appendTransition(
-			out.proofBlob, out.opTrueWitness, expected,
+		transitionInput, err := source.appendTransition(
+			out.proofBlob, out.opTrueWitness,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("child %d: %w", idx, err)

--- a/tapassets/verifier.go
+++ b/tapassets/verifier.go
@@ -3,6 +3,7 @@ package tapassets
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 
 	tapsdk "github.com/lightninglabs/tap-sdk"
@@ -35,19 +36,17 @@ type proofLineageClient interface {
 }
 
 type expectedUnconfirmedAnchor struct {
-	stepIndex        uint16
 	previousOutpoint tapsdk.Outpoint
 	anchorOutpoint   tapsdk.Outpoint
 	transaction      []byte
 }
 
 type proofInventoryVerifier struct {
-	client      proofInventoryClient
-	assetRef    tapsdk.AssetRef
-	amount      uint64
-	anchor      tapsdk.Outpoint
-	assetRoot   tapsdk.Hash
-	unconfirmed *expectedUnconfirmedAnchor
+	client    proofInventoryClient
+	assetRef  tapsdk.AssetRef
+	amount    uint64
+	anchor    tapsdk.Outpoint
+	assetRoot tapsdk.Hash
 }
 
 // VerifyConfirmedProof asks tapd to verify the proof chain and then binds its
@@ -124,43 +123,13 @@ func (v *proofInventoryVerifier) VerifyConfirmedProof(ctx context.Context,
 	}, nil
 }
 
-// VerifyUnconfirmedAnchor binds the compact proof step to the exact committed
-// checkpoint transaction that Wavelength will later submit and sign.
-func (v *proofInventoryVerifier) VerifyUnconfirmedAnchor(_ context.Context,
-	transition tapsdk.UnconfirmedAnchorVerification) error {
-
-	if v == nil || v.unconfirmed == nil {
-		return fmt.Errorf("unconfirmed Wavelength anchor is not " +
-			"configured")
-	}
-	expected := v.unconfirmed
-	if transition.StepIndex != expected.stepIndex {
-		return fmt.Errorf("unexpected unconfirmed proof step %d",
-			transition.StepIndex)
-	}
-	if transition.PreviousAnchorOutpoint != expected.previousOutpoint {
-		return fmt.Errorf("unconfirmed proof previous outpoint " +
-			"mismatch")
-	}
-	if transition.AnchorOutpoint != expected.anchorOutpoint {
-		return fmt.Errorf("unconfirmed proof anchor outpoint mismatch")
-	}
-	if !bytes.Equal(transition.AnchorTransaction, expected.transaction) {
-		return fmt.Errorf("unconfirmed proof anchor transaction " +
-			"mismatch")
-	}
-
-	return nil
-}
-
 // proofLineageVerifier verifies a chained path's confirmed base with tapd and
 // delegates cryptographic validation of every sealed unconfirmed step to
 // tap-sdk. The exact package that created the local VTXO is the authority for
 // passive isolation; a receiver must not need the sender's base anchor in its
 // own ListUtxos inventory.
 type proofLineageVerifier struct {
-	client       proofLineageClient
-	expectedLast *expectedUnconfirmedAnchor
+	client proofLineageClient
 }
 
 // VerifyConfirmedProof verifies the confirmed base through tapd. Complete
@@ -228,26 +197,157 @@ func bootstrapProofIssuance(ctx context.Context, client proofLineageClient,
 }
 
 // VerifyUnconfirmedAnchor accepts sealed historical steps after tap-sdk has
-// verified their transactions and asset transitions. When a new checkpoint
-// step is appended, it additionally binds that last step to Wavelength's exact
-// committed transaction.
-func (v *proofLineageVerifier) VerifyUnconfirmedAnchor(_ context.Context,
+// verified their transactions and asset transitions. Binding a freshly
+// appended checkpoint step to Wavelength's exact committed transaction is
+// the transition verifier's job, which routes by anchor edge instead of the
+// per-path step index that repeats inside co-input paths.
+func (v *proofLineageVerifier) VerifyUnconfirmedAnchor(context.Context,
+	tapsdk.UnconfirmedAnchorVerification) error {
+
+	return nil
+}
+
+// assetAnchorEdge identifies one unconfirmed transition by the asset-bearing
+// outpoint it consumes and the one it creates. Every outpoint is consumed at
+// most once across the transfer DAG, so the pair routes verification
+// callbacks unambiguously, unlike per-path step indices, which repeat inside
+// co-input paths.
+type assetAnchorEdge struct {
+	previous tapsdk.Outpoint
+	anchor   tapsdk.Outpoint
+}
+
+// assetTransitionVerifier fans one SDK verifier callback across every asset
+// input of the Ark transition build. Confirmed base proofs route to their
+// input's own verifier by exact content, failing closed on proofs outside
+// the declared set. Appended checkpoint steps are bound to the committed
+// checkpoint transactions by their (previous, anchor) edge; steps matching
+// no edge are historical, already cryptographically verified by tap-sdk and
+// bound to their transactions when the packages that created them committed.
+type assetTransitionVerifier struct {
+	confirmed map[[sha256.Size]byte]tapsdk.ConfirmedProofVerifier
+	expected  map[assetAnchorEdge]*expectedUnconfirmedAnchor
+}
+
+// newAssetTransitionVerifier indexes the sources' confirmed bases, including
+// every base inside recursive co-input paths, and the expected checkpoint
+// anchor edges of the pending Ark build.
+func newAssetTransitionVerifier(sources []*assetSpendSource,
+	expected []*expectedUnconfirmedAnchor) (*assetTransitionVerifier,
+	error) {
+
+	verifier := &assetTransitionVerifier{
+		confirmed: make(
+			map[[sha256.Size]byte]tapsdk.ConfirmedProofVerifier,
+		),
+		expected: make(
+			map[assetAnchorEdge]*expectedUnconfirmedAnchor,
+			len(expected),
+		),
+	}
+	for idx, source := range sources {
+		if source == nil || source.verifier == nil {
+			return nil, fmt.Errorf("asset source %d verifier is "+
+				"required", idx)
+		}
+		if len(source.proofFile) != 0 {
+			verifier.addConfirmedBase(
+				source.proofFile, source.verifier,
+			)
+		}
+		if source.proofPath != nil {
+			verifier.addPathBases(
+				source.proofPath, source.verifier,
+			)
+		}
+	}
+	for _, entry := range expected {
+		edge := assetAnchorEdge{
+			previous: entry.previousOutpoint,
+			anchor:   entry.anchorOutpoint,
+		}
+		if _, ok := verifier.expected[edge]; ok {
+			return nil, fmt.Errorf("duplicate expected "+
+				"anchor edge %v", edge)
+		}
+		verifier.expected[edge] = entry
+	}
+
+	return verifier, nil
+}
+
+// addPathBases registers every confirmed base of the path's co-input tree.
+// Inputs sharing one base may overwrite each other: chained verifiers are
+// scoped to the proof file itself, never to a particular input.
+func (v *assetTransitionVerifier) addPathBases(path *tapsdk.AssetProofPath,
+	verifier tapsdk.ConfirmedProofVerifier) {
+
+	v.addConfirmedBase(path.ConfirmedBaseProof, verifier)
+	for _, base := range path.AdditionalBaseProofs {
+		v.addConfirmedBase(base, verifier)
+	}
+	for i := range path.Steps {
+		for _, coPath := range path.Steps[i].CoInputPaths {
+			v.addPathBases(coPath, verifier)
+		}
+	}
+}
+
+// addConfirmedBase indexes one confirmed proof file by content.
+func (v *assetTransitionVerifier) addConfirmedBase(base []byte,
+	verifier tapsdk.ConfirmedProofVerifier) {
+
+	if len(base) == 0 {
+		return
+	}
+	v.confirmed[sha256.Sum256(base)] = verifier
+}
+
+// VerifyConfirmedProof routes one confirmed base to the verifier of the
+// input that declared it.
+func (v *assetTransitionVerifier) VerifyConfirmedProof(ctx context.Context,
+	proofFile []byte) (*tapsdk.ConfirmedProofVerification, error) {
+
+	delegate, ok := v.confirmed[sha256.Sum256(proofFile)]
+	if !ok {
+		return nil, fmt.Errorf("confirmed base proof does not belong " +
+			"to this transfer")
+	}
+
+	return delegate.VerifyConfirmedProof(ctx, proofFile)
+}
+
+// VerifyUnconfirmedAnchor binds an appended checkpoint step to the exact
+// committed checkpoint transaction. tap-sdk derives the presented outpoints
+// from the step's own proof, so a substituted transition cannot reach its
+// expected edge without also failing the SDK's continuity checks.
+func (v *assetTransitionVerifier) VerifyUnconfirmedAnchor(_ context.Context,
 	transition tapsdk.UnconfirmedAnchorVerification) error {
 
-	if v == nil || v.expectedLast == nil ||
-		transition.StepIndex != v.expectedLast.stepIndex {
+	edge := assetAnchorEdge{
+		previous: transition.PreviousAnchorOutpoint,
+		anchor:   transition.AnchorOutpoint,
+	}
+	expected, ok := v.expected[edge]
+	if !ok {
 		return nil
 	}
 
-	expected := v.expectedLast
-	if transition.PreviousAnchorOutpoint != expected.previousOutpoint {
-		return fmt.Errorf("chained proof previous outpoint mismatch")
+	// A checkpoint transition consumes exactly its single predecessor;
+	// a merging step can never bind to a checkpoint edge.
+	if len(transition.PreviousAnchorOutpoints) > 1 {
+		return fmt.Errorf("checkpoint transition consumes %d anchors, "+
+			"want one", len(transition.PreviousAnchorOutpoints))
 	}
-	if transition.AnchorOutpoint != expected.anchorOutpoint {
-		return fmt.Errorf("chained proof anchor outpoint mismatch")
+	if len(transition.PreviousAnchorOutpoints) == 1 &&
+		transition.PreviousAnchorOutpoints[0] !=
+			expected.previousOutpoint {
+		return fmt.Errorf("checkpoint transition previous anchor " +
+			"mismatch")
 	}
 	if !bytes.Equal(transition.AnchorTransaction, expected.transaction) {
-		return fmt.Errorf("chained proof anchor transaction mismatch")
+		return fmt.Errorf("unconfirmed proof anchor transaction " +
+			"mismatch")
 	}
 
 	return nil

--- a/tapassets/verifier_test.go
+++ b/tapassets/verifier_test.go
@@ -161,6 +161,178 @@ func TestProofLineageVerifierRejectsInvalidIssuanceBootstrap(t *testing.T) {
 	}
 }
 
+// TestAssetTransitionVerifierRoutesByAnchorEdge proves checkpoint bindings
+// route by the (previous, anchor) outpoint pair: matched edges are checked
+// byte-for-byte against the committed checkpoint transaction, historical
+// steps pass through, and merging steps can never satisfy a checkpoint edge.
+func TestAssetTransitionVerifierRoutesByAnchorEdge(t *testing.T) {
+	t.Parallel()
+
+	firstEdge := &expectedUnconfirmedAnchor{
+		previousOutpoint: tapsdk.Outpoint{
+			Index: 1,
+		},
+		anchorOutpoint: tapsdk.Outpoint{
+			Index: 2,
+		},
+		transaction: []byte("checkpoint-0"),
+	}
+	secondEdge := &expectedUnconfirmedAnchor{
+		previousOutpoint: tapsdk.Outpoint{
+			Index: 3,
+		},
+		anchorOutpoint: tapsdk.Outpoint{
+			Index: 4,
+		},
+		transaction: []byte("checkpoint-1"),
+	}
+	sources := []*assetSpendSource{
+		{
+			proofFile: []byte("base-0"),
+			verifier:  &proofLineageVerifier{},
+		},
+		{
+			proofPath: &tapsdk.AssetProofPath{
+				ConfirmedBaseProof: []byte("base-1"),
+			},
+			verifier: &proofLineageVerifier{},
+		},
+	}
+	verifier, err := newAssetTransitionVerifier(
+		sources, []*expectedUnconfirmedAnchor{firstEdge, secondEdge},
+	)
+	require.NoError(t, err)
+
+	for _, edge := range []*expectedUnconfirmedAnchor{
+		firstEdge, secondEdge,
+	} {
+		transition := tapsdk.UnconfirmedAnchorVerification{
+			PreviousAnchorOutpoint: edge.previousOutpoint,
+			AnchorOutpoint:         edge.anchorOutpoint,
+			AnchorTransaction: append(
+				[]byte(nil), edge.transaction...,
+			),
+			PreviousAnchorOutpoints: []tapsdk.Outpoint{
+				edge.previousOutpoint,
+			},
+		}
+		require.NoError(
+			t,
+			verifier.VerifyUnconfirmedAnchor(
+				t.Context(), transition,
+			),
+		)
+
+		tampered := transition
+		tampered.AnchorTransaction = append(
+			[]byte(nil), edge.transaction...,
+		)
+		tampered.AnchorTransaction[0] ^= 1
+		require.ErrorContains(
+			t,
+			verifier.VerifyUnconfirmedAnchor(
+				t.Context(), tampered,
+			),
+			"transaction mismatch",
+		)
+	}
+
+	// A historical step matches no edge and is accepted here; tap-sdk
+	// verified its cryptographic transition.
+	historical := tapsdk.UnconfirmedAnchorVerification{
+		PreviousAnchorOutpoint: tapsdk.Outpoint{
+			Index: 9,
+		},
+		AnchorOutpoint: tapsdk.Outpoint{
+			Index: 10,
+		},
+		AnchorTransaction: []byte("historical"),
+	}
+	require.NoError(
+		t,
+		verifier.VerifyUnconfirmedAnchor(
+			t.Context(), historical,
+		),
+	)
+
+	// A merging transition consumes several anchors and cannot bind to a
+	// checkpoint edge, even when its spine matches.
+	merging := tapsdk.UnconfirmedAnchorVerification{
+		PreviousAnchorOutpoint: firstEdge.previousOutpoint,
+		AnchorOutpoint:         firstEdge.anchorOutpoint,
+		AnchorTransaction: append(
+			[]byte(nil), firstEdge.transaction...,
+		),
+		PreviousAnchorOutpoints: []tapsdk.Outpoint{
+			firstEdge.previousOutpoint,
+			{
+				Index: 7,
+			},
+		},
+	}
+	require.ErrorContains(
+		t,
+		verifier.VerifyUnconfirmedAnchor(
+			t.Context(), merging,
+		),
+		"want one",
+	)
+
+	// Duplicate expected edges are a bug in the build, never mergeable.
+	_, err = newAssetTransitionVerifier(
+		sources, []*expectedUnconfirmedAnchor{firstEdge, firstEdge},
+	)
+	require.ErrorContains(t, err, "duplicate expected anchor edge")
+}
+
+// TestAssetTransitionVerifierRoutesConfirmedBases proves confirmed proofs
+// route to the declaring input's verifier by content, covering bases nested
+// in recursive co-input paths, and fail closed on undeclared proofs.
+func TestAssetTransitionVerifierRoutesConfirmedBases(t *testing.T) {
+	t.Parallel()
+
+	spineClient := &fakeLineageClient{
+		rawProofs: [][]byte{
+			[]byte("issuance"),
+		},
+		decoded: &tapsdk.DecodedProof{
+			IsIssuance: true,
+		},
+		verification: &tapsdk.VerifyProofResponse{
+			Valid:        true,
+			DecodedProof: &tapsdk.DecodedProof{},
+		},
+	}
+	sources := []*assetSpendSource{{
+		proofPath: &tapsdk.AssetProofPath{
+			Version:            tapsdk.AssetProofPathVersionV2,
+			ConfirmedBaseProof: []byte("spine-base"),
+			Steps: []tapsdk.AssetProofPathStep{{
+				TransitionProof: []byte("merge"),
+				CoInputPaths: []*tapsdk.AssetProofPath{{
+					ConfirmedBaseProof: []byte("co-base"),
+				}},
+			}},
+		},
+		verifier: &proofLineageVerifier{
+			client: spineClient,
+		},
+	}}
+	verifier, err := newAssetTransitionVerifier(sources, nil)
+	require.NoError(t, err)
+
+	for _, base := range [][]byte{
+		[]byte("spine-base"), []byte("co-base"),
+	} {
+		result, err := verifier.VerifyConfirmedProof(t.Context(), base)
+		require.NoError(t, err)
+		require.True(t, result.AnchorAssetInventoryComplete)
+	}
+
+	_, err = verifier.VerifyConfirmedProof(t.Context(), []byte("foreign"))
+	require.ErrorContains(t, err, "does not belong to this transfer")
+}
+
 type fakeLineageClient struct {
 	rawProofs    [][]byte
 	rawProofsSet bool

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -118,6 +118,23 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   command performs, and it is the only recovery when the operator is
   unreachable and the commitment never confirms. Failing the entry would
   contradict `Unroll` and withhold the funding figures that recovery needs.
+- `BoardTaprootAsset` funds its round's fee from Bitcoin the client already
+  holds in Ark (`taproot_asset_round_fee.go`). An asset VTXO request is
+  `FixedAmount`, so a round carrying only one gives the operator no output to
+  stamp the seal-time residual on and `resolveChangeDesignation` rejects the
+  whole intent. `fundAssetRoundFee` therefore refreshes one live Bitcoin VTXO
+  into the same assembling round — reusing the wallet's `RefreshVTXOsRequest`
+  rather than composing forfeits itself — and the residual returns as change.
+  Selection is smallest-sufficient over `fee + MinVTXOAmountFloor()` with an
+  outpoint tie-break, so a large coin is never churned for a small fee. It is
+  skipped when the client's intents for that round already include a non-fixed
+  output it owns (`hasFeeFundingSlot`), which is what keeps the same-round
+  Bitcoin-boarding flow working unchanged. The check runs *before* the
+  boarding is persisted, so a wallet with no spendable Bitcoin fails the RPC
+  with `FailedPrecondition` naming the fix instead of assembling a round the
+  operator rejects at seal. Nothing on the operator changes: a Bitcoin forfeit
+  carries zero asset units, so `validateAssetForfeitBalance` returns early and
+  `planAssetRound`'s boarding/refresh mix guard never sees it.
 - `RefreshVTXOs` dry-run short-circuits before the wallet-ready gate
   (LeaveVTXOs parity) and attaches a best-effort advisory fee estimate
   (`rpc_refresh_estimate.go`): explicit outpoints are deduped and

--- a/waved/congestion_roundtrip_test.go
+++ b/waved/congestion_roundtrip_test.go
@@ -62,6 +62,18 @@ type fakeArkService struct {
 	// lastRequest records the most recent EstimateFeeRequest
 	// so tests can assert what the client asked for.
 	lastRequest *arkrpc.EstimateFeeRequest
+
+	// leaseResponse is the canned LeaseOORCarrier reply. Nil falls
+	// through to the embedded Unimplemented server.
+	leaseResponse *arkrpc.LeaseOORCarrierResponse
+
+	// leaseErr, when non-nil, is returned from LeaseOORCarrier instead
+	// of the canned response.
+	leaseErr error
+
+	// leaseRequests records every LeaseOORCarrierRequest so tests can
+	// assert the requested float value and the number of lease calls.
+	leaseRequests []*arkrpc.LeaseOORCarrierRequest
 }
 
 // EstimateFee records the request and returns the canned reply
@@ -105,6 +117,26 @@ func (f *fakeArkService) GetInfo(ctx context.Context,
 	}
 
 	return f.UnimplementedArkServiceServer.GetInfo(ctx, req)
+}
+
+// LeaseOORCarrier records the request and returns the canned reply (or an
+// injected error). When both fields are nil the call falls through to the
+// embedded Unimplemented server.
+func (f *fakeArkService) LeaseOORCarrier(ctx context.Context,
+	req *arkrpc.LeaseOORCarrierRequest) (*arkrpc.LeaseOORCarrierResponse,
+	error) {
+
+	f.leaseRequests = append(f.leaseRequests, req)
+
+	if f.leaseErr != nil {
+		return nil, f.leaseErr
+	}
+
+	if f.leaseResponse != nil {
+		return f.leaseResponse, nil
+	}
+
+	return f.UnimplementedArkServiceServer.LeaseOORCarrier(ctx, req)
 }
 
 // newBufconnClient builds a *grpc.ClientConn wired to an

--- a/waved/oor_carrier_lease.go
+++ b/waved/oor_carrier_lease.go
@@ -1,0 +1,161 @@
+package waved
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/lightninglabs/wavelength/oor"
+	"github.com/lightninglabs/wavelength/vtxo"
+)
+
+// leaseOORCarrier reserves one operator carrier-float VTXO covering
+// requiredSat over the same direct ArkService connection GetInfo and
+// EstimateFee use. The response is bound locally before anything spends it:
+// the returned policy must compile to the returned pkScript, contain the
+// current operator collab key, and be owned by the operator's advertised
+// carrier float key.
+func (s *Server) leaseOORCarrier(ctx context.Context,
+	terms *types.OperatorTerms, requiredSat btcutil.Amount) (
+	*oor.OORCarrierLease, error) {
+
+	if terms == nil || terms.OORCarrierPubKey == nil {
+		return nil, fmt.Errorf("operator does not fund OOR carriers")
+	}
+	if requiredSat <= 0 {
+		return nil, fmt.Errorf("required carrier value must be " +
+			"positive")
+	}
+
+	client := s.operatorArkClient()
+	if client == nil {
+		return nil, fmt.Errorf("operator connection not initialized")
+	}
+
+	resp, err := client.LeaseOORCarrier(ctx, &arkrpc.LeaseOORCarrierRequest{
+		RequiredSat: int64(requiredSat),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("LeaseOORCarrier RPC: %w", err)
+	}
+
+	outpoint, err := parseOutpointString(resp.GetOutpoint())
+	if err != nil {
+		return nil, fmt.Errorf("parse leased float outpoint %q: %w",
+			resp.GetOutpoint(), err)
+	}
+
+	lease := &oor.OORCarrierLease{
+		Outpoint:       outpoint,
+		Value:          btcutil.Amount(resp.GetValueSat()),
+		PolicyTemplate: bytes.Clone(resp.GetVtxoPolicyTemplate()),
+		PkScript:       bytes.Clone(resp.GetPkScript()),
+		ExpiresAtUnix:  resp.GetExpiresAtUnix(),
+	}
+	if err := lease.Validate(); err != nil {
+		return nil, err
+	}
+	if lease.Value < requiredSat {
+		return nil, fmt.Errorf("leased float value %d sat is below "+
+			"required %d sat", lease.Value, requiredSat)
+	}
+
+	return lease, nil
+}
+
+// BuildOperatorFundedTransferInput constructs the foreign transfer input for
+// a leased operator carrier-float VTXO. It mirrors the custom-input
+// descriptor construction, but stamps no local client key: the float owner is
+// the operator's advertised carrier key and the operator signs both legs.
+func BuildOperatorFundedTransferInput(lease *oor.OORCarrierLease,
+	floatKey, operatorKey *btcec.PublicKey) (oor.TransferInput, error) {
+
+	if err := lease.Validate(); err != nil {
+		return oor.TransferInput{}, err
+	}
+	if floatKey == nil || operatorKey == nil {
+		return oor.TransferInput{}, fmt.Errorf("carrier float and " +
+			"operator keys are required")
+	}
+
+	template, err := arkscript.DecodePolicyTemplate(lease.PolicyTemplate)
+	if err != nil {
+		return oor.TransferInput{}, fmt.Errorf("decode float "+
+			"policy: %w", err)
+	}
+
+	// Bind the semantic policy to the leased output script before any
+	// value is planned against it, exactly like custom inputs do.
+	if !template.MatchesPkScript(lease.PkScript) {
+		return oor.TransferInput{}, fmt.Errorf("float policy does " +
+			"not match the leased pkScript")
+	}
+
+	nodes := make([]arkscript.Node, len(template.Leaves))
+	for i, leaf := range template.Leaves {
+		nodes[i] = leaf.Node
+	}
+	err = arkscript.ValidatePolicy(nodes, arkscript.PolicyValidationOpts{
+		OperatorKey: operatorKey,
+	})
+	if err != nil {
+		return oor.TransferInput{}, fmt.Errorf("invalid float "+
+			"policy: %w", err)
+	}
+
+	params, err := arkscript.DecodeStandardVTXOParams(template)
+	if err != nil {
+		return oor.TransferInput{}, fmt.Errorf("decode float policy "+
+			"params: %w", err)
+	}
+
+	// The float must be owned by the advertised carrier key: anything
+	// else is not the operator's money and must not be spent unsigned.
+	if !bytes.Equal(
+		schnorr.SerializePubKey(params.OwnerKey),
+		schnorr.SerializePubKey(floatKey),
+	) {
+		return oor.TransferInput{}, fmt.Errorf("float policy owner " +
+			"is not the advertised carrier key")
+	}
+
+	// The owner leaf is the float policy's own collab leaf; owner-leaf
+	// normalization deliberately skips operator-funded inputs.
+	ownerLeafPolicy, err := arkscript.LeafTemplate{
+		Node: &arkscript.Multisig{
+			Keys: []*btcec.PublicKey{
+				params.OwnerKey,
+				params.OperatorKey,
+			},
+		},
+	}.Encode()
+	if err != nil {
+		return oor.TransferInput{}, fmt.Errorf("encode float owner "+
+			"leaf: %w", err)
+	}
+
+	input := oor.TransferInput{
+		VTXO: &vtxo.Descriptor{
+			Outpoint:       lease.Outpoint,
+			Amount:         lease.Value,
+			PolicyTemplate: bytes.Clone(lease.PolicyTemplate),
+			PkScript:       bytes.Clone(lease.PkScript),
+			OperatorKey:    params.OperatorKey,
+			RelativeExpiry: params.ExitDelay,
+		},
+		VTXOPolicyTemplate: bytes.Clone(lease.PolicyTemplate),
+		OwnerLeafPolicy:    ownerLeafPolicy,
+		OperatorFunded:     true,
+	}
+	if err := input.Validate(); err != nil {
+		return oor.TransferInput{}, err
+	}
+
+	return input, nil
+}

--- a/waved/oor_carrier_lease_test.go
+++ b/waved/oor_carrier_lease_test.go
@@ -1,0 +1,176 @@
+package waved
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/lightninglabs/wavelength/oor"
+	"github.com/stretchr/testify/require"
+)
+
+// testCarrierFloatLease builds a lease over a real standard float policy
+// owned by floatKey with operatorKey as the collab cosigner.
+func testCarrierFloatLease(t *testing.T, floatKey, operatorKey *btcec.PublicKey,
+	value btcutil.Amount) *oor.OORCarrierLease {
+
+	t.Helper()
+
+	policyTemplate, pkScript, err := arkscript.EncodeStandardVTXOArtifacts(
+		floatKey, operatorKey, 10,
+	)
+	require.NoError(t, err)
+
+	return &oor.OORCarrierLease{
+		Outpoint: wire.OutPoint{
+			Hash: [32]byte{
+				0xf1,
+			},
+			Index: 1,
+		},
+		Value:          value,
+		PolicyTemplate: policyTemplate,
+		PkScript:       pkScript,
+		ExpiresAtUnix:  1_700_000_000,
+	}
+}
+
+// TestOperatorTermsCarryOORCarrierPubKey pins the x-only carrier key parse:
+// empty means disabled, garbage fails, and a valid key round-trips.
+func TestOperatorTermsCarryOORCarrierPubKey(t *testing.T) {
+	t.Parallel()
+
+	carrierKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	resp := &arkrpc.GetInfoResponse{
+		Pubkey: testOperatorPubKeyBytes(t),
+	}
+	terms, err := operatorTermsFromResponse(resp)
+	require.NoError(t, err)
+	require.Nil(t, terms.OORCarrierPubKey)
+
+	resp.OorCarrierPubkey = schnorr.SerializePubKey(carrierKey.PubKey())
+	terms, err = operatorTermsFromResponse(resp)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		schnorr.SerializePubKey(
+			carrierKey.PubKey(),
+		),
+		schnorr.SerializePubKey(terms.OORCarrierPubKey),
+	)
+
+	resp.OorCarrierPubkey = []byte{0x01, 0x02}
+	_, err = operatorTermsFromResponse(resp)
+	require.ErrorContains(t, err, "parse OOR carrier pubkey")
+}
+
+// TestLeaseOORCarrier pins the client-side lease binding: the request carries
+// the required value and the response is validated before use.
+func TestLeaseOORCarrier(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	floatKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	lease := testCarrierFloatLease(
+		t, floatKey.PubKey(), operatorKey.PubKey(), 25_000,
+	)
+	terms := &types.OperatorTerms{
+		PubKey:           operatorKey.PubKey(),
+		OORCarrierPubKey: floatKey.PubKey(),
+	}
+
+	fake := &fakeArkService{
+		leaseResponse: &arkrpc.LeaseOORCarrierResponse{
+			Outpoint:           lease.Outpoint.String(),
+			ValueSat:           int64(lease.Value),
+			VtxoPolicyTemplate: lease.PolicyTemplate,
+			PkScript:           lease.PkScript,
+			ExpiresAtUnix:      lease.ExpiresAtUnix,
+		},
+	}
+	server := &Server{serverConn: newBufconnClient(t, fake)}
+
+	granted, err := server.leaseOORCarrier(t.Context(), terms, 2_000)
+	require.NoError(t, err)
+	require.True(t, lease.FundingEquals(granted))
+	require.Len(t, fake.leaseRequests, 1)
+	require.EqualValues(t, 2_000, fake.leaseRequests[0].GetRequiredSat())
+
+	// A float below the required value must be refused.
+	_, err = server.leaseOORCarrier(t.Context(), terms, 30_000)
+	require.ErrorContains(t, err, "below required")
+
+	// An operator that advertises no carrier key never gets asked.
+	callsBefore := len(fake.leaseRequests)
+	_, err = server.leaseOORCarrier(
+		t.Context(), &types.OperatorTerms{
+			PubKey: operatorKey.PubKey(),
+		},
+		2_000,
+	)
+	require.ErrorContains(t, err, "does not fund OOR carriers")
+	require.Len(t, fake.leaseRequests, callsBefore)
+}
+
+// TestBuildOperatorFundedTransferInput pins the binding checks between the
+// lease, the advertised float key, and the current operator key.
+func TestBuildOperatorFundedTransferInput(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	floatKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	otherKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	lease := testCarrierFloatLease(
+		t, floatKey.PubKey(), operatorKey.PubKey(), 25_000,
+	)
+
+	in, err := BuildOperatorFundedTransferInput(
+		lease, floatKey.PubKey(), operatorKey.PubKey(),
+	)
+	require.NoError(t, err)
+	require.True(t, in.OperatorFunded)
+	require.Nil(t, in.VTXO.ClientKey.PubKey)
+	require.Equal(t, lease.Outpoint, in.VTXO.Outpoint)
+	require.Equal(t, lease.Value, in.VTXO.Amount)
+	require.Equal(t, lease.PkScript, in.VTXO.PkScript)
+	require.NotEmpty(t, in.OwnerLeafScript)
+
+	// A pkScript the policy does not compile to is a lie about the float.
+	tampered := lease.Clone()
+	tampered.PkScript[len(tampered.PkScript)-1] ^= 0x01
+	_, err = BuildOperatorFundedTransferInput(
+		tampered, floatKey.PubKey(), operatorKey.PubKey(),
+	)
+	require.ErrorContains(t, err, "does not match the leased pkScript")
+
+	// A policy owned by someone other than the advertised carrier key is
+	// not the operator's float.
+	_, err = BuildOperatorFundedTransferInput(
+		lease, otherKey.PubKey(), operatorKey.PubKey(),
+	)
+	require.ErrorContains(t, err, "not the advertised carrier key")
+
+	// A policy whose collab leaf lacks the current operator key fails
+	// policy validation.
+	foreign := testCarrierFloatLease(
+		t, floatKey.PubKey(), otherKey.PubKey(), 25_000,
+	)
+	_, err = BuildOperatorFundedTransferInput(
+		foreign, floatKey.PubKey(), operatorKey.PubKey(),
+	)
+	require.ErrorContains(t, err, "invalid float policy")
+}

--- a/waved/operator_negotiation.go
+++ b/waved/operator_negotiation.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/lib/types"
@@ -54,6 +55,17 @@ func operatorTermsFromResponse(resp *arkrpc.GetInfoResponse) (
 		minVTXOAmount = resp.DustLimit
 	}
 
+	// The carrier float owner key is advertised x-only; an empty field
+	// means the operator does not fund OOR carriers.
+	var carrierKey *btcec.PublicKey
+	if len(resp.OorCarrierPubkey) != 0 {
+		carrierKey, err = schnorr.ParsePubKey(resp.OorCarrierPubkey)
+		if err != nil {
+			return nil, fmt.Errorf("parse OOR carrier pubkey: %w",
+				err)
+		}
+	}
+
 	// The forfeit penalty key, sweep key and sweep delay are no longer
 	// global operator terms; they are delivered per round in the batch
 	// info, so GetInfo no longer carries them.
@@ -71,6 +83,7 @@ func operatorTermsFromResponse(resp *arkrpc.GetInfoResponse) (
 		MinConfirmations:        resp.MinConfirmations,
 		MaxOORLineageVBytes:     resp.MaxOorLineageVbytes,
 		MaxUserBalance:          btcutil.Amount(resp.MaxUserBalance),
+		OORCarrierPubKey:        carrierKey,
 	}, nil
 }
 

--- a/waved/operator_negotiation_test.go
+++ b/waved/operator_negotiation_test.go
@@ -129,6 +129,14 @@ func (s *stubArkServiceClient) EstimateFee(_ context.Context,
 	return &arkrpc.EstimateFeeResponse{}, nil
 }
 
+// LeaseOORCarrier is unused by these tests.
+func (s *stubArkServiceClient) LeaseOORCarrier(_ context.Context,
+	_ *arkrpc.LeaseOORCarrierRequest, _ ...grpc.CallOption) (
+	*arkrpc.LeaseOORCarrierResponse, error) {
+
+	return &arkrpc.LeaseOORCarrierResponse{}, nil
+}
+
 // testOperatorPubKeyBytes returns a valid compressed secp256k1 public key for
 // populating a fake GetInfo response.
 func testOperatorPubKeyBytes(t *testing.T) []byte {

--- a/waved/rpc_auth.go
+++ b/waved/rpc_auth.go
@@ -134,7 +134,8 @@ func newWavedRPCPermissions() map[string][]bakery.Op {
 	)
 	grant(
 		daemon, entityOnChain, "write", "SendOnChain", "Board",
-		"OnboardTaprootAsset", "SweepBoardingUTXOs", "Unroll",
+		"OnboardTaprootAsset", "BoardTaprootAsset",
+		"ClaimTaprootAssetVTXO", "SweepBoardingUTXOs", "Unroll",
 	)
 	grant(
 		daemon, entityRound, "read", "ListRounds", "GetRound",

--- a/waved/rpc_oor_idempotency_test.go
+++ b/waved/rpc_oor_idempotency_test.go
@@ -1433,6 +1433,18 @@ func newSendOORTestStores(t *testing.T) (*db.VTXOPersistenceStore,
 
 	t.Helper()
 
+	vtxoStore, deliveryStore, registryStore, _ :=
+		newSendOORTestStoresWithArtifacts(t)
+
+	return vtxoStore, deliveryStore, registryStore
+}
+
+func newSendOORTestStoresWithArtifacts(t *testing.T) (*db.VTXOPersistenceStore,
+	actor.DeliveryStore, *db.OORSessionRegistryStoreDB,
+	*db.OORArtifactPersistenceStore) {
+
+	t.Helper()
+
 	sqlDB := db.NewTestDB(t)
 	roundDB := db.NewTransactionExecutor(
 		sqlDB.BaseDB,
@@ -1458,8 +1470,9 @@ func newSendOORTestStores(t *testing.T) (*db.VTXOPersistenceStore,
 	registryStore := dbStore.NewOORSessionRegistryStore(
 		clock.NewDefaultClock(),
 	)
+	artifactStore := dbStore.NewOORArtifactStore(clock.NewDefaultClock())
 
-	return vtxoStore, deliveryStore, registryStore
+	return vtxoStore, deliveryStore, registryStore, artifactStore
 }
 
 func newSendOORTestVTXO(t *testing.T, operatorKey *btcec.PublicKey,

--- a/waved/rpc_oor_receive.go
+++ b/waved/rpc_oor_receive.go
@@ -8,7 +8,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/waverpc"
-	"github.com/lightningnetwork/lnd/clock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -96,16 +95,11 @@ func (r *RPCServer) NewReceiveScript(ctx context.Context,
 func (r *RPCServer) newOORReceiveScriptStore() (*db.OORArtifactPersistenceStore,
 	error) {
 
-	if r.server.db == nil {
-		return nil, fmt.Errorf("database not initialized")
+	if r.server.oorArtifactStore == nil {
+		return nil, fmt.Errorf("artifact store not initialized")
 	}
 
-	dbStore := db.NewStore(
-		r.server.db.DB, r.server.db.Queries, r.server.db.Backend(),
-		r.server.subLogger(db.Subsystem),
-	)
-
-	return dbStore.NewOORArtifactStore(clock.NewDefaultClock()), nil
+	return r.server.oorArtifactStore, nil
 }
 
 // oorReceiveKeyOps returns the fresh-key derivation function and signer

--- a/waved/rpc_oor_taproot_asset.go
+++ b/waved/rpc_oor_taproot_asset.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/btcsuite/btcd/wire/v2"
-	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
 	"github.com/lightninglabs/wavelength/oor"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightninglabs/wavelength/waverpc"
@@ -72,7 +71,9 @@ func taprootAssetOORIntent(req *waverpc.SendOORRequest) (
 	}
 
 	intent := &oor.TaprootAssetOORIntent{
-		InputVTXOOutpoint:    inputOutpoint,
+		InputVTXOOutpoints: []wire.OutPoint{
+			inputOutpoint,
+		},
 		AssetRef:             rpcIntent.GetAssetRef(),
 		AssetAmount:          rpcIntent.GetAssetAmount(),
 		RecipientAssetAmount: rpcIntent.GetRecipientAssetAmount(),
@@ -149,8 +150,7 @@ func resumeTaprootAssetOOR(ctx context.Context,
 		return nil, nil
 	}
 	if len(resume.InputOutpoints) == 0 ||
-		len(resume.InputOutpoints) >
-			oortx.MaxTaprootAssetCheckpointPackages {
+		len(resume.InputOutpoints) > oor.MaxTaprootAssetInputs {
 		return nil, invalidTaprootAssetPreparation(
 			fmt.Errorf(
 				"resume input count %d is invalid",
@@ -160,7 +160,6 @@ func resumeTaprootAssetOOR(ctx context.Context,
 	}
 
 	seen := make(map[wire.OutPoint]struct{}, len(resume.InputOutpoints))
-	assetMatches := 0
 	for _, outpoint := range resume.InputOutpoints {
 		if _, ok := seen[outpoint]; ok {
 			return nil, invalidTaprootAssetPreparation(
@@ -169,15 +168,32 @@ func resumeTaprootAssetOOR(ctx context.Context,
 			)
 		}
 		seen[outpoint] = struct{}{}
-		if outpoint == request.Intent.InputVTXOOutpoint {
-			assetMatches++
-		}
 	}
-	if assetMatches != 1 {
-		return nil, invalidTaprootAssetPreparation(
-			fmt.Errorf("resume does not contain the requested " +
-				"asset input exactly once"),
-		)
+
+	// Caller-pinned outpoints must be adopted verbatim: the journaled set
+	// has to be exactly the pinned set. A selection-mode retry pins
+	// nothing and adopts whatever selection the journal committed to.
+	pinned := request.Intent.InputVTXOOutpoints
+	if len(pinned) != 0 {
+		if len(resume.InputOutpoints) != len(pinned) {
+			return nil, invalidTaprootAssetPreparation(
+				fmt.Errorf(
+					"resume input count %d does not "+
+						"match the %d pinned asset "+
+						"inputs",
+					len(resume.InputOutpoints), len(pinned),
+				),
+			)
+		}
+		for _, outpoint := range pinned {
+			if _, ok := seen[outpoint]; !ok {
+				return nil, invalidTaprootAssetPreparation(
+					fmt.Errorf("resume does not contain "+
+						"the requested asset input "+
+						"%s exactly once", outpoint),
+				)
+			}
+		}
 	}
 
 	return resume, nil

--- a/waved/rpc_oor_taproot_asset.go
+++ b/waved/rpc_oor_taproot_asset.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/oor"
 	"github.com/lightninglabs/wavelength/vtxo"
@@ -61,19 +63,13 @@ func taprootAssetOORIntent(req *waverpc.SendOORRequest) (
 			"the operator's minimum VTXO amount")
 	}
 
-	inputOutpoint, err := parseOutpointString(
-		rpcIntent.GetInputVtxoOutpoint(),
-	)
+	inputOutpoints, err := taprootAssetIntentOutpoints(rpcIntent)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "parse "+
-			"Taproot Asset input VTXO outpoint %q: %v",
-			rpcIntent.GetInputVtxoOutpoint(), err)
+		return nil, err
 	}
 
 	intent := &oor.TaprootAssetOORIntent{
-		InputVTXOOutpoints: []wire.OutPoint{
-			inputOutpoint,
-		},
+		InputVTXOOutpoints:   inputOutpoints,
 		AssetRef:             rpcIntent.GetAssetRef(),
 		AssetAmount:          rpcIntent.GetAssetAmount(),
 		RecipientAssetAmount: rpcIntent.GetRecipientAssetAmount(),
@@ -95,6 +91,236 @@ func taprootAssetOORIntent(req *waverpc.SendOORRequest) (
 	}
 
 	return intent, nil
+}
+
+// taprootAssetIntentOutpoints resolves the pinned input, if any. An empty
+// outpoint delegates input selection to the daemon, where asset_amount
+// already names the units to send: the split between recipient and change
+// derives from whatever selection covers it.
+func taprootAssetIntentOutpoints(rpcIntent *waverpc.TaprootAssetOORIntent) (
+	[]wire.OutPoint, error) {
+
+	rawOutpoint := rpcIntent.GetInputVtxoOutpoint()
+	if rawOutpoint == "" {
+		if rpcIntent.GetRecipientAssetAmount() != 0 {
+			message := "recipient_asset_amount requires " +
+				"input_vtxo_outpoint: asset_amount already " +
+				"names the units to send"
+
+			return nil, status.Error(
+				codes.InvalidArgument, message,
+			)
+		}
+		if len(rpcIntent.GetInputProofFile()) != 0 {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"input_proof_file requires input_vtxo_outpoint")
+		}
+
+		return nil, nil
+	}
+
+	inputOutpoint, err := parseOutpointString(rawOutpoint)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "parse "+
+			"Taproot Asset input VTXO outpoint %q: %v", rawOutpoint,
+			err)
+	}
+
+	return []wire.OutPoint{inputOutpoint}, nil
+}
+
+// selectTaprootAssetOORInputs picks the live asset VTXOs one atomic transfer
+// spends to cover want units. A single sufficient VTXO wins (the smallest
+// such), otherwise the largest VTXOs accumulate until covered, spine first,
+// bounded by the per-transfer input cap.
+func selectTaprootAssetOORInputs(candidates []*vtxo.Descriptor,
+	want uint64) ([]*vtxo.Descriptor, error) {
+
+	if want == 0 {
+		return nil, fmt.Errorf("taproot asset send amount is required")
+	}
+
+	live := make([]*vtxo.Descriptor, 0, len(candidates))
+	var total uint64
+	for _, candidate := range candidates {
+		if candidate == nil ||
+			candidate.Status != vtxo.VTXOStatusLive ||
+			candidate.TaprootAssetAmount == 0 {
+
+			continue
+		}
+		if candidate.TaprootAssetAmount > ^uint64(0)-total {
+			return nil, fmt.Errorf("taproot asset balance " +
+				"overflows")
+		}
+		total += candidate.TaprootAssetAmount
+		live = append(live, candidate)
+	}
+	if total < want {
+		return nil, fmt.Errorf("insufficient taproot asset balance: "+
+			"need %d units, have %d", want, total)
+	}
+
+	// Deterministic order: units descending, outpoint as tie-break.
+	sort.Slice(live, func(i, j int) bool {
+		if live[i].TaprootAssetAmount != live[j].TaprootAssetAmount {
+			return live[i].TaprootAssetAmount >
+				live[j].TaprootAssetAmount
+		}
+
+		return live[i].Outpoint.String() < live[j].Outpoint.String()
+	})
+
+	// A single sufficient VTXO avoids merging entirely: the smallest one
+	// covering the send preserves the larger leaves. Equal amounts keep
+	// the earlier entry so the outpoint tie-break stays in force.
+	var single *vtxo.Descriptor
+	for _, candidate := range live {
+		if candidate.TaprootAssetAmount < want {
+			break
+		}
+		if single == nil ||
+			candidate.TaprootAssetAmount <
+				single.TaprootAssetAmount {
+
+			single = candidate
+		}
+	}
+	if single != nil {
+		return []*vtxo.Descriptor{single}, nil
+	}
+
+	var (
+		selected []*vtxo.Descriptor
+		covered  uint64
+	)
+	for _, candidate := range live {
+		if len(selected) == oor.MaxTaprootAssetInputs {
+			return nil, fmt.Errorf("sending %d units spans more "+
+				"than %d asset VTXOs; consolidate first", want,
+				oor.MaxTaprootAssetInputs)
+		}
+		selected = append(selected, candidate)
+		covered += candidate.TaprootAssetAmount
+		if covered >= want {
+			return selected, nil
+		}
+	}
+
+	return nil, fmt.Errorf("sending %d units spans more than %d asset "+
+		"VTXOs; consolidate first", want, oor.MaxTaprootAssetInputs)
+}
+
+// resolveTaprootAssetOORIntent turns the public intent into the resolved
+// per-input shape: the ordered asset input set (adopted from a resumed
+// preparation, pinned by the caller, or selected from the live wallet), the
+// summed input units, and the derived recipient allocation. The second
+// return value is the summed Bitcoin carrier value wallet selection targets.
+func (r *RPCServer) resolveTaprootAssetOORIntent(ctx context.Context,
+	intent *oor.TaprootAssetOORIntent, resume *oor.TaprootAssetOORResume) (
+	*oor.TaprootAssetOORIntent, btcutil.Amount, error) {
+
+	pinned := len(intent.InputVTXOOutpoints) != 0
+
+	var outpoints []wire.OutPoint
+	switch {
+	case resume != nil:
+		outpoints = append(
+			[]wire.OutPoint(nil), resume.InputOutpoints...,
+		)
+
+	case pinned:
+		outpoints = append(
+			[]wire.OutPoint(nil), intent.InputVTXOOutpoints...,
+		)
+
+	default:
+		live, err := r.server.vtxoStore.ListLiveVTXOs(ctx)
+		if err != nil {
+			return nil, 0, status.Errorf(codes.Internal, "list "+
+				"live VTXOs: %v", err)
+		}
+
+		// Exact reference match only: the resolved inputs must carry
+		// the intent's reference verbatim through preparation.
+		candidates := make([]*vtxo.Descriptor, 0, len(live))
+		for _, desc := range live {
+			if desc.TaprootAssetRef == intent.AssetRef {
+				candidates = append(candidates, desc)
+			}
+		}
+		selected, err := selectTaprootAssetOORInputs(
+			candidates, intent.AssetAmount,
+		)
+		if err != nil {
+			return nil, 0, status.Errorf(codes.FailedPrecondition,
+				"%v", err)
+		}
+		for _, desc := range selected {
+			outpoints = append(outpoints, desc.Outpoint)
+		}
+	}
+
+	var (
+		totalUnits uint64
+		carriers   btcutil.Amount
+	)
+	for _, outpoint := range outpoints {
+		desc, err := r.server.vtxoStore.GetVTXO(ctx, outpoint)
+		if err != nil || desc == nil {
+			return nil, 0, status.Errorf(codes.InvalidArgument,
+				"unknown Taproot Asset input VTXO %s", outpoint)
+		}
+		totalUnits += desc.TaprootAssetAmount
+		carriers += desc.Amount
+	}
+
+	resolved := *intent
+	resolved.InputVTXOOutpoints = outpoints
+	if !pinned {
+		// Selection mode: the caller's asset_amount is the send
+		// total; the resolved total is whatever the inputs carry.
+		want := intent.AssetAmount
+		if want > totalUnits {
+			return nil, 0, status.Errorf(codes.FailedPrecondition,
+				"resolved asset inputs carry %d units, need %d",
+				totalUnits, want)
+		}
+		resolved.AssetAmount = totalUnits
+		resolved.RecipientAssetAmount = 0
+		if want < totalUnits {
+			resolved.RecipientAssetAmount = want
+		}
+	}
+	if err := resolved.Validate(); err != nil {
+		return nil, 0, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	return &resolved, carriers, nil
+}
+
+// orderAssetSelectedOutpoints pins wallet-locked outpoints to the intent's
+// spine-first order. The wallet must have selected exactly the required set:
+// asset sends never carry extra Bitcoin filler inputs.
+func orderAssetSelectedOutpoints(selected, required []wire.OutPoint) (
+	[]wire.OutPoint, error) {
+
+	if len(selected) != len(required) {
+		return nil, fmt.Errorf("wallet selected %d inputs, want %d",
+			len(selected), len(required))
+	}
+	seen := make(map[wire.OutPoint]struct{}, len(selected))
+	for _, outpoint := range selected {
+		seen[outpoint] = struct{}{}
+	}
+	for _, outpoint := range required {
+		if _, ok := seen[outpoint]; !ok {
+			return nil, fmt.Errorf("wallet selection misses "+
+				"required input %s", outpoint)
+		}
+	}
+
+	return append([]wire.OutPoint(nil), required...), nil
 }
 
 // requireTaprootAssetOORPreparer fails before input reservation when the

--- a/waved/rpc_oor_taproot_asset.go
+++ b/waved/rpc_oor_taproot_asset.go
@@ -210,8 +210,11 @@ func validateTaprootAssetOORResumeInputs(ctx context.Context,
 	return nil
 }
 
-// taprootAssetOORSelectionTarget adds the explicit local asset-change carrier
-// to the receiver carrier without conflating either quantity with asset units.
+// taprootAssetOORSelectionTarget adds the local asset-change carrier to the
+// receiver carrier without conflating either quantity with asset units. A
+// partial send with no explicit carrier is materialized to the operator's
+// minimum VTXO amount; the input remainder later returns to the sender as an
+// ordinary Bitcoin change output.
 func taprootAssetOORSelectionTarget(receiverCarrier btcutil.Amount,
 	intent *oor.TaprootAssetOORIntent,
 	outputFloor btcutil.Amount) (btcutil.Amount, error) {
@@ -224,6 +227,12 @@ func taprootAssetOORSelectionTarget(receiverCarrier btcutil.Amount,
 		return 0, status.Errorf(codes.InvalidArgument, "Taproot Asset "+
 			"change carrier must be <= %d",
 			int64(btcutil.MaxSatoshi))
+	}
+
+	if intent.AssetChangeCarrierValueSat == 0 &&
+		intent.EffectiveRecipientAssetAmount() < intent.AssetAmount {
+
+		intent.AssetChangeCarrierValueSat = uint64(outputFloor)
 	}
 
 	changeCarrier := btcutil.Amount(intent.AssetChangeCarrierValueSat)

--- a/waved/rpc_oor_taproot_asset.go
+++ b/waved/rpc_oor_taproot_asset.go
@@ -255,3 +255,48 @@ func invalidTaprootAssetPreparation(err error) error {
 	return status.Errorf(codes.Internal, "invalid Taproot Asset OOR "+
 		"preparation: %v", err)
 }
+
+// registerTaprootAssetChangeAliases persists composed-script ownership for the
+// wallet's own change outputs before the transfer is admitted. The incoming
+// self-notification for this session is driven by a single recipient event,
+// so a composed asset-change script must resolve as owned without relying on
+// its own event's metadata overlay.
+func (r *RPCServer) registerTaprootAssetChangeAliases(ctx context.Context,
+	preparation *oor.TaprootAssetOORPreparation) error {
+
+	store, err := r.newOORReceiveScriptStore()
+	if err != nil {
+		return fmt.Errorf("open OOR receive-script store: %w", err)
+	}
+
+	for i := range preparation.Recipients {
+		recipient := preparation.Recipients[i]
+		if recipient.Value == preparation.Receiver.Value &&
+			bytes.Equal(
+				recipient.PkScript,
+				preparation.Receiver.PkScript,
+			) {
+
+			continue
+		}
+
+		_, err := ResolveOwnedReceiveScriptKey(
+			ctx, store, oor.ArkRecipientOutput{
+				Value:    recipient.Value,
+				PkScript: recipient.PkScript,
+				VTXOPolicyTemplate: recipient.
+					VTXOPolicyTemplate,
+				TaprootAssetRoot: recipient.TaprootAssetRoot,
+				TaprootAssetRef:  recipient.TaprootAssetRef,
+				TaprootAssetAmount: recipient.
+					TaprootAssetAmount,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("resolve local change recipient "+
+				"%d: %w", i, err)
+		}
+	}
+
+	return nil
+}

--- a/waved/rpc_oor_taproot_asset.go
+++ b/waved/rpc_oor_taproot_asset.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
 	"github.com/lightninglabs/wavelength/oor"
@@ -48,6 +47,19 @@ func taprootAssetOORIntent(req *waverpc.SendOORRequest) (
 		return nil, status.Errorf(codes.InvalidArgument, "Taproot "+
 			"Asset OOR transfers require "+
 			"acknowledge_unconfirmed=true")
+
+	// New asset-leaf carriers are operator-funded at the operator's
+	// minimum VTXO amount, so no caller-chosen Bitcoin value survives.
+	case rpcIntent.GetAssetChangeCarrierValueSat() != 0:
+		return nil, status.Errorf(codes.InvalidArgument,
+			"asset_change_carrier_value_sat must be zero: "+
+				"carriers are operator-funded at the floor")
+
+	case req.GetRecipients()[0].GetAmountSat() != 0:
+		return nil, status.Errorf(codes.InvalidArgument, "recipient "+
+			"amount_sat must be zero for Taproot Asset sends: "+
+			"the daemon stamps the operator-funded carrier at "+
+			"the operator's minimum VTXO amount")
 	}
 
 	inputOutpoint, err := parseOutpointString(
@@ -210,46 +222,6 @@ func validateTaprootAssetOORResumeInputs(ctx context.Context,
 	return nil
 }
 
-// taprootAssetOORSelectionTarget adds the local asset-change carrier to the
-// receiver carrier without conflating either quantity with asset units. A
-// partial send with no explicit carrier is materialized to the operator's
-// minimum VTXO amount; the input remainder later returns to the sender as an
-// ordinary Bitcoin change output.
-func taprootAssetOORSelectionTarget(receiverCarrier btcutil.Amount,
-	intent *oor.TaprootAssetOORIntent,
-	outputFloor btcutil.Amount) (btcutil.Amount, error) {
-
-	if intent == nil {
-		return receiverCarrier, nil
-	}
-
-	if intent.AssetChangeCarrierValueSat > uint64(btcutil.MaxSatoshi) {
-		return 0, status.Errorf(codes.InvalidArgument, "Taproot Asset "+
-			"change carrier must be <= %d",
-			int64(btcutil.MaxSatoshi))
-	}
-
-	if intent.AssetChangeCarrierValueSat == 0 &&
-		intent.EffectiveRecipientAssetAmount() < intent.AssetAmount {
-
-		intent.AssetChangeCarrierValueSat = uint64(outputFloor)
-	}
-
-	changeCarrier := btcutil.Amount(intent.AssetChangeCarrierValueSat)
-	if changeCarrier != 0 && changeCarrier < outputFloor {
-		return 0, status.Errorf(codes.InvalidArgument, "Taproot Asset "+
-			"change carrier %d sat is below operator "+
-			"minimum %d sat", changeCarrier, outputFloor)
-	}
-	if receiverCarrier > btcutil.MaxSatoshi-changeCarrier {
-		return 0, status.Errorf(codes.InvalidArgument, "Taproot Asset "+
-			"carrier total must be <= %d",
-			int64(btcutil.MaxSatoshi))
-	}
-
-	return receiverCarrier + changeCarrier, nil
-}
-
 // invalidTaprootAssetPreparation reports a bug or compromised adapter result.
 func invalidTaprootAssetPreparation(err error) error {
 	return status.Errorf(codes.Internal, "invalid Taproot Asset OOR "+
@@ -262,7 +234,8 @@ func invalidTaprootAssetPreparation(err error) error {
 // so a composed asset-change script must resolve as owned without relying on
 // its own event's metadata overlay.
 func (r *RPCServer) registerTaprootAssetChangeAliases(ctx context.Context,
-	preparation *oor.TaprootAssetOORPreparation) error {
+	preparation *oor.TaprootAssetOORPreparation,
+	lease *oor.OORCarrierLease) error {
 
 	store, err := r.newOORReceiveScriptStore()
 	if err != nil {
@@ -276,6 +249,14 @@ func (r *RPCServer) registerTaprootAssetChangeAliases(ctx context.Context,
 				recipient.PkScript,
 				preparation.Receiver.PkScript,
 			) {
+
+			continue
+		}
+
+		// The operator's float residual is not wallet money and has
+		// no owned receive script to alias.
+		if lease != nil &&
+			bytes.Equal(recipient.PkScript, lease.PkScript) {
 
 			continue
 		}

--- a/waved/rpc_oor_taproot_asset_test.go
+++ b/waved/rpc_oor_taproot_asset_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -105,6 +106,11 @@ func (p *testTaprootAssetOORPreparer) PrepareTaprootAssetOOR(_ context.Context,
 		return nil
 	}
 
+	plan, err := request.CarrierAllocation()
+	if err != nil {
+		return nil, err
+	}
+
 	receiverAmount := request.Intent.EffectiveRecipientAssetAmount()
 	if err := setAssetRecipient(
 		&recipients[0], "-receiver", receiverAmount,
@@ -116,9 +122,7 @@ func (p *testTaprootAssetOORPreparer) PrepareTaprootAssetOOR(_ context.Context,
 		assetChange := cloneTestTaprootAssetRecipients(
 			request.Recipients,
 		)[0]
-		assetChange.Value = btcutil.Amount(
-			request.Intent.AssetChangeCarrierValueSat,
-		)
+		assetChange.Value = plan.AssetChange
 		if err := setAssetRecipient(
 			&assetChange, "-asset-change",
 			request.Intent.AssetAmount-receiverAmount,
@@ -128,17 +132,16 @@ func (p *testTaprootAssetOORPreparer) PrepareTaprootAssetOOR(_ context.Context,
 		recipients = append(recipients, assetChange)
 	}
 
-	var inputTotal btcutil.Amount
-	for idx := range request.Inputs {
-		inputTotal += request.Inputs[idx].VTXO.Amount
-	}
-	requiredCarrier := request.Recipients[0].Value + btcutil.Amount(
-		request.Intent.AssetChangeCarrierValueSat,
-	)
-	if bitcoinChange := inputTotal - requiredCarrier; bitcoinChange > 0 {
-		change := cloneTestTaprootAssetRecipients(request.Recipients)[0]
-		change.Value = bitcoinChange
-		recipients = append(recipients, change)
+	senderChange := cloneTestTaprootAssetRecipients(request.Recipients)[0]
+	senderChange.Value = plan.SenderChange
+	recipients = append(recipients, senderChange)
+
+	if plan.OperatorChange > 0 {
+		recipients = append(recipients, oortx.RecipientOutput{
+			PkScript:           request.Lease.PkScript,
+			Value:              plan.OperatorChange,
+			VTXOPolicyTemplate: request.Lease.PolicyTemplate,
+		})
 	}
 
 	arkPSBT, checkpointPSBTs, err := oor.BuildSubmitPackage(
@@ -193,6 +196,7 @@ func (p *testTaprootAssetOORPreparer) ResumeTaprootAssetOOR(_ context.Context,
 		InputOutpoints: append(
 			[]wire.OutPoint(nil), p.resume.InputOutpoints...,
 		),
+		Lease: p.resume.Lease.Clone(),
 	}, nil
 }
 
@@ -222,6 +226,8 @@ type taprootAssetOORRPCFixture struct {
 	desc          *vtxo.Descriptor
 	wallet        *sendOORTestWallet
 	artifactStore *db.OORArtifactPersistenceStore
+	arkService    *fakeArkService
+	lease         *oor.OORCarrierLease
 }
 
 func newTaprootAssetOORRPCFixture(t *testing.T) *taprootAssetOORRPCFixture {
@@ -325,6 +331,46 @@ func newTaprootAssetOORRPCFixtureWithActor(t *testing.T,
 		)
 	}
 
+	// The operator advertises a carrier float and grants a lease whose
+	// policy binds the float owner and current operator keys to the
+	// leased pkScript.
+	floatKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	leasePolicy, leasePkScript, err := arkscript.
+		EncodeStandardVTXOArtifacts(
+			floatKey.PubKey(), operatorKey.PubKey(), exitDelay,
+		)
+	require.NoError(t, err)
+	lease := &oor.OORCarrierLease{
+		Outpoint: wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("carrier-float")),
+			Index: 0,
+		},
+		Value:          25_000,
+		PolicyTemplate: leasePolicy,
+		PkScript:       leasePkScript,
+		ExpiresAtUnix:  1_700_000_000,
+	}
+	arkService := &fakeArkService{
+		getInfoResponse: &arkrpc.GetInfoResponse{
+			Pubkey: operatorKey.
+				PubKey().
+				SerializeCompressed(),
+			VtxoExitDelay: exitDelay,
+			DustLimit:     1000,
+			OorCarrierPubkey: schnorr.SerializePubKey(
+				floatKey.PubKey(),
+			),
+		},
+		leaseResponse: &arkrpc.LeaseOORCarrierResponse{
+			Outpoint:           lease.Outpoint.String(),
+			ValueSat:           int64(lease.Value),
+			VtxoPolicyTemplate: lease.PolicyTemplate,
+			PkScript:           lease.PkScript,
+			ExpiresAtUnix:      lease.ExpiresAtUnix,
+		},
+	}
+
 	preparer := &testTaprootAssetOORPreparer{}
 	walletReady := make(chan struct{})
 	close(walletReady)
@@ -341,22 +387,14 @@ func newTaprootAssetOORRPCFixtureWithActor(t *testing.T,
 		oorSessionStore:  sessionStore,
 		walletRef:        fn.Some(walletRef),
 		clientKeyDesc:    desc.ClientKey,
-		serverConn: newBufconnClient(t, &fakeArkService{
-			getInfoResponse: &arkrpc.GetInfoResponse{
-				Pubkey: operatorKey.
-					PubKey().
-					SerializeCompressed(),
-				VtxoExitDelay: exitDelay,
-				DustLimit:     1000,
-			},
-		}),
+		serverConn:       newBufconnClient(t, arkService),
 	}
 
 	request := &waverpc.SendOORRequest{
 		Recipients: []*waverpc.Output{
 			sendOORPolicyRecipient(
 				t, recipientKey.PubKey(), operatorKey.PubKey(),
-				exitDelay, int64(amountSat),
+				exitDelay, 0,
 			),
 		},
 		IdempotencyKey: "taproot-asset-request-1",
@@ -377,6 +415,8 @@ func newTaprootAssetOORRPCFixtureWithActor(t *testing.T,
 		desc:          desc,
 		wallet:        testWallet,
 		artifactStore: artifactStore,
+		arkService:    arkService,
+		lease:         lease,
 	}
 }
 
@@ -416,6 +456,23 @@ func TestSendOORTaprootAssetPreparesBeforeActor(t *testing.T) {
 		prepareRequest.Inputs[0].TaprootAssetRoot,
 	)
 
+	// The daemon stamps the receiver leaf at the floor, leases one float
+	// covering it, and rides the float along as a foreign input.
+	require.Equal(
+		t, btcutil.Amount(1000), prepareRequest.Recipients[0].Value,
+	)
+	require.True(t, fixture.lease.FundingEquals(prepareRequest.Lease))
+	require.Len(t, prepareRequest.Inputs, 2)
+	require.True(t, prepareRequest.Inputs[1].OperatorFunded)
+	require.Equal(
+		t, fixture.lease.Outpoint,
+		prepareRequest.Inputs[1].VTXO.Outpoint,
+	)
+	require.Len(t, fixture.arkService.leaseRequests, 1)
+	require.EqualValues(
+		t, 1000, fixture.arkService.leaseRequests[0].GetRequiredSat(),
+	)
+
 	actorRequests := fixture.oorActor.capturedRequests()
 	require.Len(t, actorRequests, 1)
 	actorRequest := actorRequests[0]
@@ -424,25 +481,43 @@ func TestSendOORTaprootAssetPreparesBeforeActor(t *testing.T) {
 	require.NoError(
 		t, actorRequest.Recipients[0].ValidateTaprootAssetCommitment(),
 	)
+
+	// Full send: floor-valued receiver, the sender's returned carrier,
+	// and the operator's float residual.
+	require.Len(t, actorRequest.Recipients, 3)
+	require.Equal(
+		t, btcutil.Amount(1000), actorRequest.Recipients[0].Value,
+	)
+	require.Equal(
+		t, btcutil.Amount(50_000), actorRequest.Recipients[1].Value,
+	)
+	require.Equal(
+		t, btcutil.Amount(24_000), actorRequest.Recipients[2].Value,
+	)
+	require.Equal(
+		t, fixture.lease.PkScript, actorRequest.Recipients[2].PkScript,
+	)
+
 	selectRequests := fixture.wallet.selectionRequests()
 	require.Len(t, selectRequests, 1)
 	require.Equal(
 		t, []wire.OutPoint{fixture.desc.Outpoint},
 		selectRequests[0].RequiredOutpoints,
 	)
+	require.Equal(
+		t, btcutil.Amount(50_000), selectRequests[0].TargetAmount,
+	)
 	require.True(t, selectRequests[0].WaitForDurable)
 	require.Empty(t, fixture.wallet.unlockBatches())
 }
 
-// TestSendOORTaprootAssetFiltersChangeOutpoints proves an explicit partial
-// allocation funds local asset change but returns only the caller's receiver.
+// TestSendOORTaprootAssetFiltersChangeOutpoints proves a partial allocation
+// funds local asset change but returns only the caller's receiver.
 func TestSendOORTaprootAssetFiltersChangeOutpoints(t *testing.T) {
 	t.Parallel()
 
 	fixture := newTaprootAssetOORRPCFixture(t)
-	fixture.request.Recipients[0].AmountSat = 48_000
 	fixture.request.TaprootAsset.RecipientAssetAmount = 13
-	fixture.request.TaprootAsset.AssetChangeCarrierValueSat = 1000
 
 	response, err := fixture.rpcServer.SendOOR(
 		t.Context(), fixture.request,
@@ -457,26 +532,40 @@ func TestSendOORTaprootAssetFiltersChangeOutpoints(t *testing.T) {
 		t, 13,
 		prepareRequests[0].Intent.EffectiveRecipientAssetAmount(),
 	)
+
+	// Both new asset leaves are leased from the operator float.
+	require.Len(t, fixture.arkService.leaseRequests, 1)
 	require.EqualValues(
-		t, 1000, prepareRequests[0].Intent.AssetChangeCarrierValueSat,
+		t, 2000, fixture.arkService.leaseRequests[0].GetRequiredSat(),
 	)
 
 	selectRequests := fixture.wallet.selectionRequests()
 	require.Len(t, selectRequests, 1)
-	require.Equal(t, btcutil.Amount(49_000), selectRequests[0].TargetAmount)
+	require.Equal(t, btcutil.Amount(50_000), selectRequests[0].TargetAmount)
 
 	actorRequests := fixture.oorActor.capturedRequests()
 	require.Len(t, actorRequests, 1)
-	require.Len(t, actorRequests[0].Recipients, 3)
+	require.Len(t, actorRequests[0].Recipients, 4)
 	require.EqualValues(
 		t, 13, actorRequests[0].Recipients[0].TaprootAssetAmount,
 	)
 	require.EqualValues(
 		t, 8, actorRequests[0].Recipients[1].TaprootAssetAmount,
 	)
+	require.Equal(
+		t, btcutil.Amount(1000), actorRequests[0].Recipients[1].Value,
+	)
 	require.Nil(t, actorRequests[0].Recipients[2].TaprootAssetRoot)
 	require.Equal(
-		t, btcutil.Amount(1000), actorRequests[0].Recipients[2].Value,
+		t, btcutil.Amount(50_000), actorRequests[0].Recipients[2].Value,
+	)
+	require.Nil(t, actorRequests[0].Recipients[3].TaprootAssetRoot)
+	require.Equal(
+		t, btcutil.Amount(23_000), actorRequests[0].Recipients[3].Value,
+	)
+	require.Equal(
+		t, fixture.lease.PkScript,
+		actorRequests[0].Recipients[3].PkScript,
 	)
 
 	sessionHash := chainhash.HashH([]byte("taproot-asset-oor-session"))
@@ -490,28 +579,14 @@ func TestSendOORTaprootAssetFiltersChangeOutpoints(t *testing.T) {
 	)
 }
 
-// TestSendOORTaprootAssetDefaultsChangeCarrier proves a partial send with no
-// explicit carrier rides on the operator minimum and returns the rest of the
-// selected Bitcoin VTXO as a plain change output.
-func TestSendOORTaprootAssetDefaultsChangeCarrier(t *testing.T) {
+// TestSendOORTaprootAssetFundsCarriersFromFloat proves a partial send funds
+// both new asset leaves at the operator floor out of the leased float while
+// the sender's full carrier returns as one plain change output.
+func TestSendOORTaprootAssetFundsCarriersFromFloat(t *testing.T) {
 	t.Parallel()
 
 	fixture := newTaprootAssetOORRPCFixture(t)
 	fixture.request.TaprootAsset.RecipientAssetAmount = 20
-
-	carrierDesc, _ := newSendOORTestVTXO(
-		t, fixture.desc.OperatorKey, 0x62, 30_000,
-	)
-	require.NoError(
-		t,
-		fixture.rpcServer.server.vtxoStore.SaveVTXO(
-			t.Context(), carrierDesc,
-		),
-	)
-	fixture.wallet.selections = [][]wallet.SelectedVTXO{{
-		selectedVTXOFromDescriptor(fixture.desc),
-		selectedVTXOFromDescriptor(carrierDesc),
-	}}
 
 	response, err := fixture.rpcServer.SendOOR(
 		t.Context(), fixture.request,
@@ -519,35 +594,43 @@ func TestSendOORTaprootAssetDefaultsChangeCarrier(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "submitted", response.GetStatus())
 
-	// The daemon materializes the operator floor before selection and
-	// preparation see the intent.
+	// Selection targets exactly the asset input; no Bitcoin filler VTXO
+	// is selected.
 	selectRequests := fixture.wallet.selectionRequests()
 	require.Len(t, selectRequests, 1)
-	require.Equal(t, btcutil.Amount(51_000), selectRequests[0].TargetAmount)
+	require.Equal(t, btcutil.Amount(50_000), selectRequests[0].TargetAmount)
+	require.Equal(
+		t, []wire.OutPoint{fixture.desc.Outpoint},
+		selectRequests[0].RequiredOutpoints,
+	)
 
 	prepareRequests := fixture.preparer.captured()
 	require.Len(t, prepareRequests, 1)
 	prepareRequest := prepareRequests[0]
-	require.EqualValues(
-		t, 1000, prepareRequest.Intent.AssetChangeCarrierValueSat,
-	)
+	require.Zero(t, prepareRequest.Intent.AssetChangeCarrierValueSat)
 
-	assetChange, bitcoinChange, err := prepareRequest.CarrierAllocation()
+	plan, err := prepareRequest.CarrierAllocation()
 	require.NoError(t, err)
-	require.Equal(t, btcutil.Amount(1000), assetChange)
-	require.Equal(t, btcutil.Amount(29_000), bitcoinChange)
+	require.Equal(t, btcutil.Amount(1000), plan.AssetChange)
+	require.Equal(t, btcutil.Amount(50_000), plan.SenderChange)
+	require.Equal(t, btcutil.Amount(23_000), plan.OperatorChange)
 
-	// The receiver and the minimal asset-change carrier are asset-bearing;
-	// the remainder returns as one plain Bitcoin output.
+	// The receiver and the floor-valued asset-change carrier are
+	// asset-bearing; the sender's carrier and the operator's residual
+	// return as plain Bitcoin outputs.
 	actorRequests := fixture.oorActor.capturedRequests()
 	require.Len(t, actorRequests, 1)
 	recipients := actorRequests[0].Recipients
-	require.Len(t, recipients, 3)
+	require.Len(t, recipients, 4)
 	require.NotNil(t, recipients[0].TaprootAssetRoot)
+	require.Equal(t, btcutil.Amount(1000), recipients[0].Value)
 	require.NotNil(t, recipients[1].TaprootAssetRoot)
 	require.Equal(t, btcutil.Amount(1000), recipients[1].Value)
 	require.Nil(t, recipients[2].TaprootAssetRoot)
-	require.Equal(t, btcutil.Amount(29_000), recipients[2].Value)
+	require.Equal(t, btcutil.Amount(50_000), recipients[2].Value)
+	require.Nil(t, recipients[3].TaprootAssetRoot)
+	require.Equal(t, btcutil.Amount(23_000), recipients[3].Value)
+	require.Equal(t, fixture.lease.PkScript, recipients[3].PkScript)
 
 	// The composed asset-change script is registered as an owned alias
 	// before admission, so the incoming self-notification resolves it
@@ -559,6 +642,13 @@ func TestSendOORTaprootAssetDefaultsChangeCarrier(t *testing.T) {
 	require.Equal(
 		t, db.OwnedReceiveScriptSourceAssetAlias, alias.Source,
 	)
+
+	// The operator's float residual pays a foreign script and must not
+	// be registered as an owned alias.
+	_, err = fixture.artifactStore.LookupOwnedReceiveScript(
+		t.Context(), recipients[3].PkScript,
+	)
+	require.Error(t, err)
 }
 
 // TestSendOORTaprootAssetAdoptsPreparedInputs proves an RPC retry after the
@@ -572,6 +662,7 @@ func TestSendOORTaprootAssetAdoptsPreparedInputs(t *testing.T) {
 		InputOutpoints: []wire.OutPoint{
 			fixture.desc.Outpoint,
 		},
+		Lease: fixture.lease,
 	}
 	require.NoError(
 		t,
@@ -591,6 +682,41 @@ func TestSendOORTaprootAssetAdoptsPreparedInputs(t *testing.T) {
 	require.Len(t, fixture.preparer.capturedResumes(), 1)
 	require.Len(t, fixture.preparer.captured(), 1)
 	require.Len(t, fixture.oorActor.capturedRequests(), 1)
+
+	// A resumed request reuses the journaled lease; it never re-leases.
+	require.Empty(t, fixture.arkService.leaseRequests)
+	prepareRequests := fixture.preparer.captured()
+	require.True(
+		t, fixture.lease.FundingEquals(prepareRequests[0].Lease),
+	)
+}
+
+// TestSendOORTaprootAssetResumeRequiresJournaledLease proves an adopted
+// preparation without a journaled carrier lease fails into reconciliation
+// instead of leasing a fresh float under a committed graph.
+func TestSendOORTaprootAssetResumeRequiresJournaledLease(t *testing.T) {
+	t.Parallel()
+
+	fixture := newTaprootAssetOORRPCFixture(t)
+	fixture.preparer.resume = &oor.TaprootAssetOORResume{
+		InputOutpoints: []wire.OutPoint{
+			fixture.desc.Outpoint,
+		},
+	}
+	require.NoError(
+		t,
+		fixture.rpcServer.server.vtxoStore.UpdateVTXOStatus(
+			t.Context(), fixture.desc.Outpoint,
+			vtxo.VTXOStatusSpending,
+		),
+	)
+
+	_, err := fixture.rpcServer.SendOOR(t.Context(), fixture.request)
+	require.Equal(t, codes.Aborted, status.Code(err))
+	require.ErrorContains(t, err, "no journaled carrier lease")
+	require.Empty(t, fixture.arkService.leaseRequests)
+	require.Zero(t, fixture.wallet.selectCount())
+	require.Empty(t, fixture.oorActor.capturedRequests())
 }
 
 // TestSendOORTaprootAssetQuarantinesAfterPreparation proves a later OOR actor
@@ -849,69 +975,51 @@ func TestSendOORTaprootAssetFailsClosed(t *testing.T) {
 			wantContains: "recipient amount exceeds input amount",
 		},
 		{
-			name: "partial send defaults the carrier",
-			mutate: func(f *taprootAssetOORRPCFixture) {
-				f.request.TaprootAsset.RecipientAssetAmount = 20
-			},
-			wantCode:     codes.InvalidArgument,
-			wantContains: "below Taproot Asset carrier amount",
-			wantSelect:   true,
-			wantUnlock:   true,
-		},
-		{
-			name: "full send with change carrier",
-			mutate: func(f *taprootAssetOORRPCFixture) {
-				f.request.TaprootAsset.
-					AssetChangeCarrierValueSat = 1000
-			},
-			wantCode:     codes.InvalidArgument,
-			wantContains: "change carrier must be zero",
-		},
-		{
-			name: "change carrier exceeds Bitcoin maximum",
-			mutate: func(f *taprootAssetOORRPCFixture) {
-				assetIntent := f.request.TaprootAsset
-				assetIntent.RecipientAssetAmount = 20
-				assetIntent.AssetChangeCarrierValueSat =
-					uint64(btcutil.MaxSatoshi) + 1
-			},
-			wantCode:     codes.InvalidArgument,
-			wantContains: "change carrier exceeds maximum",
-		},
-		{
-			name: "change carrier below output floor",
-			mutate: func(f *taprootAssetOORRPCFixture) {
-				f.request.TaprootAsset.RecipientAssetAmount = 20
-				f.request.TaprootAsset.
-					AssetChangeCarrierValueSat = 999
-			},
-			wantCode:     codes.InvalidArgument,
-			wantContains: "below operator minimum",
-		},
-		{
-			name: "carrier total overflows Bitcoin maximum",
-			mutate: func(f *taprootAssetOORRPCFixture) {
-				f.request.Recipients[0].AmountSat = int64(
-					btcutil.MaxSatoshi,
-				)
-				f.request.TaprootAsset.RecipientAssetAmount = 20
-				f.request.TaprootAsset.
-					AssetChangeCarrierValueSat = 1000
-			},
-			wantCode:     codes.InvalidArgument,
-			wantContains: "carrier total must be",
-		},
-		{
-			name: "selected carrier funding is insufficient",
+			name: "caller-set change carrier",
 			mutate: func(f *taprootAssetOORRPCFixture) {
 				f.request.TaprootAsset.RecipientAssetAmount = 20
 				f.request.TaprootAsset.
 					AssetChangeCarrierValueSat = 1000
 			},
+			wantCode: codes.InvalidArgument,
+			wantContains: "asset_change_carrier_value_sat must " +
+				"be zero",
+		},
+		{
+			name: "caller-set recipient amount",
+			mutate: func(f *taprootAssetOORRPCFixture) {
+				f.request.Recipients[0].AmountSat = 48_000
+			},
 			wantCode:     codes.InvalidArgument,
-			wantContains: "below Taproot Asset carrier amount",
-			wantSelect:   true,
-			wantUnlock:   true,
+			wantContains: "recipient amount_sat must be zero",
+		},
+		{
+			name: "unknown asset input VTXO",
+			mutate: func(f *taprootAssetOORRPCFixture) {
+				f.request.TaprootAsset.InputVtxoOutpoint =
+					"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+						"aaaaaaaaaaaaaaaaaaaaaaaa" +
+						"aaaaaaaa:0"
+			},
+			wantCode:     codes.InvalidArgument,
+			wantContains: "unknown Taproot Asset input VTXO",
+		},
+		{
+			name: "carrier funding disabled",
+			mutate: func(f *taprootAssetOORRPCFixture) {
+				f.arkService.getInfoResponse.
+					OorCarrierPubkey = nil
+			},
+			wantCode:     codes.FailedPrecondition,
+			wantContains: "does not fund OOR carriers",
+		},
+		{
+			name: "leased float below the floors",
+			mutate: func(f *taprootAssetOORRPCFixture) {
+				f.arkService.leaseResponse.ValueSat = 500
+			},
+			wantCode:     codes.FailedPrecondition,
+			wantContains: "below required",
 		},
 		{
 			name: "adapter changes value",

--- a/waved/rpc_oor_taproot_asset_test.go
+++ b/waved/rpc_oor_taproot_asset_test.go
@@ -458,6 +458,66 @@ func TestSendOORTaprootAssetFiltersChangeOutpoints(t *testing.T) {
 	)
 }
 
+// TestSendOORTaprootAssetDefaultsChangeCarrier proves a partial send with no
+// explicit carrier rides on the operator minimum and returns the rest of the
+// selected Bitcoin VTXO as a plain change output.
+func TestSendOORTaprootAssetDefaultsChangeCarrier(t *testing.T) {
+	t.Parallel()
+
+	fixture := newTaprootAssetOORRPCFixture(t)
+	fixture.request.TaprootAsset.RecipientAssetAmount = 20
+
+	carrierDesc, _ := newSendOORTestVTXO(
+		t, fixture.desc.OperatorKey, 0x62, 30_000,
+	)
+	require.NoError(
+		t,
+		fixture.rpcServer.server.vtxoStore.SaveVTXO(
+			t.Context(), carrierDesc,
+		),
+	)
+	fixture.wallet.selections = [][]wallet.SelectedVTXO{{
+		selectedVTXOFromDescriptor(fixture.desc),
+		selectedVTXOFromDescriptor(carrierDesc),
+	}}
+
+	response, err := fixture.rpcServer.SendOOR(
+		t.Context(), fixture.request,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "submitted", response.GetStatus())
+
+	// The daemon materializes the operator floor before selection and
+	// preparation see the intent.
+	selectRequests := fixture.wallet.selectionRequests()
+	require.Len(t, selectRequests, 1)
+	require.Equal(t, btcutil.Amount(51_000), selectRequests[0].TargetAmount)
+
+	prepareRequests := fixture.preparer.captured()
+	require.Len(t, prepareRequests, 1)
+	prepareRequest := prepareRequests[0]
+	require.EqualValues(
+		t, 1000, prepareRequest.Intent.AssetChangeCarrierValueSat,
+	)
+
+	assetChange, bitcoinChange, err := prepareRequest.CarrierAllocation()
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(1000), assetChange)
+	require.Equal(t, btcutil.Amount(29_000), bitcoinChange)
+
+	// The receiver and the minimal asset-change carrier are asset-bearing;
+	// the remainder returns as one plain Bitcoin output.
+	actorRequests := fixture.oorActor.capturedRequests()
+	require.Len(t, actorRequests, 1)
+	recipients := actorRequests[0].Recipients
+	require.Len(t, recipients, 3)
+	require.NotNil(t, recipients[0].TaprootAssetRoot)
+	require.NotNil(t, recipients[1].TaprootAssetRoot)
+	require.Equal(t, btcutil.Amount(1000), recipients[1].Value)
+	require.Nil(t, recipients[2].TaprootAssetRoot)
+	require.Equal(t, btcutil.Amount(29_000), recipients[2].Value)
+}
+
 // TestSendOORTaprootAssetAdoptsPreparedInputs proves an RPC retry after the
 // asset commits can rebuild the exact journaled inputs without asking wallet
 // selection to reserve an already-Spending asset VTXO again.
@@ -746,12 +806,14 @@ func TestSendOORTaprootAssetFailsClosed(t *testing.T) {
 			wantContains: "recipient amount exceeds input amount",
 		},
 		{
-			name: "partial send missing change carrier",
+			name: "partial send defaults the carrier",
 			mutate: func(f *taprootAssetOORRPCFixture) {
 				f.request.TaprootAsset.RecipientAssetAmount = 20
 			},
 			wantCode:     codes.InvalidArgument,
-			wantContains: "change carrier is required",
+			wantContains: "below Taproot Asset carrier amount",
+			wantSelect:   true,
+			wantUnlock:   true,
 		},
 		{
 			name: "full send with change carrier",

--- a/waved/rpc_oor_taproot_asset_test.go
+++ b/waved/rpc_oor_taproot_asset_test.go
@@ -132,9 +132,13 @@ func (p *testTaprootAssetOORPreparer) PrepareTaprootAssetOOR(_ context.Context,
 		recipients = append(recipients, assetChange)
 	}
 
-	senderChange := cloneTestTaprootAssetRecipients(request.Recipients)[0]
-	senderChange.Value = plan.SenderChange
-	recipients = append(recipients, senderChange)
+	if plan.SenderChange > 0 {
+		senderChange := cloneTestTaprootAssetRecipients(
+			request.Recipients,
+		)[0]
+		senderChange.Value = plan.SenderChange
+		recipients = append(recipients, senderChange)
+	}
 
 	if plan.OperatorChange > 0 {
 		recipients = append(recipients, oortx.RecipientOutput{
@@ -237,6 +241,16 @@ func newTaprootAssetOORRPCFixture(t *testing.T) *taprootAssetOORRPCFixture {
 func newTaprootAssetOORRPCFixtureWithActor(t *testing.T,
 	blockingActor *blockingSendOORActor) *taprootAssetOORRPCFixture {
 
+	return newTaprootAssetOORRPCFixtureWithOrigin(t, blockingActor, true)
+}
+
+// newTaprootAssetOORRPCFixtureWithOrigin stores the asset input with or
+// without the sealed round package, the discriminator the daemon derives the
+// carrier origin from.
+func newTaprootAssetOORRPCFixtureWithOrigin(t *testing.T,
+	blockingActor *blockingSendOORActor,
+	roundCreated bool) *taprootAssetOORRPCFixture {
+
 	t.Helper()
 
 	operatorKey, err := btcec.NewPrivateKey()
@@ -255,6 +269,9 @@ func newTaprootAssetOORRPCFixtureWithActor(t *testing.T,
 	desc.TaprootAssetRoot = &inputAssetRoot
 	desc.TaprootAssetRef = "tapr1asset"
 	desc.TaprootAssetAmount = 21
+	if roundCreated {
+		desc.TaprootAssetSealedPackage = []byte("sealed-package")
+	}
 	desc.PkScript, err = desc.EffectivePkScript()
 	require.NoError(t, err)
 
@@ -463,7 +480,9 @@ func TestSendOORTaprootAssetPreparesBeforeActor(t *testing.T) {
 	)
 	require.True(t, fixture.lease.FundingEquals(prepareRequest.Lease))
 	require.Len(t, prepareRequest.Inputs, 2)
+	require.True(t, prepareRequest.Inputs[0].TaprootAssetRoundCreated)
 	require.True(t, prepareRequest.Inputs[1].OperatorFunded)
+	require.False(t, prepareRequest.Inputs[1].TaprootAssetRoundCreated)
 	require.Equal(
 		t, fixture.lease.Outpoint,
 		prepareRequest.Inputs[1].VTXO.Outpoint,
@@ -649,6 +668,43 @@ func TestSendOORTaprootAssetFundsCarriersFromFloat(t *testing.T) {
 		t.Context(), recipients[3].PkScript,
 	)
 	require.Error(t, err)
+}
+
+// TestSendOORTaprootAssetReclaimsOORCreatedCarrier proves the daemon derives
+// the leaf origin from the stored descriptor (no sealed package means the
+// leaf was OOR-created) and hands the operator the reclaimed carrier instead
+// of paying the sender plain change.
+func TestSendOORTaprootAssetReclaimsOORCreatedCarrier(t *testing.T) {
+	t.Parallel()
+
+	fixture := newTaprootAssetOORRPCFixtureWithOrigin(t, nil, false)
+	response, err := fixture.rpcServer.SendOOR(
+		t.Context(), fixture.request,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "submitted", response.GetStatus())
+
+	prepareRequests := fixture.preparer.captured()
+	require.Len(t, prepareRequests, 1)
+	prepareRequest := prepareRequests[0]
+	require.False(t, prepareRequest.Inputs[0].TaprootAssetRoundCreated)
+
+	// 25_000 sat lease, one 1_000 sat floor for the receiver leaf, and
+	// the 50_000 sat OOR-created carrier reclaimed on top of the residual.
+	plan, err := prepareRequest.CarrierAllocation()
+	require.NoError(t, err)
+	require.Zero(t, plan.SenderChange)
+	require.Equal(t, btcutil.Amount(74_000), plan.OperatorChange)
+
+	actorRequests := fixture.oorActor.capturedRequests()
+	require.Len(t, actorRequests, 1)
+	recipients := actorRequests[0].Recipients
+	require.Len(t, recipients, 2)
+	require.NotNil(t, recipients[0].TaprootAssetRoot)
+	require.Equal(t, btcutil.Amount(1_000), recipients[0].Value)
+	require.Nil(t, recipients[1].TaprootAssetRoot)
+	require.Equal(t, btcutil.Amount(74_000), recipients[1].Value)
+	require.Equal(t, fixture.lease.PkScript, recipients[1].PkScript)
 }
 
 // TestSendOORTaprootAssetAdoptsPreparedInputs proves an RPC retry after the

--- a/waved/rpc_oor_taproot_asset_test.go
+++ b/waved/rpc_oor_taproot_asset_test.go
@@ -215,12 +215,13 @@ func (p *testTaprootAssetOORPreparer) capturedResumes() []*assetResumeRequest {
 }
 
 type taprootAssetOORRPCFixture struct {
-	rpcServer *RPCServer
-	preparer  *testTaprootAssetOORPreparer
-	oorActor  *capturingSendOORActor
-	request   *waverpc.SendOORRequest
-	desc      *vtxo.Descriptor
-	wallet    *sendOORTestWallet
+	rpcServer     *RPCServer
+	preparer      *testTaprootAssetOORPreparer
+	oorActor      *capturingSendOORActor
+	request       *waverpc.SendOORRequest
+	desc          *vtxo.Descriptor
+	wallet        *sendOORTestWallet
+	artifactStore *db.OORArtifactPersistenceStore
 }
 
 func newTaprootAssetOORRPCFixture(t *testing.T) *taprootAssetOORRPCFixture {
@@ -251,8 +252,37 @@ func newTaprootAssetOORRPCFixtureWithActor(t *testing.T,
 	desc.PkScript, err = desc.EffectivePkScript()
 	require.NoError(t, err)
 
-	vtxoStore, _, sessionStore := newSendOORTestStores(t)
+	vtxoStore, _, sessionStore, artifactStore :=
+		newSendOORTestStoresWithArtifacts(t)
 	require.NoError(t, vtxoStore.SaveVTXO(t.Context(), desc))
+
+	// The mock preparer derives change recipients from the request
+	// recipient's policy script, so registering that script as owned lets
+	// the daemon's change-alias registration resolve them like the real
+	// wallet-derived change scripts.
+	recipientPolicy, err := arkscript.EncodeStandardVTXOTemplate(
+		recipientKey.PubKey(), operatorKey.PubKey(), exitDelay,
+	)
+	require.NoError(t, err)
+	recipientTemplate, err := arkscript.DecodePolicyTemplate(
+		recipientPolicy,
+	)
+	require.NoError(t, err)
+	recipientPkScript, err := recipientTemplate.PkScript()
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		artifactStore.UpsertOwnedReceiveScript(
+			t.Context(), db.OwnedReceiveScriptRecord{
+				PkScript:       recipientPkScript,
+				ClientKey:      desc.ClientKey,
+				OperatorPubKey: operatorKey.PubKey(),
+				ExitDelay:      int64(exitDelay),
+				Source:         db.OwnedReceiveScriptSourceRPC,
+				CreatedAt:      time.Now(),
+			},
+		),
+	)
 
 	system := actor.NewActorSystem()
 	t.Cleanup(func() {
@@ -302,14 +332,15 @@ func newTaprootAssetOORRPCFixtureWithActor(t *testing.T,
 		cfg: &Config{
 			TaprootAssetOORPreparer: preparer,
 		},
-		log:             btclog.Disabled,
-		walletReady:     walletReady,
-		chainParams:     &chaincfg.RegressionNetParams,
-		actorSystem:     system,
-		vtxoStore:       vtxoStore,
-		oorSessionStore: sessionStore,
-		walletRef:       fn.Some(walletRef),
-		clientKeyDesc:   desc.ClientKey,
+		log:              btclog.Disabled,
+		walletReady:      walletReady,
+		chainParams:      &chaincfg.RegressionNetParams,
+		actorSystem:      system,
+		oorArtifactStore: artifactStore,
+		vtxoStore:        vtxoStore,
+		oorSessionStore:  sessionStore,
+		walletRef:        fn.Some(walletRef),
+		clientKeyDesc:    desc.ClientKey,
 		serverConn: newBufconnClient(t, &fakeArkService{
 			getInfoResponse: &arkrpc.GetInfoResponse{
 				Pubkey: operatorKey.
@@ -339,12 +370,13 @@ func newTaprootAssetOORRPCFixtureWithActor(t *testing.T,
 	}
 
 	return &taprootAssetOORRPCFixture{
-		rpcServer: NewRPCServer(server),
-		preparer:  preparer,
-		oorActor:  oorActor,
-		request:   request,
-		desc:      desc,
-		wallet:    testWallet,
+		rpcServer:     NewRPCServer(server),
+		preparer:      preparer,
+		oorActor:      oorActor,
+		request:       request,
+		desc:          desc,
+		wallet:        testWallet,
+		artifactStore: artifactStore,
 	}
 }
 
@@ -516,6 +548,17 @@ func TestSendOORTaprootAssetDefaultsChangeCarrier(t *testing.T) {
 	require.Equal(t, btcutil.Amount(1000), recipients[1].Value)
 	require.Nil(t, recipients[2].TaprootAssetRoot)
 	require.Equal(t, btcutil.Amount(29_000), recipients[2].Value)
+
+	// The composed asset-change script is registered as an owned alias
+	// before admission, so the incoming self-notification resolves it
+	// regardless of which recipient event drives the receive session.
+	alias, err := fixture.artifactStore.LookupOwnedReceiveScript(
+		t.Context(), recipients[1].PkScript,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, db.OwnedReceiveScriptSourceAssetAlias, alias.Source,
+	)
 }
 
 // TestSendOORTaprootAssetAdoptsPreparedInputs proves an RPC retry after the

--- a/waved/rpc_oor_taproot_asset_test.go
+++ b/waved/rpc_oor_taproot_asset_test.go
@@ -534,6 +534,210 @@ func TestSendOORTaprootAssetPreparesBeforeActor(t *testing.T) {
 	require.Empty(t, fixture.wallet.unlockBatches())
 }
 
+// addAssetVTXO stores one more live asset VTXO sharing the fixture's asset
+// reference and signing material.
+func (f *taprootAssetOORRPCFixture) addAssetVTXO(t *testing.T, seed byte,
+	units uint64, carrier btcutil.Amount) *vtxo.Descriptor {
+
+	t.Helper()
+
+	clone := *f.desc
+	clone.Outpoint.Hash[0] = seed
+	clone.TaprootAssetAmount = units
+	clone.Amount = carrier
+	require.NoError(
+		t,
+		f.rpcServer.server.vtxoStore.SaveVTXO(
+			t.Context(), &clone,
+		),
+	)
+
+	return &clone
+}
+
+// TestSendOORTaprootAssetSelectsInputs proves an empty input outpoint
+// delegates selection to the daemon: the largest VTXOs accumulate until the
+// requested units are covered and feed ONE atomic transfer, spine first,
+// regardless of the wallet lock order.
+func TestSendOORTaprootAssetSelectsInputs(t *testing.T) {
+	t.Parallel()
+
+	fixture := newTaprootAssetOORRPCFixture(t)
+	second := fixture.addAssetVTXO(t, 0x71, 13, 40_000)
+	fixture.addAssetVTXO(t, 0x72, 8, 30_000)
+
+	// The wallet returns the required set in its own order; the daemon
+	// re-pins the spine-first transition order.
+	fixture.wallet.selections = [][]wallet.SelectedVTXO{{
+		selectedVTXOFromDescriptor(second),
+		selectedVTXOFromDescriptor(fixture.desc),
+	}}
+
+	fixture.request.TaprootAsset.InputVtxoOutpoint = ""
+	fixture.request.TaprootAsset.InputProofFile = nil
+	fixture.request.TaprootAsset.AssetAmount = 30
+
+	response, err := fixture.rpcServer.SendOOR(
+		t.Context(), fixture.request,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "submitted", response.GetStatus())
+
+	// 21 + 13 covers 30; the 8-unit leaf stays untouched. The spine is
+	// the largest input and the resolved intent carries the summed units
+	// with the requested send as the recipient allocation.
+	prepareRequests := fixture.preparer.captured()
+	require.Len(t, prepareRequests, 1)
+	prepareRequest := prepareRequests[0]
+	require.Equal(
+		t, []wire.OutPoint{fixture.desc.Outpoint, second.Outpoint},
+		prepareRequest.Intent.InputVTXOOutpoints,
+	)
+	require.EqualValues(t, 34, prepareRequest.Intent.AssetAmount)
+	require.EqualValues(
+		t, 30, prepareRequest.Intent.RecipientAssetAmount,
+	)
+	require.Len(t, prepareRequest.Inputs, 3)
+	require.Equal(
+		t, fixture.desc.Outpoint,
+		prepareRequest.Inputs[0].VTXO.Outpoint,
+	)
+	require.Equal(
+		t, second.Outpoint, prepareRequest.Inputs[1].VTXO.Outpoint,
+	)
+	require.True(t, prepareRequest.Inputs[2].OperatorFunded)
+
+	// Wallet selection targets exactly the two carriers and requires the
+	// exact selected outpoints; the recipient and asset-change leaves are
+	// leased from the float.
+	selectRequests := fixture.wallet.selectionRequests()
+	require.Len(t, selectRequests, 1)
+	require.Equal(
+		t, []wire.OutPoint{fixture.desc.Outpoint, second.Outpoint},
+		selectRequests[0].RequiredOutpoints,
+	)
+	require.Equal(
+		t, btcutil.Amount(90_000), selectRequests[0].TargetAmount,
+	)
+	require.Len(t, fixture.arkService.leaseRequests, 1)
+	require.EqualValues(
+		t, 2000, fixture.arkService.leaseRequests[0].GetRequiredSat(),
+	)
+
+	// Both spent leaves are round-created, so their summed carriers come
+	// back as one sender change output beside the operator residual.
+	actorRequests := fixture.oorActor.capturedRequests()
+	require.Len(t, actorRequests, 1)
+	recipients := actorRequests[0].Recipients
+	require.Len(t, recipients, 4)
+	require.EqualValues(t, 30, recipients[0].TaprootAssetAmount)
+	require.EqualValues(t, 4, recipients[1].TaprootAssetAmount)
+	require.Equal(t, btcutil.Amount(90_000), recipients[2].Value)
+	require.Equal(t, btcutil.Amount(23_000), recipients[3].Value)
+	require.Equal(t, fixture.lease.PkScript, recipients[3].PkScript)
+}
+
+// TestSendOORTaprootAssetSelectsSingleSufficientInput proves selection keeps
+// the current single-input behavior when one VTXO covers the send: the
+// smallest sufficient leaf wins.
+func TestSendOORTaprootAssetSelectsSingleSufficientInput(t *testing.T) {
+	t.Parallel()
+
+	fixture := newTaprootAssetOORRPCFixture(t)
+	second := fixture.addAssetVTXO(t, 0x71, 13, 40_000)
+	fixture.wallet.selections = [][]wallet.SelectedVTXO{{
+		selectedVTXOFromDescriptor(second),
+	}}
+	fixture.request.TaprootAsset.InputVtxoOutpoint = ""
+	fixture.request.TaprootAsset.InputProofFile = nil
+	fixture.request.TaprootAsset.AssetAmount = 10
+
+	response, err := fixture.rpcServer.SendOOR(
+		t.Context(), fixture.request,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "submitted", response.GetStatus())
+
+	prepareRequests := fixture.preparer.captured()
+	require.Len(t, prepareRequests, 1)
+	require.Equal(
+		t, []wire.OutPoint{second.Outpoint},
+		prepareRequests[0].Intent.InputVTXOOutpoints,
+	)
+	require.EqualValues(t, 13, prepareRequests[0].Intent.AssetAmount)
+	require.EqualValues(
+		t, 10, prepareRequests[0].Intent.RecipientAssetAmount,
+	)
+}
+
+// TestSelectTaprootAssetOORInputs pins the selection policy: smallest
+// sufficient single VTXO, largest-first accumulation, the eight-input cap
+// with a consolidate-first error, and the need/have insufficiency error.
+func TestSelectTaprootAssetOORInputs(t *testing.T) {
+	t.Parallel()
+
+	leaf := func(seed byte, units uint64) *vtxo.Descriptor {
+		return &vtxo.Descriptor{
+			Outpoint: wire.OutPoint{
+				Hash: chainhash.Hash{
+					seed,
+				},
+			},
+			Status:             vtxo.VTXOStatusLive,
+			TaprootAssetAmount: units,
+		}
+	}
+	outpoints := func(selected []*vtxo.Descriptor) []wire.OutPoint {
+		result := make([]wire.OutPoint, len(selected))
+		for idx := range selected {
+			result[idx] = selected[idx].Outpoint
+		}
+
+		return result
+	}
+
+	candidates := []*vtxo.Descriptor{
+		leaf(1, 50), leaf(2, 200), leaf(3, 50),
+	}
+
+	// Single sufficient: the smallest covering leaf, not the largest.
+	selected, err := selectTaprootAssetOORInputs(candidates, 40)
+	require.NoError(t, err)
+	require.Equal(
+		t, []wire.OutPoint{
+			{Hash: chainhash.Hash{1}},
+		},
+		outpoints(selected),
+	)
+
+	// Largest-first accumulation, spine first: 200 + 50 covers 240.
+	selected, err = selectTaprootAssetOORInputs(candidates, 240)
+	require.NoError(t, err)
+	require.Equal(
+		t, []wire.OutPoint{
+			{Hash: chainhash.Hash{2}},
+			{Hash: chainhash.Hash{1}},
+		},
+		outpoints(selected),
+	)
+
+	// A mid-spend leaf holds no selectable balance.
+	spending := leaf(4, 1_000)
+	spending.Status = vtxo.VTXOStatusSpending
+	_, err = selectTaprootAssetOORInputs(
+		append(candidates, spending), 400,
+	)
+	require.ErrorContains(t, err, "need 400 units, have 300")
+
+	// Nine leaves cover the send but exceed the atomic input cap.
+	var many []*vtxo.Descriptor
+	for seed := byte(1); seed <= 9; seed++ {
+		many = append(many, leaf(seed, 10))
+	}
+	_, err = selectTaprootAssetOORInputs(many, 90)
+	require.ErrorContains(t, err, "consolidate first")
+}
+
 // TestSendOORTaprootAssetFiltersChangeOutpoints proves a partial allocation
 // funds local asset change but returns only the caller's receiver.
 func TestSendOORTaprootAssetFiltersChangeOutpoints(t *testing.T) {
@@ -972,12 +1176,34 @@ func TestSendOORTaprootAssetFailsClosed(t *testing.T) {
 		wantUnlock   bool
 	}{
 		{
-			name: "missing managed input outpoint",
+			name: "proof file requires a pinned input",
 			mutate: func(f *taprootAssetOORRPCFixture) {
 				f.request.TaprootAsset.InputVtxoOutpoint = ""
 			},
-			wantCode:     codes.InvalidArgument,
-			wantContains: "input VTXO outpoint",
+			wantCode: codes.InvalidArgument,
+			wantContains: "input_proof_file requires " +
+				"input_vtxo_outpoint",
+		},
+		{
+			name: "recipient amount requires a pinned input",
+			mutate: func(f *taprootAssetOORRPCFixture) {
+				f.request.TaprootAsset.InputVtxoOutpoint = ""
+				f.request.TaprootAsset.InputProofFile = nil
+				f.request.TaprootAsset.RecipientAssetAmount = 5
+			},
+			wantCode: codes.InvalidArgument,
+			wantContains: "recipient_asset_amount requires " +
+				"input_vtxo_outpoint",
+		},
+		{
+			name: "insufficient live asset balance",
+			mutate: func(f *taprootAssetOORRPCFixture) {
+				f.request.TaprootAsset.InputVtxoOutpoint = ""
+				f.request.TaprootAsset.InputProofFile = nil
+				f.request.TaprootAsset.AssetAmount = 100
+			},
+			wantCode:     codes.FailedPrecondition,
+			wantContains: "need 100 units, have 21",
 		},
 		{
 			name: "malformed managed input outpoint",

--- a/waved/rpc_oor_taproot_asset_test.go
+++ b/waved/rpc_oor_taproot_asset_test.go
@@ -155,11 +155,15 @@ func (p *testTaprootAssetOORPreparer) PrepareTaprootAssetOOR(_ context.Context,
 		return nil, err
 	}
 	checkpointPackages := make([][]byte, len(request.Inputs))
-	assetInputIndex, err := request.AssetInputIndex()
+	assetInputIndices, err := request.AssetInputIndices()
 	if err != nil {
 		return nil, err
 	}
-	checkpointPackages[assetInputIndex] = []byte("checkpoint-package")
+	for _, assetInputIndex := range assetInputIndices {
+		checkpointPackages[assetInputIndex] = []byte(
+			"checkpoint-package",
+		)
+	}
 	preparation := &oor.TaprootAssetOORPreparation{
 		PreparedSubmit: &oor.PreparedSubmitPackage{
 			ArkPSBT:         arkPSBT,
@@ -465,8 +469,8 @@ func TestSendOORTaprootAssetPreparesBeforeActor(t *testing.T) {
 	require.Equal(t, btcutil.Amount(1000), prepareRequest.OutputFloor)
 	require.NotNil(t, prepareRequest.BuildChangeRecipient)
 	require.Equal(
-		t, fixture.desc.Outpoint,
-		prepareRequest.Intent.InputVTXOOutpoint,
+		t, []wire.OutPoint{fixture.desc.Outpoint},
+		prepareRequest.Intent.InputVTXOOutpoints,
 	)
 	require.Equal(
 		t, fixture.desc.TaprootAssetRoot,
@@ -907,8 +911,9 @@ func TestSendOORTaprootAssetRejectsInvalidResume(t *testing.T) {
 					}},
 				}
 			},
-			wantCode:     codes.Internal,
-			wantContains: "requested asset input exactly once",
+			wantCode: codes.Internal,
+			wantContains: "does not contain the requested " +
+				"asset input",
 		},
 		{
 			name: "duplicate input",

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -846,6 +846,8 @@ func (r *RPCServer) GetBalance(ctx context.Context,
 			}
 		}
 		resp.VtxoUnilateralExitSat = int64(exitSat)
+
+		resp.TaprootAssets = taprootAssetBalances(liveVTXOs, exiting)
 	}
 
 	// Fetch the confirmed balance of the backing on-chain wallet so
@@ -1306,6 +1308,9 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 	}
 
 	filtered := vtxo.FilterDescriptors(dbVTXOs, filterOpts)
+	if req.AssetRef != "" {
+		filtered = filterDescriptorsByAssetRef(filtered, req.AssetRef)
+	}
 
 	// Resolving the OOR package for an outpoint costs one artifact-store
 	// read per VTXO, so listing-only callers can opt out of checkpoint

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -3241,9 +3241,20 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		return nil, err
 	}
 
-	targetAmt, err := sumSendOORRecipientAmounts(requestRecipients)
+	assetIntent, err := taprootAssetOORIntent(req)
 	if err != nil {
 		return nil, err
+	}
+
+	// Asset sends derive every Bitcoin-side value on the daemon: the
+	// recipient leaf is stamped at the operator floor and selection
+	// targets only the asset input's own carrier.
+	var targetAmt btcutil.Amount
+	if assetIntent == nil {
+		targetAmt, err = sumSendOORRecipientAmounts(requestRecipients)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if req.GetExistingOnly() && req.GetIdempotencyKey() == "" {
@@ -3257,11 +3268,6 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 	if req.GetAdmissionDeadlineUnixNanos() < 0 {
 		return nil, status.Errorf(codes.InvalidArgument,
 			"admission_deadline_unix_nanos must not be negative")
-	}
-
-	assetIntent, err := taprootAssetOORIntent(req)
-	if err != nil {
-		return nil, err
 	}
 
 	if req.GetIdempotencyKey() != "" && !req.DryRun {
@@ -3363,18 +3369,41 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		return nil, status.Errorf(codes.Internal, "unable to fetch "+
 			"operator terms: %v", err)
 	}
-	targetAmt, err = taprootAssetOORSelectionTarget(
-		targetAmt, assetIntent, terms.MinVTXOAmountFloor(),
-	)
-	if err != nil {
-		return nil, err
+
+	// For asset sends the sender contributes no Bitcoin VTXO: the
+	// operator float funds every new asset leaf at the floor, the asset
+	// input's carrier returns whole as plain change, so selection targets
+	// exactly the asset input.
+	recipientOutputs := requestRecipients
+	var assetInputCarrier btcutil.Amount
+	if assetIntent != nil {
+		if r.server.vtxoStore == nil {
+			return nil, status.Errorf(codes.Internal, "VTXO "+
+				"store not initialized")
+		}
+
+		inputDesc, err := r.server.vtxoStore.GetVTXO(
+			ctx, assetIntent.InputVTXOOutpoint,
+		)
+		if err != nil || inputDesc == nil {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"unknown Taproot Asset input VTXO %s",
+				assetIntent.InputVTXOOutpoint)
+		}
+		assetInputCarrier = inputDesc.Amount
+		targetAmt = assetInputCarrier
+
+		recipientOutputs = []*waverpc.Output{{
+			Destination: requestRecipients[0].Destination,
+			AmountSat:   int64(terms.MinVTXOAmountFloor()),
+		}}
 	}
 
 	// Resolve the recipients' pkScripts from the destination oneofs
 	// and bind any supplied semantic policy templates to those scripts.
 	phaseStart = time.Now()
 	oorRecipients, err := r.buildSendOORRecipients(
-		ctx, requestRecipients, terms,
+		ctx, recipientOutputs, terms,
 	)
 	resolveScriptDuration = time.Since(phaseStart)
 	if err != nil {
@@ -3442,6 +3471,50 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 			); err != nil {
 				return nil, err
 			}
+		}
+	}
+
+	// Lease the operator carrier float before any wallet reservation. A
+	// resumed request must reuse its journaled lease: the committed graph
+	// already spends that exact float.
+	var (
+		carrierLease *oor.OORCarrierLease
+		floatInput   oor.TransferInput
+	)
+	if assetIntent != nil {
+		if assetResume != nil {
+			if assetResume.Lease == nil {
+				missingLease := fmt.Errorf("%w: request %q "+
+					"has no journaled carrier lease",
+					oor.ErrTaprootAssetCommitOutcomeUnknown,
+					req.GetIdempotencyKey())
+
+				return nil, taprootAssetOORPreparationError(
+					missingLease,
+				)
+			}
+			carrierLease = assetResume.Lease
+		} else {
+			floor := terms.MinVTXOAmountFloor()
+			requiredSat := floor * btcutil.Amount(
+				assetIntent.NewAssetLeafCount(),
+			)
+			carrierLease, err = r.server.leaseOORCarrier(
+				ctx, terms, requiredSat,
+			)
+			if err != nil {
+				return nil, status.Errorf(
+					codes.FailedPrecondition, "lease OOR "+
+						"carrier float: %v", err)
+			}
+		}
+
+		floatInput, err = BuildOperatorFundedTransferInput(
+			carrierLease, terms.OORCarrierPubKey, terms.PubKey,
+		)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "build "+
+				"operator-funded input: %v", err)
 		}
 	}
 
@@ -3515,6 +3588,12 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		}
 	}
 
+	// The leased float rides along as an extra ark input the wallet
+	// neither reserved nor can sign.
+	if assetIntent != nil {
+		selectedInputs = append(selectedInputs, floatInput)
+	}
+
 	requestOORRecipients := append(
 		[]oortx.RecipientOutput(nil), oorRecipients...,
 	)
@@ -3545,14 +3624,9 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 			return nil, err
 		}
 	} else {
-		if inputTotal < targetAmt {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"selected input amount %d sat is below "+
-					"Taproot Asset carrier amount %d sat",
-				inputTotal, targetAmt)
-		}
-
-		changeAmt = inputTotal - targetAmt
+		// The sender's change is its own returned carrier; the
+		// prepare-request validation enforces full conservation.
+		changeAmt = assetInputCarrier
 	}
 	changeOutputDuration = time.Since(phaseStart)
 
@@ -3585,6 +3659,7 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 				)
 			},
 			Intent: *assetIntent,
+			Lease:  carrierLease,
 		}
 		if err := prepareRequest.Validate(); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "%v",
@@ -3592,15 +3667,14 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		}
 
 		// SendOORResponse has no carrier fields, so the split between
-		// asset-bearing carriers and returned Bitcoin change is
-		// disclosed here.
-		assetChangeSat, bitcoinChangeSat, err := prepareRequest.
-			CarrierAllocation()
+		// asset-bearing carriers, the sender's returned carrier, and
+		// the operator's float residual is disclosed here.
+		plan, err := prepareRequest.CarrierAllocation()
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "%v",
 				err)
 		}
-		changeAmt = bitcoinChangeSat
+		changeAmt = plan.SenderChange
 		r.server.log.InfoS(ctx, "Taproot Asset OOR carriers",
 			slog.Int64(
 				"receiver_carrier_sat",
@@ -3608,11 +3682,20 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 			),
 			slog.Int64(
 				"asset_change_carrier_sat",
-				int64(assetChangeSat),
+				int64(plan.AssetChange),
 			),
 			slog.Int64(
-				"bitcoin_change_sat", int64(bitcoinChangeSat),
-			))
+				"sender_change_sat", int64(plan.SenderChange),
+			),
+			slog.Int64(
+				"operator_change_sat",
+				int64(plan.OperatorChange),
+			),
+			slog.String(
+				"float_outpoint",
+				carrierLease.Outpoint.String(),
+			),
+			slog.Int64("float_value_sat", int64(carrierLease.Value)))
 
 		preparation, err := assetPreparer.PrepareTaprootAssetOOR(
 			ctx, prepareRequest,
@@ -3635,7 +3718,7 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 			return nil, invalidTaprootAssetPreparation(err)
 		}
 		if err := r.registerTaprootAssetChangeAliases(
-			ctx, preparation,
+			ctx, preparation, carrierLease,
 		); err != nil {
 			return nil, taprootAssetOORPreparationError(err)
 		}

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -3147,6 +3147,19 @@ func (r *RPCServer) prepareWalletOORInputs(ctx context.Context,
 		for _, selected := range locked.SelectedVTXOs {
 			outpoints = append(outpoints, selected.Outpoint)
 		}
+
+		// Asset sends pin the transition input order (spine first);
+		// the wallet's own selection order is not significant.
+		if assetIntent != nil {
+			outpoints, err = orderAssetSelectedOutpoints(
+				outpoints, assetIntent.InputVTXOOutpoints,
+			)
+			if err != nil {
+				return nil, locked, 0, 0, status.Errorf(
+					codes.Internal, "order asset "+
+						"selection: %v", err)
+			}
+		}
 	}
 	selectDuration := time.Since(selectStart)
 
@@ -3373,30 +3386,16 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 	}
 
 	// For asset sends the sender contributes no Bitcoin VTXO: the
-	// operator float funds every new asset leaf at the floor and the
+	// operator float funds every new asset leaf at the floor and each
 	// spent leaf's carrier follows its origin (returned to the sender or
-	// reclaimed by the operator), so selection targets exactly the asset
-	// input.
+	// reclaimed by the operator), so selection later targets exactly the
+	// asset inputs' own carriers.
 	recipientOutputs := requestRecipients
-	var assetInputCarrier btcutil.Amount
 	if assetIntent != nil {
 		if r.server.vtxoStore == nil {
 			return nil, status.Errorf(codes.Internal, "VTXO "+
 				"store not initialized")
 		}
-
-		for _, outpoint := range assetIntent.InputVTXOOutpoints {
-			inputDesc, err := r.server.vtxoStore.GetVTXO(
-				ctx, outpoint,
-			)
-			if err != nil || inputDesc == nil {
-				return nil, status.Errorf(codes.InvalidArgument,
-					"unknown Taproot Asset input VTXO %s",
-					outpoint)
-			}
-			assetInputCarrier += inputDesc.Amount
-		}
-		targetAmt = assetInputCarrier
 
 		recipientOutputs = []*waverpc.Output{{
 			Destination: requestRecipients[0].Destination,
@@ -3476,6 +3475,16 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 			); err != nil {
 				return nil, err
 			}
+		}
+
+		// Resolve the ordered asset input set only after the resume
+		// probe: a journaled selection is immutable, while a fresh
+		// request may pin one input or delegate selection entirely.
+		assetIntent, targetAmt, err = r.resolveTaprootAssetOORIntent(
+			ctx, assetIntent, assetResume,
+		)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -3088,7 +3088,9 @@ func sendOORRequiredOutpoints(
 		return nil
 	}
 
-	return []wire.OutPoint{assetIntent.InputVTXOOutpoint}
+	return append(
+		[]wire.OutPoint(nil), assetIntent.InputVTXOOutpoints...,
+	)
 }
 
 func (r *RPCServer) prepareWalletOORInputs(ctx context.Context,
@@ -3383,15 +3385,17 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 				"store not initialized")
 		}
 
-		inputDesc, err := r.server.vtxoStore.GetVTXO(
-			ctx, assetIntent.InputVTXOOutpoint,
-		)
-		if err != nil || inputDesc == nil {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"unknown Taproot Asset input VTXO %s",
-				assetIntent.InputVTXOOutpoint)
+		for _, outpoint := range assetIntent.InputVTXOOutpoints {
+			inputDesc, err := r.server.vtxoStore.GetVTXO(
+				ctx, outpoint,
+			)
+			if err != nil || inputDesc == nil {
+				return nil, status.Errorf(codes.InvalidArgument,
+					"unknown Taproot Asset input VTXO %s",
+					outpoint)
+			}
+			assetInputCarrier += inputDesc.Amount
 		}
-		assetInputCarrier = inputDesc.Amount
 		targetAmt = assetInputCarrier
 
 		recipientOutputs = []*waverpc.Output{{

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -3634,6 +3634,11 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		if err := preparation.Validate(prepareRequest); err != nil {
 			return nil, invalidTaprootAssetPreparation(err)
 		}
+		if err := r.registerTaprootAssetChangeAliases(
+			ctx, preparation,
+		); err != nil {
+			return nil, taprootAssetOORPreparationError(err)
+		}
 
 		preparedSubmit = preparation.PreparedSubmit
 		recipients = preparation.Recipients

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -3371,9 +3371,10 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 	}
 
 	// For asset sends the sender contributes no Bitcoin VTXO: the
-	// operator float funds every new asset leaf at the floor, the asset
-	// input's carrier returns whole as plain change, so selection targets
-	// exactly the asset input.
+	// operator float funds every new asset leaf at the floor and the
+	// spent leaf's carrier follows its origin (returned to the sender or
+	// reclaimed by the operator), so selection targets exactly the asset
+	// input.
 	recipientOutputs := requestRecipients
 	var assetInputCarrier btcutil.Amount
 	if assetIntent != nil {
@@ -3623,10 +3624,6 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		// The sender's change is its own returned carrier; the
-		// prepare-request validation enforces full conservation.
-		changeAmt = assetInputCarrier
 	}
 	changeOutputDuration = time.Since(phaseStart)
 

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -3591,6 +3591,29 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 				err)
 		}
 
+		// SendOORResponse has no carrier fields, so the split between
+		// asset-bearing carriers and returned Bitcoin change is
+		// disclosed here.
+		assetChangeSat, bitcoinChangeSat, err := prepareRequest.
+			CarrierAllocation()
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "%v",
+				err)
+		}
+		changeAmt = bitcoinChangeSat
+		r.server.log.InfoS(ctx, "Taproot Asset OOR carriers",
+			slog.Int64(
+				"receiver_carrier_sat",
+				int64(recipients[0].Value),
+			),
+			slog.Int64(
+				"asset_change_carrier_sat",
+				int64(assetChangeSat),
+			),
+			slog.Int64(
+				"bitcoin_change_sat", int64(bitcoinChangeSat),
+			))
+
 		preparation, err := assetPreparer.PrepareTaprootAssetOOR(
 			ctx, prepareRequest,
 		)

--- a/waved/rpc_taproot_asset_manage.go
+++ b/waved/rpc_taproot_asset_manage.go
@@ -182,6 +182,14 @@ func (s *Server) assetClaimConfirmations(ctx context.Context,
 		return nil, fmt.Errorf("decode claim proof path: %w", err)
 	}
 
+	// The chain backend requires an output script beside the txid, and
+	// every lineage anchor is a transaction of the VTXO's own ancestry:
+	// the commitment transaction or a node of its tree fragment.
+	lineageOutputs, err := assetLineageOutputs(desc)
+	if err != nil {
+		return nil, fmt.Errorf("index claim lineage outputs: %w", err)
+	}
+
 	confirmations := make(
 		map[chainhash.Hash]tapsdk.AnchorConfirmation, len(path.Steps),
 	)
@@ -198,8 +206,16 @@ func (s *Server) assetClaimConfirmations(ctx context.Context,
 			continue
 		}
 
+		outs := lineageOutputs[txid]
+		index := summary.AnchorOutpoint.Index
+		if int(index) >= len(outs) || outs[index] == nil {
+			return nil, fmt.Errorf("lineage tx %v output %d is "+
+				"not part of the VTXO's ancestry", txid, index)
+		}
+
 		event, err := s.lineageConfirmation(
-			ctx, chainRef, txid, uint32(desc.CreatedHeight),
+			ctx, chainRef, txid, outs[index].PkScript,
+			uint32(desc.CreatedHeight),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("confirm lineage tx %v: %w",
@@ -229,18 +245,62 @@ func (s *Server) assetClaimConfirmations(ctx context.Context,
 	return confirmations, nil
 }
 
+// assetLineageOutputs indexes the outputs of every transaction in the
+// VTXO's ancestry by txid: the commitment transaction's batch output plus
+// each tree node's outputs. The lineage confirmation watch resolves its
+// output script from this index.
+func assetLineageOutputs(desc *vtxo.Descriptor) (
+	map[chainhash.Hash][]*wire.TxOut, error) {
+
+	outputs := make(map[chainhash.Hash][]*wire.TxOut)
+	for i := range desc.Ancestry {
+		path := desc.Ancestry[i].TreePath
+		if path == nil {
+			continue
+		}
+
+		if path.BatchOutput != nil {
+			index := path.BatchOutpoint.Index
+			outs := make([]*wire.TxOut, index+1)
+			outs[index] = path.BatchOutput
+			outputs[path.BatchOutpoint.Hash] = outs
+		}
+
+		if path.Root == nil {
+			continue
+		}
+		for node := range path.Root.NodesIter() {
+			txid, err := node.TXID()
+			if err != nil {
+				return nil, fmt.Errorf("lineage node txid: %w",
+					err)
+			}
+			outputs[txid] = node.Outputs
+		}
+	}
+
+	return outputs, nil
+}
+
 // lineageConfirmation resolves one lineage transaction's confirmation with
 // the full block attached. The transactions are already confirmed by the
 // time a claim runs, so the await is bounded by the historical-dispatch
 // rescan rather than a future block.
 func (s *Server) lineageConfirmation(ctx context.Context,
-	chainRef chainSourceRef, txid chainhash.Hash, heightHint uint32) (
-	*chainsource.ConfirmationEvent, error) {
+	chainRef chainSourceRef, txid chainhash.Hash, pkScript []byte,
+	heightHint uint32) (*chainsource.ConfirmationEvent, error) {
+
+	// The chain backend refuses a zero hint; a legacy descriptor
+	// without a creation height falls back to the lowest scan start.
+	if heightHint == 0 {
+		heightHint = 1
+	}
 
 	resp, err := chainRef.Ask(
 		context.WithoutCancel(ctx), &chainsource.RegisterConfRequest{
 			CallerID:     "taproot-asset-claim-" + txid.String(),
 			Txid:         &txid,
+			PkScript:     append([]byte(nil), pkScript...),
 			TargetConfs:  1,
 			HeightHint:   heightHint,
 			IncludeBlock: true,

--- a/waved/rpc_taproot_asset_manage.go
+++ b/waved/rpc_taproot_asset_manage.go
@@ -1,0 +1,389 @@
+package waved
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/chainsource"
+	"github.com/lightninglabs/wavelength/tapassets"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// assetClaimVsizeEstimate is the conservative virtual size used to derive a
+// default claim fee: one taproot script-path input with the composed exit
+// witness plus one taproot output.
+const assetClaimVsizeEstimate = 200
+
+// BoardTaprootAsset implements the user-facing boarding-completion RPC.
+func (r *RPCServer) BoardTaprootAsset(ctx context.Context,
+	req *waverpc.BoardTaprootAssetRequest) (
+	*waverpc.BoardTaprootAssetResponse, error) {
+
+	if r == nil || r.server == nil || r.server.cfg == nil {
+		return nil, status.Error(
+			codes.Unavailable, "daemon unavailable",
+		)
+	}
+	if req == nil || req.GetIdempotencyKey() == "" {
+		return nil, status.Error(
+			codes.InvalidArgument, "idempotency key is required",
+		)
+	}
+	if r.server.WalletLifecycleState() != WalletStateReady {
+		return nil, status.Error(
+			codes.FailedPrecondition, "wallet is not ready",
+		)
+	}
+	if r.server.cfg.TaprootAssetOnboarder == nil {
+		return nil, status.Error(
+			codes.FailedPrecondition,
+			"Taproot Asset onboarding is disabled",
+		)
+	}
+
+	result, err := r.server.BoardTaprootAsset(
+		ctx, req.GetIdempotencyKey(),
+	)
+	if errors.Is(err, ErrAssetBoardingUnconfirmed) {
+		return nil, status.Error(
+			codes.FailedPrecondition, "onboarded output is not "+
+				"confirmed yet; retry after the next block",
+		)
+	}
+	if errors.Is(err, tapassets.ErrStoreNotFound) {
+		return nil, status.Errorf(codes.NotFound, "no onboarding "+
+			"found for idempotency key %q", req.GetIdempotencyKey())
+	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "board Taproot "+
+			"Asset: %v", err)
+	}
+
+	return &waverpc.BoardTaprootAssetResponse{
+		Outpoint:       result.Outpoint.String(),
+		ValueSat:       result.ValueSat,
+		AssetRef:       result.AssetRef,
+		AssetAmount:    result.AssetAmount,
+		AlreadyBoarded: result.AlreadyBoarded,
+	}, nil
+}
+
+// ClaimTaprootAssetVTXO implements the user-facing exit-claim RPC. The
+// daemon gathers the leaf's lineage confirmations itself before delegating
+// to the claim workflow.
+func (r *RPCServer) ClaimTaprootAssetVTXO(ctx context.Context,
+	req *waverpc.ClaimTaprootAssetVTXORequest) (
+	*waverpc.ClaimTaprootAssetVTXOResponse, error) {
+
+	if r == nil || r.server == nil || r.server.cfg == nil {
+		return nil, status.Error(
+			codes.Unavailable, "daemon unavailable",
+		)
+	}
+	if req == nil || req.GetOutpoint() == "" {
+		return nil, status.Error(
+			codes.InvalidArgument, "outpoint is required",
+		)
+	}
+	outpoint, err := wire.NewOutPointFromString(req.GetOutpoint())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid "+
+			"outpoint: %v", err)
+	}
+	if req.GetFeeSat() < 0 {
+		return nil, status.Error(
+			codes.InvalidArgument, "fee must not be negative",
+		)
+	}
+	if r.server.WalletLifecycleState() != WalletStateReady {
+		return nil, status.Error(
+			codes.FailedPrecondition, "wallet is not ready",
+		)
+	}
+
+	feeSat := req.GetFeeSat()
+	if feeSat == 0 {
+		feeSat, err = r.server.estimateAssetClaimFee(ctx)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "estimate "+
+				"claim fee: %v", err)
+		}
+	}
+
+	confirmations, err := r.server.assetClaimConfirmations(ctx, *outpoint)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "gather claim "+
+			"lineage confirmations: %v", err)
+	}
+
+	claim, err := r.server.ClaimAssetVTXO(
+		ctx, *outpoint, feeSat, confirmations,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "claim Taproot "+
+			"Asset VTXO: %v", err)
+	}
+
+	return &waverpc.ClaimTaprootAssetVTXOResponse{
+		Txid:           claim.Txid.String(),
+		AnchorOutpoint: claim.AnchorOutpoint.String(),
+		OutputValueSat: claim.OutputValueSat,
+		FeeSat:         feeSat,
+	}, nil
+}
+
+// assetClaimConfirmations gathers the raw block and height of every anchor
+// transaction in an exited leaf's lineage. The lineage txids come from the
+// leaf's sealed package; the chain source resolves each to its confirmed
+// block. The round's creation height serves as the rescan hint, since no
+// lineage transaction can confirm before the commitment.
+func (s *Server) assetClaimConfirmations(ctx context.Context,
+	outpoint wire.OutPoint) (map[chainhash.Hash]tapsdk.AnchorConfirmation,
+	error) {
+
+	if s.vtxoStore == nil || s.actorSystem == nil {
+		return nil, fmt.Errorf("daemon is not fully initialized")
+	}
+	desc, err := s.vtxoStore.GetVTXO(ctx, outpoint)
+	if err != nil {
+		return nil, fmt.Errorf("load VTXO %v: %w", outpoint, err)
+	}
+	if desc.TaprootAssetRoot == nil || desc.TaprootAssetRef == "" ||
+		len(desc.TaprootAssetSealedPackage) == 0 {
+		return nil, fmt.Errorf("VTXO %v carries no claimable Taproot "+
+			"Asset state", outpoint)
+	}
+	if desc.Status != vtxo.VTXOStatusUnilateralExit {
+		return nil, fmt.Errorf("VTXO %v is not in unilateral exit",
+			outpoint)
+	}
+
+	source, err := tapassets.ResolveCreatedAssetProofSource(
+		desc.TaprootAssetSealedPackage, outpoint, int64(desc.Amount),
+		desc.TaprootAssetRef, desc.TaprootAssetAmount,
+		*desc.TaprootAssetRoot,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("resolve claim lineage: %w", err)
+	}
+
+	var path tapsdk.AssetProofPath
+	if err := path.UnmarshalBinary(source.CompactProofPath); err != nil {
+		return nil, fmt.Errorf("decode claim proof path: %w", err)
+	}
+
+	confirmations := make(
+		map[chainhash.Hash]tapsdk.AnchorConfirmation, len(path.Steps),
+	)
+	chainRef := chainsource.ChainSourceKey.Ref(s.actorSystem)
+	for i := range path.Steps {
+		summary, err := path.Steps[i].Summary()
+		if err != nil {
+			return nil, fmt.Errorf("summarize lineage step %d: %w",
+				i, err)
+		}
+
+		txid := chainhash.Hash(summary.AnchorOutpoint.Txid)
+		if _, ok := confirmations[txid]; ok {
+			continue
+		}
+
+		event, err := s.lineageConfirmation(
+			ctx, chainRef, txid, uint32(desc.CreatedHeight),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("confirm lineage tx %v: %w",
+				txid, err)
+		}
+
+		var encoded []byte
+		if event.Block != nil {
+			var err error
+			encoded, err = serializeBlock(event.Block)
+			if err != nil {
+				return nil, fmt.Errorf("serialize lineage "+
+					"block: %w", err)
+			}
+		}
+		if len(encoded) == 0 {
+			return nil, fmt.Errorf("lineage confirmation for %v "+
+				"carries no block", txid)
+		}
+
+		confirmations[txid] = tapsdk.AnchorConfirmation{
+			BlockHeight: uint32(event.BlockHeight),
+			Block:       encoded,
+		}
+	}
+
+	return confirmations, nil
+}
+
+// lineageConfirmation resolves one lineage transaction's confirmation with
+// the full block attached. The transactions are already confirmed by the
+// time a claim runs, so the await is bounded by the historical-dispatch
+// rescan rather than a future block.
+func (s *Server) lineageConfirmation(ctx context.Context,
+	chainRef chainSourceRef, txid chainhash.Hash, heightHint uint32) (
+	*chainsource.ConfirmationEvent, error) {
+
+	resp, err := chainRef.Ask(
+		context.WithoutCancel(ctx), &chainsource.RegisterConfRequest{
+			CallerID:     "taproot-asset-claim-" + txid.String(),
+			Txid:         &txid,
+			TargetConfs:  1,
+			HeightHint:   heightHint,
+			IncludeBlock: true,
+		},
+	).Await(ctx).Unpack()
+	if err != nil {
+		return nil, fmt.Errorf("register confirmation watch: %w", err)
+	}
+	confResp, ok := resp.(*chainsource.RegisterConfResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected chain source response %T",
+			resp)
+	}
+
+	event, err := confResp.Future.Await(ctx).Unpack()
+	if err != nil {
+		return nil, fmt.Errorf("await confirmation: %w", err)
+	}
+
+	return &event, nil
+}
+
+// chainSourceRef is the actor handle the confirmation helpers ask.
+type chainSourceRef = actor.ActorRef[
+	chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+]
+
+// serializeBlock encodes a block in wire format for the tap-sdk proof
+// assembler.
+func serializeBlock(block *wire.MsgBlock) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := block.Serialize(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// estimateAssetClaimFee derives a default claim fee from the shared LND
+// wallet's estimator at a conservative confirmation target.
+func (s *Server) estimateAssetClaimFee(ctx context.Context) (int64, error) {
+	if s.cfg.Wallet.Type != WalletTypeLnd || !s.lnd.IsSome() {
+		return 0, fmt.Errorf("claim fee estimation requires the LND " +
+			"wallet backend; pass fee_sat explicitly")
+	}
+
+	rate, err := s.lnd.UnsafeFromSome().WalletKit.EstimateFeeRate(ctx, 6)
+	if err != nil {
+		return 0, fmt.Errorf("estimate fee rate: %w", err)
+	}
+
+	fee := int64(rate.FeePerKVByte()) * assetClaimVsizeEstimate / 1000
+	if fee <= 0 {
+		return 0, fmt.Errorf("fee estimator returned a non-positive " +
+			"rate")
+	}
+
+	return fee, nil
+}
+
+// taprootAssetBalances aggregates asset-bearing VTXO holdings by asset
+// reference. live holds the non-terminal set (live and mid-spend states);
+// exiting holds VTXOs in unilateral exit. Output order is stable by
+// reference so repeated calls diff cleanly.
+func taprootAssetBalances(
+	live, exiting []*vtxo.Descriptor) []*waverpc.TaprootAssetBalance {
+
+	byRef := make(map[string]*waverpc.TaprootAssetBalance)
+	balance := func(ref string) *waverpc.TaprootAssetBalance {
+		entry, ok := byRef[ref]
+		if !ok {
+			entry = &waverpc.TaprootAssetBalance{AssetRef: ref}
+			byRef[ref] = entry
+		}
+
+		return entry
+	}
+
+	for _, desc := range live {
+		if desc.TaprootAssetRef == "" {
+			continue
+		}
+		entry := balance(desc.TaprootAssetRef)
+		if desc.Status == vtxo.VTXOStatusLive {
+			entry.LiveAmount += desc.TaprootAssetAmount
+			entry.LiveVtxoCount++
+		} else {
+			entry.PendingAmount += desc.TaprootAssetAmount
+		}
+	}
+	for _, desc := range exiting {
+		if desc.TaprootAssetRef == "" {
+			continue
+		}
+		balance(desc.TaprootAssetRef).ExitingAmount +=
+			desc.TaprootAssetAmount
+	}
+
+	refs := make([]string, 0, len(byRef))
+	for ref := range byRef {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+
+	balances := make([]*waverpc.TaprootAssetBalance, 0, len(refs))
+	for _, ref := range refs {
+		balances = append(balances, byRef[ref])
+	}
+
+	return balances
+}
+
+// filterDescriptorsByAssetRef keeps the descriptors whose asset reference
+// is equivalent to ref. References parse through tap-sdk so an issuance-ID
+// form matches its stored canonical form; an unparseable ref falls back to
+// exact string comparison.
+func filterDescriptorsByAssetRef(descriptors []*vtxo.Descriptor,
+	ref string) []*vtxo.Descriptor {
+
+	want, wantErr := tapsdk.ParseAssetRef(ref)
+	matches := func(stored string) bool {
+		if stored == ref {
+			return true
+		}
+		if wantErr != nil {
+			return false
+		}
+		parsed, err := tapsdk.ParseAssetRef(stored)
+		if err != nil {
+			return false
+		}
+
+		return parsed.Equivalent(want)
+	}
+
+	filtered := make([]*vtxo.Descriptor, 0, len(descriptors))
+	for _, desc := range descriptors {
+		if desc.TaprootAssetRef != "" &&
+			matches(desc.TaprootAssetRef) {
+
+			filtered = append(filtered, desc)
+		}
+	}
+
+	return filtered
+}

--- a/waved/rpc_taproot_asset_manage.go
+++ b/waved/rpc_taproot_asset_manage.go
@@ -198,30 +198,34 @@ func (s *Server) assetClaimConfirmations(ctx context.Context,
 
 	// The chain backend requires an output script beside the txid, and
 	// every lineage anchor is a transaction of the VTXO's own ancestry:
-	// the commitment transaction or a node of its tree fragment.
+	// the commitment transaction or a node of its tree fragment. A
+	// multi-input transfer's co-input anchors are covered too, since the
+	// ancestry fragments span every Bitcoin-side branch of the DAG.
 	lineageOutputs, err := assetLineageOutputs(desc)
 	if err != nil {
 		return nil, fmt.Errorf("index claim lineage outputs: %w", err)
 	}
 
+	// The lineage is a DAG, not a chain: every step of the spine plus,
+	// recursively, each merging step's co-input paths needs its anchor
+	// confirmed before the compact path completes into a proof file.
+	anchors, err := tapassets.CollectAssetProofPathAnchors(&path)
+	if err != nil {
+		return nil, fmt.Errorf("collect claim lineage anchors: %w", err)
+	}
+
 	confirmations := make(
-		map[chainhash.Hash]tapsdk.AnchorConfirmation, len(path.Steps),
+		map[chainhash.Hash]tapsdk.AnchorConfirmation, len(anchors),
 	)
 	chainRef := chainsource.ChainSourceKey.Ref(s.actorSystem)
-	for i := range path.Steps {
-		summary, err := path.Steps[i].Summary()
-		if err != nil {
-			return nil, fmt.Errorf("summarize lineage step %d: %w",
-				i, err)
-		}
-
-		txid := chainhash.Hash(summary.AnchorOutpoint.Txid)
+	for _, anchor := range anchors {
+		txid := anchor.Txid
 		if _, ok := confirmations[txid]; ok {
 			continue
 		}
 
 		outs := lineageOutputs[txid]
-		index := summary.AnchorOutpoint.Index
+		index := anchor.OutputIndex
 		if int(index) >= len(outs) || outs[index] == nil {
 			return nil, fmt.Errorf("lineage tx %v output %d is "+
 				"not part of the VTXO's ancestry", txid, index)

--- a/waved/rpc_taproot_asset_manage.go
+++ b/waved/rpc_taproot_asset_manage.go
@@ -64,18 +64,32 @@ func (r *RPCServer) BoardTaprootAsset(ctx context.Context,
 		return nil, status.Errorf(codes.NotFound, "no onboarding "+
 			"found for idempotency key %q", req.GetIdempotencyKey())
 	}
+
+	// The wallet holding no spendable Bitcoin is the caller's to fix, and
+	// the sentinel's message says how, so pass it through verbatim.
+	if errors.Is(err, ErrNoFeeFundingVTXO) {
+		return nil, status.Error(
+			codes.FailedPrecondition, err.Error(),
+		)
+	}
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "board Taproot "+
 			"Asset: %v", err)
 	}
 
-	return &waverpc.BoardTaprootAssetResponse{
+	resp := &waverpc.BoardTaprootAssetResponse{
 		Outpoint:       result.Outpoint.String(),
 		ValueSat:       result.ValueSat,
 		AssetRef:       result.AssetRef,
 		AssetAmount:    result.AssetAmount,
 		AlreadyBoarded: result.AlreadyBoarded,
-	}, nil
+	}
+	if result.FeeFunding != nil {
+		resp.FeeFundingOutpoint = result.FeeFunding.Outpoint.String()
+		resp.FeeFundingValueSat = result.FeeFunding.ValueSat
+	}
+
+	return resp, nil
 }
 
 // ClaimTaprootAssetVTXO implements the user-facing exit-claim RPC. The

--- a/waved/rpc_taproot_asset_manage_test.go
+++ b/waved/rpc_taproot_asset_manage_test.go
@@ -1,0 +1,79 @@
+package waved
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/stretchr/testify/require"
+)
+
+// assetDescriptor builds a minimal asset-bearing descriptor for aggregation
+// tests.
+func assetDescriptor(ref string, amount uint64,
+	status vtxo.VTXOStatus) *vtxo.Descriptor {
+
+	root := chainhash.Hash{1}
+
+	return &vtxo.Descriptor{
+		TaprootAssetRef:    ref,
+		TaprootAssetAmount: amount,
+		TaprootAssetRoot:   &root,
+		Status:             status,
+	}
+}
+
+// TestTaprootAssetBalances verifies the per-reference aggregation buckets
+// live, pending, and exiting amounts and skips Bitcoin-only VTXOs.
+func TestTaprootAssetBalances(t *testing.T) {
+	t.Parallel()
+
+	live := []*vtxo.Descriptor{
+		assetDescriptor("usd", 600, vtxo.VTXOStatusLive),
+		assetDescriptor("usd", 300, vtxo.VTXOStatusLive),
+		assetDescriptor("usd", 100, vtxo.VTXOStatusSpending),
+		assetDescriptor("eur", 50, vtxo.VTXOStatusLive),
+		{
+			Status: vtxo.VTXOStatusLive,
+		},
+	}
+	exiting := []*vtxo.Descriptor{
+		assetDescriptor("usd", 200, vtxo.VTXOStatusUnilateralExit),
+		{
+			Status: vtxo.VTXOStatusUnilateralExit,
+		},
+	}
+
+	balances := taprootAssetBalances(live, exiting)
+	require.Len(t, balances, 2)
+
+	require.Equal(t, "eur", balances[0].AssetRef)
+	require.EqualValues(t, 50, balances[0].LiveAmount)
+	require.EqualValues(t, 1, balances[0].LiveVtxoCount)
+
+	require.Equal(t, "usd", balances[1].AssetRef)
+	require.EqualValues(t, 900, balances[1].LiveAmount)
+	require.EqualValues(t, 100, balances[1].PendingAmount)
+	require.EqualValues(t, 200, balances[1].ExitingAmount)
+	require.EqualValues(t, 2, balances[1].LiveVtxoCount)
+}
+
+// TestFilterDescriptorsByAssetRef verifies exact-match filtering and that
+// Bitcoin-only VTXOs never match.
+func TestFilterDescriptorsByAssetRef(t *testing.T) {
+	t.Parallel()
+
+	descriptors := []*vtxo.Descriptor{
+		assetDescriptor("usd", 600, vtxo.VTXOStatusLive),
+		assetDescriptor("eur", 50, vtxo.VTXOStatusLive),
+		{
+			Status: vtxo.VTXOStatusLive,
+		},
+	}
+
+	filtered := filterDescriptorsByAssetRef(descriptors, "usd")
+	require.Len(t, filtered, 1)
+	require.Equal(t, "usd", filtered[0].TaprootAssetRef)
+
+	require.Empty(t, filterDescriptorsByAssetRef(descriptors, "gbp"))
+}

--- a/waved/rpc_taproot_asset_onboarding.go
+++ b/waved/rpc_taproot_asset_onboarding.go
@@ -135,6 +135,13 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 		)
 	}
 
+	// The anchor cannot confirm below the current height, so it seeds
+	// the boarding confirmation watch after a restart or a late replay.
+	heightHint, err := r.currentBlockHeight(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// The onboarded output is spent as a round boarding input, so it
 	// carries the boarding exit delay; AssetBoardingDisclosure replays
 	// the onboarding under the same delay when the boarding completes.
@@ -169,7 +176,9 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 	// Persist the replay slice so BoardTaprootAsset can rebuild the
 	// disclosure from the idempotency key alone. The onboarding is
 	// idempotent, so a retry after a persist failure lands here again.
-	err = r.server.storeTaprootAssetBoardRequest(ctx, onboardingRequest)
+	err = r.server.storeTaprootAssetBoardRequest(
+		ctx, onboardingRequest, uint32(heightHint),
+	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "persist boarding "+
 			"replay request: %v", err)

--- a/waved/rpc_taproot_asset_onboarding.go
+++ b/waved/rpc_taproot_asset_onboarding.go
@@ -105,7 +105,8 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 		)
 	}
 	terms := r.server.loadOperatorTerms()
-	if terms == nil || terms.PubKey == nil || terms.VTXOExitDelay == 0 {
+	if terms == nil || terms.PubKey == nil ||
+		terms.BoardingExitDelay == 0 {
 		return nil, status.Error(
 			codes.FailedPrecondition,
 			"operator terms are not ready",
@@ -134,6 +135,9 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 		)
 	}
 
+	// The onboarded output is spent as a round boarding input, so it
+	// carries the boarding exit delay; AssetBoardingDisclosure replays
+	// the onboarding under the same delay when the boarding completes.
 	onboardingRequest := &tapassets.OnboardingRequest{
 		RequestID:   req.GetIdempotencyKey(),
 		AssetRef:    req.GetAssetRef(),
@@ -146,7 +150,7 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 		TargetConf:         req.GetTargetConf(),
 		MaxFeeSat:          req.GetMaxFeeSat(),
 		OperatorKey:        terms.PubKey,
-		ExitDelay:          terms.VTXOExitDelay,
+		ExitDelay:          terms.BoardingExitDelay,
 	}
 	result, err := onboarder.Onboard(ctx, onboardingRequest)
 	if errors.Is(err, tapassets.ErrReconciliationRequired) {

--- a/waved/rpc_taproot_asset_onboarding.go
+++ b/waved/rpc_taproot_asset_onboarding.go
@@ -78,11 +78,10 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 	}
 	if req == nil || req.GetIdempotencyKey() == "" ||
 		req.GetAssetRef() == "" || req.GetAssetAmount() == 0 ||
-		len(req.GetInputProofFile()) == 0 || req.GetMaxFeeSat() == 0 {
+		req.GetMaxFeeSat() == 0 {
 		return nil, status.Error(
 			codes.InvalidArgument, "idempotency key, asset "+
-				"ref, amount, proof, and maximum fee are "+
-				"required",
+				"ref, amount, and maximum fee are required",
 		)
 	}
 	if (req.GetFeeRateSatPerVbyte() == 0) ==
@@ -142,16 +141,46 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 		return nil, err
 	}
 
+	// Without an explicit proof the daemon exports it from its own tapd,
+	// which requires the wallet to hold the amount in exactly one UTXO.
+	// A replay must reuse the originally resolved proof instead: the
+	// onboarding itself spends the source UTXO, so re-resolving after
+	// success finds nothing and would break idempotency.
+	proofFile := append([]byte(nil), req.GetInputProofFile()...)
+	if len(proofFile) == 0 {
+		stored, _, loadErr := r.server.loadTaprootAssetBoardRequest(
+			ctx, req.GetIdempotencyKey(),
+		)
+		switch {
+		case loadErr == nil:
+			proofFile = stored.ProofFile
+
+		case errors.Is(loadErr, tapassets.ErrStoreNotFound):
+			proofFile, err = tapassets.ResolveOwnedAssetProof(
+				ctx, r.server.taprootAssetWallet,
+				req.GetAssetRef(), req.GetAssetAmount(),
+			)
+			if err != nil {
+				return nil, status.Errorf(
+					codes.FailedPrecondition,
+					"resolve owned asset proof: %v", err,
+				)
+			}
+
+		default:
+			return nil, status.Errorf(codes.Internal, "load "+
+				"boarding replay request: %v", loadErr)
+		}
+	}
+
 	// The onboarded output is spent as a round boarding input, so it
 	// carries the boarding exit delay; AssetBoardingDisclosure replays
 	// the onboarding under the same delay when the boarding completes.
 	onboardingRequest := &tapassets.OnboardingRequest{
-		RequestID:   req.GetIdempotencyKey(),
-		AssetRef:    req.GetAssetRef(),
-		AssetAmount: req.GetAssetAmount(),
-		ProofFile: append(
-			[]byte(nil), req.GetInputProofFile()...,
-		),
+		RequestID:          req.GetIdempotencyKey(),
+		AssetRef:           req.GetAssetRef(),
+		AssetAmount:        req.GetAssetAmount(),
+		ProofFile:          proofFile,
 		CarrierValueSat:    carrierValue,
 		FeeRateSatPerVByte: req.GetFeeRateSatPerVbyte(),
 		TargetConf:         req.GetTargetConf(),

--- a/waved/rpc_taproot_asset_onboarding.go
+++ b/waved/rpc_taproot_asset_onboarding.go
@@ -61,6 +61,7 @@ func (r *RPCServer) ConfigureTaprootAssetOnboarding(wallet *tapsdk.Wallet,
 	}
 	r.server.cfg.TaprootAssetOnboarder = onboarder
 	r.server.taprootAssetWallet = wallet
+	r.server.taprootAssetStore = store
 
 	return nil
 }
@@ -133,7 +134,7 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 		)
 	}
 
-	result, err := onboarder.Onboard(ctx, &tapassets.OnboardingRequest{
+	onboardingRequest := &tapassets.OnboardingRequest{
 		RequestID:   req.GetIdempotencyKey(),
 		AssetRef:    req.GetAssetRef(),
 		AssetAmount: req.GetAssetAmount(),
@@ -146,7 +147,8 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 		MaxFeeSat:          req.GetMaxFeeSat(),
 		OperatorKey:        terms.PubKey,
 		ExitDelay:          terms.VTXOExitDelay,
-	})
+	}
+	result, err := onboarder.Onboard(ctx, onboardingRequest)
 	if errors.Is(err, tapassets.ErrReconciliationRequired) {
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
@@ -158,6 +160,15 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 		return nil, status.Error(
 			codes.Internal, "onboarding service returned no result",
 		)
+	}
+
+	// Persist the replay slice so BoardTaprootAsset can rebuild the
+	// disclosure from the idempotency key alone. The onboarding is
+	// idempotent, so a retry after a persist failure lands here again.
+	err = r.server.storeTaprootAssetBoardRequest(ctx, onboardingRequest)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "persist boarding "+
+			"replay request: %v", err)
 	}
 
 	response := &waverpc.OnboardTaprootAssetResponse{

--- a/waved/rpc_taproot_asset_onboarding.go
+++ b/waved/rpc_taproot_asset_onboarding.go
@@ -141,30 +141,38 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 		return nil, err
 	}
 
-	// Without an explicit proof the daemon exports it from its own tapd,
-	// which requires the wallet to hold the amount in exactly one UTXO.
-	// A replay must reuse the originally resolved proof instead: the
-	// onboarding itself spends the source UTXO, so re-resolving after
+	// Without an explicit proof the daemon selects and exports the proofs
+	// of its own tapd UTXOs, which must together cover the amount. A
+	// replay must reuse the originally resolved proofs instead: the
+	// onboarding itself spends the source UTXOs, so re-resolving after
 	// success finds nothing and would break idempotency.
-	proofFile := append([]byte(nil), req.GetInputProofFile()...)
-	if len(proofFile) == 0 {
+	var proofFiles [][]byte
+	if explicit := req.GetInputProofFile(); len(explicit) != 0 {
+		proofFiles = [][]byte{append([]byte(nil), explicit...)}
+	} else {
 		stored, _, loadErr := r.server.loadTaprootAssetBoardRequest(
 			ctx, req.GetIdempotencyKey(),
 		)
 		switch {
 		case loadErr == nil:
-			proofFile = stored.ProofFile
+			// A slice written before multi-UTXO funding carries
+			// its single proof in the singular field.
+			proofFiles = stored.ProofFiles
+			if len(proofFiles) == 0 &&
+				len(stored.ProofFile) != 0 {
+
+				proofFiles = [][]byte{stored.ProofFile}
+			}
 
 		case errors.Is(loadErr, tapassets.ErrStoreNotFound):
-			proofFile, err = tapassets.ResolveOwnedAssetProof(
+			proofFiles, err = tapassets.ResolveOwnedAssetProofs(
 				ctx, r.server.taprootAssetWallet,
 				req.GetAssetRef(), req.GetAssetAmount(),
 			)
 			if err != nil {
 				return nil, status.Errorf(
-					codes.FailedPrecondition,
-					"resolve owned asset proof: %v", err,
-				)
+					codes.FailedPrecondition, "resolve "+
+						"owned asset proofs: %v", err)
 			}
 
 		default:
@@ -180,7 +188,7 @@ func (r *RPCServer) OnboardTaprootAsset(ctx context.Context,
 		RequestID:          req.GetIdempotencyKey(),
 		AssetRef:           req.GetAssetRef(),
 		AssetAmount:        req.GetAssetAmount(),
-		ProofFile:          proofFile,
+		ProofFiles:         proofFiles,
 		CarrierValueSat:    carrierValue,
 		FeeRateSatPerVByte: req.GetFeeRateSatPerVbyte(),
 		TargetConf:         req.GetTargetConf(),

--- a/waved/rpc_taproot_asset_onboarding_test.go
+++ b/waved/rpc_taproot_asset_onboarding_test.go
@@ -31,9 +31,9 @@ func TestOnboardTaprootAssetValidatesCarrierAndFeePolicy(t *testing.T) {
 	server := &Server{cfg: cfg, walletReady: make(chan struct{})}
 	server.walletState.Store(int32(WalletStateReady))
 	server.operatorTerms.Store(&types.OperatorTerms{
-		PubKey:        operator.PubKey(),
-		VTXOExitDelay: 144,
-		MinVTXOAmount: 1_000,
+		PubKey:            operator.PubKey(),
+		BoardingExitDelay: 144,
+		MinVTXOAmount:     1_000,
 	})
 	rpcServer := &RPCServer{server: server}
 	request := &waverpc.OnboardTaprootAssetRequest{

--- a/waved/server.go
+++ b/waved/server.go
@@ -57,6 +57,7 @@ import (
 	"github.com/lightninglabs/wavelength/rpc/roundpb"
 	"github.com/lightninglabs/wavelength/rpcauth"
 	"github.com/lightninglabs/wavelength/serverconn"
+	"github.com/lightninglabs/wavelength/tapassets"
 	"github.com/lightninglabs/wavelength/timeout"
 	"github.com/lightninglabs/wavelength/txconfirm"
 	"github.com/lightninglabs/wavelength/unroll"
@@ -322,6 +323,11 @@ type Server struct {
 	// optional Taproot Asset integration is configured. Onboarding and
 	// the exit claim build their transitions through it.
 	taprootAssetWallet *tapsdk.Wallet
+
+	// taprootAssetStore is the durable Taproot Asset journal shared with
+	// the onboarding workflow; BoardTaprootAsset replays onboardings
+	// from it.
+	taprootAssetStore tapassets.Store
 
 	// operatorTerms caches the operator policy fetched during daemon
 	// bootstrap so local RPC callers can inspect the current server

--- a/waved/server.go
+++ b/waved/server.go
@@ -197,6 +197,11 @@ type Server struct {
 	roundStore       *db.RoundPersistenceStore
 	ueStore          *db.UnilateralExitPersistenceStore
 
+	// oorArtifactStore persists owned receive-script and OOR package
+	// artifacts. Initialized with the database so RPC handlers share one
+	// store instead of constructing per-call instances.
+	oorArtifactStore *db.OORArtifactPersistenceStore
+
 	// oorSessionStore exposes the OOR session-registry control-plane rows
 	// for direct RPC reads (idempotency pre-flight); the OOR registry
 	// actor owns all writes.
@@ -3695,6 +3700,11 @@ func (s *Server) initDatabase(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to open database: %w", err)
 	}
+
+	s.oorArtifactStore = db.NewStore(
+		s.db.DB, s.db.Queries, s.db.Backend(),
+		s.subLogger(db.Subsystem),
+	).NewOORArtifactStore(s.clk)
 
 	s.deliveryStore, err = actordelivery.NewTxAwareDeliveryStoreFromDB(
 		s.db.DB, s.db.Backend(), s.clk, s.subLogger(actor.Subsystem),

--- a/waved/taproot_asset_board.go
+++ b/waved/taproot_asset_board.go
@@ -1,0 +1,270 @@
+package waved
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/chainsource"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/tapassets"
+)
+
+// taprootAssetBoardRequestKeyPrefix namespaces the persisted replay slice of
+// an onboarding request in the Taproot Asset journal, away from the
+// onboarder's own state under the bare request ID.
+const taprootAssetBoardRequestKeyPrefix = "board-request/"
+
+// assetBoardingConfWait bounds how long BoardTaprootAsset blocks on the
+// onboarded output's confirmation before telling the caller to retry.
+const assetBoardingConfWait = 30 * time.Second
+
+// taprootAssetBoardRequest is the durable replay slice of an onboarding
+// request. It carries exactly the caller-owned fields; the operator key and
+// exit delay are re-derived from live operator terms on every replay.
+type taprootAssetBoardRequest struct {
+	AssetRef           string `json:"asset_ref"`
+	AssetAmount        uint64 `json:"asset_amount"`
+	ProofFile          []byte `json:"proof_file"`
+	CarrierValueSat    uint64 `json:"carrier_value_sat"`
+	FeeRateSatPerVByte uint64 `json:"fee_rate_sat_per_vbyte"`
+	TargetConf         uint32 `json:"target_conf"`
+	MaxFeeSat          uint64 `json:"max_fee_sat"`
+}
+
+// storeTaprootAssetBoardRequest persists the replay slice of a successful
+// onboarding so a later BoardTaprootAsset can rebuild the disclosure from
+// the idempotency key alone.
+func (s *Server) storeTaprootAssetBoardRequest(ctx context.Context,
+	req *tapassets.OnboardingRequest) error {
+
+	if s.taprootAssetStore == nil {
+		return fmt.Errorf("taproot asset store is not configured")
+	}
+
+	encoded, err := json.Marshal(&taprootAssetBoardRequest{
+		AssetRef:           req.AssetRef,
+		AssetAmount:        req.AssetAmount,
+		ProofFile:          req.ProofFile,
+		CarrierValueSat:    req.CarrierValueSat,
+		FeeRateSatPerVByte: req.FeeRateSatPerVByte,
+		TargetConf:         req.TargetConf,
+		MaxFeeSat:          req.MaxFeeSat,
+	})
+	if err != nil {
+		return fmt.Errorf("encode board replay request: %w", err)
+	}
+
+	return s.taprootAssetStore.Store(
+		ctx, taprootAssetBoardRequestKeyPrefix+req.RequestID, encoded,
+	)
+}
+
+// loadTaprootAssetBoardRequest rebuilds the onboarding request persisted by
+// a successful OnboardTaprootAsset call.
+func (s *Server) loadTaprootAssetBoardRequest(ctx context.Context,
+	requestID string) (*tapassets.OnboardingRequest, error) {
+
+	if s.taprootAssetStore == nil {
+		return nil, fmt.Errorf("taproot asset store is not configured")
+	}
+
+	encoded, err := s.taprootAssetStore.Load(
+		ctx, taprootAssetBoardRequestKeyPrefix+requestID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var stored taprootAssetBoardRequest
+	if err := json.Unmarshal(encoded, &stored); err != nil {
+		return nil, fmt.Errorf("decode board replay request: %w", err)
+	}
+
+	return &tapassets.OnboardingRequest{
+		RequestID:          requestID,
+		AssetRef:           stored.AssetRef,
+		AssetAmount:        stored.AssetAmount,
+		ProofFile:          stored.ProofFile,
+		CarrierValueSat:    stored.CarrierValueSat,
+		FeeRateSatPerVByte: stored.FeeRateSatPerVByte,
+		TargetConf:         stored.TargetConf,
+		MaxFeeSat:          stored.MaxFeeSat,
+	}, nil
+}
+
+// BoardTaprootAssetResult reports a completed (or replayed) asset boarding.
+type BoardTaprootAssetResult struct {
+	// Outpoint is the boarded composed output.
+	Outpoint wire.OutPoint
+
+	// ValueSat is the output's carrier Bitcoin value.
+	ValueSat int64
+
+	// AssetRef and AssetAmount identify the boarded units.
+	AssetRef    string
+	AssetAmount uint64
+
+	// AlreadyBoarded reports an idempotent replay: the boarding intent
+	// already existed and no new round registration was sent.
+	AlreadyBoarded bool
+}
+
+// ErrAssetBoardingUnconfirmed reports an onboarded output that has not
+// confirmed yet; the caller retries once it has.
+var ErrAssetBoardingUnconfirmed = errors.New("onboarded output is not " +
+	"confirmed yet")
+
+// BoardTaprootAsset completes an onboarded output's path into a round. It
+// rebuilds the boarding disclosure from the onboarding named by requestID,
+// gathers the confirmation and the boarded asset proof itself, persists the
+// boarding intent, and registers the boarding together with a matching
+// asset VTXO request.
+func (s *Server) BoardTaprootAsset(ctx context.Context, requestID string) (
+	*BoardTaprootAssetResult, error) {
+
+	onboardingReq, err := s.loadTaprootAssetBoardRequest(ctx, requestID)
+	if err != nil {
+		return nil, fmt.Errorf("load onboarding %q: %w", requestID, err)
+	}
+
+	disclosure, err := s.AssetBoardingDisclosure(ctx, onboardingReq)
+	if err != nil {
+		return nil, fmt.Errorf("rebuild boarding disclosure: %w", err)
+	}
+
+	result := &BoardTaprootAssetResult{
+		Outpoint:    disclosure.Outpoint,
+		AssetRef:    disclosure.AssetRef,
+		AssetAmount: disclosure.AssetAmount,
+	}
+
+	// An existing boarding intent for the outpoint means an earlier call
+	// already completed the round registration; replaying it would hand
+	// the round actor a duplicate intent.
+	existing, err := s.newBoardingStore().FetchBoardingIntentOutpoints(
+		ctx,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list boarding intents: %w", err)
+	}
+	for _, op := range existing {
+		if op == disclosure.Outpoint {
+			result.AlreadyBoarded = true
+
+			return result, nil
+		}
+	}
+
+	// The disclosure carries everything the operator authenticates except
+	// the on-chain confirmation and the boarded proof; gather both.
+	policyTemplate, err := arkscript.EncodeStandardVTXOTemplate(
+		disclosure.KeyDesc.PubKey, disclosure.OperatorKey,
+		disclosure.ExitDelay,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("encode boarding policy: %w", err)
+	}
+	pkScript, _, _, err := tapassets.ComposedBoardingScript(
+		policyTemplate, [32]byte(disclosure.AssetCommitmentLeafHash),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("compose boarding script: %w", err)
+	}
+
+	conf, err := s.assetBoardingConfirmation(
+		ctx, disclosure.Outpoint, pkScript,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if int(disclosure.Outpoint.Index) >= len(conf.Tx.TxOut) {
+		return nil, fmt.Errorf("confirmed transaction does not carry " +
+			"the boarded output")
+	}
+	result.ValueSat = conf.Tx.TxOut[disclosure.Outpoint.Index].Value
+
+	proofFile, err := tapassets.ExportBoardedProof(
+		ctx, s.taprootAssetWallet, disclosure.Outpoint,
+	)
+	if errors.Is(err, tapassets.ErrBoardedProofPending) {
+		return nil, ErrAssetBoardingUnconfirmed
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	disclosure.ConfTx = conf.Tx
+	disclosure.ConfHeight = conf.BlockHeight
+	disclosure.AssetProof = proofFile
+
+	if err := s.RegisterAssetBoarding(ctx, disclosure); err != nil {
+		return nil, fmt.Errorf("register asset boarding: %w", err)
+	}
+
+	err = s.RegisterAssetVTXORequest(
+		ctx, btcutil.Amount(result.ValueSat), disclosure.AssetRef,
+		disclosure.AssetAmount,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("register asset VTXO request: %w", err)
+	}
+
+	return result, nil
+}
+
+// assetBoardingConfirmation resolves the onboarded output's confirmation
+// through the chain source. The wait is bounded: an unconfirmed output
+// returns ErrAssetBoardingUnconfirmed rather than blocking the RPC until
+// the next block.
+func (s *Server) assetBoardingConfirmation(ctx context.Context,
+	outpoint wire.OutPoint, pkScript []byte) (
+	*chainsource.ConfirmationEvent, error) {
+
+	if s.actorSystem == nil {
+		return nil, fmt.Errorf("actor system not initialized")
+	}
+
+	chainRef := chainsource.ChainSourceKey.Ref(s.actorSystem)
+	txid := outpoint.Hash
+	resp, err := chainRef.Ask(
+		context.WithoutCancel(ctx), &chainsource.RegisterConfRequest{
+			CallerID: "taproot-asset-board-" +
+				outpoint.String(),
+			Txid:        &txid,
+			PkScript:    pkScript,
+			TargetConfs: 1,
+		},
+	).Await(ctx).Unpack()
+	if err != nil {
+		return nil, fmt.Errorf("register boarding confirmation "+
+			"watch: %w", err)
+	}
+	confResp, ok := resp.(*chainsource.RegisterConfResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected chain source response %T",
+			resp)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, assetBoardingConfWait)
+	defer cancel()
+
+	event, err := confResp.Future.Await(waitCtx).Unpack()
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, ErrAssetBoardingUnconfirmed
+		}
+
+		return nil, fmt.Errorf("await boarding confirmation: %w", err)
+	}
+	if event.Tx == nil {
+		return nil, fmt.Errorf("boarding confirmation carries no " +
+			"transaction")
+	}
+
+	return &event, nil
+}

--- a/waved/taproot_asset_board.go
+++ b/waved/taproot_asset_board.go
@@ -133,6 +133,11 @@ type BoardTaprootAssetResult struct {
 	// AlreadyBoarded reports an idempotent replay: the boarding intent
 	// already existed and no new round registration was sent.
 	AlreadyBoarded bool
+
+	// FeeFunding names the Bitcoin VTXO this boarding pulled into the
+	// round to pay its fee, and that VTXO's value. Nil when the round
+	// already carried a fee-bearing output of the client's own.
+	FeeFunding *assetRoundFeeFunding
 }
 
 // ErrAssetBoardingUnconfirmed reports an onboarded output that has not
@@ -224,6 +229,19 @@ func (s *Server) BoardTaprootAsset(ctx context.Context, requestID string) (
 	disclosure.ConfTx = conf.Tx
 	disclosure.ConfHeight = conf.BlockHeight
 	disclosure.AssetProof = proofFile
+
+	// The round needs an output whose amount the operator may shrink
+	// before it can charge this boarding a fee, and the asset request
+	// below is fixed. Resolve that first: the boarding is not yet
+	// registered, so a client with no Bitcoin to spend fails here with
+	// something it can act on rather than inside a round that would be
+	// rejected at seal. An earlier retry of this call cannot have churned
+	// a VTXO either — everything above only reads.
+	funding, err := s.fundAssetRoundFee(ctx, result.ValueSat)
+	if err != nil {
+		return nil, err
+	}
+	result.FeeFunding = funding
 
 	if err := s.RegisterAssetBoarding(ctx, disclosure); err != nil {
 		return nil, fmt.Errorf("register asset boarding: %w", err)

--- a/waved/taproot_asset_board.go
+++ b/waved/taproot_asset_board.go
@@ -28,9 +28,18 @@ const assetBoardingConfWait = 30 * time.Second
 // at onboarding time; the operator key and exit delay are re-derived from
 // live operator terms on every replay.
 type taprootAssetBoardRequest struct {
-	AssetRef           string `json:"asset_ref"`
-	AssetAmount        uint64 `json:"asset_amount"`
-	ProofFile          []byte `json:"proof_file"`
+	AssetRef    string `json:"asset_ref"`
+	AssetAmount uint64 `json:"asset_amount"`
+
+	// ProofFile is the funding proof of a slice written before onboarding
+	// could select more than one UTXO. Newer slices carry ProofFiles.
+	ProofFile []byte `json:"proof_file,omitempty"`
+
+	// ProofFiles are the funding proofs of every UTXO the onboarding
+	// spent. A replay runs after those UTXOs are gone, so the complete
+	// set has to survive here rather than be re-selected.
+	ProofFiles [][]byte `json:"proof_files,omitempty"`
+
 	CarrierValueSat    uint64 `json:"carrier_value_sat"`
 	FeeRateSatPerVByte uint64 `json:"fee_rate_sat_per_vbyte"`
 	TargetConf         uint32 `json:"target_conf"`
@@ -56,6 +65,7 @@ func (s *Server) storeTaprootAssetBoardRequest(ctx context.Context,
 		AssetRef:           req.AssetRef,
 		AssetAmount:        req.AssetAmount,
 		ProofFile:          req.ProofFile,
+		ProofFiles:         req.ProofFiles,
 		CarrierValueSat:    req.CarrierValueSat,
 		FeeRateSatPerVByte: req.FeeRateSatPerVByte,
 		TargetConf:         req.TargetConf,
@@ -100,6 +110,7 @@ func (s *Server) loadTaprootAssetBoardRequest(ctx context.Context,
 		AssetRef:           stored.AssetRef,
 		AssetAmount:        stored.AssetAmount,
 		ProofFile:          stored.ProofFile,
+		ProofFiles:         stored.ProofFiles,
 		CarrierValueSat:    stored.CarrierValueSat,
 		FeeRateSatPerVByte: stored.FeeRateSatPerVByte,
 		TargetConf:         stored.TargetConf,

--- a/waved/taproot_asset_board.go
+++ b/waved/taproot_asset_board.go
@@ -24,8 +24,9 @@ const taprootAssetBoardRequestKeyPrefix = "board-request/"
 const assetBoardingConfWait = 30 * time.Second
 
 // taprootAssetBoardRequest is the durable replay slice of an onboarding
-// request. It carries exactly the caller-owned fields; the operator key and
-// exit delay are re-derived from live operator terms on every replay.
+// request. It carries exactly the caller-owned fields plus the chain height
+// at onboarding time; the operator key and exit delay are re-derived from
+// live operator terms on every replay.
 type taprootAssetBoardRequest struct {
 	AssetRef           string `json:"asset_ref"`
 	AssetAmount        uint64 `json:"asset_amount"`
@@ -34,13 +35,18 @@ type taprootAssetBoardRequest struct {
 	FeeRateSatPerVByte uint64 `json:"fee_rate_sat_per_vbyte"`
 	TargetConf         uint32 `json:"target_conf"`
 	MaxFeeSat          uint64 `json:"max_fee_sat"`
+
+	// HeightHint is the best chain height when the onboarding ran. The
+	// anchor cannot confirm below it, so it seeds the confirmation
+	// watch's rescan.
+	HeightHint uint32 `json:"height_hint"`
 }
 
 // storeTaprootAssetBoardRequest persists the replay slice of a successful
 // onboarding so a later BoardTaprootAsset can rebuild the disclosure from
 // the idempotency key alone.
 func (s *Server) storeTaprootAssetBoardRequest(ctx context.Context,
-	req *tapassets.OnboardingRequest) error {
+	req *tapassets.OnboardingRequest, heightHint uint32) error {
 
 	if s.taprootAssetStore == nil {
 		return fmt.Errorf("taproot asset store is not configured")
@@ -54,6 +60,7 @@ func (s *Server) storeTaprootAssetBoardRequest(ctx context.Context,
 		FeeRateSatPerVByte: req.FeeRateSatPerVByte,
 		TargetConf:         req.TargetConf,
 		MaxFeeSat:          req.MaxFeeSat,
+		HeightHint:         heightHint,
 	})
 	if err != nil {
 		return fmt.Errorf("encode board replay request: %w", err)
@@ -65,24 +72,27 @@ func (s *Server) storeTaprootAssetBoardRequest(ctx context.Context,
 }
 
 // loadTaprootAssetBoardRequest rebuilds the onboarding request persisted by
-// a successful OnboardTaprootAsset call.
+// a successful OnboardTaprootAsset call, together with the chain height at
+// onboarding time.
 func (s *Server) loadTaprootAssetBoardRequest(ctx context.Context,
-	requestID string) (*tapassets.OnboardingRequest, error) {
+	requestID string) (*tapassets.OnboardingRequest, uint32, error) {
 
 	if s.taprootAssetStore == nil {
-		return nil, fmt.Errorf("taproot asset store is not configured")
+		return nil, 0, fmt.Errorf("taproot asset store is not " +
+			"configured")
 	}
 
 	encoded, err := s.taprootAssetStore.Load(
 		ctx, taprootAssetBoardRequestKeyPrefix+requestID,
 	)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	var stored taprootAssetBoardRequest
 	if err := json.Unmarshal(encoded, &stored); err != nil {
-		return nil, fmt.Errorf("decode board replay request: %w", err)
+		return nil, 0, fmt.Errorf("decode board replay request: %w",
+			err)
 	}
 
 	return &tapassets.OnboardingRequest{
@@ -94,7 +104,7 @@ func (s *Server) loadTaprootAssetBoardRequest(ctx context.Context,
 		FeeRateSatPerVByte: stored.FeeRateSatPerVByte,
 		TargetConf:         stored.TargetConf,
 		MaxFeeSat:          stored.MaxFeeSat,
-	}, nil
+	}, stored.HeightHint, nil
 }
 
 // BoardTaprootAssetResult reports a completed (or replayed) asset boarding.
@@ -127,7 +137,9 @@ var ErrAssetBoardingUnconfirmed = errors.New("onboarded output is not " +
 func (s *Server) BoardTaprootAsset(ctx context.Context, requestID string) (
 	*BoardTaprootAssetResult, error) {
 
-	onboardingReq, err := s.loadTaprootAssetBoardRequest(ctx, requestID)
+	onboardingReq, heightHint, err := s.loadTaprootAssetBoardRequest(
+		ctx, requestID,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("load onboarding %q: %w", requestID, err)
 	}
@@ -177,7 +189,7 @@ func (s *Server) BoardTaprootAsset(ctx context.Context, requestID string) (
 	}
 
 	conf, err := s.assetBoardingConfirmation(
-		ctx, disclosure.Outpoint, pkScript,
+		ctx, disclosure.Outpoint, pkScript, heightHint,
 	)
 	if err != nil {
 		return nil, err
@@ -222,11 +234,17 @@ func (s *Server) BoardTaprootAsset(ctx context.Context, requestID string) (
 // returns ErrAssetBoardingUnconfirmed rather than blocking the RPC until
 // the next block.
 func (s *Server) assetBoardingConfirmation(ctx context.Context,
-	outpoint wire.OutPoint, pkScript []byte) (
+	outpoint wire.OutPoint, pkScript []byte, heightHint uint32) (
 	*chainsource.ConfirmationEvent, error) {
 
 	if s.actorSystem == nil {
 		return nil, fmt.Errorf("actor system not initialized")
+	}
+
+	// The LND backend refuses a zero hint; a stored slice predating the
+	// hint falls back to the lowest scan start.
+	if heightHint == 0 {
+		heightHint = 1
 	}
 
 	chainRef := chainsource.ChainSourceKey.Ref(s.actorSystem)
@@ -238,6 +256,7 @@ func (s *Server) assetBoardingConfirmation(ctx context.Context,
 			Txid:        &txid,
 			PkScript:    pkScript,
 			TargetConfs: 1,
+			HeightHint:  heightHint,
 		},
 	).Await(ctx).Unpack()
 	if err != nil {

--- a/waved/taproot_asset_board.go
+++ b/waved/taproot_asset_board.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/chainsource"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/round"
 	"github.com/lightninglabs/wavelength/tapassets"
 )
 
@@ -172,8 +173,10 @@ func (s *Server) BoardTaprootAsset(ctx context.Context, requestID string) (
 	}
 
 	// An existing boarding intent for the outpoint means an earlier call
-	// already completed the round registration; replaying it would hand
-	// the round actor a duplicate intent.
+	// already registered the intents; replaying it would hand the round
+	// actor a duplicate intent. Still nudge the join: a crash between
+	// that registration and the join would otherwise park the intents
+	// until an unrelated round join flushes them.
 	existing, err := s.newBoardingStore().FetchBoardingIntentOutpoints(
 		ctx,
 	)
@@ -183,6 +186,10 @@ func (s *Server) BoardTaprootAsset(ctx context.Context, requestID string) (
 	for _, op := range existing {
 		if op == disclosure.Outpoint {
 			result.AlreadyBoarded = true
+
+			if err := s.joinAssetBoardingRound(ctx); err != nil {
+				return nil, err
+			}
 
 			return result, nil
 		}
@@ -255,7 +262,26 @@ func (s *Server) BoardTaprootAsset(ctx context.Context, requestID string) (
 		return nil, fmt.Errorf("register asset VTXO request: %w", err)
 	}
 
+	if err := s.joinAssetBoardingRound(ctx); err != nil {
+		return nil, err
+	}
+
 	return result, nil
+}
+
+// joinAssetBoardingRound commits the queued boarding intents to the next
+// round. The registrations only queue intents, and the standalone build does
+// not join eagerly, so without this nudge the round actor waits for an
+// external JoinNextRound that a one-shot boarding caller never sends.
+// ErrNoPendingRound is benign: a join is already in flight (eager mode) or
+// an earlier call committed the intents.
+func (s *Server) joinAssetBoardingRound(ctx context.Context) error {
+	err := s.TriggerRoundRegistration(ctx)
+	if err != nil && !errors.Is(err, round.ErrNoPendingRound) {
+		return fmt.Errorf("trigger round registration: %w", err)
+	}
+
+	return nil
 }
 
 // assetBoardingConfirmation resolves the onboarded output's confirmation

--- a/waved/taproot_asset_round_fee.go
+++ b/waved/taproot_asset_round_fee.go
@@ -1,0 +1,364 @@
+package waved
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/lightninglabs/wavelength/round"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightninglabs/wavelength/wallet"
+)
+
+// ErrNoFeeFundingVTXO reports that the wallet holds no Bitcoin VTXO able to
+// pay an asset round's fee. The message is the user's instruction, not a
+// diagnostic: holding Bitcoin in Ark is what moving assets costs, the same
+// way gas funds a token transfer.
+var ErrNoFeeFundingVTXO = errors.New("moving assets needs Bitcoin in Ark to " +
+	"pay the round fee: board Bitcoin first (ark board), then retry")
+
+// feeFundingCandidate is a live Bitcoin-only VTXO the client could spend
+// into an asset round so the round has a non-fixed output to charge its fee
+// against.
+type feeFundingCandidate struct {
+	outpoint wire.OutPoint
+	amount   btcutil.Amount
+}
+
+// feeFundingQuoter prices the round fee the given candidate would have to
+// absorb. It is a seam so the selection rule can be tested without an
+// operator, and so a quote failure degrades in one place.
+type feeFundingQuoter func(ctx context.Context,
+	candidate feeFundingCandidate) (btcutil.Amount, error)
+
+// assetRoundFeeFunding describes the Bitcoin VTXO added to an asset round to
+// carry its fee. Its residual returns to the client as change.
+type assetRoundFeeFunding struct {
+	// Outpoint is the forfeited Bitcoin VTXO.
+	Outpoint wire.OutPoint
+
+	// ValueSat is that VTXO's value. The operator stamps the round's
+	// change output with ValueSat minus the fee at seal time.
+	ValueSat int64
+}
+
+// selectFeeFundingVTXO picks the least-waste fee payer: candidates are
+// walked smallest first and the first one that can absorb its own quoted
+// fee and still leave floor behind wins, so a large VTXO is never churned
+// when a small one suffices. The floor term is not optional headroom — the
+// operator stamps the round's change output with (inputs - fixed outputs -
+// fee) at seal time and rejects the client's whole intent when that
+// residual lands below its minimum VTXO amount.
+//
+// Equal-value candidates tie-break on outpoint so the choice is stable
+// across restarts and across the order the live-VTXO listing returns.
+func selectFeeFundingVTXO(ctx context.Context, candidates []feeFundingCandidate,
+	floor btcutil.Amount,
+	quote feeFundingQuoter) (feeFundingCandidate, error) {
+
+	ordered := make([]feeFundingCandidate, len(candidates))
+	copy(ordered, candidates)
+	sort.Slice(ordered, func(i, j int) bool {
+		return preferFeeFunding(ordered[i], ordered[j])
+	})
+
+	for _, candidate := range ordered {
+		fee, err := quote(ctx, candidate)
+		if err != nil {
+			return feeFundingCandidate{}, err
+		}
+		if candidate.amount < fee+floor {
+			continue
+		}
+
+		return candidate, nil
+	}
+
+	return feeFundingCandidate{}, ErrNoFeeFundingVTXO
+}
+
+// preferFeeFunding orders candidates by ascending value, falling back to
+// outpoint order so ties are deterministic.
+func preferFeeFunding(a, b feeFundingCandidate) bool {
+	if a.amount != b.amount {
+		return a.amount < b.amount
+	}
+
+	cmp := bytes.Compare(a.outpoint.Hash[:], b.outpoint.Hash[:])
+	if cmp != 0 {
+		return cmp < 0
+	}
+
+	return a.outpoint.Index < b.outpoint.Index
+}
+
+// hasFeeFundingSlot reports whether the accumulated VTXO requests already
+// contain an output the client owns whose amount the operator may shrink.
+// That output is the round's fee payer, so a caller that finds one must not
+// add a second.
+//
+// The IsChange marker itself is not what to look for: it is stamped
+// centrally by the round FSM once the intent leaves assembly, so during
+// assembly a fee-bearing slot is simply a non-fixed request the client
+// owns. Asset requests are pinned with FixedAmount so the seal quote cannot
+// shrink a carrier, which is exactly why an asset-only intent has no slot.
+func hasFeeFundingSlot(reqs []types.VTXORequest) bool {
+	for i := range reqs {
+		req := &reqs[i]
+		if !req.FixedAmount && req.HasLocalOwner() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// assemblingRoundHasFeeFundingSlot reports whether the round the client is
+// currently assembling intents into already carries a fee-bearing slot the
+// client owns — because it is boarding Bitcoin in the same round, or
+// refreshing a Bitcoin VTXO into it.
+//
+// Only PendingRoundAssembly is inspected. New intents join through the
+// round actor's findAssemblingRound, which returns either that state or
+// Idle, and an Idle round holds no requests at all. The actor assembles one
+// round at a time, so the first assembling round found is the one a new
+// intent joins.
+func (s *Server) assemblingRoundHasFeeFundingSlot(ctx context.Context) (bool,
+	error) {
+
+	if s.actorSystem == nil {
+		return false, fmt.Errorf("actor system not initialized")
+	}
+
+	roundRef := round.NewServiceKey().Ref(s.actorSystem)
+	resp, err := roundRef.Ask(
+		ctx, &round.GetClientStateRequest{},
+	).Await(ctx).Unpack()
+	if err != nil {
+		return false, fmt.Errorf("query round state: %w", err)
+	}
+
+	stateResp, ok := resp.(*round.GetClientStateResponse)
+	if !ok {
+		return false, fmt.Errorf("unexpected round state response %T",
+			resp)
+	}
+
+	for _, info := range stateResp.States {
+		assembling, ok := info.State.(*round.PendingRoundAssembly)
+		if !ok {
+			continue
+		}
+		if hasFeeFundingSlot(assembling.VTXOs) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// assetRoundFeeQuoter prices what a candidate must absorb: the round fee
+// covers both the asset boarding input and the Bitcoin forfeit this adds,
+// so both legs are quoted. The boarding leg is hoisted out of the walk
+// since it does not vary with the candidate.
+//
+// remainingBlocks is left at zero deliberately. The operator reads zero as
+// "price the full sweep-delay lifetime", which is the correct shape for a
+// coin being refreshed into a fresh batch and errs high rather than low —
+// the point of the quote is to keep a doomed round from being assembled,
+// and the binding fee is still the operator's own at seal time.
+//
+// A quote the operator cannot serve degrades to the advertised flat
+// minimum rather than failing the board: an unavailable estimate is not
+// evidence the client cannot pay, and the seal handshake remains the
+// authority either way.
+func (s *Server) assetRoundFeeQuoter(boardedValueSat int64,
+	fallback btcutil.Amount) feeFundingQuoter {
+
+	var (
+		boardingFee   btcutil.Amount
+		boardingKnown bool
+	)
+
+	return func(ctx context.Context, candidate feeFundingCandidate) (
+		btcutil.Amount, error) {
+
+		if !boardingKnown {
+			fee, err := s.quoteOperatorFee(
+				ctx, boardedValueSat, true, /* isBoarding */
+				0,
+			)
+			if err != nil {
+				s.log.WarnS(ctx, "Asset round fee funding: "+
+					"boarding quote unavailable", err)
+
+				return fallback, nil
+			}
+
+			boardingFee = fee
+			boardingKnown = true
+		}
+
+		forfeitFee, err := s.quoteOperatorFee(
+			ctx, int64(candidate.amount), false, /* isBoarding */
+			0,
+		)
+		if err != nil {
+			s.log.WarnS(ctx, "Asset round fee funding: forfeit "+
+				"quote unavailable", err)
+
+			return fallback, nil
+		}
+
+		return boardingFee + forfeitFee, nil
+	}
+}
+
+// fundAssetRoundFee makes sure the round an asset intent is about to join
+// can pay its own fee. An asset VTXO request is fixed-amount, so a round
+// holding nothing else gives the operator no output to charge against and
+// its seal-time quote rejects the whole intent. When the client has no
+// fee-bearing slot in that round yet, one Bitcoin VTXO is refreshed into
+// it: the forfeit adds input value and the refresh output is the non-fixed
+// slot the residual lands on, returning the remainder as change.
+//
+// Refreshing is what the wallet already does for exactly this shape, so
+// this selects the coin and delegates; nothing here re-implements forfeit
+// composition or reservation.
+//
+// A nil funding with no error means the round already had a slot and
+// nothing was added.
+func (s *Server) fundAssetRoundFee(ctx context.Context, boardedValueSat int64) (
+	*assetRoundFeeFunding, error) {
+
+	hasSlot, err := s.assemblingRoundHasFeeFundingSlot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if hasSlot {
+		s.log.InfoS(
+			ctx, "Asset round already carries a fee-bearing "+
+				"output; adding none",
+		)
+
+		return nil, nil
+	}
+
+	if s.vtxoStore == nil {
+		return nil, fmt.Errorf("vtxo store not initialized")
+	}
+
+	// Only strictly Live coins qualify. The broader non-terminal listing
+	// also returns VTXOs already committed elsewhere (PendingForfeit,
+	// Forfeiting, Spending), and picking one of those would just fail the
+	// wallet's reservation.
+	rows, err := s.vtxoStore.ListSelectionCandidatesByStatus(
+		ctx, vtxo.VTXOStatusLive,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list selection candidates: %w", err)
+	}
+
+	// An asset-bearing VTXO cannot pay the fee: its carrier value is
+	// pinned by the asset transition that reissues its units.
+	candidates := make([]feeFundingCandidate, 0, len(rows))
+	for _, row := range rows {
+		if row.TaprootAssetRoot != nil {
+			continue
+		}
+
+		candidates = append(candidates, feeFundingCandidate{
+			outpoint: row.Outpoint,
+			amount:   row.Amount,
+		})
+	}
+
+	terms, err := s.fetchCachedOperatorTerms(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch operator terms: %w", err)
+	}
+	if terms == nil {
+		return nil, fmt.Errorf("operator terms are not ready")
+	}
+
+	floor := terms.MinVTXOAmountFloor()
+	selected, err := selectFeeFundingVTXO(
+		ctx, candidates, floor,
+		s.assetRoundFeeQuoter(boardedValueSat, terms.MinOperatorFee),
+	)
+	if err != nil {
+		s.log.WarnS(ctx, "No Bitcoin VTXO can fund the asset round fee",
+			err,
+			slog.Int("candidates", len(candidates)),
+			slog.Int("floor_sat", int(floor)),
+		)
+
+		return nil, err
+	}
+
+	if err := s.refreshFeeFundingVTXO(ctx, selected.outpoint); err != nil {
+		return nil, err
+	}
+
+	s.log.InfoS(ctx, "Taproot Asset round fee funded from a Bitcoin VTXO",
+		slog.String("outpoint", selected.outpoint.String()),
+		slog.Int("value_sat", int(selected.amount)),
+		slog.Int("floor_sat", int(floor)),
+	)
+
+	return &assetRoundFeeFunding{
+		Outpoint: selected.outpoint,
+		ValueSat: int64(selected.amount),
+	}, nil
+}
+
+// refreshFeeFundingVTXO refreshes the selected Bitcoin VTXO into the
+// assembling round through the wallet, which reserves the forfeit and
+// composes the non-fixed replacement output the round's fee is charged
+// against.
+func (s *Server) refreshFeeFundingVTXO(ctx context.Context,
+	outpoint wire.OutPoint) error {
+
+	if !s.walletRef.IsSome() {
+		return fmt.Errorf("wallet actor not initialized")
+	}
+	walletRef := s.walletRef.UnsafeFromSome()
+
+	// The refresh registers a round intent, so the same detachment the
+	// other round-joining paths use applies: this call returning must not
+	// cancel the registration handshake mid-flight.
+	askCtx := context.WithoutCancel(ctx)
+	resp, err := walletRef.Ask(askCtx, &wallet.RefreshVTXOsRequest{
+		TargetOutpoints: []wire.OutPoint{
+			outpoint,
+		},
+		ForceRefresh: true,
+	}).Await(ctx).Unpack()
+	if err != nil {
+		return fmt.Errorf("refresh fee funding VTXO: %w", err)
+	}
+
+	refreshResp, ok := resp.(*wallet.RefreshVTXOsResponse)
+	if !ok {
+		return fmt.Errorf("unexpected refresh response %T", resp)
+	}
+
+	// A per-outpoint error means the wallet never composed the forfeit,
+	// so the round still has no fee-bearing output.
+	if refreshErr, ok := refreshResp.Errors[outpoint]; ok {
+		return fmt.Errorf("refresh fee funding VTXO %s: %w", outpoint,
+			refreshErr)
+	}
+	if refreshResp.RefreshingCount == 0 {
+		return fmt.Errorf("refresh of fee funding VTXO %s was "+
+			"not queued", outpoint)
+	}
+
+	return nil
+}

--- a/waved/taproot_asset_round_fee_test.go
+++ b/waved/taproot_asset_round_fee_test.go
@@ -1,0 +1,295 @@
+package waved
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// feeFundingOutpoint builds a deterministic outpoint whose txid is filled
+// with the given byte, so ordering between two candidates is predictable.
+func feeFundingOutpoint(fill byte, index uint32) wire.OutPoint {
+	var hash chainhash.Hash
+	for i := range hash {
+		hash[i] = fill
+	}
+
+	return wire.OutPoint{Hash: hash, Index: index}
+}
+
+// flatFeeQuoter prices every candidate the same, which isolates the
+// selection rule from the quote.
+func flatFeeQuoter(fee btcutil.Amount) feeFundingQuoter {
+	return func(context.Context, feeFundingCandidate) (btcutil.Amount,
+		error) {
+
+		return fee, nil
+	}
+}
+
+// TestSelectFeeFundingVTXOSmallestSufficient asserts the rule is
+// least-waste: among the candidates that clear the requirement the
+// smallest is taken, so a large VTXO is never churned when a small one
+// suffices.
+func TestSelectFeeFundingVTXOSmallestSufficient(t *testing.T) {
+	t.Parallel()
+
+	small := feeFundingCandidate{
+		outpoint: feeFundingOutpoint(0x01, 0),
+		amount:   20_000,
+	}
+	large := feeFundingCandidate{
+		outpoint: feeFundingOutpoint(0x02, 0),
+		amount:   500_000,
+	}
+
+	// The larger candidate is listed first so a "first sufficient"
+	// implementation over the input order would pick it.
+	selected, err := selectFeeFundingVTXO(
+		t.Context(), []feeFundingCandidate{large, small}, 1_000,
+		flatFeeQuoter(500),
+	)
+	require.NoError(t, err)
+	require.Equal(t, small, selected)
+}
+
+// TestSelectFeeFundingVTXORespectsFloor asserts a candidate that could
+// cover the fee alone but would leave the change output under the
+// operator's minimum is skipped in favour of one that clears both. The
+// operator rejects the whole intent when the residual falls below the
+// floor, so covering only the fee is not enough.
+func TestSelectFeeFundingVTXORespectsFloor(t *testing.T) {
+	t.Parallel()
+
+	const (
+		fee   btcutil.Amount = 800
+		floor btcutil.Amount = 1_000
+	)
+
+	// 1_500 covers the fee but leaves 700, which is below the floor.
+	tooTight := feeFundingCandidate{
+		outpoint: feeFundingOutpoint(0x01, 0),
+		amount:   1_500,
+	}
+	sufficient := feeFundingCandidate{
+		outpoint: feeFundingOutpoint(0x02, 0),
+		amount:   1_900,
+	}
+
+	selected, err := selectFeeFundingVTXO(
+		t.Context(), []feeFundingCandidate{tooTight, sufficient}, floor,
+		flatFeeQuoter(fee),
+	)
+	require.NoError(t, err)
+	require.Equal(t, sufficient, selected)
+
+	// Exactly meeting fee + floor is enough: the residual lands on the
+	// floor rather than below it.
+	exact := feeFundingCandidate{
+		outpoint: feeFundingOutpoint(0x03, 0),
+		amount:   fee + floor,
+	}
+	selected, err = selectFeeFundingVTXO(
+		t.Context(), []feeFundingCandidate{sufficient, exact}, floor,
+		flatFeeQuoter(fee),
+	)
+	require.NoError(t, err)
+	require.Equal(t, exact, selected)
+}
+
+// TestSelectFeeFundingVTXOTieBreak asserts equal-value candidates resolve
+// deterministically on outpoint, so the choice does not drift with the
+// order the live-VTXO listing happens to return.
+func TestSelectFeeFundingVTXOTieBreak(t *testing.T) {
+	t.Parallel()
+
+	lower := feeFundingCandidate{
+		outpoint: feeFundingOutpoint(0x01, 7),
+		amount:   50_000,
+	}
+	higherHash := feeFundingCandidate{
+		outpoint: feeFundingOutpoint(0x02, 0),
+		amount:   50_000,
+	}
+	higherIndex := feeFundingCandidate{
+		outpoint: feeFundingOutpoint(0x01, 9),
+		amount:   50_000,
+	}
+
+	// Every permutation must resolve to the same winner.
+	orders := [][]feeFundingCandidate{
+		{
+			lower,
+			higherHash,
+			higherIndex,
+		},
+		{
+			higherIndex,
+			lower,
+			higherHash,
+		},
+		{
+			higherHash,
+			higherIndex,
+			lower,
+		},
+	}
+	for _, candidates := range orders {
+		selected, err := selectFeeFundingVTXO(
+			t.Context(), candidates, 1_000, flatFeeQuoter(0),
+		)
+		require.NoError(t, err)
+		require.Equal(t, lower, selected)
+	}
+}
+
+// TestSelectFeeFundingVTXONoCandidate asserts both an empty and an
+// all-too-small candidate set surface the actionable sentinel rather than
+// a zero value the caller could mistake for a selection.
+func TestSelectFeeFundingVTXONoCandidate(t *testing.T) {
+	t.Parallel()
+
+	_, err := selectFeeFundingVTXO(
+		t.Context(), nil, 1_000, flatFeeQuoter(0),
+	)
+	require.ErrorIs(t, err, ErrNoFeeFundingVTXO)
+
+	// Both clear the floor on their own but neither survives the fee.
+	tooSmall := []feeFundingCandidate{{
+		outpoint: feeFundingOutpoint(0x01, 0),
+		amount:   1_400,
+	}, {
+		outpoint: feeFundingOutpoint(0x02, 0),
+		amount:   1_200,
+	}}
+	_, err = selectFeeFundingVTXO(
+		t.Context(), tooSmall, 1_000, flatFeeQuoter(500),
+	)
+	require.ErrorIs(t, err, ErrNoFeeFundingVTXO)
+}
+
+// TestSelectFeeFundingVTXOZeroFee asserts the zero-quote case: the whole
+// input returns as change, so any candidate at or above the floor
+// qualifies and the smallest still wins.
+func TestSelectFeeFundingVTXOZeroFee(t *testing.T) {
+	t.Parallel()
+
+	atFloor := feeFundingCandidate{
+		outpoint: feeFundingOutpoint(0x01, 0),
+		amount:   1_000,
+	}
+	larger := feeFundingCandidate{
+		outpoint: feeFundingOutpoint(0x02, 0),
+		amount:   9_000,
+	}
+
+	selected, err := selectFeeFundingVTXO(
+		t.Context(), []feeFundingCandidate{larger, atFloor}, 1_000,
+		flatFeeQuoter(0),
+	)
+	require.NoError(t, err)
+	require.Equal(t, atFloor, selected)
+}
+
+// TestSelectFeeFundingVTXOQuoteError asserts a quote failure surfaces
+// rather than being read as "this candidate does not qualify" — the
+// production quoter degrades to a flat fallback, so an error reaching
+// here means something the caller must not paper over.
+func TestSelectFeeFundingVTXOQuoteError(t *testing.T) {
+	t.Parallel()
+
+	quoteErr := errors.New("quote unavailable")
+	candidates := []feeFundingCandidate{{
+		outpoint: feeFundingOutpoint(0x01, 0),
+		amount:   50_000,
+	}}
+
+	_, err := selectFeeFundingVTXO(
+		t.Context(), candidates, 1_000,
+		func(context.Context, feeFundingCandidate) (btcutil.Amount,
+			error) {
+
+			return 0, quoteErr
+		},
+	)
+	require.ErrorIs(t, err, quoteErr)
+}
+
+// TestHasFeeFundingSlot asserts the skip-when-a-slot-exists predicate: an
+// asset-only intent has no slot of its own because asset carriers are
+// fixed, while an intent that already boards or refreshes Bitcoin does and
+// must not be given a second fee payer.
+func TestHasFeeFundingSlot(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	ownerKey := keychain.KeyDescriptor{
+		PubKey: privKey.PubKey(),
+	}
+
+	assetCarrier := types.VTXORequest{
+		Amount:      30_000,
+		AssetRef:    "asset-ref",
+		AssetAmount: 900,
+		FixedAmount: true,
+		OwnerKey:    ownerKey,
+	}
+	bitcoinChange := types.VTXORequest{
+		Amount:   100_000,
+		OwnerKey: ownerKey,
+	}
+	foreignRecipient := types.VTXORequest{
+		Amount: 100_000,
+	}
+
+	require.False(t, hasFeeFundingSlot(nil))
+
+	// An asset boarding on its own: one fixed carrier, no slot.
+	require.False(
+		t,
+		hasFeeFundingSlot(
+			[]types.VTXORequest{
+				assetCarrier,
+			},
+		),
+	)
+
+	// A directed send's recipient output is non-fixed but not the
+	// client's, so it cannot absorb the client's fee.
+	require.False(
+		t,
+		hasFeeFundingSlot(
+			[]types.VTXORequest{
+				assetCarrier, foreignRecipient,
+			},
+		),
+	)
+
+	// Boarding Bitcoin in the same round, or refreshing one into it,
+	// already supplies the slot.
+	require.True(
+		t,
+		hasFeeFundingSlot(
+			[]types.VTXORequest{
+				assetCarrier, bitcoinChange,
+			},
+		),
+	)
+	require.True(
+		t,
+		hasFeeFundingSlot(
+			[]types.VTXORequest{
+				bitcoinChange,
+			},
+		),
+	)
+}

--- a/waved/wallet_ops.go
+++ b/waved/wallet_ops.go
@@ -94,10 +94,19 @@ func BuildTransferInputs(ctx context.Context, store vtxo.VTXOStore,
 				op, err)
 		}
 
+		// Only a round-created asset leaf stores a sealed package
+		// (OOR-received leaves never do), so its presence proves the
+		// leaf's carrier is the sender's own money rather than
+		// operator float. Deriving this from the store keeps
+		// idempotent replays deterministic without journaling it.
+		roundCreated := desc.TaprootAssetRef != "" &&
+			len(desc.TaprootAssetSealedPackage) > 0
+
 		inputs = append(inputs, oor.TransferInput{
-			VTXO:             desc,
-			OwnerLeafScript:  collabLeaf.Script,
-			TaprootAssetRoot: desc.TaprootAssetRoot,
+			VTXO:                     desc,
+			OwnerLeafScript:          collabLeaf.Script,
+			TaprootAssetRoot:         desc.TaprootAssetRoot,
+			TaprootAssetRoundCreated: roundCreated,
 		})
 	}
 

--- a/waved/wallet_ops_test.go
+++ b/waved/wallet_ops_test.go
@@ -192,6 +192,64 @@ func TestBuildTransferInputsCarriesTaprootAssetRoot(t *testing.T) {
 	require.NoError(t, inputs[0].Validate())
 }
 
+// TestBuildTransferInputsDerivesRoundCreatedFromSealedPackage pins the
+// carrier-origin discriminator: only a round-created asset leaf stores a
+// sealed package, so its presence is what marks the leaf's carrier as the
+// sender's own money rather than reclaimable operator float.
+func TestBuildTransferInputsDerivesRoundCreatedFromSealedPackage(t *testing.T) {
+	t.Parallel()
+
+	owner, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operator, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	template, err := arkscript.EncodeStandardVTXOTemplate(
+		owner.PubKey(), operator.PubKey(), 10,
+	)
+	require.NoError(t, err)
+
+	assetRoot := chainhash.Hash{0x77, 0x88, 0x99}
+	desc := &vtxo.Descriptor{
+		Outpoint:           testWalletOpsOutpoint(0x43),
+		Amount:             50_000,
+		PolicyTemplate:     template,
+		TaprootAssetRoot:   &assetRoot,
+		TaprootAssetRef:    "tapr1asset",
+		TaprootAssetAmount: 21,
+		ClientKey: keychain.KeyDescriptor{
+			PubKey: owner.PubKey(),
+		},
+		OperatorKey:    operator.PubKey(),
+		RelativeExpiry: 10,
+	}
+	desc.PkScript, err = desc.EffectivePkScript()
+	require.NoError(t, err)
+	desc.TapScript, err = desc.StandardTapScript()
+	require.NoError(t, err)
+
+	desc.TaprootAssetSealedPackage = []byte("sealed-package")
+	inputs, err := BuildTransferInputs(
+		t.Context(), &testCustomInputStore{
+			desc: desc,
+		},
+		[]wire.OutPoint{desc.Outpoint},
+	)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+	require.True(t, inputs[0].TaprootAssetRoundCreated)
+
+	desc.TaprootAssetSealedPackage = nil
+	inputs, err = BuildTransferInputs(
+		t.Context(), &testCustomInputStore{
+			desc: desc,
+		},
+		[]wire.OutPoint{desc.Outpoint},
+	)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+	require.False(t, inputs[0].TaprootAssetRoundCreated)
+}
+
 // TestBuildCustomTransferInputsCarriesTaprootAssetRoot proves an explicitly
 // selected local VTXO retains its stored root. Taproot Asset sends use custom
 // inputs because generic Bitcoin coin selection deliberately excludes these

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -1041,6 +1041,262 @@ func (x *OnboardTaprootAssetResponse) GetActualFeeSat() uint64 {
 	return 0
 }
 
+type BoardTaprootAssetRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// idempotency_key names the completed onboarding to board. It is the
+	// same key the caller passed to OnboardTaprootAsset.
+	IdempotencyKey string `protobuf:"bytes,1,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *BoardTaprootAssetRequest) Reset() {
+	*x = BoardTaprootAssetRequest{}
+	mi := &file_daemon_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BoardTaprootAssetRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BoardTaprootAssetRequest) ProtoMessage() {}
+
+func (x *BoardTaprootAssetRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BoardTaprootAssetRequest.ProtoReflect.Descriptor instead.
+func (*BoardTaprootAssetRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *BoardTaprootAssetRequest) GetIdempotencyKey() string {
+	if x != nil {
+		return x.IdempotencyKey
+	}
+	return ""
+}
+
+type BoardTaprootAssetResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoint is the boarded composed output.
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// value_sat is the output's carrier Bitcoin value.
+	ValueSat int64 `protobuf:"varint,2,opt,name=value_sat,json=valueSat,proto3" json:"value_sat,omitempty"`
+	// asset_ref and asset_amount identify the boarded units.
+	AssetRef    string `protobuf:"bytes,3,opt,name=asset_ref,json=assetRef,proto3" json:"asset_ref,omitempty"`
+	AssetAmount uint64 `protobuf:"varint,4,opt,name=asset_amount,json=assetAmount,proto3" json:"asset_amount,omitempty"`
+	// already_boarded reports an idempotent replay: the boarding intent
+	// already existed and no new round registration was sent.
+	AlreadyBoarded bool `protobuf:"varint,5,opt,name=already_boarded,json=alreadyBoarded,proto3" json:"already_boarded,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *BoardTaprootAssetResponse) Reset() {
+	*x = BoardTaprootAssetResponse{}
+	mi := &file_daemon_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BoardTaprootAssetResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BoardTaprootAssetResponse) ProtoMessage() {}
+
+func (x *BoardTaprootAssetResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BoardTaprootAssetResponse.ProtoReflect.Descriptor instead.
+func (*BoardTaprootAssetResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *BoardTaprootAssetResponse) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *BoardTaprootAssetResponse) GetValueSat() int64 {
+	if x != nil {
+		return x.ValueSat
+	}
+	return 0
+}
+
+func (x *BoardTaprootAssetResponse) GetAssetRef() string {
+	if x != nil {
+		return x.AssetRef
+	}
+	return ""
+}
+
+func (x *BoardTaprootAssetResponse) GetAssetAmount() uint64 {
+	if x != nil {
+		return x.AssetAmount
+	}
+	return 0
+}
+
+func (x *BoardTaprootAssetResponse) GetAlreadyBoarded() bool {
+	if x != nil {
+		return x.AlreadyBoarded
+	}
+	return false
+}
+
+type ClaimTaprootAssetVTXORequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoint identifies the exited asset VTXO in "txid:vout" format.
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// fee_sat is the on-chain miner fee, paid out of the VTXO's carrier
+	// value. Zero lets the daemon estimate one from the wallet's fee
+	// estimator.
+	FeeSat        int64 `protobuf:"varint,2,opt,name=fee_sat,json=feeSat,proto3" json:"fee_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClaimTaprootAssetVTXORequest) Reset() {
+	*x = ClaimTaprootAssetVTXORequest{}
+	mi := &file_daemon_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClaimTaprootAssetVTXORequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClaimTaprootAssetVTXORequest) ProtoMessage() {}
+
+func (x *ClaimTaprootAssetVTXORequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClaimTaprootAssetVTXORequest.ProtoReflect.Descriptor instead.
+func (*ClaimTaprootAssetVTXORequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ClaimTaprootAssetVTXORequest) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *ClaimTaprootAssetVTXORequest) GetFeeSat() int64 {
+	if x != nil {
+		return x.FeeSat
+	}
+	return 0
+}
+
+type ClaimTaprootAssetVTXOResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// txid is the published claim transaction.
+	Txid string `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
+	// anchor_outpoint is the new tapd-owned anchor holding the claimed
+	// units.
+	AnchorOutpoint string `protobuf:"bytes,2,opt,name=anchor_outpoint,json=anchorOutpoint,proto3" json:"anchor_outpoint,omitempty"`
+	// output_value_sat is the new anchor's Bitcoin value.
+	OutputValueSat int64 `protobuf:"varint,3,opt,name=output_value_sat,json=outputValueSat,proto3" json:"output_value_sat,omitempty"`
+	// fee_sat is the miner fee the claim actually paid.
+	FeeSat        int64 `protobuf:"varint,4,opt,name=fee_sat,json=feeSat,proto3" json:"fee_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClaimTaprootAssetVTXOResponse) Reset() {
+	*x = ClaimTaprootAssetVTXOResponse{}
+	mi := &file_daemon_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClaimTaprootAssetVTXOResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClaimTaprootAssetVTXOResponse) ProtoMessage() {}
+
+func (x *ClaimTaprootAssetVTXOResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClaimTaprootAssetVTXOResponse.ProtoReflect.Descriptor instead.
+func (*ClaimTaprootAssetVTXOResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ClaimTaprootAssetVTXOResponse) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *ClaimTaprootAssetVTXOResponse) GetAnchorOutpoint() string {
+	if x != nil {
+		return x.AnchorOutpoint
+	}
+	return ""
+}
+
+func (x *ClaimTaprootAssetVTXOResponse) GetOutputValueSat() int64 {
+	if x != nil {
+		return x.OutputValueSat
+	}
+	return 0
+}
+
+func (x *ClaimTaprootAssetVTXOResponse) GetFeeSat() int64 {
+	if x != nil {
+		return x.FeeSat
+	}
+	return 0
+}
+
 type GetInfoRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -1049,7 +1305,7 @@ type GetInfoRequest struct {
 
 func (x *GetInfoRequest) Reset() {
 	*x = GetInfoRequest{}
-	mi := &file_daemon_proto_msgTypes[2]
+	mi := &file_daemon_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1061,7 +1317,7 @@ func (x *GetInfoRequest) String() string {
 func (*GetInfoRequest) ProtoMessage() {}
 
 func (x *GetInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[2]
+	mi := &file_daemon_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1074,7 +1330,7 @@ func (x *GetInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetInfoRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{2}
+	return file_daemon_proto_rawDescGZIP(), []int{6}
 }
 
 type GetInfoResponse struct {
@@ -1132,7 +1388,7 @@ type GetInfoResponse struct {
 
 func (x *GetInfoResponse) Reset() {
 	*x = GetInfoResponse{}
-	mi := &file_daemon_proto_msgTypes[3]
+	mi := &file_daemon_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1144,7 +1400,7 @@ func (x *GetInfoResponse) String() string {
 func (*GetInfoResponse) ProtoMessage() {}
 
 func (x *GetInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[3]
+	mi := &file_daemon_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1157,7 +1413,7 @@ func (x *GetInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetInfoResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{3}
+	return file_daemon_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetInfoResponse) GetVersion() string {
@@ -1285,7 +1541,7 @@ type ServerInfo struct {
 
 func (x *ServerInfo) Reset() {
 	*x = ServerInfo{}
-	mi := &file_daemon_proto_msgTypes[4]
+	mi := &file_daemon_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1297,7 +1553,7 @@ func (x *ServerInfo) String() string {
 func (*ServerInfo) ProtoMessage() {}
 
 func (x *ServerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[4]
+	mi := &file_daemon_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1310,7 +1566,7 @@ func (x *ServerInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerInfo.ProtoReflect.Descriptor instead.
 func (*ServerInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{4}
+	return file_daemon_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ServerInfo) GetOperatorPubkey() []byte {
@@ -1409,7 +1665,7 @@ type GenSeedRequest struct {
 
 func (x *GenSeedRequest) Reset() {
 	*x = GenSeedRequest{}
-	mi := &file_daemon_proto_msgTypes[5]
+	mi := &file_daemon_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1421,7 +1677,7 @@ func (x *GenSeedRequest) String() string {
 func (*GenSeedRequest) ProtoMessage() {}
 
 func (x *GenSeedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[5]
+	mi := &file_daemon_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1434,7 +1690,7 @@ func (x *GenSeedRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenSeedRequest.ProtoReflect.Descriptor instead.
 func (*GenSeedRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{5}
+	return file_daemon_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GenSeedRequest) GetSeedPassphrase() []byte {
@@ -1458,7 +1714,7 @@ type GenSeedResponse struct {
 
 func (x *GenSeedResponse) Reset() {
 	*x = GenSeedResponse{}
-	mi := &file_daemon_proto_msgTypes[6]
+	mi := &file_daemon_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1470,7 +1726,7 @@ func (x *GenSeedResponse) String() string {
 func (*GenSeedResponse) ProtoMessage() {}
 
 func (x *GenSeedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[6]
+	mi := &file_daemon_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1483,7 +1739,7 @@ func (x *GenSeedResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenSeedResponse.ProtoReflect.Descriptor instead.
 func (*GenSeedResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{6}
+	return file_daemon_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GenSeedResponse) GetMnemonic() []string {
@@ -1525,7 +1781,7 @@ type InitWalletRequest struct {
 
 func (x *InitWalletRequest) Reset() {
 	*x = InitWalletRequest{}
-	mi := &file_daemon_proto_msgTypes[7]
+	mi := &file_daemon_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1537,7 +1793,7 @@ func (x *InitWalletRequest) String() string {
 func (*InitWalletRequest) ProtoMessage() {}
 
 func (x *InitWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[7]
+	mi := &file_daemon_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1550,7 +1806,7 @@ func (x *InitWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InitWalletRequest.ProtoReflect.Descriptor instead.
 func (*InitWalletRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{7}
+	return file_daemon_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *InitWalletRequest) GetMnemonic() []string {
@@ -1618,7 +1874,7 @@ type InitWalletResponse struct {
 
 func (x *InitWalletResponse) Reset() {
 	*x = InitWalletResponse{}
-	mi := &file_daemon_proto_msgTypes[8]
+	mi := &file_daemon_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1630,7 +1886,7 @@ func (x *InitWalletResponse) String() string {
 func (*InitWalletResponse) ProtoMessage() {}
 
 func (x *InitWalletResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[8]
+	mi := &file_daemon_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1643,7 +1899,7 @@ func (x *InitWalletResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InitWalletResponse.ProtoReflect.Descriptor instead.
 func (*InitWalletResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{8}
+	return file_daemon_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *InitWalletResponse) GetIdentityPubkey() string {
@@ -1706,7 +1962,7 @@ type UnlockWalletRequest struct {
 
 func (x *UnlockWalletRequest) Reset() {
 	*x = UnlockWalletRequest{}
-	mi := &file_daemon_proto_msgTypes[9]
+	mi := &file_daemon_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1718,7 +1974,7 @@ func (x *UnlockWalletRequest) String() string {
 func (*UnlockWalletRequest) ProtoMessage() {}
 
 func (x *UnlockWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[9]
+	mi := &file_daemon_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1731,7 +1987,7 @@ func (x *UnlockWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlockWalletRequest.ProtoReflect.Descriptor instead.
 func (*UnlockWalletRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{9}
+	return file_daemon_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *UnlockWalletRequest) GetWalletPassword() []byte {
@@ -1753,7 +2009,7 @@ type UnlockWalletResponse struct {
 
 func (x *UnlockWalletResponse) Reset() {
 	*x = UnlockWalletResponse{}
-	mi := &file_daemon_proto_msgTypes[10]
+	mi := &file_daemon_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1765,7 +2021,7 @@ func (x *UnlockWalletResponse) String() string {
 func (*UnlockWalletResponse) ProtoMessage() {}
 
 func (x *UnlockWalletResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[10]
+	mi := &file_daemon_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1778,7 +2034,7 @@ func (x *UnlockWalletResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlockWalletResponse.ProtoReflect.Descriptor instead.
 func (*UnlockWalletResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{10}
+	return file_daemon_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *UnlockWalletResponse) GetIdentityPubkey() string {
@@ -1796,7 +2052,7 @@ type GetBalanceRequest struct {
 
 func (x *GetBalanceRequest) Reset() {
 	*x = GetBalanceRequest{}
-	mi := &file_daemon_proto_msgTypes[11]
+	mi := &file_daemon_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1808,7 +2064,7 @@ func (x *GetBalanceRequest) String() string {
 func (*GetBalanceRequest) ProtoMessage() {}
 
 func (x *GetBalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[11]
+	mi := &file_daemon_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1821,7 +2077,7 @@ func (x *GetBalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBalanceRequest.ProtoReflect.Descriptor instead.
 func (*GetBalanceRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{11}
+	return file_daemon_proto_rawDescGZIP(), []int{15}
 }
 
 type GetBalanceResponse struct {
@@ -1873,13 +2129,17 @@ type GetBalanceResponse struct {
 	// total_confirmed_sat; reappears under onchain_wallet_confirmed_sat
 	// once the sweep confirms.
 	VtxoUnilateralExitSat int64 `protobuf:"varint,10,opt,name=vtxo_unilateral_exit_sat,json=vtxoUnilateralExitSat,proto3" json:"vtxo_unilateral_exit_sat,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// taproot_assets breaks down asset-bearing VTXO holdings by asset
+	// reference. The carrier satoshis of these VTXOs stay counted in the
+	// Bitcoin fields above.
+	TaprootAssets []*TaprootAssetBalance `protobuf:"bytes,11,rep,name=taproot_assets,json=taprootAssets,proto3" json:"taproot_assets,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetBalanceResponse) Reset() {
 	*x = GetBalanceResponse{}
-	mi := &file_daemon_proto_msgTypes[12]
+	mi := &file_daemon_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1891,7 +2151,7 @@ func (x *GetBalanceResponse) String() string {
 func (*GetBalanceResponse) ProtoMessage() {}
 
 func (x *GetBalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[12]
+	mi := &file_daemon_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1904,7 +2164,7 @@ func (x *GetBalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBalanceResponse.ProtoReflect.Descriptor instead.
 func (*GetBalanceResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{12}
+	return file_daemon_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetBalanceResponse) GetBoardingConfirmedSat() int64 {
@@ -1977,6 +2237,98 @@ func (x *GetBalanceResponse) GetVtxoUnilateralExitSat() int64 {
 	return 0
 }
 
+func (x *GetBalanceResponse) GetTaprootAssets() []*TaprootAssetBalance {
+	if x != nil {
+		return x.TaprootAssets
+	}
+	return nil
+}
+
+// TaprootAssetBalance is one asset reference's VTXO holdings, in asset
+// units.
+type TaprootAssetBalance struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// asset_ref is the tap-sdk asset or group reference.
+	AssetRef string `protobuf:"bytes,1,opt,name=asset_ref,json=assetRef,proto3" json:"asset_ref,omitempty"`
+	// live_amount is the total held in live (spendable) VTXOs.
+	LiveAmount uint64 `protobuf:"varint,2,opt,name=live_amount,json=liveAmount,proto3" json:"live_amount,omitempty"`
+	// pending_amount is the total held in VTXOs that are not yet live or
+	// are mid-spend.
+	PendingAmount uint64 `protobuf:"varint,3,opt,name=pending_amount,json=pendingAmount,proto3" json:"pending_amount,omitempty"`
+	// exiting_amount is the total held in VTXOs mid unilateral exit,
+	// claimable once the exit matures.
+	ExitingAmount uint64 `protobuf:"varint,4,opt,name=exiting_amount,json=exitingAmount,proto3" json:"exiting_amount,omitempty"`
+	// live_vtxo_count is the number of live VTXOs carrying this asset.
+	LiveVtxoCount uint32 `protobuf:"varint,5,opt,name=live_vtxo_count,json=liveVtxoCount,proto3" json:"live_vtxo_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TaprootAssetBalance) Reset() {
+	*x = TaprootAssetBalance{}
+	mi := &file_daemon_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TaprootAssetBalance) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaprootAssetBalance) ProtoMessage() {}
+
+func (x *TaprootAssetBalance) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaprootAssetBalance.ProtoReflect.Descriptor instead.
+func (*TaprootAssetBalance) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *TaprootAssetBalance) GetAssetRef() string {
+	if x != nil {
+		return x.AssetRef
+	}
+	return ""
+}
+
+func (x *TaprootAssetBalance) GetLiveAmount() uint64 {
+	if x != nil {
+		return x.LiveAmount
+	}
+	return 0
+}
+
+func (x *TaprootAssetBalance) GetPendingAmount() uint64 {
+	if x != nil {
+		return x.PendingAmount
+	}
+	return 0
+}
+
+func (x *TaprootAssetBalance) GetExitingAmount() uint64 {
+	if x != nil {
+		return x.ExitingAmount
+	}
+	return 0
+}
+
+func (x *TaprootAssetBalance) GetLiveVtxoCount() uint32 {
+	if x != nil {
+		return x.LiveVtxoCount
+	}
+	return 0
+}
+
 // VTXOExpiryInfo reports the thresholds and current classification the
 // wallet/VTXO layer uses for expiry monitoring.
 type VTXOExpiryInfo struct {
@@ -2010,7 +2362,7 @@ type VTXOExpiryInfo struct {
 
 func (x *VTXOExpiryInfo) Reset() {
 	*x = VTXOExpiryInfo{}
-	mi := &file_daemon_proto_msgTypes[13]
+	mi := &file_daemon_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2022,7 +2374,7 @@ func (x *VTXOExpiryInfo) String() string {
 func (*VTXOExpiryInfo) ProtoMessage() {}
 
 func (x *VTXOExpiryInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[13]
+	mi := &file_daemon_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2035,7 +2387,7 @@ func (x *VTXOExpiryInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXOExpiryInfo.ProtoReflect.Descriptor instead.
 func (*VTXOExpiryInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{13}
+	return file_daemon_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *VTXOExpiryInfo) GetStatus() VTXOExpiryStatus {
@@ -2152,7 +2504,7 @@ type VTXO struct {
 
 func (x *VTXO) Reset() {
 	*x = VTXO{}
-	mi := &file_daemon_proto_msgTypes[14]
+	mi := &file_daemon_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2164,7 +2516,7 @@ func (x *VTXO) String() string {
 func (*VTXO) ProtoMessage() {}
 
 func (x *VTXO) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[14]
+	mi := &file_daemon_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2177,7 +2529,7 @@ func (x *VTXO) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXO.ProtoReflect.Descriptor instead.
 func (*VTXO) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{14}
+	return file_daemon_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *VTXO) GetOutpoint() string {
@@ -2301,7 +2653,7 @@ type VTXOTaprootAsset struct {
 
 func (x *VTXOTaprootAsset) Reset() {
 	*x = VTXOTaprootAsset{}
-	mi := &file_daemon_proto_msgTypes[15]
+	mi := &file_daemon_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2313,7 +2665,7 @@ func (x *VTXOTaprootAsset) String() string {
 func (*VTXOTaprootAsset) ProtoMessage() {}
 
 func (x *VTXOTaprootAsset) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[15]
+	mi := &file_daemon_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2326,7 +2678,7 @@ func (x *VTXOTaprootAsset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXOTaprootAsset.ProtoReflect.Descriptor instead.
 func (*VTXOTaprootAsset) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{15}
+	return file_daemon_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *VTXOTaprootAsset) GetAssetRef() string {
@@ -2369,7 +2721,7 @@ type VTXOSettlement struct {
 
 func (x *VTXOSettlement) Reset() {
 	*x = VTXOSettlement{}
-	mi := &file_daemon_proto_msgTypes[16]
+	mi := &file_daemon_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2381,7 +2733,7 @@ func (x *VTXOSettlement) String() string {
 func (*VTXOSettlement) ProtoMessage() {}
 
 func (x *VTXOSettlement) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[16]
+	mi := &file_daemon_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2394,7 +2746,7 @@ func (x *VTXOSettlement) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXOSettlement.ProtoReflect.Descriptor instead.
 func (*VTXOSettlement) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{16}
+	return file_daemon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *VTXOSettlement) GetTxid() string {
@@ -2431,13 +2783,16 @@ type ListVTXOsRequest struct {
 	// consumers (balance views, coin selection) that never inspect the
 	// PSBTs. The default keeps the full response for compatibility.
 	ExcludeCheckpointPsbts bool `protobuf:"varint,3,opt,name=exclude_checkpoint_psbts,json=excludeCheckpointPsbts,proto3" json:"exclude_checkpoint_psbts,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// asset_ref restricts the response to VTXOs carrying this Taproot
+	// Asset reference. Empty applies no asset filter.
+	AssetRef      string `protobuf:"bytes,4,opt,name=asset_ref,json=assetRef,proto3" json:"asset_ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListVTXOsRequest) Reset() {
 	*x = ListVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[17]
+	mi := &file_daemon_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2449,7 +2804,7 @@ func (x *ListVTXOsRequest) String() string {
 func (*ListVTXOsRequest) ProtoMessage() {}
 
 func (x *ListVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[17]
+	mi := &file_daemon_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2462,7 +2817,7 @@ func (x *ListVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*ListVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{17}
+	return file_daemon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListVTXOsRequest) GetStatusFilter() VTXOStatus {
@@ -2486,6 +2841,13 @@ func (x *ListVTXOsRequest) GetExcludeCheckpointPsbts() bool {
 	return false
 }
 
+func (x *ListVTXOsRequest) GetAssetRef() string {
+	if x != nil {
+		return x.AssetRef
+	}
+	return ""
+}
+
 type ListVTXOsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// vtxos is the list of VTXOs matching the request filters.
@@ -2496,7 +2858,7 @@ type ListVTXOsResponse struct {
 
 func (x *ListVTXOsResponse) Reset() {
 	*x = ListVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2508,7 +2870,7 @@ func (x *ListVTXOsResponse) String() string {
 func (*ListVTXOsResponse) ProtoMessage() {}
 
 func (x *ListVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2521,7 +2883,7 @@ func (x *ListVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*ListVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{18}
+	return file_daemon_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListVTXOsResponse) GetVtxos() []*VTXO {
@@ -2539,7 +2901,7 @@ type NewAddressRequest struct {
 
 func (x *NewAddressRequest) Reset() {
 	*x = NewAddressRequest{}
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2551,7 +2913,7 @@ func (x *NewAddressRequest) String() string {
 func (*NewAddressRequest) ProtoMessage() {}
 
 func (x *NewAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2564,7 +2926,7 @@ func (x *NewAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewAddressRequest.ProtoReflect.Descriptor instead.
 func (*NewAddressRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{19}
+	return file_daemon_proto_rawDescGZIP(), []int{24}
 }
 
 type NewAddressResponse struct {
@@ -2577,7 +2939,7 @@ type NewAddressResponse struct {
 
 func (x *NewAddressResponse) Reset() {
 	*x = NewAddressResponse{}
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2589,7 +2951,7 @@ func (x *NewAddressResponse) String() string {
 func (*NewAddressResponse) ProtoMessage() {}
 
 func (x *NewAddressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2602,7 +2964,7 @@ func (x *NewAddressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewAddressResponse.ProtoReflect.Descriptor instead.
 func (*NewAddressResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{20}
+	return file_daemon_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *NewAddressResponse) GetAddress() string {
@@ -2623,7 +2985,7 @@ type NewReceiveScriptRequest struct {
 
 func (x *NewReceiveScriptRequest) Reset() {
 	*x = NewReceiveScriptRequest{}
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2635,7 +2997,7 @@ func (x *NewReceiveScriptRequest) String() string {
 func (*NewReceiveScriptRequest) ProtoMessage() {}
 
 func (x *NewReceiveScriptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2648,7 +3010,7 @@ func (x *NewReceiveScriptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewReceiveScriptRequest.ProtoReflect.Descriptor instead.
 func (*NewReceiveScriptRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{21}
+	return file_daemon_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *NewReceiveScriptRequest) GetLabel() string {
@@ -2676,7 +3038,7 @@ type NewReceiveScriptResponse struct {
 
 func (x *NewReceiveScriptResponse) Reset() {
 	*x = NewReceiveScriptResponse{}
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2688,7 +3050,7 @@ func (x *NewReceiveScriptResponse) String() string {
 func (*NewReceiveScriptResponse) ProtoMessage() {}
 
 func (x *NewReceiveScriptResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2701,7 +3063,7 @@ func (x *NewReceiveScriptResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewReceiveScriptResponse.ProtoReflect.Descriptor instead.
 func (*NewReceiveScriptResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{22}
+	return file_daemon_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *NewReceiveScriptResponse) GetPkScriptHex() string {
@@ -2750,7 +3112,7 @@ type ReceiveAuthKeyRequest struct {
 
 func (x *ReceiveAuthKeyRequest) Reset() {
 	*x = ReceiveAuthKeyRequest{}
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2762,7 +3124,7 @@ func (x *ReceiveAuthKeyRequest) String() string {
 func (*ReceiveAuthKeyRequest) ProtoMessage() {}
 
 func (x *ReceiveAuthKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2775,7 +3137,7 @@ func (x *ReceiveAuthKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthKeyRequest.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthKeyRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{23}
+	return file_daemon_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ReceiveAuthKeyRequest) GetPaymentHash() []byte {
@@ -2796,7 +3158,7 @@ type ReceiveAuthKeyResponse struct {
 
 func (x *ReceiveAuthKeyResponse) Reset() {
 	*x = ReceiveAuthKeyResponse{}
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2808,7 +3170,7 @@ func (x *ReceiveAuthKeyResponse) String() string {
 func (*ReceiveAuthKeyResponse) ProtoMessage() {}
 
 func (x *ReceiveAuthKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2821,7 +3183,7 @@ func (x *ReceiveAuthKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthKeyResponse.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthKeyResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{24}
+	return file_daemon_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ReceiveAuthKeyResponse) GetPubkey() []byte {
@@ -2847,7 +3209,7 @@ type SignReceiveAuthMessageRequest struct {
 
 func (x *SignReceiveAuthMessageRequest) Reset() {
 	*x = SignReceiveAuthMessageRequest{}
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2859,7 +3221,7 @@ func (x *SignReceiveAuthMessageRequest) String() string {
 func (*SignReceiveAuthMessageRequest) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2872,7 +3234,7 @@ func (x *SignReceiveAuthMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignReceiveAuthMessageRequest.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{25}
+	return file_daemon_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SignReceiveAuthMessageRequest) GetPaymentHash() []byte {
@@ -2906,7 +3268,7 @@ type SignReceiveAuthMessageResponse struct {
 
 func (x *SignReceiveAuthMessageResponse) Reset() {
 	*x = SignReceiveAuthMessageResponse{}
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2918,7 +3280,7 @@ func (x *SignReceiveAuthMessageResponse) String() string {
 func (*SignReceiveAuthMessageResponse) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2931,7 +3293,7 @@ func (x *SignReceiveAuthMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignReceiveAuthMessageResponse.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{26}
+	return file_daemon_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *SignReceiveAuthMessageResponse) GetSignature() []byte {
@@ -2957,7 +3319,7 @@ type SignReceiveAuthMessageCompactRequest struct {
 
 func (x *SignReceiveAuthMessageCompactRequest) Reset() {
 	*x = SignReceiveAuthMessageCompactRequest{}
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2969,7 +3331,7 @@ func (x *SignReceiveAuthMessageCompactRequest) String() string {
 func (*SignReceiveAuthMessageCompactRequest) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageCompactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2982,7 +3344,7 @@ func (x *SignReceiveAuthMessageCompactRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use SignReceiveAuthMessageCompactRequest.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageCompactRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{27}
+	return file_daemon_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SignReceiveAuthMessageCompactRequest) GetPaymentHash() []byte {
@@ -3016,7 +3378,7 @@ type SignReceiveAuthMessageCompactResponse struct {
 
 func (x *SignReceiveAuthMessageCompactResponse) Reset() {
 	*x = SignReceiveAuthMessageCompactResponse{}
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3028,7 +3390,7 @@ func (x *SignReceiveAuthMessageCompactResponse) String() string {
 func (*SignReceiveAuthMessageCompactResponse) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageCompactResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3041,7 +3403,7 @@ func (x *SignReceiveAuthMessageCompactResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use SignReceiveAuthMessageCompactResponse.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageCompactResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{28}
+	return file_daemon_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *SignReceiveAuthMessageCompactResponse) GetSignature() []byte {
@@ -3064,7 +3426,7 @@ type ReceiveAuthECDHRequest struct {
 
 func (x *ReceiveAuthECDHRequest) Reset() {
 	*x = ReceiveAuthECDHRequest{}
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3076,7 +3438,7 @@ func (x *ReceiveAuthECDHRequest) String() string {
 func (*ReceiveAuthECDHRequest) ProtoMessage() {}
 
 func (x *ReceiveAuthECDHRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3089,7 +3451,7 @@ func (x *ReceiveAuthECDHRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthECDHRequest.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthECDHRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{29}
+	return file_daemon_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ReceiveAuthECDHRequest) GetPaymentHash() []byte {
@@ -3116,7 +3478,7 @@ type ReceiveAuthECDHResponse struct {
 
 func (x *ReceiveAuthECDHResponse) Reset() {
 	*x = ReceiveAuthECDHResponse{}
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3128,7 +3490,7 @@ func (x *ReceiveAuthECDHResponse) String() string {
 func (*ReceiveAuthECDHResponse) ProtoMessage() {}
 
 func (x *ReceiveAuthECDHResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3141,7 +3503,7 @@ func (x *ReceiveAuthECDHResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthECDHResponse.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthECDHResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{30}
+	return file_daemon_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ReceiveAuthECDHResponse) GetSharedSecret() []byte {
@@ -3164,7 +3526,7 @@ type GetIndexedVTXOByPkScriptRequest struct {
 
 func (x *GetIndexedVTXOByPkScriptRequest) Reset() {
 	*x = GetIndexedVTXOByPkScriptRequest{}
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3176,7 +3538,7 @@ func (x *GetIndexedVTXOByPkScriptRequest) String() string {
 func (*GetIndexedVTXOByPkScriptRequest) ProtoMessage() {}
 
 func (x *GetIndexedVTXOByPkScriptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3189,7 +3551,7 @@ func (x *GetIndexedVTXOByPkScriptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIndexedVTXOByPkScriptRequest.ProtoReflect.Descriptor instead.
 func (*GetIndexedVTXOByPkScriptRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{31}
+	return file_daemon_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetIndexedVTXOByPkScriptRequest) GetPkScript() []byte {
@@ -3216,7 +3578,7 @@ type GetIndexedVTXOByPkScriptResponse struct {
 
 func (x *GetIndexedVTXOByPkScriptResponse) Reset() {
 	*x = GetIndexedVTXOByPkScriptResponse{}
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3228,7 +3590,7 @@ func (x *GetIndexedVTXOByPkScriptResponse) String() string {
 func (*GetIndexedVTXOByPkScriptResponse) ProtoMessage() {}
 
 func (x *GetIndexedVTXOByPkScriptResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3241,7 +3603,7 @@ func (x *GetIndexedVTXOByPkScriptResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIndexedVTXOByPkScriptResponse.ProtoReflect.Descriptor instead.
 func (*GetIndexedVTXOByPkScriptResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{32}
+	return file_daemon_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GetIndexedVTXOByPkScriptResponse) GetVtxo() *VTXO {
@@ -3277,7 +3639,7 @@ type GetVTXOExpiryInfoRequest struct {
 
 func (x *GetVTXOExpiryInfoRequest) Reset() {
 	*x = GetVTXOExpiryInfoRequest{}
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3289,7 +3651,7 @@ func (x *GetVTXOExpiryInfoRequest) String() string {
 func (*GetVTXOExpiryInfoRequest) ProtoMessage() {}
 
 func (x *GetVTXOExpiryInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3302,7 +3664,7 @@ func (x *GetVTXOExpiryInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVTXOExpiryInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetVTXOExpiryInfoRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{33}
+	return file_daemon_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GetVTXOExpiryInfoRequest) GetTarget() isGetVTXOExpiryInfoRequest_Target {
@@ -3379,7 +3741,7 @@ type GetVTXOExpiryInfoResponse struct {
 
 func (x *GetVTXOExpiryInfoResponse) Reset() {
 	*x = GetVTXOExpiryInfoResponse{}
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3391,7 +3753,7 @@ func (x *GetVTXOExpiryInfoResponse) String() string {
 func (*GetVTXOExpiryInfoResponse) ProtoMessage() {}
 
 func (x *GetVTXOExpiryInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3404,7 +3766,7 @@ func (x *GetVTXOExpiryInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVTXOExpiryInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetVTXOExpiryInfoResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{34}
+	return file_daemon_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetVTXOExpiryInfoResponse) GetFound() bool {
@@ -3440,7 +3802,7 @@ type GetIndexedOORSessionByTxidRequest struct {
 
 func (x *GetIndexedOORSessionByTxidRequest) Reset() {
 	*x = GetIndexedOORSessionByTxidRequest{}
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3452,7 +3814,7 @@ func (x *GetIndexedOORSessionByTxidRequest) String() string {
 func (*GetIndexedOORSessionByTxidRequest) ProtoMessage() {}
 
 func (x *GetIndexedOORSessionByTxidRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3465,7 +3827,7 @@ func (x *GetIndexedOORSessionByTxidRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetIndexedOORSessionByTxidRequest.ProtoReflect.Descriptor instead.
 func (*GetIndexedOORSessionByTxidRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{35}
+	return file_daemon_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetIndexedOORSessionByTxidRequest) GetPkScript() []byte {
@@ -3495,7 +3857,7 @@ type GetIndexedOORSessionByTxidResponse struct {
 
 func (x *GetIndexedOORSessionByTxidResponse) Reset() {
 	*x = GetIndexedOORSessionByTxidResponse{}
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3507,7 +3869,7 @@ func (x *GetIndexedOORSessionByTxidResponse) String() string {
 func (*GetIndexedOORSessionByTxidResponse) ProtoMessage() {}
 
 func (x *GetIndexedOORSessionByTxidResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3520,7 +3882,7 @@ func (x *GetIndexedOORSessionByTxidResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetIndexedOORSessionByTxidResponse.ProtoReflect.Descriptor instead.
 func (*GetIndexedOORSessionByTxidResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{36}
+	return file_daemon_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetIndexedOORSessionByTxidResponse) GetArkPsbt() []byte {
@@ -3558,7 +3920,7 @@ type Output struct {
 
 func (x *Output) Reset() {
 	*x = Output{}
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3570,7 +3932,7 @@ func (x *Output) String() string {
 func (*Output) ProtoMessage() {}
 
 func (x *Output) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3583,7 +3945,7 @@ func (x *Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Output.ProtoReflect.Descriptor instead.
 func (*Output) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{37}
+	return file_daemon_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *Output) GetDestination() isOutput_Destination {
@@ -3680,7 +4042,7 @@ type SendVTXORequest struct {
 
 func (x *SendVTXORequest) Reset() {
 	*x = SendVTXORequest{}
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3692,7 +4054,7 @@ func (x *SendVTXORequest) String() string {
 func (*SendVTXORequest) ProtoMessage() {}
 
 func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3705,7 +4067,7 @@ func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXORequest.ProtoReflect.Descriptor instead.
 func (*SendVTXORequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{38}
+	return file_daemon_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *SendVTXORequest) GetRecipients() []*Output {
@@ -3745,7 +4107,7 @@ type SendVTXOResponse struct {
 
 func (x *SendVTXOResponse) Reset() {
 	*x = SendVTXOResponse{}
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3757,7 +4119,7 @@ func (x *SendVTXOResponse) String() string {
 func (*SendVTXOResponse) ProtoMessage() {}
 
 func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3770,7 +4132,7 @@ func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXOResponse.ProtoReflect.Descriptor instead.
 func (*SendVTXOResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{39}
+	return file_daemon_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *SendVTXOResponse) GetStatus() string {
@@ -3848,7 +4210,7 @@ type SendOORRequest struct {
 
 func (x *SendOORRequest) Reset() {
 	*x = SendOORRequest{}
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3860,7 +4222,7 @@ func (x *SendOORRequest) String() string {
 func (*SendOORRequest) ProtoMessage() {}
 
 func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3873,7 +4235,7 @@ func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORRequest.ProtoReflect.Descriptor instead.
 func (*SendOORRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{40}
+	return file_daemon_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *SendOORRequest) GetRecipients() []*Output {
@@ -3971,7 +4333,7 @@ type TaprootAssetOORIntent struct {
 
 func (x *TaprootAssetOORIntent) Reset() {
 	*x = TaprootAssetOORIntent{}
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3983,7 +4345,7 @@ func (x *TaprootAssetOORIntent) String() string {
 func (*TaprootAssetOORIntent) ProtoMessage() {}
 
 func (x *TaprootAssetOORIntent) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3996,7 +4358,7 @@ func (x *TaprootAssetOORIntent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaprootAssetOORIntent.ProtoReflect.Descriptor instead.
 func (*TaprootAssetOORIntent) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{41}
+	return file_daemon_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *TaprootAssetOORIntent) GetAssetRef() string {
@@ -4097,7 +4459,7 @@ type CustomOORInput struct {
 
 func (x *CustomOORInput) Reset() {
 	*x = CustomOORInput{}
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4109,7 +4471,7 @@ func (x *CustomOORInput) String() string {
 func (*CustomOORInput) ProtoMessage() {}
 
 func (x *CustomOORInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4122,7 +4484,7 @@ func (x *CustomOORInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CustomOORInput.ProtoReflect.Descriptor instead.
 func (*CustomOORInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{42}
+	return file_daemon_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CustomOORInput) GetOutpoint() string {
@@ -4187,7 +4549,7 @@ type TaprootScriptSignature struct {
 
 func (x *TaprootScriptSignature) Reset() {
 	*x = TaprootScriptSignature{}
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4199,7 +4561,7 @@ func (x *TaprootScriptSignature) String() string {
 func (*TaprootScriptSignature) ProtoMessage() {}
 
 func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4212,7 +4574,7 @@ func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaprootScriptSignature.ProtoReflect.Descriptor instead.
 func (*TaprootScriptSignature) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{43}
+	return file_daemon_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *TaprootScriptSignature) GetPubkey() []byte {
@@ -4263,7 +4625,7 @@ type SendOORResponse struct {
 
 func (x *SendOORResponse) Reset() {
 	*x = SendOORResponse{}
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4275,7 +4637,7 @@ func (x *SendOORResponse) String() string {
 func (*SendOORResponse) ProtoMessage() {}
 
 func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4288,7 +4650,7 @@ func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORResponse.ProtoReflect.Descriptor instead.
 func (*SendOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{44}
+	return file_daemon_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *SendOORResponse) GetStatus() string {
@@ -4326,7 +4688,7 @@ type PrepareOORRequest struct {
 
 func (x *PrepareOORRequest) Reset() {
 	*x = PrepareOORRequest{}
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4338,7 +4700,7 @@ func (x *PrepareOORRequest) String() string {
 func (*PrepareOORRequest) ProtoMessage() {}
 
 func (x *PrepareOORRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4351,7 +4713,7 @@ func (x *PrepareOORRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareOORRequest.ProtoReflect.Descriptor instead.
 func (*PrepareOORRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{45}
+	return file_daemon_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *PrepareOORRequest) GetRecipient() *Output {
@@ -4386,7 +4748,7 @@ type PreparedOORCustomInput struct {
 
 func (x *PreparedOORCustomInput) Reset() {
 	*x = PreparedOORCustomInput{}
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4398,7 +4760,7 @@ func (x *PreparedOORCustomInput) String() string {
 func (*PreparedOORCustomInput) ProtoMessage() {}
 
 func (x *PreparedOORCustomInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4411,7 +4773,7 @@ func (x *PreparedOORCustomInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedOORCustomInput.ProtoReflect.Descriptor instead.
 func (*PreparedOORCustomInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{46}
+	return file_daemon_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *PreparedOORCustomInput) GetOutpoint() string {
@@ -4459,7 +4821,7 @@ type PrepareOORResponse struct {
 
 func (x *PrepareOORResponse) Reset() {
 	*x = PrepareOORResponse{}
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4471,7 +4833,7 @@ func (x *PrepareOORResponse) String() string {
 func (*PrepareOORResponse) ProtoMessage() {}
 
 func (x *PrepareOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4484,7 +4846,7 @@ func (x *PrepareOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareOORResponse.ProtoReflect.Descriptor instead.
 func (*PrepareOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{47}
+	return file_daemon_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *PrepareOORResponse) GetArkPsbt() []byte {
@@ -4527,7 +4889,7 @@ type SignOORCustomInputRequest struct {
 
 func (x *SignOORCustomInputRequest) Reset() {
 	*x = SignOORCustomInputRequest{}
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4539,7 +4901,7 @@ func (x *SignOORCustomInputRequest) String() string {
 func (*SignOORCustomInputRequest) ProtoMessage() {}
 
 func (x *SignOORCustomInputRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4552,7 +4914,7 @@ func (x *SignOORCustomInputRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignOORCustomInputRequest.ProtoReflect.Descriptor instead.
 func (*SignOORCustomInputRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{48}
+	return file_daemon_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *SignOORCustomInputRequest) GetCustomInput() *CustomOORInput {
@@ -4579,7 +4941,7 @@ type SignOORCustomInputResponse struct {
 
 func (x *SignOORCustomInputResponse) Reset() {
 	*x = SignOORCustomInputResponse{}
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4591,7 +4953,7 @@ func (x *SignOORCustomInputResponse) String() string {
 func (*SignOORCustomInputResponse) ProtoMessage() {}
 
 func (x *SignOORCustomInputResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4604,7 +4966,7 @@ func (x *SignOORCustomInputResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignOORCustomInputResponse.ProtoReflect.Descriptor instead.
 func (*SignOORCustomInputResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{49}
+	return file_daemon_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *SignOORCustomInputResponse) GetSignature() *TaprootScriptSignature {
@@ -4645,7 +5007,7 @@ type SignVTXOForfeitRequest struct {
 
 func (x *SignVTXOForfeitRequest) Reset() {
 	*x = SignVTXOForfeitRequest{}
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4657,7 +5019,7 @@ func (x *SignVTXOForfeitRequest) String() string {
 func (*SignVTXOForfeitRequest) ProtoMessage() {}
 
 func (x *SignVTXOForfeitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4670,7 +5032,7 @@ func (x *SignVTXOForfeitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignVTXOForfeitRequest.ProtoReflect.Descriptor instead.
 func (*SignVTXOForfeitRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{50}
+	return file_daemon_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *SignVTXOForfeitRequest) GetVtxoOutpoint() string {
@@ -4755,7 +5117,7 @@ type SignVTXOForfeitResponse struct {
 
 func (x *SignVTXOForfeitResponse) Reset() {
 	*x = SignVTXOForfeitResponse{}
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4767,7 +5129,7 @@ func (x *SignVTXOForfeitResponse) String() string {
 func (*SignVTXOForfeitResponse) ProtoMessage() {}
 
 func (x *SignVTXOForfeitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4780,7 +5142,7 @@ func (x *SignVTXOForfeitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignVTXOForfeitResponse.ProtoReflect.Descriptor instead.
 func (*SignVTXOForfeitResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{51}
+	return file_daemon_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *SignVTXOForfeitResponse) GetPubkey() []byte {
@@ -4818,7 +5180,7 @@ type ForfeitSigningContext struct {
 
 func (x *ForfeitSigningContext) Reset() {
 	*x = ForfeitSigningContext{}
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4830,7 +5192,7 @@ func (x *ForfeitSigningContext) String() string {
 func (*ForfeitSigningContext) ProtoMessage() {}
 
 func (x *ForfeitSigningContext) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4843,7 +5205,7 @@ func (x *ForfeitSigningContext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForfeitSigningContext.ProtoReflect.Descriptor instead.
 func (*ForfeitSigningContext) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{52}
+	return file_daemon_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ForfeitSigningContext) GetPaymentHash() []byte {
@@ -4873,7 +5235,7 @@ type OutpointSelection struct {
 
 func (x *OutpointSelection) Reset() {
 	*x = OutpointSelection{}
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4885,7 +5247,7 @@ func (x *OutpointSelection) String() string {
 func (*OutpointSelection) ProtoMessage() {}
 
 func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4898,7 +5260,7 @@ func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutpointSelection.ProtoReflect.Descriptor instead.
 func (*OutpointSelection) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{53}
+	return file_daemon_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *OutpointSelection) GetOutpoints() []string {
@@ -4923,7 +5285,7 @@ type RefreshVTXOsRequest struct {
 
 func (x *RefreshVTXOsRequest) Reset() {
 	*x = RefreshVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4935,7 +5297,7 @@ func (x *RefreshVTXOsRequest) String() string {
 func (*RefreshVTXOsRequest) ProtoMessage() {}
 
 func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4948,7 +5310,7 @@ func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{54}
+	return file_daemon_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *RefreshVTXOsRequest) GetSelection() isRefreshVTXOsRequest_Selection {
@@ -5020,7 +5382,7 @@ type RefreshVTXOsResponse struct {
 
 func (x *RefreshVTXOsResponse) Reset() {
 	*x = RefreshVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5032,7 +5394,7 @@ func (x *RefreshVTXOsResponse) String() string {
 func (*RefreshVTXOsResponse) ProtoMessage() {}
 
 func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5045,7 +5407,7 @@ func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{55}
+	return file_daemon_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *RefreshVTXOsResponse) GetQueuedOutpoints() []string {
@@ -5111,7 +5473,7 @@ type RefreshFeeEstimate struct {
 
 func (x *RefreshFeeEstimate) Reset() {
 	*x = RefreshFeeEstimate{}
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5123,7 +5485,7 @@ func (x *RefreshFeeEstimate) String() string {
 func (*RefreshFeeEstimate) ProtoMessage() {}
 
 func (x *RefreshFeeEstimate) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5136,7 +5498,7 @@ func (x *RefreshFeeEstimate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshFeeEstimate.ProtoReflect.Descriptor instead.
 func (*RefreshFeeEstimate) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{56}
+	return file_daemon_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *RefreshFeeEstimate) GetEstimatedTotalFeeSat() int64 {
@@ -5204,7 +5566,7 @@ type OutpointFeeEstimate struct {
 
 func (x *OutpointFeeEstimate) Reset() {
 	*x = OutpointFeeEstimate{}
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5216,7 +5578,7 @@ func (x *OutpointFeeEstimate) String() string {
 func (*OutpointFeeEstimate) ProtoMessage() {}
 
 func (x *OutpointFeeEstimate) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5229,7 +5591,7 @@ func (x *OutpointFeeEstimate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutpointFeeEstimate.ProtoReflect.Descriptor instead.
 func (*OutpointFeeEstimate) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{57}
+	return file_daemon_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *OutpointFeeEstimate) GetOutpoint() string {
@@ -5329,7 +5691,7 @@ type CustomRefreshVTXOInput struct {
 
 func (x *CustomRefreshVTXOInput) Reset() {
 	*x = CustomRefreshVTXOInput{}
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5341,7 +5703,7 @@ func (x *CustomRefreshVTXOInput) String() string {
 func (*CustomRefreshVTXOInput) ProtoMessage() {}
 
 func (x *CustomRefreshVTXOInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5354,7 +5716,7 @@ func (x *CustomRefreshVTXOInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CustomRefreshVTXOInput.ProtoReflect.Descriptor instead.
 func (*CustomRefreshVTXOInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{58}
+	return file_daemon_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *CustomRefreshVTXOInput) GetOutpoint() string {
@@ -5428,7 +5790,7 @@ type CustomRefreshVTXOOutput struct {
 
 func (x *CustomRefreshVTXOOutput) Reset() {
 	*x = CustomRefreshVTXOOutput{}
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5440,7 +5802,7 @@ func (x *CustomRefreshVTXOOutput) String() string {
 func (*CustomRefreshVTXOOutput) ProtoMessage() {}
 
 func (x *CustomRefreshVTXOOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5453,7 +5815,7 @@ func (x *CustomRefreshVTXOOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CustomRefreshVTXOOutput.ProtoReflect.Descriptor instead.
 func (*CustomRefreshVTXOOutput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{59}
+	return file_daemon_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *CustomRefreshVTXOOutput) GetAmountSat() int64 {
@@ -5500,7 +5862,7 @@ type RefreshCustomVTXOsRequest struct {
 
 func (x *RefreshCustomVTXOsRequest) Reset() {
 	*x = RefreshCustomVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5512,7 +5874,7 @@ func (x *RefreshCustomVTXOsRequest) String() string {
 func (*RefreshCustomVTXOsRequest) ProtoMessage() {}
 
 func (x *RefreshCustomVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5525,7 +5887,7 @@ func (x *RefreshCustomVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshCustomVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*RefreshCustomVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{60}
+	return file_daemon_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *RefreshCustomVTXOsRequest) GetInputs() []*CustomRefreshVTXOInput {
@@ -5561,7 +5923,7 @@ type RefreshCustomVTXOsResponse struct {
 
 func (x *RefreshCustomVTXOsResponse) Reset() {
 	*x = RefreshCustomVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5573,7 +5935,7 @@ func (x *RefreshCustomVTXOsResponse) String() string {
 func (*RefreshCustomVTXOsResponse) ProtoMessage() {}
 
 func (x *RefreshCustomVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5586,7 +5948,7 @@ func (x *RefreshCustomVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshCustomVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*RefreshCustomVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{61}
+	return file_daemon_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *RefreshCustomVTXOsResponse) GetQueuedOutpoints() []string {
@@ -5655,7 +6017,7 @@ type PendingForfeitParticipantSignatureRequest struct {
 
 func (x *PendingForfeitParticipantSignatureRequest) Reset() {
 	*x = PendingForfeitParticipantSignatureRequest{}
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5667,7 +6029,7 @@ func (x *PendingForfeitParticipantSignatureRequest) String() string {
 func (*PendingForfeitParticipantSignatureRequest) ProtoMessage() {}
 
 func (x *PendingForfeitParticipantSignatureRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5680,7 +6042,7 @@ func (x *PendingForfeitParticipantSignatureRequest) ProtoReflect() protoreflect.
 
 // Deprecated: Use PendingForfeitParticipantSignatureRequest.ProtoReflect.Descriptor instead.
 func (*PendingForfeitParticipantSignatureRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{62}
+	return file_daemon_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *PendingForfeitParticipantSignatureRequest) GetRequestId() []byte {
@@ -5794,7 +6156,7 @@ type ListPendingForfeitParticipantSignatureRequestsRequest struct {
 
 func (x *ListPendingForfeitParticipantSignatureRequestsRequest) Reset() {
 	*x = ListPendingForfeitParticipantSignatureRequestsRequest{}
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5806,7 +6168,7 @@ func (x *ListPendingForfeitParticipantSignatureRequestsRequest) String() string 
 func (*ListPendingForfeitParticipantSignatureRequestsRequest) ProtoMessage() {}
 
 func (x *ListPendingForfeitParticipantSignatureRequestsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5819,7 +6181,7 @@ func (x *ListPendingForfeitParticipantSignatureRequestsRequest) ProtoReflect() p
 
 // Deprecated: Use ListPendingForfeitParticipantSignatureRequestsRequest.ProtoReflect.Descriptor instead.
 func (*ListPendingForfeitParticipantSignatureRequestsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{63}
+	return file_daemon_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ListPendingForfeitParticipantSignatureRequestsRequest) GetAfterSequence() uint64 {
@@ -5846,7 +6208,7 @@ type ListPendingForfeitParticipantSignatureRequestsResponse struct {
 
 func (x *ListPendingForfeitParticipantSignatureRequestsResponse) Reset() {
 	*x = ListPendingForfeitParticipantSignatureRequestsResponse{}
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5858,7 +6220,7 @@ func (x *ListPendingForfeitParticipantSignatureRequestsResponse) String() string
 func (*ListPendingForfeitParticipantSignatureRequestsResponse) ProtoMessage() {}
 
 func (x *ListPendingForfeitParticipantSignatureRequestsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5871,7 +6233,7 @@ func (x *ListPendingForfeitParticipantSignatureRequestsResponse) ProtoReflect() 
 
 // Deprecated: Use ListPendingForfeitParticipantSignatureRequestsResponse.ProtoReflect.Descriptor instead.
 func (*ListPendingForfeitParticipantSignatureRequestsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{64}
+	return file_daemon_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *ListPendingForfeitParticipantSignatureRequestsResponse) GetRequests() []*PendingForfeitParticipantSignatureRequest {
@@ -5903,7 +6265,7 @@ type ForfeitParticipantSignature struct {
 
 func (x *ForfeitParticipantSignature) Reset() {
 	*x = ForfeitParticipantSignature{}
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5915,7 +6277,7 @@ func (x *ForfeitParticipantSignature) String() string {
 func (*ForfeitParticipantSignature) ProtoMessage() {}
 
 func (x *ForfeitParticipantSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5928,7 +6290,7 @@ func (x *ForfeitParticipantSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForfeitParticipantSignature.ProtoReflect.Descriptor instead.
 func (*ForfeitParticipantSignature) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{65}
+	return file_daemon_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *ForfeitParticipantSignature) GetPubkey() []byte {
@@ -5962,7 +6324,7 @@ type SubmitForfeitParticipantSignaturesRequest struct {
 
 func (x *SubmitForfeitParticipantSignaturesRequest) Reset() {
 	*x = SubmitForfeitParticipantSignaturesRequest{}
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5974,7 +6336,7 @@ func (x *SubmitForfeitParticipantSignaturesRequest) String() string {
 func (*SubmitForfeitParticipantSignaturesRequest) ProtoMessage() {}
 
 func (x *SubmitForfeitParticipantSignaturesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5987,7 +6349,7 @@ func (x *SubmitForfeitParticipantSignaturesRequest) ProtoReflect() protoreflect.
 
 // Deprecated: Use SubmitForfeitParticipantSignaturesRequest.ProtoReflect.Descriptor instead.
 func (*SubmitForfeitParticipantSignaturesRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{66}
+	return file_daemon_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *SubmitForfeitParticipantSignaturesRequest) GetRequestId() []byte {
@@ -6012,7 +6374,7 @@ type SubmitForfeitParticipantSignaturesResponse struct {
 
 func (x *SubmitForfeitParticipantSignaturesResponse) Reset() {
 	*x = SubmitForfeitParticipantSignaturesResponse{}
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6024,7 +6386,7 @@ func (x *SubmitForfeitParticipantSignaturesResponse) String() string {
 func (*SubmitForfeitParticipantSignaturesResponse) ProtoMessage() {}
 
 func (x *SubmitForfeitParticipantSignaturesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6037,7 +6399,7 @@ func (x *SubmitForfeitParticipantSignaturesResponse) ProtoReflect() protoreflect
 
 // Deprecated: Use SubmitForfeitParticipantSignaturesResponse.ProtoReflect.Descriptor instead.
 func (*SubmitForfeitParticipantSignaturesResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{67}
+	return file_daemon_proto_rawDescGZIP(), []int{72}
 }
 
 // LeaveDestination describes where a single leave output should land.
@@ -6057,7 +6419,7 @@ type LeaveDestination struct {
 
 func (x *LeaveDestination) Reset() {
 	*x = LeaveDestination{}
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6069,7 +6431,7 @@ func (x *LeaveDestination) String() string {
 func (*LeaveDestination) ProtoMessage() {}
 
 func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6082,7 +6444,7 @@ func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveDestination.ProtoReflect.Descriptor instead.
 func (*LeaveDestination) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{68}
+	return file_daemon_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *LeaveDestination) GetTarget() isLeaveDestination_Target {
@@ -6163,7 +6525,7 @@ type LeaveVTXOsRequest struct {
 
 func (x *LeaveVTXOsRequest) Reset() {
 	*x = LeaveVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6175,7 +6537,7 @@ func (x *LeaveVTXOsRequest) String() string {
 func (*LeaveVTXOsRequest) ProtoMessage() {}
 
 func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6188,7 +6550,7 @@ func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{69}
+	return file_daemon_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *LeaveVTXOsRequest) GetSelection() isLeaveVTXOsRequest_Selection {
@@ -6271,7 +6633,7 @@ type LeaveVTXOsResponse struct {
 
 func (x *LeaveVTXOsResponse) Reset() {
 	*x = LeaveVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6283,7 +6645,7 @@ func (x *LeaveVTXOsResponse) String() string {
 func (*LeaveVTXOsResponse) ProtoMessage() {}
 
 func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6296,7 +6658,7 @@ func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{70}
+	return file_daemon_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *LeaveVTXOsResponse) GetQueuedOutpoints() []string {
@@ -6334,7 +6696,7 @@ type SendOnChainRequest struct {
 
 func (x *SendOnChainRequest) Reset() {
 	*x = SendOnChainRequest{}
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6346,7 +6708,7 @@ func (x *SendOnChainRequest) String() string {
 func (*SendOnChainRequest) ProtoMessage() {}
 
 func (x *SendOnChainRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6359,7 +6721,7 @@ func (x *SendOnChainRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOnChainRequest.ProtoReflect.Descriptor instead.
 func (*SendOnChainRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{71}
+	return file_daemon_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *SendOnChainRequest) GetDestination() *LeaveDestination {
@@ -6467,7 +6829,7 @@ type SendOnChainResponse struct {
 
 func (x *SendOnChainResponse) Reset() {
 	*x = SendOnChainResponse{}
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6479,7 +6841,7 @@ func (x *SendOnChainResponse) String() string {
 func (*SendOnChainResponse) ProtoMessage() {}
 
 func (x *SendOnChainResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6492,7 +6854,7 @@ func (x *SendOnChainResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOnChainResponse.ProtoReflect.Descriptor instead.
 func (*SendOnChainResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{72}
+	return file_daemon_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *SendOnChainResponse) GetActualAmountSat() int64 {
@@ -6558,7 +6920,7 @@ type BoardRequest struct {
 
 func (x *BoardRequest) Reset() {
 	*x = BoardRequest{}
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6570,7 +6932,7 @@ func (x *BoardRequest) String() string {
 func (*BoardRequest) ProtoMessage() {}
 
 func (x *BoardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6583,7 +6945,7 @@ func (x *BoardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardRequest.ProtoReflect.Descriptor instead.
 func (*BoardRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{73}
+	return file_daemon_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *BoardRequest) GetTargetVtxoCount() uint32 {
@@ -6614,7 +6976,7 @@ type BoardResponse struct {
 
 func (x *BoardResponse) Reset() {
 	*x = BoardResponse{}
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6626,7 +6988,7 @@ func (x *BoardResponse) String() string {
 func (*BoardResponse) ProtoMessage() {}
 
 func (x *BoardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6639,7 +7001,7 @@ func (x *BoardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardResponse.ProtoReflect.Descriptor instead.
 func (*BoardResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{74}
+	return file_daemon_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *BoardResponse) GetStatus() string {
@@ -6664,7 +7026,7 @@ type JoinNextRoundRequest struct {
 
 func (x *JoinNextRoundRequest) Reset() {
 	*x = JoinNextRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6676,7 +7038,7 @@ func (x *JoinNextRoundRequest) String() string {
 func (*JoinNextRoundRequest) ProtoMessage() {}
 
 func (x *JoinNextRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6689,7 +7051,7 @@ func (x *JoinNextRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinNextRoundRequest.ProtoReflect.Descriptor instead.
 func (*JoinNextRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{75}
+	return file_daemon_proto_rawDescGZIP(), []int{80}
 }
 
 type JoinNextRoundResponse struct {
@@ -6704,7 +7066,7 @@ type JoinNextRoundResponse struct {
 
 func (x *JoinNextRoundResponse) Reset() {
 	*x = JoinNextRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[76]
+	mi := &file_daemon_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6716,7 +7078,7 @@ func (x *JoinNextRoundResponse) String() string {
 func (*JoinNextRoundResponse) ProtoMessage() {}
 
 func (x *JoinNextRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[76]
+	mi := &file_daemon_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6729,7 +7091,7 @@ func (x *JoinNextRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinNextRoundResponse.ProtoReflect.Descriptor instead.
 func (*JoinNextRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{76}
+	return file_daemon_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *JoinNextRoundResponse) GetStatus() string {
@@ -6765,7 +7127,7 @@ type SweepBoardingUTXOsRequest struct {
 
 func (x *SweepBoardingUTXOsRequest) Reset() {
 	*x = SweepBoardingUTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[77]
+	mi := &file_daemon_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6777,7 +7139,7 @@ func (x *SweepBoardingUTXOsRequest) String() string {
 func (*SweepBoardingUTXOsRequest) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[77]
+	mi := &file_daemon_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6790,7 +7152,7 @@ func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsRequest.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{77}
+	return file_daemon_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *SweepBoardingUTXOsRequest) GetOutpoints() []string {
@@ -6843,7 +7205,7 @@ type BoardingSweepOutput struct {
 
 func (x *BoardingSweepOutput) Reset() {
 	*x = BoardingSweepOutput{}
-	mi := &file_daemon_proto_msgTypes[78]
+	mi := &file_daemon_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6855,7 +7217,7 @@ func (x *BoardingSweepOutput) String() string {
 func (*BoardingSweepOutput) ProtoMessage() {}
 
 func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[78]
+	mi := &file_daemon_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6868,7 +7230,7 @@ func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepOutput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepOutput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{78}
+	return file_daemon_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *BoardingSweepOutput) GetOutpoint() string {
@@ -6934,7 +7296,7 @@ type SweepBoardingUTXOsResponse struct {
 
 func (x *SweepBoardingUTXOsResponse) Reset() {
 	*x = SweepBoardingUTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[79]
+	mi := &file_daemon_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6946,7 +7308,7 @@ func (x *SweepBoardingUTXOsResponse) String() string {
 func (*SweepBoardingUTXOsResponse) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[79]
+	mi := &file_daemon_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6959,7 +7321,7 @@ func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsResponse.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{79}
+	return file_daemon_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *SweepBoardingUTXOsResponse) GetStatus() string {
@@ -7063,7 +7425,7 @@ type ListBoardingSweepsRequest struct {
 
 func (x *ListBoardingSweepsRequest) Reset() {
 	*x = ListBoardingSweepsRequest{}
-	mi := &file_daemon_proto_msgTypes[80]
+	mi := &file_daemon_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7075,7 +7437,7 @@ func (x *ListBoardingSweepsRequest) String() string {
 func (*ListBoardingSweepsRequest) ProtoMessage() {}
 
 func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[80]
+	mi := &file_daemon_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7088,7 +7450,7 @@ func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsRequest.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{80}
+	return file_daemon_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *ListBoardingSweepsRequest) GetStatus() string {
@@ -7131,7 +7493,7 @@ type BoardingSweepInput struct {
 
 func (x *BoardingSweepInput) Reset() {
 	*x = BoardingSweepInput{}
-	mi := &file_daemon_proto_msgTypes[81]
+	mi := &file_daemon_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7143,7 +7505,7 @@ func (x *BoardingSweepInput) String() string {
 func (*BoardingSweepInput) ProtoMessage() {}
 
 func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[81]
+	mi := &file_daemon_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7156,7 +7518,7 @@ func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepInput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{81}
+	return file_daemon_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *BoardingSweepInput) GetOutpoint() string {
@@ -7226,7 +7588,7 @@ type BoardingSweep struct {
 
 func (x *BoardingSweep) Reset() {
 	*x = BoardingSweep{}
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7238,7 +7600,7 @@ func (x *BoardingSweep) String() string {
 func (*BoardingSweep) ProtoMessage() {}
 
 func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7251,7 +7613,7 @@ func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweep.ProtoReflect.Descriptor instead.
 func (*BoardingSweep) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{82}
+	return file_daemon_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *BoardingSweep) GetTxid() string {
@@ -7343,7 +7705,7 @@ type ListBoardingSweepsResponse struct {
 
 func (x *ListBoardingSweepsResponse) Reset() {
 	*x = ListBoardingSweepsResponse{}
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7355,7 +7717,7 @@ func (x *ListBoardingSweepsResponse) String() string {
 func (*ListBoardingSweepsResponse) ProtoMessage() {}
 
 func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7368,7 +7730,7 @@ func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsResponse.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{83}
+	return file_daemon_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *ListBoardingSweepsResponse) GetSweeps() []*BoardingSweep {
@@ -7398,7 +7760,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7410,7 +7772,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7423,7 +7785,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{84}
+	return file_daemon_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -7491,7 +7853,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7503,7 +7865,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7516,7 +7878,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{85}
+	return file_daemon_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -7628,7 +7990,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7640,7 +8002,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7653,7 +8015,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{86}
+	return file_daemon_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -7708,7 +8070,7 @@ type GetRoundRequest struct {
 
 func (x *GetRoundRequest) Reset() {
 	*x = GetRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7720,7 +8082,7 @@ func (x *GetRoundRequest) String() string {
 func (*GetRoundRequest) ProtoMessage() {}
 
 func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7733,7 +8095,7 @@ func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundRequest.ProtoReflect.Descriptor instead.
 func (*GetRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{87}
+	return file_daemon_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *GetRoundRequest) GetRoundId() string {
@@ -7753,7 +8115,7 @@ type GetRoundResponse struct {
 
 func (x *GetRoundResponse) Reset() {
 	*x = GetRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7765,7 +8127,7 @@ func (x *GetRoundResponse) String() string {
 func (*GetRoundResponse) ProtoMessage() {}
 
 func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7778,7 +8140,7 @@ func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundResponse.ProtoReflect.Descriptor instead.
 func (*GetRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{88}
+	return file_daemon_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *GetRoundResponse) GetRound() *RoundInfo {
@@ -7801,7 +8163,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[89]
+	mi := &file_daemon_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7813,7 +8175,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[89]
+	mi := &file_daemon_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7826,7 +8188,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{89}
+	return file_daemon_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -7851,7 +8213,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[90]
+	mi := &file_daemon_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7863,7 +8225,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[90]
+	mi := &file_daemon_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7876,7 +8238,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{90}
+	return file_daemon_proto_rawDescGZIP(), []int{95}
 }
 
 type WatchRoundsResponse struct {
@@ -7890,7 +8252,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[91]
+	mi := &file_daemon_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7902,7 +8264,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[91]
+	mi := &file_daemon_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7915,7 +8277,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{91}
+	return file_daemon_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -7953,7 +8315,7 @@ type OORSessionInfo struct {
 
 func (x *OORSessionInfo) Reset() {
 	*x = OORSessionInfo{}
-	mi := &file_daemon_proto_msgTypes[92]
+	mi := &file_daemon_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7965,7 +8327,7 @@ func (x *OORSessionInfo) String() string {
 func (*OORSessionInfo) ProtoMessage() {}
 
 func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[92]
+	mi := &file_daemon_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7978,7 +8340,7 @@ func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OORSessionInfo.ProtoReflect.Descriptor instead.
 func (*OORSessionInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{92}
+	return file_daemon_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *OORSessionInfo) GetSessionId() string {
@@ -8062,7 +8424,7 @@ type ListOORSessionsRequest struct {
 
 func (x *ListOORSessionsRequest) Reset() {
 	*x = ListOORSessionsRequest{}
-	mi := &file_daemon_proto_msgTypes[93]
+	mi := &file_daemon_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8074,7 +8436,7 @@ func (x *ListOORSessionsRequest) String() string {
 func (*ListOORSessionsRequest) ProtoMessage() {}
 
 func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[93]
+	mi := &file_daemon_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8087,7 +8449,7 @@ func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{93}
+	return file_daemon_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *ListOORSessionsRequest) GetPageSize() int32 {
@@ -8131,7 +8493,7 @@ type ListOORSessionsResponse struct {
 
 func (x *ListOORSessionsResponse) Reset() {
 	*x = ListOORSessionsResponse{}
-	mi := &file_daemon_proto_msgTypes[94]
+	mi := &file_daemon_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8143,7 +8505,7 @@ func (x *ListOORSessionsResponse) String() string {
 func (*ListOORSessionsResponse) ProtoMessage() {}
 
 func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[94]
+	mi := &file_daemon_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8156,7 +8518,7 @@ func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{94}
+	return file_daemon_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *ListOORSessionsResponse) GetSessions() []*OORSessionInfo {
@@ -8183,7 +8545,7 @@ type GetOORSessionRequest struct {
 
 func (x *GetOORSessionRequest) Reset() {
 	*x = GetOORSessionRequest{}
-	mi := &file_daemon_proto_msgTypes[95]
+	mi := &file_daemon_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8195,7 +8557,7 @@ func (x *GetOORSessionRequest) String() string {
 func (*GetOORSessionRequest) ProtoMessage() {}
 
 func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[95]
+	mi := &file_daemon_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8208,7 +8570,7 @@ func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetOORSessionRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{95}
+	return file_daemon_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *GetOORSessionRequest) GetSessionId() string {
@@ -8228,7 +8590,7 @@ type GetOORSessionResponse struct {
 
 func (x *GetOORSessionResponse) Reset() {
 	*x = GetOORSessionResponse{}
-	mi := &file_daemon_proto_msgTypes[96]
+	mi := &file_daemon_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8240,7 +8602,7 @@ func (x *GetOORSessionResponse) String() string {
 func (*GetOORSessionResponse) ProtoMessage() {}
 
 func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[96]
+	mi := &file_daemon_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8253,7 +8615,7 @@ func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionResponse.ProtoReflect.Descriptor instead.
 func (*GetOORSessionResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{96}
+	return file_daemon_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *GetOORSessionResponse) GetSession() *OORSessionInfo {
@@ -8281,7 +8643,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_daemon_proto_msgTypes[97]
+	mi := &file_daemon_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8293,7 +8655,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[97]
+	mi := &file_daemon_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8306,7 +8668,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{97}
+	return file_daemon_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -8360,7 +8722,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_daemon_proto_msgTypes[98]
+	mi := &file_daemon_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8372,7 +8734,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[98]
+	mi := &file_daemon_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8385,7 +8747,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{98}
+	return file_daemon_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -8455,7 +8817,7 @@ type GetFeeHistoryRequest struct {
 
 func (x *GetFeeHistoryRequest) Reset() {
 	*x = GetFeeHistoryRequest{}
-	mi := &file_daemon_proto_msgTypes[99]
+	mi := &file_daemon_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8467,7 +8829,7 @@ func (x *GetFeeHistoryRequest) String() string {
 func (*GetFeeHistoryRequest) ProtoMessage() {}
 
 func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[99]
+	mi := &file_daemon_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8480,7 +8842,7 @@ func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{99}
+	return file_daemon_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *GetFeeHistoryRequest) GetLimit() uint32 {
@@ -8555,7 +8917,7 @@ type FeeHistoryEntry struct {
 
 func (x *FeeHistoryEntry) Reset() {
 	*x = FeeHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[100]
+	mi := &file_daemon_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8567,7 +8929,7 @@ func (x *FeeHistoryEntry) String() string {
 func (*FeeHistoryEntry) ProtoMessage() {}
 
 func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[100]
+	mi := &file_daemon_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8580,7 +8942,7 @@ func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeHistoryEntry.ProtoReflect.Descriptor instead.
 func (*FeeHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{100}
+	return file_daemon_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *FeeHistoryEntry) GetEntryId() int64 {
@@ -8660,7 +9022,7 @@ type GetFeeHistoryResponse struct {
 
 func (x *GetFeeHistoryResponse) Reset() {
 	*x = GetFeeHistoryResponse{}
-	mi := &file_daemon_proto_msgTypes[101]
+	mi := &file_daemon_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8672,7 +9034,7 @@ func (x *GetFeeHistoryResponse) String() string {
 func (*GetFeeHistoryResponse) ProtoMessage() {}
 
 func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[101]
+	mi := &file_daemon_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8685,7 +9047,7 @@ func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{101}
+	return file_daemon_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *GetFeeHistoryResponse) GetEntries() []*FeeHistoryEntry {
@@ -8726,7 +9088,7 @@ type ListTransactionsRequest struct {
 
 func (x *ListTransactionsRequest) Reset() {
 	*x = ListTransactionsRequest{}
-	mi := &file_daemon_proto_msgTypes[102]
+	mi := &file_daemon_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8738,7 +9100,7 @@ func (x *ListTransactionsRequest) String() string {
 func (*ListTransactionsRequest) ProtoMessage() {}
 
 func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[102]
+	mi := &file_daemon_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8751,7 +9113,7 @@ func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
 func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{102}
+	return file_daemon_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *ListTransactionsRequest) GetFromUnixS() int64 {
@@ -8842,7 +9204,7 @@ type TransactionHistoryEntry struct {
 
 func (x *TransactionHistoryEntry) Reset() {
 	*x = TransactionHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[103]
+	mi := &file_daemon_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8854,7 +9216,7 @@ func (x *TransactionHistoryEntry) String() string {
 func (*TransactionHistoryEntry) ProtoMessage() {}
 
 func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[103]
+	mi := &file_daemon_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8867,7 +9229,7 @@ func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionHistoryEntry.ProtoReflect.Descriptor instead.
 func (*TransactionHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{103}
+	return file_daemon_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *TransactionHistoryEntry) GetSource() string {
@@ -9004,7 +9366,7 @@ type ListTransactionsResponse struct {
 
 func (x *ListTransactionsResponse) Reset() {
 	*x = ListTransactionsResponse{}
-	mi := &file_daemon_proto_msgTypes[104]
+	mi := &file_daemon_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9016,7 +9378,7 @@ func (x *ListTransactionsResponse) String() string {
 func (*ListTransactionsResponse) ProtoMessage() {}
 
 func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[104]
+	mi := &file_daemon_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9029,7 +9391,7 @@ func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{104}
+	return file_daemon_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *ListTransactionsResponse) GetTransactions() []*TransactionHistoryEntry {
@@ -9064,7 +9426,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[105]
+	mi := &file_daemon_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9076,7 +9438,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[105]
+	mi := &file_daemon_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9089,7 +9451,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{105}
+	return file_daemon_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -9112,7 +9474,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[106]
+	mi := &file_daemon_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9124,7 +9486,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[106]
+	mi := &file_daemon_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9137,7 +9499,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{106}
+	return file_daemon_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -9169,7 +9531,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[107]
+	mi := &file_daemon_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9181,7 +9543,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[107]
+	mi := &file_daemon_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9194,7 +9556,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{107}
+	return file_daemon_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -9246,7 +9608,7 @@ type UnrollProgress struct {
 
 func (x *UnrollProgress) Reset() {
 	*x = UnrollProgress{}
-	mi := &file_daemon_proto_msgTypes[108]
+	mi := &file_daemon_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9258,7 +9620,7 @@ func (x *UnrollProgress) String() string {
 func (*UnrollProgress) ProtoMessage() {}
 
 func (x *UnrollProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[108]
+	mi := &file_daemon_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9271,7 +9633,7 @@ func (x *UnrollProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollProgress.ProtoReflect.Descriptor instead.
 func (*UnrollProgress) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{108}
+	return file_daemon_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *UnrollProgress) GetConfirmedTxs() uint32 {
@@ -9356,7 +9718,7 @@ type UnrollCSV struct {
 
 func (x *UnrollCSV) Reset() {
 	*x = UnrollCSV{}
-	mi := &file_daemon_proto_msgTypes[109]
+	mi := &file_daemon_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9368,7 +9730,7 @@ func (x *UnrollCSV) String() string {
 func (*UnrollCSV) ProtoMessage() {}
 
 func (x *UnrollCSV) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[109]
+	mi := &file_daemon_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9381,7 +9743,7 @@ func (x *UnrollCSV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollCSV.ProtoReflect.Descriptor instead.
 func (*UnrollCSV) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{109}
+	return file_daemon_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *UnrollCSV) GetTargetConfirmHeight() int32 {
@@ -9446,7 +9808,7 @@ type UnrollFees struct {
 
 func (x *UnrollFees) Reset() {
 	*x = UnrollFees{}
-	mi := &file_daemon_proto_msgTypes[110]
+	mi := &file_daemon_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9458,7 +9820,7 @@ func (x *UnrollFees) String() string {
 func (*UnrollFees) ProtoMessage() {}
 
 func (x *UnrollFees) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[110]
+	mi := &file_daemon_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9471,7 +9833,7 @@ func (x *UnrollFees) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollFees.ProtoReflect.Descriptor instead.
 func (*UnrollFees) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{110}
+	return file_daemon_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *UnrollFees) GetCpfpFeeSat() int64 {
@@ -9573,7 +9935,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[111]
+	mi := &file_daemon_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9585,7 +9947,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[111]
+	mi := &file_daemon_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9598,7 +9960,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{111}
+	return file_daemon_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -9729,7 +10091,7 @@ type ArmVHTLCRecoveryRequest struct {
 
 func (x *ArmVHTLCRecoveryRequest) Reset() {
 	*x = ArmVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[112]
+	mi := &file_daemon_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9741,7 +10103,7 @@ func (x *ArmVHTLCRecoveryRequest) String() string {
 func (*ArmVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[112]
+	mi := &file_daemon_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9754,7 +10116,7 @@ func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{112}
+	return file_daemon_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *ArmVHTLCRecoveryRequest) GetRequestId() string {
@@ -9897,7 +10259,7 @@ type ArmVHTLCRecoveryResponse struct {
 
 func (x *ArmVHTLCRecoveryResponse) Reset() {
 	*x = ArmVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[113]
+	mi := &file_daemon_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9909,7 +10271,7 @@ func (x *ArmVHTLCRecoveryResponse) String() string {
 func (*ArmVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[113]
+	mi := &file_daemon_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9922,7 +10284,7 @@ func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{113}
+	return file_daemon_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *ArmVHTLCRecoveryResponse) GetRecoveryId() string {
@@ -9962,7 +10324,7 @@ type EscalateVHTLCRecoveryRequest struct {
 
 func (x *EscalateVHTLCRecoveryRequest) Reset() {
 	*x = EscalateVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[114]
+	mi := &file_daemon_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9974,7 +10336,7 @@ func (x *EscalateVHTLCRecoveryRequest) String() string {
 func (*EscalateVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[114]
+	mi := &file_daemon_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9987,7 +10349,7 @@ func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{114}
+	return file_daemon_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *EscalateVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -10021,7 +10383,7 @@ type EscalateVHTLCRecoveryResponse struct {
 
 func (x *EscalateVHTLCRecoveryResponse) Reset() {
 	*x = EscalateVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[115]
+	mi := &file_daemon_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10033,7 +10395,7 @@ func (x *EscalateVHTLCRecoveryResponse) String() string {
 func (*EscalateVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[115]
+	mi := &file_daemon_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10046,7 +10408,7 @@ func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{115}
+	return file_daemon_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *EscalateVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -10070,7 +10432,7 @@ type CancelVHTLCRecoveryRequest struct {
 
 func (x *CancelVHTLCRecoveryRequest) Reset() {
 	*x = CancelVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[116]
+	mi := &file_daemon_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10082,7 +10444,7 @@ func (x *CancelVHTLCRecoveryRequest) String() string {
 func (*CancelVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[116]
+	mi := &file_daemon_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10095,7 +10457,7 @@ func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{116}
+	return file_daemon_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *CancelVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -10129,7 +10491,7 @@ type CancelVHTLCRecoveryResponse struct {
 
 func (x *CancelVHTLCRecoveryResponse) Reset() {
 	*x = CancelVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[117]
+	mi := &file_daemon_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10141,7 +10503,7 @@ func (x *CancelVHTLCRecoveryResponse) String() string {
 func (*CancelVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[117]
+	mi := &file_daemon_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10154,7 +10516,7 @@ func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{117}
+	return file_daemon_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *CancelVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -10174,7 +10536,7 @@ type GetVHTLCRecoveryStatusRequest struct {
 
 func (x *GetVHTLCRecoveryStatusRequest) Reset() {
 	*x = GetVHTLCRecoveryStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[118]
+	mi := &file_daemon_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10186,7 +10548,7 @@ func (x *GetVHTLCRecoveryStatusRequest) String() string {
 func (*GetVHTLCRecoveryStatusRequest) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[118]
+	mi := &file_daemon_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10199,7 +10561,7 @@ func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{118}
+	return file_daemon_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *GetVHTLCRecoveryStatusRequest) GetRecoveryId() string {
@@ -10221,7 +10583,7 @@ type GetVHTLCRecoveryStatusResponse struct {
 
 func (x *GetVHTLCRecoveryStatusResponse) Reset() {
 	*x = GetVHTLCRecoveryStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[119]
+	mi := &file_daemon_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10233,7 +10595,7 @@ func (x *GetVHTLCRecoveryStatusResponse) String() string {
 func (*GetVHTLCRecoveryStatusResponse) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[119]
+	mi := &file_daemon_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10246,7 +10608,7 @@ func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{119}
+	return file_daemon_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *GetVHTLCRecoveryStatusResponse) GetFound() bool {
@@ -10273,7 +10635,7 @@ type ListVHTLCRecoveriesRequest struct {
 
 func (x *ListVHTLCRecoveriesRequest) Reset() {
 	*x = ListVHTLCRecoveriesRequest{}
-	mi := &file_daemon_proto_msgTypes[120]
+	mi := &file_daemon_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10285,7 +10647,7 @@ func (x *ListVHTLCRecoveriesRequest) String() string {
 func (*ListVHTLCRecoveriesRequest) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[120]
+	mi := &file_daemon_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10298,7 +10660,7 @@ func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesRequest.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{120}
+	return file_daemon_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *ListVHTLCRecoveriesRequest) GetIncludeTerminal() bool {
@@ -10318,7 +10680,7 @@ type ListVHTLCRecoveriesResponse struct {
 
 func (x *ListVHTLCRecoveriesResponse) Reset() {
 	*x = ListVHTLCRecoveriesResponse{}
-	mi := &file_daemon_proto_msgTypes[121]
+	mi := &file_daemon_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10330,7 +10692,7 @@ func (x *ListVHTLCRecoveriesResponse) String() string {
 func (*ListVHTLCRecoveriesResponse) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[121]
+	mi := &file_daemon_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10343,7 +10705,7 @@ func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesResponse.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{121}
+	return file_daemon_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *ListVHTLCRecoveriesResponse) GetStatuses() []*VHTLCRecoveryStatus {
@@ -10418,7 +10780,7 @@ type VHTLCRecoveryStatus struct {
 
 func (x *VHTLCRecoveryStatus) Reset() {
 	*x = VHTLCRecoveryStatus{}
-	mi := &file_daemon_proto_msgTypes[122]
+	mi := &file_daemon_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10430,7 +10792,7 @@ func (x *VHTLCRecoveryStatus) String() string {
 func (*VHTLCRecoveryStatus) ProtoMessage() {}
 
 func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[122]
+	mi := &file_daemon_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10443,7 +10805,7 @@ func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCRecoveryStatus.ProtoReflect.Descriptor instead.
 func (*VHTLCRecoveryStatus) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{122}
+	return file_daemon_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *VHTLCRecoveryStatus) GetRecoveryId() string {
@@ -10635,7 +10997,7 @@ type SignOutSwapHtlcAckRequest struct {
 
 func (x *SignOutSwapHtlcAckRequest) Reset() {
 	*x = SignOutSwapHtlcAckRequest{}
-	mi := &file_daemon_proto_msgTypes[123]
+	mi := &file_daemon_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10647,7 +11009,7 @@ func (x *SignOutSwapHtlcAckRequest) String() string {
 func (*SignOutSwapHtlcAckRequest) ProtoMessage() {}
 
 func (x *SignOutSwapHtlcAckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[123]
+	mi := &file_daemon_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10660,7 +11022,7 @@ func (x *SignOutSwapHtlcAckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignOutSwapHtlcAckRequest.ProtoReflect.Descriptor instead.
 func (*SignOutSwapHtlcAckRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{123}
+	return file_daemon_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *SignOutSwapHtlcAckRequest) GetPaymentHash() []byte {
@@ -10694,7 +11056,7 @@ type SignOutSwapHtlcAckResponse struct {
 
 func (x *SignOutSwapHtlcAckResponse) Reset() {
 	*x = SignOutSwapHtlcAckResponse{}
-	mi := &file_daemon_proto_msgTypes[124]
+	mi := &file_daemon_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10706,7 +11068,7 @@ func (x *SignOutSwapHtlcAckResponse) String() string {
 func (*SignOutSwapHtlcAckResponse) ProtoMessage() {}
 
 func (x *SignOutSwapHtlcAckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[124]
+	mi := &file_daemon_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10719,7 +11081,7 @@ func (x *SignOutSwapHtlcAckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignOutSwapHtlcAckResponse.ProtoReflect.Descriptor instead.
 func (*SignOutSwapHtlcAckResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{124}
+	return file_daemon_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *SignOutSwapHtlcAckResponse) GetSignature() []byte {
@@ -10747,7 +11109,7 @@ type SignCreditAccountAuthorizationRequest struct {
 
 func (x *SignCreditAccountAuthorizationRequest) Reset() {
 	*x = SignCreditAccountAuthorizationRequest{}
-	mi := &file_daemon_proto_msgTypes[125]
+	mi := &file_daemon_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10759,7 +11121,7 @@ func (x *SignCreditAccountAuthorizationRequest) String() string {
 func (*SignCreditAccountAuthorizationRequest) ProtoMessage() {}
 
 func (x *SignCreditAccountAuthorizationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[125]
+	mi := &file_daemon_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10772,7 +11134,7 @@ func (x *SignCreditAccountAuthorizationRequest) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use SignCreditAccountAuthorizationRequest.ProtoReflect.Descriptor instead.
 func (*SignCreditAccountAuthorizationRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{125}
+	return file_daemon_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *SignCreditAccountAuthorizationRequest) GetRequestDigest() []byte {
@@ -10813,7 +11175,7 @@ type SignCreditAccountAuthorizationResponse struct {
 
 func (x *SignCreditAccountAuthorizationResponse) Reset() {
 	*x = SignCreditAccountAuthorizationResponse{}
-	mi := &file_daemon_proto_msgTypes[126]
+	mi := &file_daemon_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10825,7 +11187,7 @@ func (x *SignCreditAccountAuthorizationResponse) String() string {
 func (*SignCreditAccountAuthorizationResponse) ProtoMessage() {}
 
 func (x *SignCreditAccountAuthorizationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[126]
+	mi := &file_daemon_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10838,7 +11200,7 @@ func (x *SignCreditAccountAuthorizationResponse) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use SignCreditAccountAuthorizationResponse.ProtoReflect.Descriptor instead.
 func (*SignCreditAccountAuthorizationResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{126}
+	return file_daemon_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *SignCreditAccountAuthorizationResponse) GetSignature() []byte {
@@ -10868,7 +11230,23 @@ const file_daemon_proto_rawDesc = "" +
 	"\tvalue_sat\x18\x03 \x01(\x03R\bvalueSat\x12\x1b\n" +
 	"\tpk_script\x18\x04 \x01(\fR\bpkScript\x12,\n" +
 	"\x12taproot_asset_root\x18\x05 \x01(\fR\x10taprootAssetRoot\x12$\n" +
-	"\x0eactual_fee_sat\x18\a \x01(\x04R\factualFeeSat\"\x10\n" +
+	"\x0eactual_fee_sat\x18\a \x01(\x04R\factualFeeSat\"C\n" +
+	"\x18BoardTaprootAssetRequest\x12'\n" +
+	"\x0fidempotency_key\x18\x01 \x01(\tR\x0eidempotencyKey\"\xbd\x01\n" +
+	"\x19BoardTaprootAssetResponse\x12\x1a\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1b\n" +
+	"\tvalue_sat\x18\x02 \x01(\x03R\bvalueSat\x12\x1b\n" +
+	"\tasset_ref\x18\x03 \x01(\tR\bassetRef\x12!\n" +
+	"\fasset_amount\x18\x04 \x01(\x04R\vassetAmount\x12'\n" +
+	"\x0falready_boarded\x18\x05 \x01(\bR\x0ealreadyBoarded\"S\n" +
+	"\x1cClaimTaprootAssetVTXORequest\x12\x1a\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x17\n" +
+	"\afee_sat\x18\x02 \x01(\x03R\x06feeSat\"\x9f\x01\n" +
+	"\x1dClaimTaprootAssetVTXOResponse\x12\x12\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\x12'\n" +
+	"\x0fanchor_outpoint\x18\x02 \x01(\tR\x0eanchorOutpoint\x12(\n" +
+	"\x10output_value_sat\x18\x03 \x01(\x03R\x0eoutputValueSat\x12\x17\n" +
+	"\afee_sat\x18\x04 \x01(\x03R\x06feeSat\"\x10\n" +
 	"\x0eGetInfoRequest\"\xb1\x03\n" +
 	"\x0fGetInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
@@ -10924,7 +11302,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\"?\n" +
 	"\x14UnlockWalletResponse\x12'\n" +
 	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\"\x13\n" +
-	"\x11GetBalanceRequest\"\x9f\x04\n" +
+	"\x11GetBalanceRequest\"\xe4\x04\n" +
 	"\x12GetBalanceResponse\x124\n" +
 	"\x16boarding_confirmed_sat\x18\x01 \x01(\x03R\x14boardingConfirmedSat\x128\n" +
 	"\x18boarding_unconfirmed_sat\x18\x02 \x01(\x03R\x16boardingUnconfirmedSat\x12(\n" +
@@ -10936,7 +11314,15 @@ const file_daemon_proto_rawDesc = "" +
 	"\x14boarding_adopted_sat\x18\b \x01(\x03R\x12boardingAdoptedSat\x12(\n" +
 	"\x10vtxo_pending_sat\x18\t \x01(\x03R\x0evtxoPendingSat\x127\n" +
 	"\x18vtxo_unilateral_exit_sat\x18\n" +
-	" \x01(\x03R\x15vtxoUnilateralExitSat\"\x9e\x03\n" +
+	" \x01(\x03R\x15vtxoUnilateralExitSat\x12C\n" +
+	"\x0etaproot_assets\x18\v \x03(\v2\x1c.waverpc.TaprootAssetBalanceR\rtaprootAssets\"\xc9\x01\n" +
+	"\x13TaprootAssetBalance\x12\x1b\n" +
+	"\tasset_ref\x18\x01 \x01(\tR\bassetRef\x12\x1f\n" +
+	"\vlive_amount\x18\x02 \x01(\x04R\n" +
+	"liveAmount\x12%\n" +
+	"\x0epending_amount\x18\x03 \x01(\x04R\rpendingAmount\x12%\n" +
+	"\x0eexiting_amount\x18\x04 \x01(\x04R\rexitingAmount\x12&\n" +
+	"\x0flive_vtxo_count\x18\x05 \x01(\rR\rliveVtxoCount\"\x9e\x03\n" +
 	"\x0eVTXOExpiryInfo\x121\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x19.waverpc.VTXOExpiryStatusR\x06status\x12%\n" +
 	"\x0ecurrent_height\x18\x02 \x01(\x05R\rcurrentHeight\x12!\n" +
@@ -10977,11 +11363,12 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0eVTXOSettlement\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x16\n" +
 	"\x06height\x18\x02 \x01(\x05R\x06height\x12\x17\n" +
-	"\afee_sat\x18\x03 \x01(\x03R\x06feeSat\"\xac\x01\n" +
+	"\afee_sat\x18\x03 \x01(\x03R\x06feeSat\"\xc9\x01\n" +
 	"\x10ListVTXOsRequest\x128\n" +
 	"\rstatus_filter\x18\x01 \x01(\x0e2\x13.waverpc.VTXOStatusR\fstatusFilter\x12$\n" +
 	"\x0emin_amount_sat\x18\x02 \x01(\x03R\fminAmountSat\x128\n" +
-	"\x18exclude_checkpoint_psbts\x18\x03 \x01(\bR\x16excludeCheckpointPsbts\"8\n" +
+	"\x18exclude_checkpoint_psbts\x18\x03 \x01(\bR\x16excludeCheckpointPsbts\x12\x1b\n" +
+	"\tasset_ref\x18\x04 \x01(\tR\bassetRef\"8\n" +
 	"\x11ListVTXOsResponse\x12#\n" +
 	"\x05vtxos\x18\x01 \x03(\v2\r.waverpc.VTXOR\x05vtxos\"\x13\n" +
 	"\x11NewAddressRequest\".\n" +
@@ -11684,7 +12071,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1eVHTLC_RECOVERY_STATE_COMPLETED\x10\t\x12\"\n" +
 	"\x1eVHTLC_RECOVERY_STATE_CANCELLED\x10\n" +
 	"\x12\x1f\n" +
-	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\x97!\n" +
+	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xdb\"\n" +
 	"\rDaemonService\x12<\n" +
 	"\aGetInfo\x12\x17.waverpc.GetInfoRequest\x1a\x18.waverpc.GetInfoResponse\x12<\n" +
 	"\aGenSeed\x12\x17.waverpc.GenSeedRequest\x1a\x18.waverpc.GenSeedResponse\x12E\n" +
@@ -11706,7 +12093,9 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1aGetIndexedOORSessionByTxid\x12*.waverpc.GetIndexedOORSessionByTxidRequest\x1a+.waverpc.GetIndexedOORSessionByTxidResponse\x12?\n" +
 	"\bSendVTXO\x12\x18.waverpc.SendVTXORequest\x1a\x19.waverpc.SendVTXOResponse\x12<\n" +
 	"\aSendOOR\x12\x17.waverpc.SendOORRequest\x1a\x18.waverpc.SendOORResponse\x12`\n" +
-	"\x13OnboardTaprootAsset\x12#.waverpc.OnboardTaprootAssetRequest\x1a$.waverpc.OnboardTaprootAssetResponse\x12E\n" +
+	"\x13OnboardTaprootAsset\x12#.waverpc.OnboardTaprootAssetRequest\x1a$.waverpc.OnboardTaprootAssetResponse\x12Z\n" +
+	"\x11BoardTaprootAsset\x12!.waverpc.BoardTaprootAssetRequest\x1a\".waverpc.BoardTaprootAssetResponse\x12f\n" +
+	"\x15ClaimTaprootAssetVTXO\x12%.waverpc.ClaimTaprootAssetVTXORequest\x1a&.waverpc.ClaimTaprootAssetVTXOResponse\x12E\n" +
 	"\n" +
 	"PrepareOOR\x12\x1a.waverpc.PrepareOORRequest\x1a\x1b.waverpc.PrepareOORResponse\x12]\n" +
 	"\x12SignOORCustomInput\x12\".waverpc.SignOORCustomInputRequest\x1a#.waverpc.SignOORCustomInputResponse\x12T\n" +
@@ -11754,7 +12143,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 128)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 133)
 var file_daemon_proto_goTypes = []any{
 	(WalletState)(0),                                               // 0: waverpc.WalletState
 	(VTXOStatus)(0),                                                // 1: waverpc.VTXOStatus
@@ -11769,306 +12158,316 @@ var file_daemon_proto_goTypes = []any{
 	(VHTLCRecoveryState)(0),                                        // 10: waverpc.VHTLCRecoveryState
 	(*OnboardTaprootAssetRequest)(nil),                             // 11: waverpc.OnboardTaprootAssetRequest
 	(*OnboardTaprootAssetResponse)(nil),                            // 12: waverpc.OnboardTaprootAssetResponse
-	(*GetInfoRequest)(nil),                                         // 13: waverpc.GetInfoRequest
-	(*GetInfoResponse)(nil),                                        // 14: waverpc.GetInfoResponse
-	(*ServerInfo)(nil),                                             // 15: waverpc.ServerInfo
-	(*GenSeedRequest)(nil),                                         // 16: waverpc.GenSeedRequest
-	(*GenSeedResponse)(nil),                                        // 17: waverpc.GenSeedResponse
-	(*InitWalletRequest)(nil),                                      // 18: waverpc.InitWalletRequest
-	(*InitWalletResponse)(nil),                                     // 19: waverpc.InitWalletResponse
-	(*UnlockWalletRequest)(nil),                                    // 20: waverpc.UnlockWalletRequest
-	(*UnlockWalletResponse)(nil),                                   // 21: waverpc.UnlockWalletResponse
-	(*GetBalanceRequest)(nil),                                      // 22: waverpc.GetBalanceRequest
-	(*GetBalanceResponse)(nil),                                     // 23: waverpc.GetBalanceResponse
-	(*VTXOExpiryInfo)(nil),                                         // 24: waverpc.VTXOExpiryInfo
-	(*VTXO)(nil),                                                   // 25: waverpc.VTXO
-	(*VTXOTaprootAsset)(nil),                                       // 26: waverpc.VTXOTaprootAsset
-	(*VTXOSettlement)(nil),                                         // 27: waverpc.VTXOSettlement
-	(*ListVTXOsRequest)(nil),                                       // 28: waverpc.ListVTXOsRequest
-	(*ListVTXOsResponse)(nil),                                      // 29: waverpc.ListVTXOsResponse
-	(*NewAddressRequest)(nil),                                      // 30: waverpc.NewAddressRequest
-	(*NewAddressResponse)(nil),                                     // 31: waverpc.NewAddressResponse
-	(*NewReceiveScriptRequest)(nil),                                // 32: waverpc.NewReceiveScriptRequest
-	(*NewReceiveScriptResponse)(nil),                               // 33: waverpc.NewReceiveScriptResponse
-	(*ReceiveAuthKeyRequest)(nil),                                  // 34: waverpc.ReceiveAuthKeyRequest
-	(*ReceiveAuthKeyResponse)(nil),                                 // 35: waverpc.ReceiveAuthKeyResponse
-	(*SignReceiveAuthMessageRequest)(nil),                          // 36: waverpc.SignReceiveAuthMessageRequest
-	(*SignReceiveAuthMessageResponse)(nil),                         // 37: waverpc.SignReceiveAuthMessageResponse
-	(*SignReceiveAuthMessageCompactRequest)(nil),                   // 38: waverpc.SignReceiveAuthMessageCompactRequest
-	(*SignReceiveAuthMessageCompactResponse)(nil),                  // 39: waverpc.SignReceiveAuthMessageCompactResponse
-	(*ReceiveAuthECDHRequest)(nil),                                 // 40: waverpc.ReceiveAuthECDHRequest
-	(*ReceiveAuthECDHResponse)(nil),                                // 41: waverpc.ReceiveAuthECDHResponse
-	(*GetIndexedVTXOByPkScriptRequest)(nil),                        // 42: waverpc.GetIndexedVTXOByPkScriptRequest
-	(*GetIndexedVTXOByPkScriptResponse)(nil),                       // 43: waverpc.GetIndexedVTXOByPkScriptResponse
-	(*GetVTXOExpiryInfoRequest)(nil),                               // 44: waverpc.GetVTXOExpiryInfoRequest
-	(*GetVTXOExpiryInfoResponse)(nil),                              // 45: waverpc.GetVTXOExpiryInfoResponse
-	(*GetIndexedOORSessionByTxidRequest)(nil),                      // 46: waverpc.GetIndexedOORSessionByTxidRequest
-	(*GetIndexedOORSessionByTxidResponse)(nil),                     // 47: waverpc.GetIndexedOORSessionByTxidResponse
-	(*Output)(nil),                                                 // 48: waverpc.Output
-	(*SendVTXORequest)(nil),                                        // 49: waverpc.SendVTXORequest
-	(*SendVTXOResponse)(nil),                                       // 50: waverpc.SendVTXOResponse
-	(*SendOORRequest)(nil),                                         // 51: waverpc.SendOORRequest
-	(*TaprootAssetOORIntent)(nil),                                  // 52: waverpc.TaprootAssetOORIntent
-	(*CustomOORInput)(nil),                                         // 53: waverpc.CustomOORInput
-	(*TaprootScriptSignature)(nil),                                 // 54: waverpc.TaprootScriptSignature
-	(*SendOORResponse)(nil),                                        // 55: waverpc.SendOORResponse
-	(*PrepareOORRequest)(nil),                                      // 56: waverpc.PrepareOORRequest
-	(*PreparedOORCustomInput)(nil),                                 // 57: waverpc.PreparedOORCustomInput
-	(*PrepareOORResponse)(nil),                                     // 58: waverpc.PrepareOORResponse
-	(*SignOORCustomInputRequest)(nil),                              // 59: waverpc.SignOORCustomInputRequest
-	(*SignOORCustomInputResponse)(nil),                             // 60: waverpc.SignOORCustomInputResponse
-	(*SignVTXOForfeitRequest)(nil),                                 // 61: waverpc.SignVTXOForfeitRequest
-	(*SignVTXOForfeitResponse)(nil),                                // 62: waverpc.SignVTXOForfeitResponse
-	(*ForfeitSigningContext)(nil),                                  // 63: waverpc.ForfeitSigningContext
-	(*OutpointSelection)(nil),                                      // 64: waverpc.OutpointSelection
-	(*RefreshVTXOsRequest)(nil),                                    // 65: waverpc.RefreshVTXOsRequest
-	(*RefreshVTXOsResponse)(nil),                                   // 66: waverpc.RefreshVTXOsResponse
-	(*RefreshFeeEstimate)(nil),                                     // 67: waverpc.RefreshFeeEstimate
-	(*OutpointFeeEstimate)(nil),                                    // 68: waverpc.OutpointFeeEstimate
-	(*CustomRefreshVTXOInput)(nil),                                 // 69: waverpc.CustomRefreshVTXOInput
-	(*CustomRefreshVTXOOutput)(nil),                                // 70: waverpc.CustomRefreshVTXOOutput
-	(*RefreshCustomVTXOsRequest)(nil),                              // 71: waverpc.RefreshCustomVTXOsRequest
-	(*RefreshCustomVTXOsResponse)(nil),                             // 72: waverpc.RefreshCustomVTXOsResponse
-	(*PendingForfeitParticipantSignatureRequest)(nil),              // 73: waverpc.PendingForfeitParticipantSignatureRequest
-	(*ListPendingForfeitParticipantSignatureRequestsRequest)(nil),  // 74: waverpc.ListPendingForfeitParticipantSignatureRequestsRequest
-	(*ListPendingForfeitParticipantSignatureRequestsResponse)(nil), // 75: waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
-	(*ForfeitParticipantSignature)(nil),                            // 76: waverpc.ForfeitParticipantSignature
-	(*SubmitForfeitParticipantSignaturesRequest)(nil),              // 77: waverpc.SubmitForfeitParticipantSignaturesRequest
-	(*SubmitForfeitParticipantSignaturesResponse)(nil),             // 78: waverpc.SubmitForfeitParticipantSignaturesResponse
-	(*LeaveDestination)(nil),                                       // 79: waverpc.LeaveDestination
-	(*LeaveVTXOsRequest)(nil),                                      // 80: waverpc.LeaveVTXOsRequest
-	(*LeaveVTXOsResponse)(nil),                                     // 81: waverpc.LeaveVTXOsResponse
-	(*SendOnChainRequest)(nil),                                     // 82: waverpc.SendOnChainRequest
-	(*SendOnChainResponse)(nil),                                    // 83: waverpc.SendOnChainResponse
-	(*BoardRequest)(nil),                                           // 84: waverpc.BoardRequest
-	(*BoardResponse)(nil),                                          // 85: waverpc.BoardResponse
-	(*JoinNextRoundRequest)(nil),                                   // 86: waverpc.JoinNextRoundRequest
-	(*JoinNextRoundResponse)(nil),                                  // 87: waverpc.JoinNextRoundResponse
-	(*SweepBoardingUTXOsRequest)(nil),                              // 88: waverpc.SweepBoardingUTXOsRequest
-	(*BoardingSweepOutput)(nil),                                    // 89: waverpc.BoardingSweepOutput
-	(*SweepBoardingUTXOsResponse)(nil),                             // 90: waverpc.SweepBoardingUTXOsResponse
-	(*ListBoardingSweepsRequest)(nil),                              // 91: waverpc.ListBoardingSweepsRequest
-	(*BoardingSweepInput)(nil),                                     // 92: waverpc.BoardingSweepInput
-	(*BoardingSweep)(nil),                                          // 93: waverpc.BoardingSweep
-	(*ListBoardingSweepsResponse)(nil),                             // 94: waverpc.ListBoardingSweepsResponse
-	(*RoundVTXOInfo)(nil),                                          // 95: waverpc.RoundVTXOInfo
-	(*RoundInfo)(nil),                                              // 96: waverpc.RoundInfo
-	(*ListRoundsRequest)(nil),                                      // 97: waverpc.ListRoundsRequest
-	(*GetRoundRequest)(nil),                                        // 98: waverpc.GetRoundRequest
-	(*GetRoundResponse)(nil),                                       // 99: waverpc.GetRoundResponse
-	(*ListRoundsResponse)(nil),                                     // 100: waverpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),                                     // 101: waverpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),                                    // 102: waverpc.WatchRoundsResponse
-	(*OORSessionInfo)(nil),                                         // 103: waverpc.OORSessionInfo
-	(*ListOORSessionsRequest)(nil),                                 // 104: waverpc.ListOORSessionsRequest
-	(*ListOORSessionsResponse)(nil),                                // 105: waverpc.ListOORSessionsResponse
-	(*GetOORSessionRequest)(nil),                                   // 106: waverpc.GetOORSessionRequest
-	(*GetOORSessionResponse)(nil),                                  // 107: waverpc.GetOORSessionResponse
-	(*EstimateFeeRequest)(nil),                                     // 108: waverpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),                                    // 109: waverpc.EstimateFeeResponse
-	(*GetFeeHistoryRequest)(nil),                                   // 110: waverpc.GetFeeHistoryRequest
-	(*FeeHistoryEntry)(nil),                                        // 111: waverpc.FeeHistoryEntry
-	(*GetFeeHistoryResponse)(nil),                                  // 112: waverpc.GetFeeHistoryResponse
-	(*ListTransactionsRequest)(nil),                                // 113: waverpc.ListTransactionsRequest
-	(*TransactionHistoryEntry)(nil),                                // 114: waverpc.TransactionHistoryEntry
-	(*ListTransactionsResponse)(nil),                               // 115: waverpc.ListTransactionsResponse
-	(*UnrollRequest)(nil),                                          // 116: waverpc.UnrollRequest
-	(*UnrollResponse)(nil),                                         // 117: waverpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),                                 // 118: waverpc.GetUnrollStatusRequest
-	(*UnrollProgress)(nil),                                         // 119: waverpc.UnrollProgress
-	(*UnrollCSV)(nil),                                              // 120: waverpc.UnrollCSV
-	(*UnrollFees)(nil),                                             // 121: waverpc.UnrollFees
-	(*GetUnrollStatusResponse)(nil),                                // 122: waverpc.GetUnrollStatusResponse
-	(*ArmVHTLCRecoveryRequest)(nil),                                // 123: waverpc.ArmVHTLCRecoveryRequest
-	(*ArmVHTLCRecoveryResponse)(nil),                               // 124: waverpc.ArmVHTLCRecoveryResponse
-	(*EscalateVHTLCRecoveryRequest)(nil),                           // 125: waverpc.EscalateVHTLCRecoveryRequest
-	(*EscalateVHTLCRecoveryResponse)(nil),                          // 126: waverpc.EscalateVHTLCRecoveryResponse
-	(*CancelVHTLCRecoveryRequest)(nil),                             // 127: waverpc.CancelVHTLCRecoveryRequest
-	(*CancelVHTLCRecoveryResponse)(nil),                            // 128: waverpc.CancelVHTLCRecoveryResponse
-	(*GetVHTLCRecoveryStatusRequest)(nil),                          // 129: waverpc.GetVHTLCRecoveryStatusRequest
-	(*GetVHTLCRecoveryStatusResponse)(nil),                         // 130: waverpc.GetVHTLCRecoveryStatusResponse
-	(*ListVHTLCRecoveriesRequest)(nil),                             // 131: waverpc.ListVHTLCRecoveriesRequest
-	(*ListVHTLCRecoveriesResponse)(nil),                            // 132: waverpc.ListVHTLCRecoveriesResponse
-	(*VHTLCRecoveryStatus)(nil),                                    // 133: waverpc.VHTLCRecoveryStatus
-	(*SignOutSwapHtlcAckRequest)(nil),                              // 134: waverpc.SignOutSwapHtlcAckRequest
-	(*SignOutSwapHtlcAckResponse)(nil),                             // 135: waverpc.SignOutSwapHtlcAckResponse
-	(*SignCreditAccountAuthorizationRequest)(nil),                  // 136: waverpc.SignCreditAccountAuthorizationRequest
-	(*SignCreditAccountAuthorizationResponse)(nil),                 // 137: waverpc.SignCreditAccountAuthorizationResponse
-	nil, // 138: waverpc.LeaveVTXOsRequest.DestinationsEntry
+	(*BoardTaprootAssetRequest)(nil),                               // 13: waverpc.BoardTaprootAssetRequest
+	(*BoardTaprootAssetResponse)(nil),                              // 14: waverpc.BoardTaprootAssetResponse
+	(*ClaimTaprootAssetVTXORequest)(nil),                           // 15: waverpc.ClaimTaprootAssetVTXORequest
+	(*ClaimTaprootAssetVTXOResponse)(nil),                          // 16: waverpc.ClaimTaprootAssetVTXOResponse
+	(*GetInfoRequest)(nil),                                         // 17: waverpc.GetInfoRequest
+	(*GetInfoResponse)(nil),                                        // 18: waverpc.GetInfoResponse
+	(*ServerInfo)(nil),                                             // 19: waverpc.ServerInfo
+	(*GenSeedRequest)(nil),                                         // 20: waverpc.GenSeedRequest
+	(*GenSeedResponse)(nil),                                        // 21: waverpc.GenSeedResponse
+	(*InitWalletRequest)(nil),                                      // 22: waverpc.InitWalletRequest
+	(*InitWalletResponse)(nil),                                     // 23: waverpc.InitWalletResponse
+	(*UnlockWalletRequest)(nil),                                    // 24: waverpc.UnlockWalletRequest
+	(*UnlockWalletResponse)(nil),                                   // 25: waverpc.UnlockWalletResponse
+	(*GetBalanceRequest)(nil),                                      // 26: waverpc.GetBalanceRequest
+	(*GetBalanceResponse)(nil),                                     // 27: waverpc.GetBalanceResponse
+	(*TaprootAssetBalance)(nil),                                    // 28: waverpc.TaprootAssetBalance
+	(*VTXOExpiryInfo)(nil),                                         // 29: waverpc.VTXOExpiryInfo
+	(*VTXO)(nil),                                                   // 30: waverpc.VTXO
+	(*VTXOTaprootAsset)(nil),                                       // 31: waverpc.VTXOTaprootAsset
+	(*VTXOSettlement)(nil),                                         // 32: waverpc.VTXOSettlement
+	(*ListVTXOsRequest)(nil),                                       // 33: waverpc.ListVTXOsRequest
+	(*ListVTXOsResponse)(nil),                                      // 34: waverpc.ListVTXOsResponse
+	(*NewAddressRequest)(nil),                                      // 35: waverpc.NewAddressRequest
+	(*NewAddressResponse)(nil),                                     // 36: waverpc.NewAddressResponse
+	(*NewReceiveScriptRequest)(nil),                                // 37: waverpc.NewReceiveScriptRequest
+	(*NewReceiveScriptResponse)(nil),                               // 38: waverpc.NewReceiveScriptResponse
+	(*ReceiveAuthKeyRequest)(nil),                                  // 39: waverpc.ReceiveAuthKeyRequest
+	(*ReceiveAuthKeyResponse)(nil),                                 // 40: waverpc.ReceiveAuthKeyResponse
+	(*SignReceiveAuthMessageRequest)(nil),                          // 41: waverpc.SignReceiveAuthMessageRequest
+	(*SignReceiveAuthMessageResponse)(nil),                         // 42: waverpc.SignReceiveAuthMessageResponse
+	(*SignReceiveAuthMessageCompactRequest)(nil),                   // 43: waverpc.SignReceiveAuthMessageCompactRequest
+	(*SignReceiveAuthMessageCompactResponse)(nil),                  // 44: waverpc.SignReceiveAuthMessageCompactResponse
+	(*ReceiveAuthECDHRequest)(nil),                                 // 45: waverpc.ReceiveAuthECDHRequest
+	(*ReceiveAuthECDHResponse)(nil),                                // 46: waverpc.ReceiveAuthECDHResponse
+	(*GetIndexedVTXOByPkScriptRequest)(nil),                        // 47: waverpc.GetIndexedVTXOByPkScriptRequest
+	(*GetIndexedVTXOByPkScriptResponse)(nil),                       // 48: waverpc.GetIndexedVTXOByPkScriptResponse
+	(*GetVTXOExpiryInfoRequest)(nil),                               // 49: waverpc.GetVTXOExpiryInfoRequest
+	(*GetVTXOExpiryInfoResponse)(nil),                              // 50: waverpc.GetVTXOExpiryInfoResponse
+	(*GetIndexedOORSessionByTxidRequest)(nil),                      // 51: waverpc.GetIndexedOORSessionByTxidRequest
+	(*GetIndexedOORSessionByTxidResponse)(nil),                     // 52: waverpc.GetIndexedOORSessionByTxidResponse
+	(*Output)(nil),                                                 // 53: waverpc.Output
+	(*SendVTXORequest)(nil),                                        // 54: waverpc.SendVTXORequest
+	(*SendVTXOResponse)(nil),                                       // 55: waverpc.SendVTXOResponse
+	(*SendOORRequest)(nil),                                         // 56: waverpc.SendOORRequest
+	(*TaprootAssetOORIntent)(nil),                                  // 57: waverpc.TaprootAssetOORIntent
+	(*CustomOORInput)(nil),                                         // 58: waverpc.CustomOORInput
+	(*TaprootScriptSignature)(nil),                                 // 59: waverpc.TaprootScriptSignature
+	(*SendOORResponse)(nil),                                        // 60: waverpc.SendOORResponse
+	(*PrepareOORRequest)(nil),                                      // 61: waverpc.PrepareOORRequest
+	(*PreparedOORCustomInput)(nil),                                 // 62: waverpc.PreparedOORCustomInput
+	(*PrepareOORResponse)(nil),                                     // 63: waverpc.PrepareOORResponse
+	(*SignOORCustomInputRequest)(nil),                              // 64: waverpc.SignOORCustomInputRequest
+	(*SignOORCustomInputResponse)(nil),                             // 65: waverpc.SignOORCustomInputResponse
+	(*SignVTXOForfeitRequest)(nil),                                 // 66: waverpc.SignVTXOForfeitRequest
+	(*SignVTXOForfeitResponse)(nil),                                // 67: waverpc.SignVTXOForfeitResponse
+	(*ForfeitSigningContext)(nil),                                  // 68: waverpc.ForfeitSigningContext
+	(*OutpointSelection)(nil),                                      // 69: waverpc.OutpointSelection
+	(*RefreshVTXOsRequest)(nil),                                    // 70: waverpc.RefreshVTXOsRequest
+	(*RefreshVTXOsResponse)(nil),                                   // 71: waverpc.RefreshVTXOsResponse
+	(*RefreshFeeEstimate)(nil),                                     // 72: waverpc.RefreshFeeEstimate
+	(*OutpointFeeEstimate)(nil),                                    // 73: waverpc.OutpointFeeEstimate
+	(*CustomRefreshVTXOInput)(nil),                                 // 74: waverpc.CustomRefreshVTXOInput
+	(*CustomRefreshVTXOOutput)(nil),                                // 75: waverpc.CustomRefreshVTXOOutput
+	(*RefreshCustomVTXOsRequest)(nil),                              // 76: waverpc.RefreshCustomVTXOsRequest
+	(*RefreshCustomVTXOsResponse)(nil),                             // 77: waverpc.RefreshCustomVTXOsResponse
+	(*PendingForfeitParticipantSignatureRequest)(nil),              // 78: waverpc.PendingForfeitParticipantSignatureRequest
+	(*ListPendingForfeitParticipantSignatureRequestsRequest)(nil),  // 79: waverpc.ListPendingForfeitParticipantSignatureRequestsRequest
+	(*ListPendingForfeitParticipantSignatureRequestsResponse)(nil), // 80: waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
+	(*ForfeitParticipantSignature)(nil),                            // 81: waverpc.ForfeitParticipantSignature
+	(*SubmitForfeitParticipantSignaturesRequest)(nil),              // 82: waverpc.SubmitForfeitParticipantSignaturesRequest
+	(*SubmitForfeitParticipantSignaturesResponse)(nil),             // 83: waverpc.SubmitForfeitParticipantSignaturesResponse
+	(*LeaveDestination)(nil),                                       // 84: waverpc.LeaveDestination
+	(*LeaveVTXOsRequest)(nil),                                      // 85: waverpc.LeaveVTXOsRequest
+	(*LeaveVTXOsResponse)(nil),                                     // 86: waverpc.LeaveVTXOsResponse
+	(*SendOnChainRequest)(nil),                                     // 87: waverpc.SendOnChainRequest
+	(*SendOnChainResponse)(nil),                                    // 88: waverpc.SendOnChainResponse
+	(*BoardRequest)(nil),                                           // 89: waverpc.BoardRequest
+	(*BoardResponse)(nil),                                          // 90: waverpc.BoardResponse
+	(*JoinNextRoundRequest)(nil),                                   // 91: waverpc.JoinNextRoundRequest
+	(*JoinNextRoundResponse)(nil),                                  // 92: waverpc.JoinNextRoundResponse
+	(*SweepBoardingUTXOsRequest)(nil),                              // 93: waverpc.SweepBoardingUTXOsRequest
+	(*BoardingSweepOutput)(nil),                                    // 94: waverpc.BoardingSweepOutput
+	(*SweepBoardingUTXOsResponse)(nil),                             // 95: waverpc.SweepBoardingUTXOsResponse
+	(*ListBoardingSweepsRequest)(nil),                              // 96: waverpc.ListBoardingSweepsRequest
+	(*BoardingSweepInput)(nil),                                     // 97: waverpc.BoardingSweepInput
+	(*BoardingSweep)(nil),                                          // 98: waverpc.BoardingSweep
+	(*ListBoardingSweepsResponse)(nil),                             // 99: waverpc.ListBoardingSweepsResponse
+	(*RoundVTXOInfo)(nil),                                          // 100: waverpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                                              // 101: waverpc.RoundInfo
+	(*ListRoundsRequest)(nil),                                      // 102: waverpc.ListRoundsRequest
+	(*GetRoundRequest)(nil),                                        // 103: waverpc.GetRoundRequest
+	(*GetRoundResponse)(nil),                                       // 104: waverpc.GetRoundResponse
+	(*ListRoundsResponse)(nil),                                     // 105: waverpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),                                     // 106: waverpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),                                    // 107: waverpc.WatchRoundsResponse
+	(*OORSessionInfo)(nil),                                         // 108: waverpc.OORSessionInfo
+	(*ListOORSessionsRequest)(nil),                                 // 109: waverpc.ListOORSessionsRequest
+	(*ListOORSessionsResponse)(nil),                                // 110: waverpc.ListOORSessionsResponse
+	(*GetOORSessionRequest)(nil),                                   // 111: waverpc.GetOORSessionRequest
+	(*GetOORSessionResponse)(nil),                                  // 112: waverpc.GetOORSessionResponse
+	(*EstimateFeeRequest)(nil),                                     // 113: waverpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),                                    // 114: waverpc.EstimateFeeResponse
+	(*GetFeeHistoryRequest)(nil),                                   // 115: waverpc.GetFeeHistoryRequest
+	(*FeeHistoryEntry)(nil),                                        // 116: waverpc.FeeHistoryEntry
+	(*GetFeeHistoryResponse)(nil),                                  // 117: waverpc.GetFeeHistoryResponse
+	(*ListTransactionsRequest)(nil),                                // 118: waverpc.ListTransactionsRequest
+	(*TransactionHistoryEntry)(nil),                                // 119: waverpc.TransactionHistoryEntry
+	(*ListTransactionsResponse)(nil),                               // 120: waverpc.ListTransactionsResponse
+	(*UnrollRequest)(nil),                                          // 121: waverpc.UnrollRequest
+	(*UnrollResponse)(nil),                                         // 122: waverpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),                                 // 123: waverpc.GetUnrollStatusRequest
+	(*UnrollProgress)(nil),                                         // 124: waverpc.UnrollProgress
+	(*UnrollCSV)(nil),                                              // 125: waverpc.UnrollCSV
+	(*UnrollFees)(nil),                                             // 126: waverpc.UnrollFees
+	(*GetUnrollStatusResponse)(nil),                                // 127: waverpc.GetUnrollStatusResponse
+	(*ArmVHTLCRecoveryRequest)(nil),                                // 128: waverpc.ArmVHTLCRecoveryRequest
+	(*ArmVHTLCRecoveryResponse)(nil),                               // 129: waverpc.ArmVHTLCRecoveryResponse
+	(*EscalateVHTLCRecoveryRequest)(nil),                           // 130: waverpc.EscalateVHTLCRecoveryRequest
+	(*EscalateVHTLCRecoveryResponse)(nil),                          // 131: waverpc.EscalateVHTLCRecoveryResponse
+	(*CancelVHTLCRecoveryRequest)(nil),                             // 132: waverpc.CancelVHTLCRecoveryRequest
+	(*CancelVHTLCRecoveryResponse)(nil),                            // 133: waverpc.CancelVHTLCRecoveryResponse
+	(*GetVHTLCRecoveryStatusRequest)(nil),                          // 134: waverpc.GetVHTLCRecoveryStatusRequest
+	(*GetVHTLCRecoveryStatusResponse)(nil),                         // 135: waverpc.GetVHTLCRecoveryStatusResponse
+	(*ListVHTLCRecoveriesRequest)(nil),                             // 136: waverpc.ListVHTLCRecoveriesRequest
+	(*ListVHTLCRecoveriesResponse)(nil),                            // 137: waverpc.ListVHTLCRecoveriesResponse
+	(*VHTLCRecoveryStatus)(nil),                                    // 138: waverpc.VHTLCRecoveryStatus
+	(*SignOutSwapHtlcAckRequest)(nil),                              // 139: waverpc.SignOutSwapHtlcAckRequest
+	(*SignOutSwapHtlcAckResponse)(nil),                             // 140: waverpc.SignOutSwapHtlcAckResponse
+	(*SignCreditAccountAuthorizationRequest)(nil),                  // 141: waverpc.SignCreditAccountAuthorizationRequest
+	(*SignCreditAccountAuthorizationResponse)(nil),                 // 142: waverpc.SignCreditAccountAuthorizationResponse
+	nil, // 143: waverpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,   // 0: waverpc.GetInfoResponse.wallet_state:type_name -> waverpc.WalletState
-	15,  // 1: waverpc.GetInfoResponse.server_info:type_name -> waverpc.ServerInfo
-	2,   // 2: waverpc.VTXOExpiryInfo.status:type_name -> waverpc.VTXOExpiryStatus
-	1,   // 3: waverpc.VTXO.status:type_name -> waverpc.VTXOStatus
-	24,  // 4: waverpc.VTXO.expiry_info:type_name -> waverpc.VTXOExpiryInfo
-	27,  // 5: waverpc.VTXO.settlement:type_name -> waverpc.VTXOSettlement
-	26,  // 6: waverpc.VTXO.taproot_asset:type_name -> waverpc.VTXOTaprootAsset
-	1,   // 7: waverpc.ListVTXOsRequest.status_filter:type_name -> waverpc.VTXOStatus
-	25,  // 8: waverpc.ListVTXOsResponse.vtxos:type_name -> waverpc.VTXO
-	1,   // 9: waverpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> waverpc.VTXOStatus
-	25,  // 10: waverpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> waverpc.VTXO
-	1,   // 11: waverpc.GetVTXOExpiryInfoRequest.status_filter:type_name -> waverpc.VTXOStatus
-	24,  // 12: waverpc.GetVTXOExpiryInfoResponse.expiry_info:type_name -> waverpc.VTXOExpiryInfo
-	25,  // 13: waverpc.GetVTXOExpiryInfoResponse.vtxo:type_name -> waverpc.VTXO
-	48,  // 14: waverpc.SendVTXORequest.recipients:type_name -> waverpc.Output
-	48,  // 15: waverpc.SendOORRequest.recipients:type_name -> waverpc.Output
-	53,  // 16: waverpc.SendOORRequest.custom_inputs:type_name -> waverpc.CustomOORInput
-	52,  // 17: waverpc.SendOORRequest.taproot_asset:type_name -> waverpc.TaprootAssetOORIntent
-	54,  // 18: waverpc.CustomOORInput.external_signatures:type_name -> waverpc.TaprootScriptSignature
-	48,  // 19: waverpc.PrepareOORRequest.recipient:type_name -> waverpc.Output
-	53,  // 20: waverpc.PrepareOORRequest.custom_inputs:type_name -> waverpc.CustomOORInput
-	57,  // 21: waverpc.PrepareOORResponse.custom_inputs:type_name -> waverpc.PreparedOORCustomInput
-	53,  // 22: waverpc.SignOORCustomInputRequest.custom_input:type_name -> waverpc.CustomOORInput
-	54,  // 23: waverpc.SignOORCustomInputResponse.signature:type_name -> waverpc.TaprootScriptSignature
-	3,   // 24: waverpc.ForfeitSigningContext.signing_route:type_name -> waverpc.ForfeitSigningRoute
-	64,  // 25: waverpc.RefreshVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
-	67,  // 26: waverpc.RefreshVTXOsResponse.fee_estimate:type_name -> waverpc.RefreshFeeEstimate
-	68,  // 27: waverpc.RefreshFeeEstimate.outpoints:type_name -> waverpc.OutpointFeeEstimate
-	63,  // 28: waverpc.CustomRefreshVTXOInput.forfeit_signing_context:type_name -> waverpc.ForfeitSigningContext
-	69,  // 29: waverpc.RefreshCustomVTXOsRequest.inputs:type_name -> waverpc.CustomRefreshVTXOInput
-	70,  // 30: waverpc.RefreshCustomVTXOsRequest.outputs:type_name -> waverpc.CustomRefreshVTXOOutput
-	3,   // 31: waverpc.PendingForfeitParticipantSignatureRequest.signing_route:type_name -> waverpc.ForfeitSigningRoute
-	73,  // 32: waverpc.ListPendingForfeitParticipantSignatureRequestsResponse.requests:type_name -> waverpc.PendingForfeitParticipantSignatureRequest
-	76,  // 33: waverpc.SubmitForfeitParticipantSignaturesRequest.signatures:type_name -> waverpc.ForfeitParticipantSignature
-	64,  // 34: waverpc.LeaveVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
-	79,  // 35: waverpc.LeaveVTXOsRequest.default_destination:type_name -> waverpc.LeaveDestination
-	138, // 36: waverpc.LeaveVTXOsRequest.destinations:type_name -> waverpc.LeaveVTXOsRequest.DestinationsEntry
-	79,  // 37: waverpc.SendOnChainRequest.destination:type_name -> waverpc.LeaveDestination
-	89,  // 38: waverpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> waverpc.BoardingSweepOutput
-	92,  // 39: waverpc.BoardingSweep.inputs:type_name -> waverpc.BoardingSweepInput
-	93,  // 40: waverpc.ListBoardingSweepsResponse.sweeps:type_name -> waverpc.BoardingSweep
-	4,   // 41: waverpc.RoundInfo.state:type_name -> waverpc.RoundState
-	95,  // 42: waverpc.RoundInfo.vtxos:type_name -> waverpc.RoundVTXOInfo
-	4,   // 43: waverpc.ListRoundsRequest.state_filter:type_name -> waverpc.RoundState
-	96,  // 44: waverpc.GetRoundResponse.round:type_name -> waverpc.RoundInfo
-	96,  // 45: waverpc.ListRoundsResponse.rounds:type_name -> waverpc.RoundInfo
-	96,  // 46: waverpc.WatchRoundsResponse.round:type_name -> waverpc.RoundInfo
-	5,   // 47: waverpc.OORSessionInfo.direction:type_name -> waverpc.OORSessionDirection
-	6,   // 48: waverpc.OORSessionInfo.status:type_name -> waverpc.OORSessionStatus
-	5,   // 49: waverpc.ListOORSessionsRequest.direction_filter:type_name -> waverpc.OORSessionDirection
-	6,   // 50: waverpc.ListOORSessionsRequest.status_filter:type_name -> waverpc.OORSessionStatus
-	103, // 51: waverpc.ListOORSessionsResponse.sessions:type_name -> waverpc.OORSessionInfo
-	103, // 52: waverpc.GetOORSessionResponse.session:type_name -> waverpc.OORSessionInfo
-	111, // 53: waverpc.GetFeeHistoryResponse.entries:type_name -> waverpc.FeeHistoryEntry
-	114, // 54: waverpc.ListTransactionsResponse.transactions:type_name -> waverpc.TransactionHistoryEntry
-	7,   // 55: waverpc.GetUnrollStatusResponse.status:type_name -> waverpc.UnrollJobStatus
-	119, // 56: waverpc.GetUnrollStatusResponse.progress:type_name -> waverpc.UnrollProgress
-	120, // 57: waverpc.GetUnrollStatusResponse.csv:type_name -> waverpc.UnrollCSV
-	121, // 58: waverpc.GetUnrollStatusResponse.fees:type_name -> waverpc.UnrollFees
-	8,   // 59: waverpc.ArmVHTLCRecoveryRequest.direction:type_name -> waverpc.VHTLCRecoveryDirection
-	9,   // 60: waverpc.ArmVHTLCRecoveryRequest.action:type_name -> waverpc.VHTLCRecoveryAction
-	133, // 61: waverpc.ArmVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
-	133, // 62: waverpc.EscalateVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
-	133, // 63: waverpc.CancelVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
-	133, // 64: waverpc.GetVHTLCRecoveryStatusResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
-	133, // 65: waverpc.ListVHTLCRecoveriesResponse.statuses:type_name -> waverpc.VHTLCRecoveryStatus
-	8,   // 66: waverpc.VHTLCRecoveryStatus.direction:type_name -> waverpc.VHTLCRecoveryDirection
-	9,   // 67: waverpc.VHTLCRecoveryStatus.action:type_name -> waverpc.VHTLCRecoveryAction
-	10,  // 68: waverpc.VHTLCRecoveryStatus.state:type_name -> waverpc.VHTLCRecoveryState
-	7,   // 69: waverpc.VHTLCRecoveryStatus.unroll_status:type_name -> waverpc.UnrollJobStatus
-	79,  // 70: waverpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> waverpc.LeaveDestination
-	13,  // 71: waverpc.DaemonService.GetInfo:input_type -> waverpc.GetInfoRequest
-	16,  // 72: waverpc.DaemonService.GenSeed:input_type -> waverpc.GenSeedRequest
-	18,  // 73: waverpc.DaemonService.InitWallet:input_type -> waverpc.InitWalletRequest
-	20,  // 74: waverpc.DaemonService.UnlockWallet:input_type -> waverpc.UnlockWalletRequest
-	22,  // 75: waverpc.DaemonService.GetBalance:input_type -> waverpc.GetBalanceRequest
-	28,  // 76: waverpc.DaemonService.ListVTXOs:input_type -> waverpc.ListVTXOsRequest
-	30,  // 77: waverpc.DaemonService.NewAddress:input_type -> waverpc.NewAddressRequest
-	32,  // 78: waverpc.DaemonService.NewReceiveScript:input_type -> waverpc.NewReceiveScriptRequest
-	34,  // 79: waverpc.DaemonService.ReceiveAuthKey:input_type -> waverpc.ReceiveAuthKeyRequest
-	36,  // 80: waverpc.DaemonService.SignReceiveAuthMessage:input_type -> waverpc.SignReceiveAuthMessageRequest
-	38,  // 81: waverpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> waverpc.SignReceiveAuthMessageCompactRequest
-	40,  // 82: waverpc.DaemonService.ReceiveAuthECDH:input_type -> waverpc.ReceiveAuthECDHRequest
-	42,  // 83: waverpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> waverpc.GetIndexedVTXOByPkScriptRequest
-	44,  // 84: waverpc.DaemonService.GetVTXOExpiryInfo:input_type -> waverpc.GetVTXOExpiryInfoRequest
-	46,  // 85: waverpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> waverpc.GetIndexedOORSessionByTxidRequest
-	49,  // 86: waverpc.DaemonService.SendVTXO:input_type -> waverpc.SendVTXORequest
-	51,  // 87: waverpc.DaemonService.SendOOR:input_type -> waverpc.SendOORRequest
-	11,  // 88: waverpc.DaemonService.OnboardTaprootAsset:input_type -> waverpc.OnboardTaprootAssetRequest
-	56,  // 89: waverpc.DaemonService.PrepareOOR:input_type -> waverpc.PrepareOORRequest
-	59,  // 90: waverpc.DaemonService.SignOORCustomInput:input_type -> waverpc.SignOORCustomInputRequest
-	61,  // 91: waverpc.DaemonService.SignVTXOForfeit:input_type -> waverpc.SignVTXOForfeitRequest
-	65,  // 92: waverpc.DaemonService.RefreshVTXOs:input_type -> waverpc.RefreshVTXOsRequest
-	71,  // 93: waverpc.DaemonService.RefreshCustomVTXOs:input_type -> waverpc.RefreshCustomVTXOsRequest
-	74,  // 94: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:input_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsRequest
-	77,  // 95: waverpc.DaemonService.SubmitForfeitParticipantSignatures:input_type -> waverpc.SubmitForfeitParticipantSignaturesRequest
-	80,  // 96: waverpc.DaemonService.LeaveVTXOs:input_type -> waverpc.LeaveVTXOsRequest
-	82,  // 97: waverpc.DaemonService.SendOnChain:input_type -> waverpc.SendOnChainRequest
-	84,  // 98: waverpc.DaemonService.Board:input_type -> waverpc.BoardRequest
-	86,  // 99: waverpc.DaemonService.JoinNextRound:input_type -> waverpc.JoinNextRoundRequest
-	88,  // 100: waverpc.DaemonService.SweepBoardingUTXOs:input_type -> waverpc.SweepBoardingUTXOsRequest
-	91,  // 101: waverpc.DaemonService.ListBoardingSweeps:input_type -> waverpc.ListBoardingSweepsRequest
-	97,  // 102: waverpc.DaemonService.ListRounds:input_type -> waverpc.ListRoundsRequest
-	98,  // 103: waverpc.DaemonService.GetRound:input_type -> waverpc.GetRoundRequest
-	101, // 104: waverpc.DaemonService.WatchRounds:input_type -> waverpc.WatchRoundsRequest
-	104, // 105: waverpc.DaemonService.ListOORSessions:input_type -> waverpc.ListOORSessionsRequest
-	106, // 106: waverpc.DaemonService.GetOORSession:input_type -> waverpc.GetOORSessionRequest
-	108, // 107: waverpc.DaemonService.EstimateFee:input_type -> waverpc.EstimateFeeRequest
-	110, // 108: waverpc.DaemonService.GetFeeHistory:input_type -> waverpc.GetFeeHistoryRequest
-	113, // 109: waverpc.DaemonService.ListTransactions:input_type -> waverpc.ListTransactionsRequest
-	116, // 110: waverpc.DaemonService.Unroll:input_type -> waverpc.UnrollRequest
-	118, // 111: waverpc.DaemonService.GetUnrollStatus:input_type -> waverpc.GetUnrollStatusRequest
-	123, // 112: waverpc.DaemonService.ArmVHTLCRecovery:input_type -> waverpc.ArmVHTLCRecoveryRequest
-	125, // 113: waverpc.DaemonService.EscalateVHTLCRecovery:input_type -> waverpc.EscalateVHTLCRecoveryRequest
-	127, // 114: waverpc.DaemonService.CancelVHTLCRecovery:input_type -> waverpc.CancelVHTLCRecoveryRequest
-	129, // 115: waverpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> waverpc.GetVHTLCRecoveryStatusRequest
-	131, // 116: waverpc.DaemonService.ListVHTLCRecoveries:input_type -> waverpc.ListVHTLCRecoveriesRequest
-	134, // 117: waverpc.DaemonService.SignOutSwapHtlcAck:input_type -> waverpc.SignOutSwapHtlcAckRequest
-	136, // 118: waverpc.DaemonService.SignCreditAccountAuthorization:input_type -> waverpc.SignCreditAccountAuthorizationRequest
-	14,  // 119: waverpc.DaemonService.GetInfo:output_type -> waverpc.GetInfoResponse
-	17,  // 120: waverpc.DaemonService.GenSeed:output_type -> waverpc.GenSeedResponse
-	19,  // 121: waverpc.DaemonService.InitWallet:output_type -> waverpc.InitWalletResponse
-	21,  // 122: waverpc.DaemonService.UnlockWallet:output_type -> waverpc.UnlockWalletResponse
-	23,  // 123: waverpc.DaemonService.GetBalance:output_type -> waverpc.GetBalanceResponse
-	29,  // 124: waverpc.DaemonService.ListVTXOs:output_type -> waverpc.ListVTXOsResponse
-	31,  // 125: waverpc.DaemonService.NewAddress:output_type -> waverpc.NewAddressResponse
-	33,  // 126: waverpc.DaemonService.NewReceiveScript:output_type -> waverpc.NewReceiveScriptResponse
-	35,  // 127: waverpc.DaemonService.ReceiveAuthKey:output_type -> waverpc.ReceiveAuthKeyResponse
-	37,  // 128: waverpc.DaemonService.SignReceiveAuthMessage:output_type -> waverpc.SignReceiveAuthMessageResponse
-	39,  // 129: waverpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> waverpc.SignReceiveAuthMessageCompactResponse
-	41,  // 130: waverpc.DaemonService.ReceiveAuthECDH:output_type -> waverpc.ReceiveAuthECDHResponse
-	43,  // 131: waverpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> waverpc.GetIndexedVTXOByPkScriptResponse
-	45,  // 132: waverpc.DaemonService.GetVTXOExpiryInfo:output_type -> waverpc.GetVTXOExpiryInfoResponse
-	47,  // 133: waverpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> waverpc.GetIndexedOORSessionByTxidResponse
-	50,  // 134: waverpc.DaemonService.SendVTXO:output_type -> waverpc.SendVTXOResponse
-	55,  // 135: waverpc.DaemonService.SendOOR:output_type -> waverpc.SendOORResponse
-	12,  // 136: waverpc.DaemonService.OnboardTaprootAsset:output_type -> waverpc.OnboardTaprootAssetResponse
-	58,  // 137: waverpc.DaemonService.PrepareOOR:output_type -> waverpc.PrepareOORResponse
-	60,  // 138: waverpc.DaemonService.SignOORCustomInput:output_type -> waverpc.SignOORCustomInputResponse
-	62,  // 139: waverpc.DaemonService.SignVTXOForfeit:output_type -> waverpc.SignVTXOForfeitResponse
-	66,  // 140: waverpc.DaemonService.RefreshVTXOs:output_type -> waverpc.RefreshVTXOsResponse
-	72,  // 141: waverpc.DaemonService.RefreshCustomVTXOs:output_type -> waverpc.RefreshCustomVTXOsResponse
-	75,  // 142: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
-	78,  // 143: waverpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> waverpc.SubmitForfeitParticipantSignaturesResponse
-	81,  // 144: waverpc.DaemonService.LeaveVTXOs:output_type -> waverpc.LeaveVTXOsResponse
-	83,  // 145: waverpc.DaemonService.SendOnChain:output_type -> waverpc.SendOnChainResponse
-	85,  // 146: waverpc.DaemonService.Board:output_type -> waverpc.BoardResponse
-	87,  // 147: waverpc.DaemonService.JoinNextRound:output_type -> waverpc.JoinNextRoundResponse
-	90,  // 148: waverpc.DaemonService.SweepBoardingUTXOs:output_type -> waverpc.SweepBoardingUTXOsResponse
-	94,  // 149: waverpc.DaemonService.ListBoardingSweeps:output_type -> waverpc.ListBoardingSweepsResponse
-	100, // 150: waverpc.DaemonService.ListRounds:output_type -> waverpc.ListRoundsResponse
-	99,  // 151: waverpc.DaemonService.GetRound:output_type -> waverpc.GetRoundResponse
-	102, // 152: waverpc.DaemonService.WatchRounds:output_type -> waverpc.WatchRoundsResponse
-	105, // 153: waverpc.DaemonService.ListOORSessions:output_type -> waverpc.ListOORSessionsResponse
-	107, // 154: waverpc.DaemonService.GetOORSession:output_type -> waverpc.GetOORSessionResponse
-	109, // 155: waverpc.DaemonService.EstimateFee:output_type -> waverpc.EstimateFeeResponse
-	112, // 156: waverpc.DaemonService.GetFeeHistory:output_type -> waverpc.GetFeeHistoryResponse
-	115, // 157: waverpc.DaemonService.ListTransactions:output_type -> waverpc.ListTransactionsResponse
-	117, // 158: waverpc.DaemonService.Unroll:output_type -> waverpc.UnrollResponse
-	122, // 159: waverpc.DaemonService.GetUnrollStatus:output_type -> waverpc.GetUnrollStatusResponse
-	124, // 160: waverpc.DaemonService.ArmVHTLCRecovery:output_type -> waverpc.ArmVHTLCRecoveryResponse
-	126, // 161: waverpc.DaemonService.EscalateVHTLCRecovery:output_type -> waverpc.EscalateVHTLCRecoveryResponse
-	128, // 162: waverpc.DaemonService.CancelVHTLCRecovery:output_type -> waverpc.CancelVHTLCRecoveryResponse
-	130, // 163: waverpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> waverpc.GetVHTLCRecoveryStatusResponse
-	132, // 164: waverpc.DaemonService.ListVHTLCRecoveries:output_type -> waverpc.ListVHTLCRecoveriesResponse
-	135, // 165: waverpc.DaemonService.SignOutSwapHtlcAck:output_type -> waverpc.SignOutSwapHtlcAckResponse
-	137, // 166: waverpc.DaemonService.SignCreditAccountAuthorization:output_type -> waverpc.SignCreditAccountAuthorizationResponse
-	119, // [119:167] is the sub-list for method output_type
-	71,  // [71:119] is the sub-list for method input_type
-	71,  // [71:71] is the sub-list for extension type_name
-	71,  // [71:71] is the sub-list for extension extendee
-	0,   // [0:71] is the sub-list for field type_name
+	19,  // 1: waverpc.GetInfoResponse.server_info:type_name -> waverpc.ServerInfo
+	28,  // 2: waverpc.GetBalanceResponse.taproot_assets:type_name -> waverpc.TaprootAssetBalance
+	2,   // 3: waverpc.VTXOExpiryInfo.status:type_name -> waverpc.VTXOExpiryStatus
+	1,   // 4: waverpc.VTXO.status:type_name -> waverpc.VTXOStatus
+	29,  // 5: waverpc.VTXO.expiry_info:type_name -> waverpc.VTXOExpiryInfo
+	32,  // 6: waverpc.VTXO.settlement:type_name -> waverpc.VTXOSettlement
+	31,  // 7: waverpc.VTXO.taproot_asset:type_name -> waverpc.VTXOTaprootAsset
+	1,   // 8: waverpc.ListVTXOsRequest.status_filter:type_name -> waverpc.VTXOStatus
+	30,  // 9: waverpc.ListVTXOsResponse.vtxos:type_name -> waverpc.VTXO
+	1,   // 10: waverpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> waverpc.VTXOStatus
+	30,  // 11: waverpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> waverpc.VTXO
+	1,   // 12: waverpc.GetVTXOExpiryInfoRequest.status_filter:type_name -> waverpc.VTXOStatus
+	29,  // 13: waverpc.GetVTXOExpiryInfoResponse.expiry_info:type_name -> waverpc.VTXOExpiryInfo
+	30,  // 14: waverpc.GetVTXOExpiryInfoResponse.vtxo:type_name -> waverpc.VTXO
+	53,  // 15: waverpc.SendVTXORequest.recipients:type_name -> waverpc.Output
+	53,  // 16: waverpc.SendOORRequest.recipients:type_name -> waverpc.Output
+	58,  // 17: waverpc.SendOORRequest.custom_inputs:type_name -> waverpc.CustomOORInput
+	57,  // 18: waverpc.SendOORRequest.taproot_asset:type_name -> waverpc.TaprootAssetOORIntent
+	59,  // 19: waverpc.CustomOORInput.external_signatures:type_name -> waverpc.TaprootScriptSignature
+	53,  // 20: waverpc.PrepareOORRequest.recipient:type_name -> waverpc.Output
+	58,  // 21: waverpc.PrepareOORRequest.custom_inputs:type_name -> waverpc.CustomOORInput
+	62,  // 22: waverpc.PrepareOORResponse.custom_inputs:type_name -> waverpc.PreparedOORCustomInput
+	58,  // 23: waverpc.SignOORCustomInputRequest.custom_input:type_name -> waverpc.CustomOORInput
+	59,  // 24: waverpc.SignOORCustomInputResponse.signature:type_name -> waverpc.TaprootScriptSignature
+	3,   // 25: waverpc.ForfeitSigningContext.signing_route:type_name -> waverpc.ForfeitSigningRoute
+	69,  // 26: waverpc.RefreshVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
+	72,  // 27: waverpc.RefreshVTXOsResponse.fee_estimate:type_name -> waverpc.RefreshFeeEstimate
+	73,  // 28: waverpc.RefreshFeeEstimate.outpoints:type_name -> waverpc.OutpointFeeEstimate
+	68,  // 29: waverpc.CustomRefreshVTXOInput.forfeit_signing_context:type_name -> waverpc.ForfeitSigningContext
+	74,  // 30: waverpc.RefreshCustomVTXOsRequest.inputs:type_name -> waverpc.CustomRefreshVTXOInput
+	75,  // 31: waverpc.RefreshCustomVTXOsRequest.outputs:type_name -> waverpc.CustomRefreshVTXOOutput
+	3,   // 32: waverpc.PendingForfeitParticipantSignatureRequest.signing_route:type_name -> waverpc.ForfeitSigningRoute
+	78,  // 33: waverpc.ListPendingForfeitParticipantSignatureRequestsResponse.requests:type_name -> waverpc.PendingForfeitParticipantSignatureRequest
+	81,  // 34: waverpc.SubmitForfeitParticipantSignaturesRequest.signatures:type_name -> waverpc.ForfeitParticipantSignature
+	69,  // 35: waverpc.LeaveVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
+	84,  // 36: waverpc.LeaveVTXOsRequest.default_destination:type_name -> waverpc.LeaveDestination
+	143, // 37: waverpc.LeaveVTXOsRequest.destinations:type_name -> waverpc.LeaveVTXOsRequest.DestinationsEntry
+	84,  // 38: waverpc.SendOnChainRequest.destination:type_name -> waverpc.LeaveDestination
+	94,  // 39: waverpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> waverpc.BoardingSweepOutput
+	97,  // 40: waverpc.BoardingSweep.inputs:type_name -> waverpc.BoardingSweepInput
+	98,  // 41: waverpc.ListBoardingSweepsResponse.sweeps:type_name -> waverpc.BoardingSweep
+	4,   // 42: waverpc.RoundInfo.state:type_name -> waverpc.RoundState
+	100, // 43: waverpc.RoundInfo.vtxos:type_name -> waverpc.RoundVTXOInfo
+	4,   // 44: waverpc.ListRoundsRequest.state_filter:type_name -> waverpc.RoundState
+	101, // 45: waverpc.GetRoundResponse.round:type_name -> waverpc.RoundInfo
+	101, // 46: waverpc.ListRoundsResponse.rounds:type_name -> waverpc.RoundInfo
+	101, // 47: waverpc.WatchRoundsResponse.round:type_name -> waverpc.RoundInfo
+	5,   // 48: waverpc.OORSessionInfo.direction:type_name -> waverpc.OORSessionDirection
+	6,   // 49: waverpc.OORSessionInfo.status:type_name -> waverpc.OORSessionStatus
+	5,   // 50: waverpc.ListOORSessionsRequest.direction_filter:type_name -> waverpc.OORSessionDirection
+	6,   // 51: waverpc.ListOORSessionsRequest.status_filter:type_name -> waverpc.OORSessionStatus
+	108, // 52: waverpc.ListOORSessionsResponse.sessions:type_name -> waverpc.OORSessionInfo
+	108, // 53: waverpc.GetOORSessionResponse.session:type_name -> waverpc.OORSessionInfo
+	116, // 54: waverpc.GetFeeHistoryResponse.entries:type_name -> waverpc.FeeHistoryEntry
+	119, // 55: waverpc.ListTransactionsResponse.transactions:type_name -> waverpc.TransactionHistoryEntry
+	7,   // 56: waverpc.GetUnrollStatusResponse.status:type_name -> waverpc.UnrollJobStatus
+	124, // 57: waverpc.GetUnrollStatusResponse.progress:type_name -> waverpc.UnrollProgress
+	125, // 58: waverpc.GetUnrollStatusResponse.csv:type_name -> waverpc.UnrollCSV
+	126, // 59: waverpc.GetUnrollStatusResponse.fees:type_name -> waverpc.UnrollFees
+	8,   // 60: waverpc.ArmVHTLCRecoveryRequest.direction:type_name -> waverpc.VHTLCRecoveryDirection
+	9,   // 61: waverpc.ArmVHTLCRecoveryRequest.action:type_name -> waverpc.VHTLCRecoveryAction
+	138, // 62: waverpc.ArmVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
+	138, // 63: waverpc.EscalateVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
+	138, // 64: waverpc.CancelVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
+	138, // 65: waverpc.GetVHTLCRecoveryStatusResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
+	138, // 66: waverpc.ListVHTLCRecoveriesResponse.statuses:type_name -> waverpc.VHTLCRecoveryStatus
+	8,   // 67: waverpc.VHTLCRecoveryStatus.direction:type_name -> waverpc.VHTLCRecoveryDirection
+	9,   // 68: waverpc.VHTLCRecoveryStatus.action:type_name -> waverpc.VHTLCRecoveryAction
+	10,  // 69: waverpc.VHTLCRecoveryStatus.state:type_name -> waverpc.VHTLCRecoveryState
+	7,   // 70: waverpc.VHTLCRecoveryStatus.unroll_status:type_name -> waverpc.UnrollJobStatus
+	84,  // 71: waverpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> waverpc.LeaveDestination
+	17,  // 72: waverpc.DaemonService.GetInfo:input_type -> waverpc.GetInfoRequest
+	20,  // 73: waverpc.DaemonService.GenSeed:input_type -> waverpc.GenSeedRequest
+	22,  // 74: waverpc.DaemonService.InitWallet:input_type -> waverpc.InitWalletRequest
+	24,  // 75: waverpc.DaemonService.UnlockWallet:input_type -> waverpc.UnlockWalletRequest
+	26,  // 76: waverpc.DaemonService.GetBalance:input_type -> waverpc.GetBalanceRequest
+	33,  // 77: waverpc.DaemonService.ListVTXOs:input_type -> waverpc.ListVTXOsRequest
+	35,  // 78: waverpc.DaemonService.NewAddress:input_type -> waverpc.NewAddressRequest
+	37,  // 79: waverpc.DaemonService.NewReceiveScript:input_type -> waverpc.NewReceiveScriptRequest
+	39,  // 80: waverpc.DaemonService.ReceiveAuthKey:input_type -> waverpc.ReceiveAuthKeyRequest
+	41,  // 81: waverpc.DaemonService.SignReceiveAuthMessage:input_type -> waverpc.SignReceiveAuthMessageRequest
+	43,  // 82: waverpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> waverpc.SignReceiveAuthMessageCompactRequest
+	45,  // 83: waverpc.DaemonService.ReceiveAuthECDH:input_type -> waverpc.ReceiveAuthECDHRequest
+	47,  // 84: waverpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> waverpc.GetIndexedVTXOByPkScriptRequest
+	49,  // 85: waverpc.DaemonService.GetVTXOExpiryInfo:input_type -> waverpc.GetVTXOExpiryInfoRequest
+	51,  // 86: waverpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> waverpc.GetIndexedOORSessionByTxidRequest
+	54,  // 87: waverpc.DaemonService.SendVTXO:input_type -> waverpc.SendVTXORequest
+	56,  // 88: waverpc.DaemonService.SendOOR:input_type -> waverpc.SendOORRequest
+	11,  // 89: waverpc.DaemonService.OnboardTaprootAsset:input_type -> waverpc.OnboardTaprootAssetRequest
+	13,  // 90: waverpc.DaemonService.BoardTaprootAsset:input_type -> waverpc.BoardTaprootAssetRequest
+	15,  // 91: waverpc.DaemonService.ClaimTaprootAssetVTXO:input_type -> waverpc.ClaimTaprootAssetVTXORequest
+	61,  // 92: waverpc.DaemonService.PrepareOOR:input_type -> waverpc.PrepareOORRequest
+	64,  // 93: waverpc.DaemonService.SignOORCustomInput:input_type -> waverpc.SignOORCustomInputRequest
+	66,  // 94: waverpc.DaemonService.SignVTXOForfeit:input_type -> waverpc.SignVTXOForfeitRequest
+	70,  // 95: waverpc.DaemonService.RefreshVTXOs:input_type -> waverpc.RefreshVTXOsRequest
+	76,  // 96: waverpc.DaemonService.RefreshCustomVTXOs:input_type -> waverpc.RefreshCustomVTXOsRequest
+	79,  // 97: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:input_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsRequest
+	82,  // 98: waverpc.DaemonService.SubmitForfeitParticipantSignatures:input_type -> waverpc.SubmitForfeitParticipantSignaturesRequest
+	85,  // 99: waverpc.DaemonService.LeaveVTXOs:input_type -> waverpc.LeaveVTXOsRequest
+	87,  // 100: waverpc.DaemonService.SendOnChain:input_type -> waverpc.SendOnChainRequest
+	89,  // 101: waverpc.DaemonService.Board:input_type -> waverpc.BoardRequest
+	91,  // 102: waverpc.DaemonService.JoinNextRound:input_type -> waverpc.JoinNextRoundRequest
+	93,  // 103: waverpc.DaemonService.SweepBoardingUTXOs:input_type -> waverpc.SweepBoardingUTXOsRequest
+	96,  // 104: waverpc.DaemonService.ListBoardingSweeps:input_type -> waverpc.ListBoardingSweepsRequest
+	102, // 105: waverpc.DaemonService.ListRounds:input_type -> waverpc.ListRoundsRequest
+	103, // 106: waverpc.DaemonService.GetRound:input_type -> waverpc.GetRoundRequest
+	106, // 107: waverpc.DaemonService.WatchRounds:input_type -> waverpc.WatchRoundsRequest
+	109, // 108: waverpc.DaemonService.ListOORSessions:input_type -> waverpc.ListOORSessionsRequest
+	111, // 109: waverpc.DaemonService.GetOORSession:input_type -> waverpc.GetOORSessionRequest
+	113, // 110: waverpc.DaemonService.EstimateFee:input_type -> waverpc.EstimateFeeRequest
+	115, // 111: waverpc.DaemonService.GetFeeHistory:input_type -> waverpc.GetFeeHistoryRequest
+	118, // 112: waverpc.DaemonService.ListTransactions:input_type -> waverpc.ListTransactionsRequest
+	121, // 113: waverpc.DaemonService.Unroll:input_type -> waverpc.UnrollRequest
+	123, // 114: waverpc.DaemonService.GetUnrollStatus:input_type -> waverpc.GetUnrollStatusRequest
+	128, // 115: waverpc.DaemonService.ArmVHTLCRecovery:input_type -> waverpc.ArmVHTLCRecoveryRequest
+	130, // 116: waverpc.DaemonService.EscalateVHTLCRecovery:input_type -> waverpc.EscalateVHTLCRecoveryRequest
+	132, // 117: waverpc.DaemonService.CancelVHTLCRecovery:input_type -> waverpc.CancelVHTLCRecoveryRequest
+	134, // 118: waverpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> waverpc.GetVHTLCRecoveryStatusRequest
+	136, // 119: waverpc.DaemonService.ListVHTLCRecoveries:input_type -> waverpc.ListVHTLCRecoveriesRequest
+	139, // 120: waverpc.DaemonService.SignOutSwapHtlcAck:input_type -> waverpc.SignOutSwapHtlcAckRequest
+	141, // 121: waverpc.DaemonService.SignCreditAccountAuthorization:input_type -> waverpc.SignCreditAccountAuthorizationRequest
+	18,  // 122: waverpc.DaemonService.GetInfo:output_type -> waverpc.GetInfoResponse
+	21,  // 123: waverpc.DaemonService.GenSeed:output_type -> waverpc.GenSeedResponse
+	23,  // 124: waverpc.DaemonService.InitWallet:output_type -> waverpc.InitWalletResponse
+	25,  // 125: waverpc.DaemonService.UnlockWallet:output_type -> waverpc.UnlockWalletResponse
+	27,  // 126: waverpc.DaemonService.GetBalance:output_type -> waverpc.GetBalanceResponse
+	34,  // 127: waverpc.DaemonService.ListVTXOs:output_type -> waverpc.ListVTXOsResponse
+	36,  // 128: waverpc.DaemonService.NewAddress:output_type -> waverpc.NewAddressResponse
+	38,  // 129: waverpc.DaemonService.NewReceiveScript:output_type -> waverpc.NewReceiveScriptResponse
+	40,  // 130: waverpc.DaemonService.ReceiveAuthKey:output_type -> waverpc.ReceiveAuthKeyResponse
+	42,  // 131: waverpc.DaemonService.SignReceiveAuthMessage:output_type -> waverpc.SignReceiveAuthMessageResponse
+	44,  // 132: waverpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> waverpc.SignReceiveAuthMessageCompactResponse
+	46,  // 133: waverpc.DaemonService.ReceiveAuthECDH:output_type -> waverpc.ReceiveAuthECDHResponse
+	48,  // 134: waverpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> waverpc.GetIndexedVTXOByPkScriptResponse
+	50,  // 135: waverpc.DaemonService.GetVTXOExpiryInfo:output_type -> waverpc.GetVTXOExpiryInfoResponse
+	52,  // 136: waverpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> waverpc.GetIndexedOORSessionByTxidResponse
+	55,  // 137: waverpc.DaemonService.SendVTXO:output_type -> waverpc.SendVTXOResponse
+	60,  // 138: waverpc.DaemonService.SendOOR:output_type -> waverpc.SendOORResponse
+	12,  // 139: waverpc.DaemonService.OnboardTaprootAsset:output_type -> waverpc.OnboardTaprootAssetResponse
+	14,  // 140: waverpc.DaemonService.BoardTaprootAsset:output_type -> waverpc.BoardTaprootAssetResponse
+	16,  // 141: waverpc.DaemonService.ClaimTaprootAssetVTXO:output_type -> waverpc.ClaimTaprootAssetVTXOResponse
+	63,  // 142: waverpc.DaemonService.PrepareOOR:output_type -> waverpc.PrepareOORResponse
+	65,  // 143: waverpc.DaemonService.SignOORCustomInput:output_type -> waverpc.SignOORCustomInputResponse
+	67,  // 144: waverpc.DaemonService.SignVTXOForfeit:output_type -> waverpc.SignVTXOForfeitResponse
+	71,  // 145: waverpc.DaemonService.RefreshVTXOs:output_type -> waverpc.RefreshVTXOsResponse
+	77,  // 146: waverpc.DaemonService.RefreshCustomVTXOs:output_type -> waverpc.RefreshCustomVTXOsResponse
+	80,  // 147: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
+	83,  // 148: waverpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> waverpc.SubmitForfeitParticipantSignaturesResponse
+	86,  // 149: waverpc.DaemonService.LeaveVTXOs:output_type -> waverpc.LeaveVTXOsResponse
+	88,  // 150: waverpc.DaemonService.SendOnChain:output_type -> waverpc.SendOnChainResponse
+	90,  // 151: waverpc.DaemonService.Board:output_type -> waverpc.BoardResponse
+	92,  // 152: waverpc.DaemonService.JoinNextRound:output_type -> waverpc.JoinNextRoundResponse
+	95,  // 153: waverpc.DaemonService.SweepBoardingUTXOs:output_type -> waverpc.SweepBoardingUTXOsResponse
+	99,  // 154: waverpc.DaemonService.ListBoardingSweeps:output_type -> waverpc.ListBoardingSweepsResponse
+	105, // 155: waverpc.DaemonService.ListRounds:output_type -> waverpc.ListRoundsResponse
+	104, // 156: waverpc.DaemonService.GetRound:output_type -> waverpc.GetRoundResponse
+	107, // 157: waverpc.DaemonService.WatchRounds:output_type -> waverpc.WatchRoundsResponse
+	110, // 158: waverpc.DaemonService.ListOORSessions:output_type -> waverpc.ListOORSessionsResponse
+	112, // 159: waverpc.DaemonService.GetOORSession:output_type -> waverpc.GetOORSessionResponse
+	114, // 160: waverpc.DaemonService.EstimateFee:output_type -> waverpc.EstimateFeeResponse
+	117, // 161: waverpc.DaemonService.GetFeeHistory:output_type -> waverpc.GetFeeHistoryResponse
+	120, // 162: waverpc.DaemonService.ListTransactions:output_type -> waverpc.ListTransactionsResponse
+	122, // 163: waverpc.DaemonService.Unroll:output_type -> waverpc.UnrollResponse
+	127, // 164: waverpc.DaemonService.GetUnrollStatus:output_type -> waverpc.GetUnrollStatusResponse
+	129, // 165: waverpc.DaemonService.ArmVHTLCRecovery:output_type -> waverpc.ArmVHTLCRecoveryResponse
+	131, // 166: waverpc.DaemonService.EscalateVHTLCRecovery:output_type -> waverpc.EscalateVHTLCRecoveryResponse
+	133, // 167: waverpc.DaemonService.CancelVHTLCRecovery:output_type -> waverpc.CancelVHTLCRecoveryResponse
+	135, // 168: waverpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> waverpc.GetVHTLCRecoveryStatusResponse
+	137, // 169: waverpc.DaemonService.ListVHTLCRecoveries:output_type -> waverpc.ListVHTLCRecoveriesResponse
+	140, // 170: waverpc.DaemonService.SignOutSwapHtlcAck:output_type -> waverpc.SignOutSwapHtlcAckResponse
+	142, // 171: waverpc.DaemonService.SignCreditAccountAuthorization:output_type -> waverpc.SignCreditAccountAuthorizationResponse
+	122, // [122:172] is the sub-list for method output_type
+	72,  // [72:122] is the sub-list for method input_type
+	72,  // [72:72] is the sub-list for extension type_name
+	72,  // [72:72] is the sub-list for extension extendee
+	0,   // [0:72] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -12076,29 +12475,29 @@ func file_daemon_proto_init() {
 	if File_daemon_proto != nil {
 		return
 	}
-	file_daemon_proto_msgTypes[33].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[38].OneofWrappers = []any{
 		(*GetVTXOExpiryInfoRequest_Outpoint)(nil),
 		(*GetVTXOExpiryInfoRequest_PkScript)(nil),
 	}
-	file_daemon_proto_msgTypes[37].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[42].OneofWrappers = []any{
 		(*Output_Address)(nil),
 		(*Output_Pubkey)(nil),
 		(*Output_PolicyTemplate)(nil),
 	}
-	file_daemon_proto_msgTypes[54].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[59].OneofWrappers = []any{
 		(*RefreshVTXOsRequest_Outpoints)(nil),
 		(*RefreshVTXOsRequest_All)(nil),
 	}
-	file_daemon_proto_msgTypes[56].OneofWrappers = []any{}
-	file_daemon_proto_msgTypes[68].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[61].OneofWrappers = []any{}
+	file_daemon_proto_msgTypes[73].OneofWrappers = []any{
 		(*LeaveDestination_Address)(nil),
 		(*LeaveDestination_PkScript)(nil),
 	}
-	file_daemon_proto_msgTypes[69].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[74].OneofWrappers = []any{
 		(*LeaveVTXOsRequest_Outpoints)(nil),
 		(*LeaveVTXOsRequest_All)(nil),
 	}
-	file_daemon_proto_msgTypes[71].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[76].OneofWrappers = []any{
 		(*SendOnChainRequest_AmountSat)(nil),
 		(*SendOnChainRequest_SweepAll)(nil),
 	}
@@ -12108,7 +12507,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   128,
+			NumMessages:   133,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -4223,10 +4223,11 @@ type SendOORRequest struct {
 	ExistingOnly bool `protobuf:"varint,6,opt,name=existing_only,json=existingOnly,proto3" json:"existing_only,omitempty"`
 	// taproot_asset requests the experimental proof-selected Taproot Asset
 	// extension. It requires exactly one managed asset input, one recipient,
-	// and a non-empty idempotency_key. The wallet may add ordinary Bitcoin
-	// VTXOs to cover a carrier shortfall and returns any selected value
-	// beyond the asset-bearing carriers to the sender as a plain Bitcoin
-	// change VTXO. Asset transfers identify the managed asset input through
+	// and a non-empty idempotency_key. The spent leaf's Bitcoin carrier
+	// follows its origin: a round-created leaf's carrier returns to the
+	// sender as a plain Bitcoin change VTXO, while an OOR-created leaf's
+	// operator-funded carrier is reclaimed into the operator's change.
+	// Asset transfers identify the managed asset input through
 	// taproot_asset.input_vtxo_outpoint and must not use custom_inputs.
 	// Bitcoin-only sends leave this field unset.
 	TaprootAsset  *TaprootAssetOORIntent `protobuf:"bytes,7,opt,name=taproot_asset,json=taprootAsset,proto3" json:"taproot_asset,omitempty"`
@@ -4351,9 +4352,9 @@ type TaprootAssetOORIntent struct {
 	// asset_change_carrier_value_sat is deprecated and must be zero. New
 	// asset-leaf carriers (the recipient leaf, and the asset-change leaf of
 	// a partial send) are funded by the operator's carrier float at the
-	// operator's minimum VTXO amount; the sender's asset input carrier
-	// returns whole as an ordinary Bitcoin change VTXO. A nonzero value is
-	// rejected.
+	// operator's minimum VTXO amount; the spent leaf's carrier returns to
+	// the sender only when the leaf was round-created and is otherwise
+	// reclaimed by the operator. A nonzero value is rejected.
 	AssetChangeCarrierValueSat uint64 `protobuf:"varint,10,opt,name=asset_change_carrier_value_sat,json=assetChangeCarrierValueSat,proto3" json:"asset_change_carrier_value_sat,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -4222,14 +4222,16 @@ type SendOORRequest struct {
 	// idempotency_key.
 	ExistingOnly bool `protobuf:"varint,6,opt,name=existing_only,json=existingOnly,proto3" json:"existing_only,omitempty"`
 	// taproot_asset requests the experimental proof-selected Taproot Asset
-	// extension. It requires exactly one managed asset input, one recipient,
-	// and a non-empty idempotency_key. The spent leaf's Bitcoin carrier
-	// follows its origin: a round-created leaf's carrier returns to the
-	// sender as a plain Bitcoin change VTXO, while an OOR-created leaf's
+	// extension. It requires one recipient and a non-empty idempotency_key,
+	// and spends up to eight managed asset inputs in one atomic transfer
+	// (never split into several transfers). Each spent leaf's Bitcoin
+	// carrier follows its origin: a round-created leaf's carrier returns to
+	// the sender as a plain Bitcoin change VTXO, while an OOR-created leaf's
 	// operator-funded carrier is reclaimed into the operator's change.
-	// Asset transfers identify the managed asset input through
-	// taproot_asset.input_vtxo_outpoint and must not use custom_inputs.
-	// Bitcoin-only sends leave this field unset.
+	// Asset transfers either pin one managed asset input through
+	// taproot_asset.input_vtxo_outpoint or leave it empty for daemon-side
+	// selection, and must not use custom_inputs. Bitcoin-only sends leave
+	// this field unset.
 	TaprootAsset  *TaprootAssetOORIntent `protobuf:"bytes,7,opt,name=taproot_asset,json=taprootAsset,proto3" json:"taproot_asset,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4322,8 +4324,10 @@ type TaprootAssetOORIntent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// asset_ref is the opaque tap-sdk asset or group identifier.
 	AssetRef string `protobuf:"bytes,1,opt,name=asset_ref,json=assetRef,proto3" json:"asset_ref,omitempty"`
-	// asset_amount is the exact number of asset units carried by the selected
-	// input VTXO.
+	// asset_amount depends on the selection mode. With input_vtxo_outpoint
+	// set it is the exact number of asset units carried by that input VTXO.
+	// With input_vtxo_outpoint empty it is the total number of units to
+	// send: the daemon selects live asset VTXOs covering it.
 	AssetAmount uint64 `protobuf:"varint,2,opt,name=asset_amount,json=assetAmount,proto3" json:"asset_amount,omitempty"`
 	// input_proof_file is the complete confirmed proof for an initially
 	// onboarded asset. It can be omitted for a chained Wavelength transfer
@@ -4341,13 +4345,20 @@ type TaprootAssetOORIntent struct {
 	// persists compact unconfirmed proof paths but cannot yet publish and log
 	// them through tapd's chain porter.
 	AcknowledgeUnconfirmed bool `protobuf:"varint,7,opt,name=acknowledge_unconfirmed,json=acknowledgeUnconfirmed,proto3" json:"acknowledge_unconfirmed,omitempty"`
-	// input_vtxo_outpoint identifies the wallet-managed asset-bearing VTXO in
-	// "txid:vout" form. The wallet reserves this required input through the
-	// normal VTXO manager path before any Taproot Asset commit occurs.
+	// input_vtxo_outpoint optionally pins the wallet-managed asset-bearing
+	// VTXO to spend, in "txid:vout" form. Empty delegates selection to the
+	// daemon: a single sufficient VTXO is preferred (smallest first),
+	// otherwise the largest VTXOs accumulate until asset_amount is covered,
+	// up to eight inputs spent in one atomic transfer. A send needing more
+	// than eight inputs fails; consolidate first. The wallet reserves every
+	// selected input through the normal VTXO manager path before any
+	// Taproot Asset commit occurs.
 	InputVtxoOutpoint string `protobuf:"bytes,8,opt,name=input_vtxo_outpoint,json=inputVtxoOutpoint,proto3" json:"input_vtxo_outpoint,omitempty"`
 	// recipient_asset_amount is the number of asset units assigned to the
-	// caller's recipient. Zero retains the legacy full-send behavior and
-	// assigns all asset_amount units to the recipient.
+	// caller's recipient when input_vtxo_outpoint pins the input. Zero
+	// retains the legacy full-send behavior and assigns all asset_amount
+	// units to the recipient. It must be zero with daemon-side selection,
+	// where asset_amount already names the units to send.
 	RecipientAssetAmount uint64 `protobuf:"varint,9,opt,name=recipient_asset_amount,json=recipientAssetAmount,proto3" json:"recipient_asset_amount,omitempty"`
 	// asset_change_carrier_value_sat is deprecated and must be zero. New
 	// asset-leaf carriers (the recipient leaf, and the asset-change leaf of

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -1102,8 +1102,16 @@ type BoardTaprootAssetResponse struct {
 	// already_boarded reports an idempotent replay: the boarding intent
 	// already existed and no new round registration was sent.
 	AlreadyBoarded bool `protobuf:"varint,5,opt,name=already_boarded,json=alreadyBoarded,proto3" json:"already_boarded,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// fee_funding_outpoint names the Bitcoin VTXO this boarding pulled
+	// into the round to pay its fee. The round returns the value it did
+	// not spend as a fresh change VTXO. Empty when the round already
+	// carried a fee-bearing output of the client's own.
+	FeeFundingOutpoint string `protobuf:"bytes,6,opt,name=fee_funding_outpoint,json=feeFundingOutpoint,proto3" json:"fee_funding_outpoint,omitempty"`
+	// fee_funding_value_sat is that VTXO's value. The change comes back
+	// as this amount minus the fee the operator charges at seal time.
+	FeeFundingValueSat int64 `protobuf:"varint,7,opt,name=fee_funding_value_sat,json=feeFundingValueSat,proto3" json:"fee_funding_value_sat,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *BoardTaprootAssetResponse) Reset() {
@@ -1169,6 +1177,20 @@ func (x *BoardTaprootAssetResponse) GetAlreadyBoarded() bool {
 		return x.AlreadyBoarded
 	}
 	return false
+}
+
+func (x *BoardTaprootAssetResponse) GetFeeFundingOutpoint() string {
+	if x != nil {
+		return x.FeeFundingOutpoint
+	}
+	return ""
+}
+
+func (x *BoardTaprootAssetResponse) GetFeeFundingValueSat() int64 {
+	if x != nil {
+		return x.FeeFundingValueSat
+	}
+	return 0
 }
 
 type ClaimTaprootAssetVTXORequest struct {
@@ -11238,13 +11260,15 @@ const file_daemon_proto_rawDesc = "" +
 	"\x12taproot_asset_root\x18\x05 \x01(\fR\x10taprootAssetRoot\x12$\n" +
 	"\x0eactual_fee_sat\x18\a \x01(\x04R\factualFeeSat\"C\n" +
 	"\x18BoardTaprootAssetRequest\x12'\n" +
-	"\x0fidempotency_key\x18\x01 \x01(\tR\x0eidempotencyKey\"\xbd\x01\n" +
+	"\x0fidempotency_key\x18\x01 \x01(\tR\x0eidempotencyKey\"\xa2\x02\n" +
 	"\x19BoardTaprootAssetResponse\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1b\n" +
 	"\tvalue_sat\x18\x02 \x01(\x03R\bvalueSat\x12\x1b\n" +
 	"\tasset_ref\x18\x03 \x01(\tR\bassetRef\x12!\n" +
 	"\fasset_amount\x18\x04 \x01(\x04R\vassetAmount\x12'\n" +
-	"\x0falready_boarded\x18\x05 \x01(\bR\x0ealreadyBoarded\"S\n" +
+	"\x0falready_boarded\x18\x05 \x01(\bR\x0ealreadyBoarded\x120\n" +
+	"\x14fee_funding_outpoint\x18\x06 \x01(\tR\x12feeFundingOutpoint\x121\n" +
+	"\x15fee_funding_value_sat\x18\a \x01(\x03R\x12feeFundingValueSat\"S\n" +
 	"\x1cClaimTaprootAssetVTXORequest\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x17\n" +
 	"\afee_sat\x18\x02 \x01(\x03R\x06feeSat\"\x9f\x01\n" +

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -853,6 +853,8 @@ type OnboardTaprootAssetRequest struct {
 	// in the first PoC.
 	AssetAmount uint64 `protobuf:"varint,3,opt,name=asset_amount,json=assetAmount,proto3" json:"asset_amount,omitempty"`
 	// input_proof_file is the complete confirmed Taproot Asset proof file.
+	// Optional; empty lets the daemon export the proof of its own matching
+	// UTXO from tapd.
 	InputProofFile []byte `protobuf:"bytes,4,opt,name=input_proof_file,json=inputProofFile,proto3" json:"input_proof_file,omitempty"`
 	// max_fee_sat is the hard upper bound for the on-chain miner fee. It is
 	// independent of the fee-rate or confirmation-target estimator.

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -840,21 +840,22 @@ func (VHTLCRecoveryState) EnumDescriptor() ([]byte, []int) {
 	return file_daemon_proto_rawDescGZIP(), []int{10}
 }
 
-// OnboardTaprootAssetRequest selects the complete confirmed asset proof, the
-// visible Bitcoin value carried by its Wavelength VTXO, and a bounded fee
-// policy for wallet funding.
+// OnboardTaprootAssetRequest selects the asset amount to board, the visible
+// Bitcoin value carried by its Wavelength VTXO, and a bounded fee policy for
+// wallet funding.
 type OnboardTaprootAssetRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// idempotency_key is a stable caller-generated retry key.
 	IdempotencyKey string `protobuf:"bytes,1,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
 	// asset_ref is the tap-sdk asset or group reference.
 	AssetRef string `protobuf:"bytes,2,opt,name=asset_ref,json=assetRef,proto3" json:"asset_ref,omitempty"`
-	// asset_amount must equal the complete amount selected by input_proof_file
-	// in the first PoC.
+	// asset_amount is the amount to board. The funding UTXOs must cover it;
+	// any surplus returns to the daemon's own tapd wallet as asset change.
 	AssetAmount uint64 `protobuf:"varint,3,opt,name=asset_amount,json=assetAmount,proto3" json:"asset_amount,omitempty"`
-	// input_proof_file is the complete confirmed Taproot Asset proof file.
-	// Optional; empty lets the daemon export the proof of its own matching
-	// UTXO from tapd.
+	// input_proof_file is the complete confirmed Taproot Asset proof file of
+	// one funding UTXO. Optional; empty lets the daemon select its own
+	// unleased confirmed UTXOs until they cover asset_amount and export
+	// their proofs from tapd.
 	InputProofFile []byte `protobuf:"bytes,4,opt,name=input_proof_file,json=inputProofFile,proto3" json:"input_proof_file,omitempty"`
 	// max_fee_sat is the hard upper bound for the on-chain miner fee. It is
 	// independent of the fee-rate or confirmation-target estimator.

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -4200,11 +4200,12 @@ type SendOORRequest struct {
 	ExistingOnly bool `protobuf:"varint,6,opt,name=existing_only,json=existingOnly,proto3" json:"existing_only,omitempty"`
 	// taproot_asset requests the experimental proof-selected Taproot Asset
 	// extension. It requires exactly one managed asset input, one recipient,
-	// explicit Bitcoin carriers for every asset-bearing output, and a
-	// non-empty idempotency_key. The wallet may add ordinary Bitcoin VTXOs to
-	// cover a carrier shortfall. Asset transfers identify the managed asset
-	// input through taproot_asset.input_vtxo_outpoint and must not use
-	// custom_inputs. Bitcoin-only sends leave this field unset.
+	// and a non-empty idempotency_key. The wallet may add ordinary Bitcoin
+	// VTXOs to cover a carrier shortfall and returns any selected value
+	// beyond the asset-bearing carriers to the sender as a plain Bitcoin
+	// change VTXO. Asset transfers identify the managed asset input through
+	// taproot_asset.input_vtxo_outpoint and must not use custom_inputs.
+	// Bitcoin-only sends leave this field unset.
 	TaprootAsset  *TaprootAssetOORIntent `protobuf:"bytes,7,opt,name=taproot_asset,json=taprootAsset,proto3" json:"taproot_asset,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4324,10 +4325,12 @@ type TaprootAssetOORIntent struct {
 	// caller's recipient. Zero retains the legacy full-send behavior and
 	// assigns all asset_amount units to the recipient.
 	RecipientAssetAmount uint64 `protobuf:"varint,9,opt,name=recipient_asset_amount,json=recipientAssetAmount,proto3" json:"recipient_asset_amount,omitempty"`
-	// asset_change_carrier_value_sat is the explicit Bitcoin value assigned
-	// to asset change. It is required for a partial asset send and must be
-	// zero for a full asset send. Asset units are never converted into these
-	// carrier satoshis.
+	// asset_change_carrier_value_sat is the Bitcoin value carried by the
+	// asset change output of a partial asset send. Zero uses the operator's
+	// minimum VTXO amount. It must be zero for a full asset send. Selected
+	// input value beyond the recipient and asset-change carriers returns to
+	// the sender as an ordinary Bitcoin change VTXO. Asset units are never
+	// converted into these carrier satoshis.
 	AssetChangeCarrierValueSat uint64 `protobuf:"varint,10,opt,name=asset_change_carrier_value_sat,json=assetChangeCarrierValueSat,proto3" json:"asset_change_carrier_value_sat,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -4348,12 +4348,12 @@ type TaprootAssetOORIntent struct {
 	// caller's recipient. Zero retains the legacy full-send behavior and
 	// assigns all asset_amount units to the recipient.
 	RecipientAssetAmount uint64 `protobuf:"varint,9,opt,name=recipient_asset_amount,json=recipientAssetAmount,proto3" json:"recipient_asset_amount,omitempty"`
-	// asset_change_carrier_value_sat is the Bitcoin value carried by the
-	// asset change output of a partial asset send. Zero uses the operator's
-	// minimum VTXO amount. It must be zero for a full asset send. Selected
-	// input value beyond the recipient and asset-change carriers returns to
-	// the sender as an ordinary Bitcoin change VTXO. Asset units are never
-	// converted into these carrier satoshis.
+	// asset_change_carrier_value_sat is deprecated and must be zero. New
+	// asset-leaf carriers (the recipient leaf, and the asset-change leaf of
+	// a partial send) are funded by the operator's carrier float at the
+	// operator's minimum VTXO amount; the sender's asset input carrier
+	// returns whole as an ordinary Bitcoin change VTXO. A nonzero value is
+	// rejected.
 	AssetChangeCarrierValueSat uint64 `protobuf:"varint,10,opt,name=asset_change_carrier_value_sat,json=assetChangeCarrierValueSat,proto3" json:"asset_change_carrier_value_sat,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache

--- a/waverpc/daemon.pb.gw.go
+++ b/waverpc/daemon.pb.gw.go
@@ -521,6 +521,60 @@ func local_request_DaemonService_OnboardTaprootAsset_0(ctx context.Context, mars
 	return msg, metadata, err
 }
 
+func request_DaemonService_BoardTaprootAsset_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq BoardTaprootAssetRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.BoardTaprootAsset(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_DaemonService_BoardTaprootAsset_0(ctx context.Context, marshaler runtime.Marshaler, server DaemonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq BoardTaprootAssetRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.BoardTaprootAsset(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_DaemonService_ClaimTaprootAssetVTXO_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ClaimTaprootAssetVTXORequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ClaimTaprootAssetVTXO(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_DaemonService_ClaimTaprootAssetVTXO_0(ctx context.Context, marshaler runtime.Marshaler, server DaemonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ClaimTaprootAssetVTXORequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ClaimTaprootAssetVTXO(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_DaemonService_PrepareOOR_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq PrepareOORRequest
@@ -1693,6 +1747,46 @@ func RegisterDaemonServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_OnboardTaprootAsset_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_BoardTaprootAsset_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/waverpc.DaemonService/BoardTaprootAsset", runtime.WithHTTPPathPattern("/v1/daemon/board-taproot-asset"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_DaemonService_BoardTaprootAsset_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_BoardTaprootAsset_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_ClaimTaprootAssetVTXO_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/waverpc.DaemonService/ClaimTaprootAssetVTXO", runtime.WithHTTPPathPattern("/v1/daemon/claim-taproot-asset-vtxo"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_DaemonService_ClaimTaprootAssetVTXO_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_ClaimTaprootAssetVTXO_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_DaemonService_PrepareOOR_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2626,6 +2720,40 @@ func RegisterDaemonServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_OnboardTaprootAsset_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_BoardTaprootAsset_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/waverpc.DaemonService/BoardTaprootAsset", runtime.WithHTTPPathPattern("/v1/daemon/board-taproot-asset"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_DaemonService_BoardTaprootAsset_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_BoardTaprootAsset_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_ClaimTaprootAssetVTXO_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/waverpc.DaemonService/ClaimTaprootAssetVTXO", runtime.WithHTTPPathPattern("/v1/daemon/claim-taproot-asset-vtxo"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_DaemonService_ClaimTaprootAssetVTXO_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_ClaimTaprootAssetVTXO_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_DaemonService_PrepareOOR_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3158,6 +3286,8 @@ var (
 	pattern_DaemonService_SendVTXO_0                                       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "send-vtxo"}, ""))
 	pattern_DaemonService_SendOOR_0                                        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "send-oor"}, ""))
 	pattern_DaemonService_OnboardTaprootAsset_0                            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "onboard-taproot-asset"}, ""))
+	pattern_DaemonService_BoardTaprootAsset_0                              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "board-taproot-asset"}, ""))
+	pattern_DaemonService_ClaimTaprootAssetVTXO_0                          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "claim-taproot-asset-vtxo"}, ""))
 	pattern_DaemonService_PrepareOOR_0                                     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "prepare-oor"}, ""))
 	pattern_DaemonService_SignOORCustomInput_0                             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-oor-custom-input"}, ""))
 	pattern_DaemonService_SignVTXOForfeit_0                                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-vtxo-forfeit"}, ""))
@@ -3209,6 +3339,8 @@ var (
 	forward_DaemonService_SendVTXO_0                                       = runtime.ForwardResponseMessage
 	forward_DaemonService_SendOOR_0                                        = runtime.ForwardResponseMessage
 	forward_DaemonService_OnboardTaprootAsset_0                            = runtime.ForwardResponseMessage
+	forward_DaemonService_BoardTaprootAsset_0                              = runtime.ForwardResponseMessage
+	forward_DaemonService_ClaimTaprootAssetVTXO_0                          = runtime.ForwardResponseMessage
 	forward_DaemonService_PrepareOOR_0                                     = runtime.ForwardResponseMessage
 	forward_DaemonService_SignOORCustomInput_0                             = runtime.ForwardResponseMessage
 	forward_DaemonService_SignVTXOForfeit_0                                = runtime.ForwardResponseMessage

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -1211,10 +1211,11 @@ message SendOORRequest {
 
     // taproot_asset requests the experimental proof-selected Taproot Asset
     // extension. It requires exactly one managed asset input, one recipient,
-    // and a non-empty idempotency_key. The wallet may add ordinary Bitcoin
-    // VTXOs to cover a carrier shortfall and returns any selected value
-    // beyond the asset-bearing carriers to the sender as a plain Bitcoin
-    // change VTXO. Asset transfers identify the managed asset input through
+    // and a non-empty idempotency_key. The spent leaf's Bitcoin carrier
+    // follows its origin: a round-created leaf's carrier returns to the
+    // sender as a plain Bitcoin change VTXO, while an OOR-created leaf's
+    // operator-funded carrier is reclaimed into the operator's change.
+    // Asset transfers identify the managed asset input through
     // taproot_asset.input_vtxo_outpoint and must not use custom_inputs.
     // Bitcoin-only sends leave this field unset.
     TaprootAssetOORIntent taproot_asset = 7;
@@ -1266,9 +1267,9 @@ message TaprootAssetOORIntent {
     // asset_change_carrier_value_sat is deprecated and must be zero. New
     // asset-leaf carriers (the recipient leaf, and the asset-change leaf of
     // a partial send) are funded by the operator's carrier float at the
-    // operator's minimum VTXO amount; the sender's asset input carrier
-    // returns whole as an ordinary Bitcoin change VTXO. A nonzero value is
-    // rejected.
+    // operator's minimum VTXO amount; the spent leaf's carrier returns to
+    // the sender only when the leaf was round-created and is otherwise
+    // reclaimed by the operator. A nonzero value is rejected.
     uint64 asset_change_carrier_value_sat = 10;
 }
 

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -294,9 +294,9 @@ service DaemonService {
         returns (SignCreditAccountAuthorizationResponse);
 }
 
-// OnboardTaprootAssetRequest selects the complete confirmed asset proof, the
-// visible Bitcoin value carried by its Wavelength VTXO, and a bounded fee
-// policy for wallet funding.
+// OnboardTaprootAssetRequest selects the asset amount to board, the visible
+// Bitcoin value carried by its Wavelength VTXO, and a bounded fee policy for
+// wallet funding.
 message OnboardTaprootAssetRequest {
     // idempotency_key is a stable caller-generated retry key.
     string idempotency_key = 1;
@@ -304,13 +304,14 @@ message OnboardTaprootAssetRequest {
     // asset_ref is the tap-sdk asset or group reference.
     string asset_ref = 2;
 
-    // asset_amount must equal the complete amount selected by input_proof_file
-    // in the first PoC.
+    // asset_amount is the amount to board. The funding UTXOs must cover it;
+    // any surplus returns to the daemon's own tapd wallet as asset change.
     uint64 asset_amount = 3;
 
-    // input_proof_file is the complete confirmed Taproot Asset proof file.
-    // Optional; empty lets the daemon export the proof of its own matching
-    // UTXO from tapd.
+    // input_proof_file is the complete confirmed Taproot Asset proof file of
+    // one funding UTXO. Optional; empty lets the daemon select its own
+    // unleased confirmed UTXOs until they cover asset_amount and export
+    // their proofs from tapd.
     bytes input_proof_file = 4;
 
     // max_fee_sat is the hard upper bound for the on-chain miner fee. It is

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -1263,12 +1263,12 @@ message TaprootAssetOORIntent {
     // assigns all asset_amount units to the recipient.
     uint64 recipient_asset_amount = 9;
 
-    // asset_change_carrier_value_sat is the Bitcoin value carried by the
-    // asset change output of a partial asset send. Zero uses the operator's
-    // minimum VTXO amount. It must be zero for a full asset send. Selected
-    // input value beyond the recipient and asset-change carriers returns to
-    // the sender as an ordinary Bitcoin change VTXO. Asset units are never
-    // converted into these carrier satoshis.
+    // asset_change_carrier_value_sat is deprecated and must be zero. New
+    // asset-leaf carriers (the recipient leaf, and the asset-change leaf of
+    // a partial send) are funded by the operator's carrier float at the
+    // operator's minimum VTXO amount; the sender's asset input carrier
+    // returns whole as an ordinary Bitcoin change VTXO. A nonzero value is
+    // rejected.
     uint64 asset_change_carrier_value_sat = 10;
 }
 

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -96,6 +96,20 @@ service DaemonService {
     rpc OnboardTaprootAsset (OnboardTaprootAssetRequest)
         returns (OnboardTaprootAssetResponse);
 
+    // BoardTaprootAsset boards a confirmed onboarded output into the next
+    // asset round. The daemon rebuilds the boarding disclosure from the
+    // onboarding named by the idempotency key, gathers the confirmation
+    // and the boarded asset proof itself, and registers the boarding
+    // together with a matching asset VTXO request. Safe to retry.
+    rpc BoardTaprootAsset (BoardTaprootAssetRequest)
+        returns (BoardTaprootAssetResponse);
+
+    // ClaimTaprootAssetVTXO claims an exited asset VTXO into the daemon's
+    // tapd wallet once its unrolled anchor has matured past the exit
+    // delay. The daemon gathers the lineage confirmations itself.
+    rpc ClaimTaprootAssetVTXO (ClaimTaprootAssetVTXORequest)
+        returns (ClaimTaprootAssetVTXOResponse);
+
     // PrepareOOR builds the deterministic OOR package without submitting it.
     // This lets callers collect signatures from external custom-input
     // participants before calling SendOOR with the same parameters.
@@ -331,6 +345,53 @@ message OnboardTaprootAssetResponse {
     // actual_fee_sat is the exact on-chain miner fee recorded in the sealed
     // tap-sdk package. It remains stable across retries and restarts.
     uint64 actual_fee_sat = 7;
+}
+
+message BoardTaprootAssetRequest {
+    // idempotency_key names the completed onboarding to board. It is the
+    // same key the caller passed to OnboardTaprootAsset.
+    string idempotency_key = 1;
+}
+
+message BoardTaprootAssetResponse {
+    // outpoint is the boarded composed output.
+    string outpoint = 1;
+
+    // value_sat is the output's carrier Bitcoin value.
+    int64 value_sat = 2;
+
+    // asset_ref and asset_amount identify the boarded units.
+    string asset_ref = 3;
+    uint64 asset_amount = 4;
+
+    // already_boarded reports an idempotent replay: the boarding intent
+    // already existed and no new round registration was sent.
+    bool already_boarded = 5;
+}
+
+message ClaimTaprootAssetVTXORequest {
+    // outpoint identifies the exited asset VTXO in "txid:vout" format.
+    string outpoint = 1;
+
+    // fee_sat is the on-chain miner fee, paid out of the VTXO's carrier
+    // value. Zero lets the daemon estimate one from the wallet's fee
+    // estimator.
+    int64 fee_sat = 2;
+}
+
+message ClaimTaprootAssetVTXOResponse {
+    // txid is the published claim transaction.
+    string txid = 1;
+
+    // anchor_outpoint is the new tapd-owned anchor holding the claimed
+    // units.
+    string anchor_outpoint = 2;
+
+    // output_value_sat is the new anchor's Bitcoin value.
+    int64 output_value_sat = 3;
+
+    // fee_sat is the miner fee the claim actually paid.
+    int64 fee_sat = 4;
 }
 
 // WalletState mirrors the daemon's in-process wallet lifecycle enum:
@@ -626,6 +687,32 @@ message GetBalanceResponse {
     // total_confirmed_sat; reappears under onchain_wallet_confirmed_sat
     // once the sweep confirms.
     int64 vtxo_unilateral_exit_sat = 10;
+
+    // taproot_assets breaks down asset-bearing VTXO holdings by asset
+    // reference. The carrier satoshis of these VTXOs stay counted in the
+    // Bitcoin fields above.
+    repeated TaprootAssetBalance taproot_assets = 11;
+}
+
+// TaprootAssetBalance is one asset reference's VTXO holdings, in asset
+// units.
+message TaprootAssetBalance {
+    // asset_ref is the tap-sdk asset or group reference.
+    string asset_ref = 1;
+
+    // live_amount is the total held in live (spendable) VTXOs.
+    uint64 live_amount = 2;
+
+    // pending_amount is the total held in VTXOs that are not yet live or
+    // are mid-spend.
+    uint64 pending_amount = 3;
+
+    // exiting_amount is the total held in VTXOs mid unilateral exit,
+    // claimable once the exit matures.
+    uint64 exiting_amount = 4;
+
+    // live_vtxo_count is the number of live VTXOs carrying this asset.
+    uint32 live_vtxo_count = 5;
 }
 
 // VTXOStatus represents the lifecycle state of a virtual transaction
@@ -844,6 +931,10 @@ message ListVTXOsRequest {
     // consumers (balance views, coin selection) that never inspect the
     // PSBTs. The default keeps the full response for compatibility.
     bool exclude_checkpoint_psbts = 3;
+
+    // asset_ref restricts the response to VTXOs carrying this Taproot
+    // Asset reference. Empty applies no asset filter.
+    string asset_ref = 4;
 }
 
 message ListVTXOsResponse {

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -309,6 +309,8 @@ message OnboardTaprootAssetRequest {
     uint64 asset_amount = 3;
 
     // input_proof_file is the complete confirmed Taproot Asset proof file.
+    // Optional; empty lets the daemon export the proof of its own matching
+    // UTXO from tapd.
     bytes input_proof_file = 4;
 
     // max_fee_sat is the hard upper bound for the on-chain miner fee. It is

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -1200,11 +1200,12 @@ message SendOORRequest {
 
     // taproot_asset requests the experimental proof-selected Taproot Asset
     // extension. It requires exactly one managed asset input, one recipient,
-    // explicit Bitcoin carriers for every asset-bearing output, and a
-    // non-empty idempotency_key. The wallet may add ordinary Bitcoin VTXOs to
-    // cover a carrier shortfall. Asset transfers identify the managed asset
-    // input through taproot_asset.input_vtxo_outpoint and must not use
-    // custom_inputs. Bitcoin-only sends leave this field unset.
+    // and a non-empty idempotency_key. The wallet may add ordinary Bitcoin
+    // VTXOs to cover a carrier shortfall and returns any selected value
+    // beyond the asset-bearing carriers to the sender as a plain Bitcoin
+    // change VTXO. Asset transfers identify the managed asset input through
+    // taproot_asset.input_vtxo_outpoint and must not use custom_inputs.
+    // Bitcoin-only sends leave this field unset.
     TaprootAssetOORIntent taproot_asset = 7;
 }
 
@@ -1251,10 +1252,12 @@ message TaprootAssetOORIntent {
     // assigns all asset_amount units to the recipient.
     uint64 recipient_asset_amount = 9;
 
-    // asset_change_carrier_value_sat is the explicit Bitcoin value assigned
-    // to asset change. It is required for a partial asset send and must be
-    // zero for a full asset send. Asset units are never converted into these
-    // carrier satoshis.
+    // asset_change_carrier_value_sat is the Bitcoin value carried by the
+    // asset change output of a partial asset send. Zero uses the operator's
+    // minimum VTXO amount. It must be zero for a full asset send. Selected
+    // input value beyond the recipient and asset-change carriers returns to
+    // the sender as an ordinary Bitcoin change VTXO. Asset units are never
+    // converted into these carrier satoshis.
     uint64 asset_change_carrier_value_sat = 10;
 }
 

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -1210,14 +1210,16 @@ message SendOORRequest {
     bool existing_only = 6;
 
     // taproot_asset requests the experimental proof-selected Taproot Asset
-    // extension. It requires exactly one managed asset input, one recipient,
-    // and a non-empty idempotency_key. The spent leaf's Bitcoin carrier
-    // follows its origin: a round-created leaf's carrier returns to the
-    // sender as a plain Bitcoin change VTXO, while an OOR-created leaf's
+    // extension. It requires one recipient and a non-empty idempotency_key,
+    // and spends up to eight managed asset inputs in one atomic transfer
+    // (never split into several transfers). Each spent leaf's Bitcoin
+    // carrier follows its origin: a round-created leaf's carrier returns to
+    // the sender as a plain Bitcoin change VTXO, while an OOR-created leaf's
     // operator-funded carrier is reclaimed into the operator's change.
-    // Asset transfers identify the managed asset input through
-    // taproot_asset.input_vtxo_outpoint and must not use custom_inputs.
-    // Bitcoin-only sends leave this field unset.
+    // Asset transfers either pin one managed asset input through
+    // taproot_asset.input_vtxo_outpoint or leave it empty for daemon-side
+    // selection, and must not use custom_inputs. Bitcoin-only sends leave
+    // this field unset.
     TaprootAssetOORIntent taproot_asset = 7;
 }
 
@@ -1229,8 +1231,10 @@ message TaprootAssetOORIntent {
     // asset_ref is the opaque tap-sdk asset or group identifier.
     string asset_ref = 1;
 
-    // asset_amount is the exact number of asset units carried by the selected
-    // input VTXO.
+    // asset_amount depends on the selection mode. With input_vtxo_outpoint
+    // set it is the exact number of asset units carried by that input VTXO.
+    // With input_vtxo_outpoint empty it is the total number of units to
+    // send: the daemon selects live asset VTXOs covering it.
     uint64 asset_amount = 2;
 
     // input_proof_file is the complete confirmed proof for an initially
@@ -1254,14 +1258,21 @@ message TaprootAssetOORIntent {
     // them through tapd's chain porter.
     bool acknowledge_unconfirmed = 7;
 
-    // input_vtxo_outpoint identifies the wallet-managed asset-bearing VTXO in
-    // "txid:vout" form. The wallet reserves this required input through the
-    // normal VTXO manager path before any Taproot Asset commit occurs.
+    // input_vtxo_outpoint optionally pins the wallet-managed asset-bearing
+    // VTXO to spend, in "txid:vout" form. Empty delegates selection to the
+    // daemon: a single sufficient VTXO is preferred (smallest first),
+    // otherwise the largest VTXOs accumulate until asset_amount is covered,
+    // up to eight inputs spent in one atomic transfer. A send needing more
+    // than eight inputs fails; consolidate first. The wallet reserves every
+    // selected input through the normal VTXO manager path before any
+    // Taproot Asset commit occurs.
     string input_vtxo_outpoint = 8;
 
     // recipient_asset_amount is the number of asset units assigned to the
-    // caller's recipient. Zero retains the legacy full-send behavior and
-    // assigns all asset_amount units to the recipient.
+    // caller's recipient when input_vtxo_outpoint pins the input. Zero
+    // retains the legacy full-send behavior and assigns all asset_amount
+    // units to the recipient. It must be zero with daemon-side selection,
+    // where asset_amount already names the units to send.
     uint64 recipient_asset_amount = 9;
 
     // asset_change_carrier_value_sat is deprecated and must be zero. New

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -370,6 +370,16 @@ message BoardTaprootAssetResponse {
     // already_boarded reports an idempotent replay: the boarding intent
     // already existed and no new round registration was sent.
     bool already_boarded = 5;
+
+    // fee_funding_outpoint names the Bitcoin VTXO this boarding pulled
+    // into the round to pay its fee. The round returns the value it did
+    // not spend as a fresh change VTXO. Empty when the round already
+    // carried a fee-bearing output of the client's own.
+    string fee_funding_outpoint = 6;
+
+    // fee_funding_value_sat is that VTXO's value. The change comes back
+    // as this amount minus the fee the operator charges at seal time.
+    int64 fee_funding_value_sat = 7;
 }
 
 message ClaimTaprootAssetVTXORequest {

--- a/waverpc/daemon.yaml
+++ b/waverpc/daemon.yaml
@@ -93,6 +93,12 @@ http:
     - selector: waverpc.DaemonService.OnboardTaprootAsset
       post: /v1/daemon/onboard-taproot-asset
       body: "*"
+    - selector: waverpc.DaemonService.BoardTaprootAsset
+      post: /v1/daemon/board-taproot-asset
+      body: "*"
+    - selector: waverpc.DaemonService.ClaimTaprootAssetVTXO
+      post: /v1/daemon/claim-taproot-asset-vtxo
+      body: "*"
     - selector: waverpc.DaemonService.JoinNextRound
       post: /v1/daemon/join-next-round
       body: "*"

--- a/waverpc/daemon_grpc.pb.go
+++ b/waverpc/daemon_grpc.pb.go
@@ -37,6 +37,8 @@ const (
 	DaemonService_SendVTXO_FullMethodName                                       = "/waverpc.DaemonService/SendVTXO"
 	DaemonService_SendOOR_FullMethodName                                        = "/waverpc.DaemonService/SendOOR"
 	DaemonService_OnboardTaprootAsset_FullMethodName                            = "/waverpc.DaemonService/OnboardTaprootAsset"
+	DaemonService_BoardTaprootAsset_FullMethodName                              = "/waverpc.DaemonService/BoardTaprootAsset"
+	DaemonService_ClaimTaprootAssetVTXO_FullMethodName                          = "/waverpc.DaemonService/ClaimTaprootAssetVTXO"
 	DaemonService_PrepareOOR_FullMethodName                                     = "/waverpc.DaemonService/PrepareOOR"
 	DaemonService_SignOORCustomInput_FullMethodName                             = "/waverpc.DaemonService/SignOORCustomInput"
 	DaemonService_SignVTXOForfeit_FullMethodName                                = "/waverpc.DaemonService/SignVTXOForfeit"
@@ -139,6 +141,16 @@ type DaemonServiceClient interface {
 	// retry resumes publication or operator registration without committing
 	// another asset transition.
 	OnboardTaprootAsset(ctx context.Context, in *OnboardTaprootAssetRequest, opts ...grpc.CallOption) (*OnboardTaprootAssetResponse, error)
+	// BoardTaprootAsset boards a confirmed onboarded output into the next
+	// asset round. The daemon rebuilds the boarding disclosure from the
+	// onboarding named by the idempotency key, gathers the confirmation
+	// and the boarded asset proof itself, and registers the boarding
+	// together with a matching asset VTXO request. Safe to retry.
+	BoardTaprootAsset(ctx context.Context, in *BoardTaprootAssetRequest, opts ...grpc.CallOption) (*BoardTaprootAssetResponse, error)
+	// ClaimTaprootAssetVTXO claims an exited asset VTXO into the daemon's
+	// tapd wallet once its unrolled anchor has matured past the exit
+	// delay. The daemon gathers the lineage confirmations itself.
+	ClaimTaprootAssetVTXO(ctx context.Context, in *ClaimTaprootAssetVTXORequest, opts ...grpc.CallOption) (*ClaimTaprootAssetVTXOResponse, error)
 	// PrepareOOR builds the deterministic OOR package without submitting it.
 	// This lets callers collect signatures from external custom-input
 	// participants before calling SendOOR with the same parameters.
@@ -457,6 +469,26 @@ func (c *daemonServiceClient) OnboardTaprootAsset(ctx context.Context, in *Onboa
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(OnboardTaprootAssetResponse)
 	err := c.cc.Invoke(ctx, DaemonService_OnboardTaprootAsset_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) BoardTaprootAsset(ctx context.Context, in *BoardTaprootAssetRequest, opts ...grpc.CallOption) (*BoardTaprootAssetResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BoardTaprootAssetResponse)
+	err := c.cc.Invoke(ctx, DaemonService_BoardTaprootAsset_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) ClaimTaprootAssetVTXO(ctx context.Context, in *ClaimTaprootAssetVTXORequest, opts ...grpc.CallOption) (*ClaimTaprootAssetVTXOResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ClaimTaprootAssetVTXOResponse)
+	err := c.cc.Invoke(ctx, DaemonService_ClaimTaprootAssetVTXO_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -842,6 +874,16 @@ type DaemonServiceServer interface {
 	// retry resumes publication or operator registration without committing
 	// another asset transition.
 	OnboardTaprootAsset(context.Context, *OnboardTaprootAssetRequest) (*OnboardTaprootAssetResponse, error)
+	// BoardTaprootAsset boards a confirmed onboarded output into the next
+	// asset round. The daemon rebuilds the boarding disclosure from the
+	// onboarding named by the idempotency key, gathers the confirmation
+	// and the boarded asset proof itself, and registers the boarding
+	// together with a matching asset VTXO request. Safe to retry.
+	BoardTaprootAsset(context.Context, *BoardTaprootAssetRequest) (*BoardTaprootAssetResponse, error)
+	// ClaimTaprootAssetVTXO claims an exited asset VTXO into the daemon's
+	// tapd wallet once its unrolled anchor has matured past the exit
+	// delay. The daemon gathers the lineage confirmations itself.
+	ClaimTaprootAssetVTXO(context.Context, *ClaimTaprootAssetVTXORequest) (*ClaimTaprootAssetVTXOResponse, error)
 	// PrepareOOR builds the deterministic OOR package without submitting it.
 	// This lets callers collect signatures from external custom-input
 	// participants before calling SendOOR with the same parameters.
@@ -1039,6 +1081,12 @@ func (UnimplementedDaemonServiceServer) SendOOR(context.Context, *SendOORRequest
 }
 func (UnimplementedDaemonServiceServer) OnboardTaprootAsset(context.Context, *OnboardTaprootAssetRequest) (*OnboardTaprootAssetResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method OnboardTaprootAsset not implemented")
+}
+func (UnimplementedDaemonServiceServer) BoardTaprootAsset(context.Context, *BoardTaprootAssetRequest) (*BoardTaprootAssetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BoardTaprootAsset not implemented")
+}
+func (UnimplementedDaemonServiceServer) ClaimTaprootAssetVTXO(context.Context, *ClaimTaprootAssetVTXORequest) (*ClaimTaprootAssetVTXOResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ClaimTaprootAssetVTXO not implemented")
 }
 func (UnimplementedDaemonServiceServer) PrepareOOR(context.Context, *PrepareOORRequest) (*PrepareOORResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PrepareOOR not implemented")
@@ -1471,6 +1519,42 @@ func _DaemonService_OnboardTaprootAsset_Handler(srv interface{}, ctx context.Con
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(DaemonServiceServer).OnboardTaprootAsset(ctx, req.(*OnboardTaprootAssetRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_BoardTaprootAsset_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BoardTaprootAssetRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).BoardTaprootAsset(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_BoardTaprootAsset_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).BoardTaprootAsset(ctx, req.(*BoardTaprootAssetRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_ClaimTaprootAssetVTXO_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ClaimTaprootAssetVTXORequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).ClaimTaprootAssetVTXO(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_ClaimTaprootAssetVTXO_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).ClaimTaprootAssetVTXO(ctx, req.(*ClaimTaprootAssetVTXORequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2086,6 +2170,14 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "OnboardTaprootAsset",
 			Handler:    _DaemonService_OnboardTaprootAsset_Handler,
+		},
+		{
+			MethodName: "BoardTaprootAsset",
+			Handler:    _DaemonService_BoardTaprootAsset_Handler,
+		},
+		{
+			MethodName: "ClaimTaprootAssetVTXO",
+			Handler:    _DaemonService_ClaimTaprootAssetVTXO_Handler,
 		},
 		{
 			MethodName: "PrepareOOR",

--- a/waverpc/daemon_mailboxrpc.pb.go
+++ b/waverpc/daemon_mailboxrpc.pb.go
@@ -60,6 +60,10 @@ type DaemonServiceMailboxServer interface {
 	SendOOR(ctx context.Context, req *SendOORRequest) (*SendOORResponse, error)
 	// OnboardTaprootAsset handles OnboardTaprootAsset.
 	OnboardTaprootAsset(ctx context.Context, req *OnboardTaprootAssetRequest) (*OnboardTaprootAssetResponse, error)
+	// BoardTaprootAsset handles BoardTaprootAsset.
+	BoardTaprootAsset(ctx context.Context, req *BoardTaprootAssetRequest) (*BoardTaprootAssetResponse, error)
+	// ClaimTaprootAssetVTXO handles ClaimTaprootAssetVTXO.
+	ClaimTaprootAssetVTXO(ctx context.Context, req *ClaimTaprootAssetVTXORequest) (*ClaimTaprootAssetVTXOResponse, error)
 	// PrepareOOR handles PrepareOOR.
 	PrepareOOR(ctx context.Context, req *PrepareOORRequest) (*PrepareOORResponse, error)
 	// SignOORCustomInput handles SignOORCustomInput.
@@ -303,6 +307,26 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.OnboardTaprootAsset(ctx, req)
+	})
+	r.Handle("waverpc.DaemonService", "BoardTaprootAsset", func() proto.Message {
+		return &BoardTaprootAssetRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*BoardTaprootAssetRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.BoardTaprootAsset(ctx, req)
+	})
+	r.Handle("waverpc.DaemonService", "ClaimTaprootAssetVTXO", func() proto.Message {
+		return &ClaimTaprootAssetVTXORequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ClaimTaprootAssetVTXORequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ClaimTaprootAssetVTXO(ctx, req)
 	})
 	r.Handle("waverpc.DaemonService", "PrepareOOR", func() proto.Message {
 		return &PrepareOORRequest{}
@@ -1013,6 +1037,52 @@ func (c *DaemonServiceMailboxClient) OnboardTaprootAsset(ctx context.Context, re
 	}
 
 	resp := new(OnboardTaprootAssetResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// BoardTaprootAsset calls the BoardTaprootAsset RPC.
+func (c *DaemonServiceMailboxClient) BoardTaprootAsset(ctx context.Context, req *BoardTaprootAssetRequest, opts ...rpc.RPCOptions) (*BoardTaprootAssetResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "waverpc.DaemonService",
+		Method:  "BoardTaprootAsset",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(BoardTaprootAssetResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ClaimTaprootAssetVTXO calls the ClaimTaprootAssetVTXO RPC.
+func (c *DaemonServiceMailboxClient) ClaimTaprootAssetVTXO(ctx context.Context, req *ClaimTaprootAssetVTXORequest, opts ...rpc.RPCOptions) (*ClaimTaprootAssetVTXOResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "waverpc.DaemonService",
+		Method:  "ClaimTaprootAssetVTXO",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ClaimTaprootAssetVTXOResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Asset management API for the client daemon, stacked on #1062 and tracked by the [integration epic](https://github.com/lightninglabs/lumos/issues/772); design: https://taproot-assets-ark.lightning.wiki/#api.

The PoC drove asset flows through test hooks: boarding took hand-fed confirmation transactions and exported proofs, and claiming took a hand-built map of raw blocks. This PR promotes the whole lifecycle to first-class RPCs and CLI commands, with the rule that everything the daemon can derive itself stays off the wire.

**`BoardTaprootAsset`** completes an onboarded output's path into a round from the idempotency key alone. `OnboardTaprootAsset` now persists the request's replay slice next to the onboarder's journal, so the board call rebuilds the disclosure, resolves the confirmation through the chain-source actor, exports the boarded proof from the daemon's own tapd (the composed output is not tapd wallet inventory, so the proof is located through the transfer that created it), and registers the boarding together with a matching asset VTXO request. Replays are safe: an existing boarding intent short-circuits with `already_boarded`, and an unconfirmed output returns `FailedPrecondition` rather than blocking.

**`ClaimTaprootAssetVTXO`** claims a matured exited leaf with daemon-gathered lineage confirmations. The lineage txids come from the leaf's own sealed package (each proof-path step names its anchor), and the chain source resolves each to its block with `IncludeBlock`, so the caller passes an outpoint and, optionally, a fee. A zero fee estimates one from the shared LND wallet at a conservative claim size.

**Balance and listing.** `GetBalance` gains a `taproot_assets` breakdown per asset reference (live, pending, and exiting amounts in asset units; carrier satoshis stay counted as Bitcoin), and `ListVTXOs` gains an `asset_ref` filter with tap-sdk-equivalent reference matching.

**CLI.** The `taproot-assets` subtree grows `board`, `claim`, `list`, `balance`, and `send`. The send wrapper resolves the input leaf and, for a partial send, the Bitcoin VTXO that carries the asset change, so a transfer takes only the asset, the amount, the recipient key, and an idempotency key.

The new RPCs carry the same macaroon entity as `OnboardTaprootAsset` (`onchain:write`) and are wired through the REST gateway and the REST client.

Verified by the full unit suite, the new aggregation and filter unit tests, and the CLI schema-parity tests. End-to-end exercise arrives with the regtest manual-testing harness this PR exists to serve.

**Update: operator-funded OOR carriers.** Asset transfers no longer spend the sender's Bitcoin. `GetInfo` advertises the operator's carrier float key and `LeaseOORCarrier` (arkrpc) reserves one float VTXO per transfer. The daemon adds the leased VTXO as an extra ark input it cannot sign (`TransferInput.OperatorFunded`, skipped by every local signing site and persisted in the outgoing snapshot), stamps the recipient and asset-change leaves at the operator's minimum-VTXO floor, returns the sender's own carrier whole as plain Bitcoin change, and pays the float's residual back to the lease's script. The lease is journaled with the preparation, so idempotent replays reuse it. `asset_change_carrier_value_sat` and the CLI's `--change-carrier-sat` are gone; the recipient's `amount_sat` must be zero for asset sends. Verified end to end on the regtest stack: a sender pays assets spending zero satoshis, a recipient holding no Bitcoin receives and respends, and the operator's float chains across transfers.

**Update: atomic multi-input sends + carrier reclaim.** One transfer now spends up to eight asset VTXOs: the intent names an ordered outpoint set (spine first), the daemon selects it when the RPC leaves `input_vtxo_outpoint` empty (smallest sufficient single VTXO, else largest-first until the amount is covered), and preparation commits one checkpoint per input into a single merged ark transition. Created outputs carry version-2 compact proof paths (tap-sdk #178): spine lineage plus recursive co-input paths, rebuilt at respend and walked as a DAG when gathering claim confirmations. An anchor-edge-routed verifier serves all inputs' proof checks. Separately, spending a leaf whose carrier the operator funded returns that carrier to the operator's change instead of the sender (classified from the sealed-package discriminator, mirrored operator-side), so the carrier float circulates. Depends on tap-sdk #178.