### PR TITLE
multi: confine the daemon's lnd spending to one account

### DIFF
--- a/cmd/waved/main.go
+++ b/cmd/waved/main.go
@@ -119,6 +119,12 @@ func newRootCmd() *cobra.Command {
 		"lnd.macaroonpath", cfg.Lnd.MacaroonPath,
 		"path to lnd admin macaroon",
 	)
+	f.String(
+		"lnd.account", cfg.Lnd.Account, "lnd wallet account this "+
+			"daemon may spend from; empty uses lnd's default "+
+			"account. Set it when sharing an lnd node with "+
+			"another daemon so neither can drain the other's funds",
+	)
 
 	registerArkServerFlags(f, cfg)
 

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -135,6 +135,7 @@ waved \
 | `--lnd.tlspath` | | Path to lnd TLS certificate |
 | `--lnd.macaroonpath` | | Path to lnd admin macaroon |
 | `--lnd.rpctimeout` | `30s` | Timeout for lnd RPC calls |
+| `--lnd.account` | _(empty)_ | lnd wallet account to spend from; empty uses lnd's default account. Set when sharing an lnd node with another daemon |
 | `--server.host` | network default | Ark operator address override for the selected transport |
 | `--server.transport` | `grpc` | Ark operator transport: `grpc` or `rest` |
 | `--server.insecure` | `false` | Disable TLS for server connection |

--- a/lnd_boarding_wallet.go
+++ b/lnd_boarding_wallet.go
@@ -11,7 +11,8 @@ type LndBoardingBackend = lndbackend.BoardingBackend
 
 // NewLndBoardingBackend creates a new LND boarding backend.
 func NewLndBoardingBackend(walletKit lndclient.WalletKitClient,
-	chainKit lndclient.ChainKitClient) *LndBoardingBackend {
+	chainKit lndclient.ChainKitClient,
+	opts ...lndbackend.Option) *LndBoardingBackend {
 
-	return lndbackend.NewBoardingBackend(walletKit, chainKit)
+	return lndbackend.NewBoardingBackend(walletKit, chainKit, opts...)
 }

--- a/lndbackend/AGENTS.md
+++ b/lndbackend/AGENTS.md
@@ -12,10 +12,13 @@ MuSig2) for the round actor, and proof-key derivation/signing.
   Implements `wallet.BoardingBackend` and `wallet.OutputLeaser`.
   `GetTransaction` returns `*wallet.TxInfo`; `GetBlock` fetches raw blocks via
   `chainKit` for TxProof merkle inclusion. `ListUnspent` spans every wallet
-  account including imported watch-only scripts; `ListUnspentDefaultAccount`
-  restricts to the default account for CPFP fee-input selection (watch-only
-  outputs are unsignable). `LeaseOutput`/`ReleaseOutput` forward to
-  walletKit, casting `wallet.LockID` <-> `wtxmgr.LockID`.
+  account including imported watch-only scripts; `ListUnspentWalletAccount`
+  restricts to the backend's own account for CPFP fee-input selection
+  (watch-only outputs are unsignable). The account defaults to
+  `DefaultWalletAccount` (lnd's "default") and is overridden with the
+  `WithAccount` option; `Account()`/`IsDefaultAccount()` expose it to PSBT
+  builders. `LeaseOutput`/`ReleaseOutput` forward to walletKit, casting
+  `wallet.LockID` <-> `wtxmgr.LockID`.
 - `ClientWallet` — Adapts lndclient's remote signer to `input.Signer` +
   MuSig2 (`round.ClientWallet`), so the round actor can sign VTXO tree
   branches and forfeit transactions via LND's remote signer without a local
@@ -39,9 +42,23 @@ MuSig2) for the round actor, and proof-key derivation/signing.
 - `ClientWallet.signOutputRawWithLocator` always forwards the key locator
   when set (including family != 0, index == 0), working around an lndclient
   gap that otherwise breaks the family-6/index-0 identity signing path.
-- CPFP fee-input selection must use `ListUnspentDefaultAccount`, not
+- CPFP fee-input selection must use `ListUnspentWalletAccount`, not
   `ListUnspent`: offering a watch-only (imported script) output as a fee
   input makes the child PSBT unsignable.
+- Every lnd call that spends, derives change, or signs must use the same
+  account (`Account()`). A custom account lives in one key scope, so lnd
+  rejects an explicit `ChangeType` for it on the `Psbt`/`Raw` templates —
+  guard that with `IsDefaultAccount()`.
+- A custom account must be **taproot-scoped**, and not because of CPFP
+  witness types: lnd resolves a custom account name *within the key scope
+  the requested address type implies* (`keyScopeForAccountAddr`), and every
+  address this daemon derives asks for taproot, so an account under any
+  other scope fails address derivation outright with "account not found".
+- Observation must stay unscoped. Imported boarding scripts live in lnd's
+  watch-only account, which belongs to no wallet account, so an account
+  filter hides them — and lnd treats an empty account name as *every*
+  account but `"default"` as a real filter, so scoping an observation path
+  breaks it even with no account configured.
 
 ## Deep Docs
 

--- a/lndbackend/CLAUDE.md
+++ b/lndbackend/CLAUDE.md
@@ -12,10 +12,13 @@ MuSig2) for the round actor, and proof-key derivation/signing.
   Implements `wallet.BoardingBackend` and `wallet.OutputLeaser`.
   `GetTransaction` returns `*wallet.TxInfo`; `GetBlock` fetches raw blocks via
   `chainKit` for TxProof merkle inclusion. `ListUnspent` spans every wallet
-  account including imported watch-only scripts; `ListUnspentDefaultAccount`
-  restricts to the default account for CPFP fee-input selection (watch-only
-  outputs are unsignable). `LeaseOutput`/`ReleaseOutput` forward to
-  walletKit, casting `wallet.LockID` <-> `wtxmgr.LockID`.
+  account including imported watch-only scripts; `ListUnspentWalletAccount`
+  restricts to the backend's own account for CPFP fee-input selection
+  (watch-only outputs are unsignable). The account defaults to
+  `DefaultWalletAccount` (lnd's "default") and is overridden with the
+  `WithAccount` option; `Account()`/`IsDefaultAccount()` expose it to PSBT
+  builders. `LeaseOutput`/`ReleaseOutput` forward to walletKit, casting
+  `wallet.LockID` <-> `wtxmgr.LockID`.
 - `ClientWallet` — Adapts lndclient's remote signer to `input.Signer` +
   MuSig2 (`round.ClientWallet`), so the round actor can sign VTXO tree
   branches and forfeit transactions via LND's remote signer without a local
@@ -39,9 +42,23 @@ MuSig2) for the round actor, and proof-key derivation/signing.
 - `ClientWallet.signOutputRawWithLocator` always forwards the key locator
   when set (including family != 0, index == 0), working around an lndclient
   gap that otherwise breaks the family-6/index-0 identity signing path.
-- CPFP fee-input selection must use `ListUnspentDefaultAccount`, not
+- CPFP fee-input selection must use `ListUnspentWalletAccount`, not
   `ListUnspent`: offering a watch-only (imported script) output as a fee
   input makes the child PSBT unsignable.
+- Every lnd call that spends, derives change, or signs must use the same
+  account (`Account()`). A custom account lives in one key scope, so lnd
+  rejects an explicit `ChangeType` for it on the `Psbt`/`Raw` templates —
+  guard that with `IsDefaultAccount()`.
+- A custom account must be **taproot-scoped**, and not because of CPFP
+  witness types: lnd resolves a custom account name *within the key scope
+  the requested address type implies* (`keyScopeForAccountAddr`), and every
+  address this daemon derives asks for taproot, so an account under any
+  other scope fails address derivation outright with "account not found".
+- Observation must stay unscoped. Imported boarding scripts live in lnd's
+  watch-only account, which belongs to no wallet account, so an account
+  filter hides them — and lnd treats an empty account name as *every*
+  account but `"default"` as a real filter, so scoping an observation path
+  breaks it even with no account configured.
 
 ## Deep Docs
 

--- a/lndbackend/boarding_backend.go
+++ b/lndbackend/boarding_backend.go
@@ -22,6 +22,17 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
+// DefaultWalletAccount is the LND wallet account this backend spends from
+// when no other account is configured. LND's "default" account is the one
+// every wallet has and the one a freshly funded node puts its coins in, so
+// using it preserves the behaviour of deployments that never think about
+// accounts at all.
+//
+// Deployments that share one LND node between several daemons should give
+// each daemon its own account instead, so that one daemon's spending cannot
+// consume another's funds.
+const DefaultWalletAccount = lnwallet.DefaultAccountName
+
 // BoardingBackend implements the wallet.BoardingBackend interface by
 // wrapping an lndclient.WalletKitClient and ChainKitClient. This
 // provides the concrete integration with an LND node for boarding
@@ -35,19 +46,65 @@ type BoardingBackend struct {
 	// This enables TxProof construction when boarding UTXOs confirm.
 	chainKit lndclient.ChainKitClient
 
+	// account is the LND wallet account whose coins this backend may
+	// select, derive addresses from, and sign for. It never restricts
+	// which UTXOs the backend can *observe*: imported boarding scripts
+	// live in LND's separate watch-only account and are still enumerated
+	// by ListUnspent.
+	account string
+
 	// Log is an optional logger for this backend. If None, the backend
 	// falls back to extracting a logger from context.
 	Log fn.Option[btclog.Logger]
 }
 
+// Option customises a BoardingBackend at construction time.
+type Option func(*BoardingBackend)
+
+// WithAccount pins the backend to a named LND wallet account, so that coin
+// selection, change, address derivation and signing only ever touch that
+// account's funds. An empty name leaves the backend on DefaultWalletAccount.
+func WithAccount(account string) Option {
+	return func(b *BoardingBackend) {
+		if account == "" {
+			return
+		}
+
+		b.account = account
+	}
+}
+
 // NewBoardingBackend creates a new LND boarding backend.
 func NewBoardingBackend(walletKit lndclient.WalletKitClient,
-	chainKit lndclient.ChainKitClient) *BoardingBackend {
+	chainKit lndclient.ChainKitClient, opts ...Option) *BoardingBackend {
 
-	return &BoardingBackend{
+	backend := &BoardingBackend{
 		walletKit: walletKit,
 		chainKit:  chainKit,
+		account:   DefaultWalletAccount,
 	}
+
+	for _, opt := range opts {
+		opt(backend)
+	}
+
+	return backend
+}
+
+// Account returns the LND wallet account this backend spends from. Callers
+// that build PSBTs against the same LND node must fund, finalize and derive
+// change with this account so that every step stays inside the same pocket of
+// funds.
+func (l *BoardingBackend) Account() string {
+	return l.account
+}
+
+// IsDefaultAccount reports whether the backend spends from LND's built-in
+// default account. Custom accounts live in exactly one key scope, which fixes
+// their change address type, and LND rejects an explicit change type for them;
+// callers building PSBTs use this to decide whether they may ask for one.
+func (l *BoardingBackend) IsDefaultAccount() bool {
+	return l.account == DefaultWalletAccount
 }
 
 // WalletKit returns the underlying LND WalletKit client for
@@ -109,25 +166,28 @@ func (l *BoardingBackend) ImportTaprootScript(ctx context.Context,
 // The result spans every wallet account, including imported watch-only
 // script outputs (e.g. boarding scripts tracked via ImportTaprootScript).
 // Callers that need outputs the wallet can unilaterally sign, such as CPFP
-// fee-input selection, must use ListUnspentDefaultAccount instead.
+// fee-input selection, must use ListUnspentWalletAccount instead.
 func (l *BoardingBackend) ListUnspent(ctx context.Context, minConfs,
 	maxConfs int32) ([]*wallet.Utxo, error) {
 
 	return l.listUnspent(ctx, minConfs, maxConfs)
 }
 
-// ListUnspentDefaultAccount returns UTXOs from LND's default wallet account
-// only. This excludes imported watch-only script outputs (boarding and exit
-// scripts imported via ImportTaprootScript), which the wallet merely tracks
-// and cannot unilaterally sign. CPFP fee-input selection must use this
-// variant: offering a watch-only output as a fee input makes the child PSBT
-// unsignable and the fee bump fails with "PSBT is not finalizable".
-func (l *BoardingBackend) ListUnspentDefaultAccount(ctx context.Context,
+// ListUnspentWalletAccount returns UTXOs from the backend's configured LND
+// wallet account only. This excludes imported watch-only script outputs
+// (boarding and exit scripts imported via ImportTaprootScript), which the
+// wallet merely tracks and cannot unilaterally sign. CPFP fee-input selection
+// must use this variant: offering a watch-only output as a fee input makes the
+// child PSBT unsignable and the fee bump fails with "PSBT is not finalizable".
+//
+// When the backend is pinned to a non-default account, this is also what keeps
+// the daemon from spending another daemon's coins on the same LND node.
+func (l *BoardingBackend) ListUnspentWalletAccount(ctx context.Context,
 	minConfs, maxConfs int32) ([]*wallet.Utxo, error) {
 
 	return l.listUnspent(
 		ctx, minConfs, maxConfs,
-		lndclient.WithUnspentAccount(lnwallet.DefaultAccountName),
+		lndclient.WithUnspentAccount(l.account),
 	)
 }
 

--- a/lndbackend/boarding_backend_test.go
+++ b/lndbackend/boarding_backend_test.go
@@ -43,8 +43,8 @@ func (f *fakeWalletKit) ListUnspent(_ context.Context, minConfs, maxConfs int32,
 }
 
 // TestListUnspentAccountScoping verifies that the general ListUnspent
-// enumeration spans all accounts while ListUnspentDefaultAccount pins the
-// query to LND's default account. The distinction is what keeps imported
+// enumeration spans all accounts while ListUnspentWalletAccount pins the
+// query to the backend's own account. The distinction is what keeps imported
 // watch-only script outputs (boarding/exit scripts) out of CPFP fee-input
 // selection: those coins list fine but LND's FinalizePsbt cannot sign
 // them, so offering one as a fee input fails the child with "PSBT is not
@@ -87,12 +87,80 @@ func TestListUnspentAccountScoping(t *testing.T) {
 	require.Equal(t, utxo.Value, utxos[0].Amount)
 	require.Equal(t, int32(3), utxos[0].Confirmations)
 
-	// The fee-input enumeration pins the default account so only coins
-	// the wallet can unilaterally sign are offered.
-	utxos, err = backend.ListUnspentDefaultAccount(t.Context(), 1, 100)
+	// The fee-input enumeration pins the wallet's account so only coins
+	// the wallet can unilaterally sign are offered. Without an explicit
+	// account that is LND's default one.
+	utxos, err = backend.ListUnspentWalletAccount(t.Context(), 1, 100)
 	require.NoError(t, err)
-	require.Equal(
-		t, lnwallet.DefaultAccountName, walletKit.lastReq.Account,
-	)
+	require.Equal(t, DefaultWalletAccount, walletKit.lastReq.Account)
 	require.Len(t, utxos, 1)
+	require.True(t, backend.IsDefaultAccount())
+}
+
+// TestListUnspentCustomAccount verifies that a backend pinned to a named
+// account only ever offers that account's coins for spending, while still
+// enumerating every account when asked for the unfiltered view. This is what
+// stops a daemon sharing an LND node from funding its transactions out of
+// another daemon's balance.
+func TestListUnspentCustomAccount(t *testing.T) {
+	t.Parallel()
+
+	const account = "swapd"
+
+	walletKit := &fakeWalletKit{}
+	backend := NewBoardingBackend(walletKit, nil, WithAccount(account))
+
+	require.Equal(t, account, backend.Account())
+	require.False(t, backend.IsDefaultAccount())
+
+	// Spending enumeration is confined to the configured account.
+	_, err := backend.ListUnspentWalletAccount(t.Context(), 1, 100)
+	require.NoError(t, err)
+	require.Equal(t, account, walletKit.lastReq.Account)
+
+	// Observation is deliberately not: imported boarding scripts live in
+	// LND's watch-only account and must stay visible.
+	_, err = backend.ListUnspent(t.Context(), 1, 100)
+	require.NoError(t, err)
+	require.Empty(t, walletKit.lastReq.Account)
+}
+
+// TestWithAccountEmptyKeepsDefault verifies that an unset account config leaves
+// the backend on LND's default account, so deployments that never configure
+// accounts keep their existing behaviour.
+func TestWithAccountEmptyKeepsDefault(t *testing.T) {
+	t.Parallel()
+
+	backend := NewBoardingBackend(&fakeWalletKit{}, nil, WithAccount(""))
+	require.Equal(t, DefaultWalletAccount, backend.Account())
+	require.True(t, backend.IsDefaultAccount())
+}
+
+// TestListUnspentObservationStaysUnscoped is a regression guard for the split
+// between observing and spending.
+//
+// Boarding scripts are imported into LND's watch-only account, which belongs
+// to no wallet account, so an account filter excludes them. Callers that exist
+// to see pending deposits — the unconfirmed boarding balance and the boarding
+// activity view — go through the unfiltered enumeration for exactly that
+// reason. Narrowing it would empty both with no error and no log line, and
+// would do so even with no account configured, since LND treats an empty
+// account as "every account" but "default" as a real filter.
+func TestListUnspentObservationStaysUnscoped(t *testing.T) {
+	t.Parallel()
+
+	for _, account := range []string{"", DefaultWalletAccount, "swapd"} {
+		walletKit := &fakeWalletKit{}
+		backend := NewBoardingBackend(
+			walletKit, nil, WithAccount(account),
+		)
+
+		_, err := backend.ListUnspent(t.Context(), 0, 100)
+		require.NoError(t, err)
+		require.Empty(
+			t, walletKit.lastReq.Account, "observation must not "+
+				"be filtered by account, configured account %q",
+			account,
+		)
+	}
 }

--- a/sample-waved.conf
+++ b/sample-waved.conf
@@ -117,6 +117,19 @@
 # Maximum duration for individual RPC calls to lnd.
 # lnd.rpctimeout=30s
 
+# The lnd wallet account this daemon may spend from. It bounds coin selection,
+# change, address derivation and signing — but not what the daemon can observe:
+# imported boarding scripts live in lnd's watch-only account and stay visible
+# either way.
+#
+# Leave unset to use lnd's built-in "default" account. Set it when this daemon
+# shares an lnd node with another one, so that one daemon's spending cannot
+# drain the other's funds. The account must already exist on the node (lnd's
+# `wallet accounts create`) and must be taproot-scoped, because every lnd
+# address this daemon derives asks for a taproot address and lnd resolves a
+# custom account name within the key scope the address type implies.
+# lnd.account=
+
 # Ark operator server address. Empty uses the network+transport default; see
 # docs/signet.md for the public test-network endpoints.
 # server.host=

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -41,6 +41,22 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 
 ## Invariants
 
+- The lnd wallet account (`lnd.account`, empty = lnd's `default`) bounds what
+  this daemon may **spend**: `ListWalletUnspent` (fee inputs and the exit
+  preflight), `NewWalletAddress` (the deposit address), and the
+  `lndUnrollWallet` fund/sign/change triple all resolve it through
+  `Server.lndWalletAccount()`. Observation deliberately does not:
+  `listBackingWalletUnspent` stays unfiltered because
+  `fetchUnconfirmedBoardingBalance` and `ListUnconfirmedBoardingUTXOs` exist
+  to see imported boarding scripts, which live in lnd's watch-only account
+  and belong to no wallet account. Scoping that dispatcher empties both, and
+  does so even with no account configured, since lnd reads an empty account
+  as *every* account but `"default"` as a real filter.
+- `validateLndAccount` refuses to start on a configured account that is
+  missing, not taproot-scoped, or watch-only. Without it each of those fails
+  later and worse — a missing account silently filters every UTXO away, a
+  wrong-scoped one funds and signs but cannot derive a fresh script, and a
+  watch-only one fails at signing after inputs are leased.
 - `Server.run` registers a deferred `actorSystem.Shutdown()` **before** the
   deferred `db.Close()` so in-flight actor DB transactions drain before the
   connection pool tears down.

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -41,6 +41,22 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 
 ## Invariants
 
+- The lnd wallet account (`lnd.account`, empty = lnd's `default`) bounds what
+  this daemon may **spend**: `ListWalletUnspent` (fee inputs and the exit
+  preflight), `NewWalletAddress` (the deposit address), and the
+  `lndUnrollWallet` fund/sign/change triple all resolve it through
+  `Server.lndWalletAccount()`. Observation deliberately does not:
+  `listBackingWalletUnspent` stays unfiltered because
+  `fetchUnconfirmedBoardingBalance` and `ListUnconfirmedBoardingUTXOs` exist
+  to see imported boarding scripts, which live in lnd's watch-only account
+  and belong to no wallet account. Scoping that dispatcher empties both, and
+  does so even with no account configured, since lnd reads an empty account
+  as *every* account but `"default"` as a real filter.
+- `validateLndAccount` refuses to start on a configured account that is
+  missing, not taproot-scoped, or watch-only. Without it each of those fails
+  later and worse — a missing account silently filters every UTXO away, a
+  wrong-scoped one funds and signs but cannot derive a fresh script, and a
+  watch-only one fails at signing after inputs are leased.
 - `Server.run` registers a deferred `actorSystem.Shutdown()` **before** the
   deferred `db.Close()` so in-flight actor DB transactions drain before the
   connection pool tears down.

--- a/waved/boarding_sweep.go
+++ b/waved/boarding_sweep.go
@@ -40,6 +40,9 @@ func (s *Server) newSweepWallet() (unroll.SweepWallet, error) {
 		)
 		boardingBackend := lndbackend.NewBoardingBackend(
 			lndSvc.WalletKit, lndSvc.ChainKit,
+			lndbackend.WithAccount(
+				s.lndWalletAccount(),
+			),
 		)
 
 		return &lndUnrollWallet{

--- a/waved/config.go
+++ b/waved/config.go
@@ -913,6 +913,22 @@ type LndConfig struct {
 	// RPCTimeout is the maximum duration for individual RPC calls to
 	// lnd. If zero, DefaultRPCTimeout is used.
 	RPCTimeout time.Duration `mapstructure:"rpctimeout"`
+
+	// Account is the lnd wallet account this daemon may spend from. It
+	// bounds coin selection, change, address derivation and signing, but
+	// not what the daemon can observe: imported boarding scripts live in
+	// lnd's watch-only account and stay visible either way.
+	//
+	// Empty selects lndbackend.DefaultWalletAccount, lnd's built-in
+	// "default" account, which is where a freshly funded node keeps its
+	// coins. Set this when several daemons share one lnd node, so that one
+	// daemon's spending cannot drain another's funds. The named account
+	// must already exist on the node (lnd's `wallet accounts create`) and
+	// must be taproot-scoped: every lnd address this daemon derives for
+	// itself asks for a taproot address, and lnd resolves a custom account
+	// name within the key scope implied by the requested address type, so
+	// an account created under any other scope resolves as "not found".
+	Account string `mapstructure:"account"`
 }
 
 // ServerConfig holds connection parameters for the ark operator's mailbox

--- a/waved/server.go
+++ b/waved/server.go
@@ -1649,8 +1649,65 @@ func (s *Server) initLndBackend(ctx context.Context) error {
 		"pubkey", lndServices.NodePubkey,
 	)
 
+	if err := s.validateLndAccount(ctx, lndServices); err != nil {
+		return err
+	}
+
 	// In lnd mode the wallet is immediately ready.
 	s.markWalletReady()
+
+	return nil
+}
+
+// validateLndAccount refuses to start when the configured lnd account cannot
+// serve this daemon, rather than letting the daemon boot and fail later.
+//
+// Every misconfiguration here surfaces late and badly otherwise, and one of
+// them is silent. A name that does not exist makes lnd's ListUnspent filter
+// every output away rather than error, so the exit preflight simply concludes
+// there is nothing to spend. An account under the wrong key scope is worse
+// than that: coin selection and signing resolve it by name across all scopes
+// and work fine, while address derivation pins the taproot scope and fails —
+// so the daemon runs until the moment a unilateral exit or a boarding sweep
+// needs a fresh script. A watch-only account fails later still, at signing,
+// once inputs are already leased.
+//
+// One lookup filtered by both name and address type distinguishes all three.
+//
+// NOTE: this confirms the taproot-scoped account exists, which is what address
+// derivation needs. It does not rule out the same name also existing under
+// another key scope, in which case funding's lookupFirstCustomAccount could
+// resolve to the other one. lnd only allowed that on older versions, so it is
+// not guarded against here.
+func (s *Server) validateLndAccount(ctx context.Context,
+	lnd *lndclient.GrpcLndServices) error {
+
+	account := s.lndWalletAccount()
+	if account == lndbackend.DefaultWalletAccount {
+		return nil
+	}
+
+	accounts, err := lnd.WalletKit.ListAccounts(
+		ctx, account, walletrpc.AddressType_TAPROOT_PUBKEY,
+	)
+	if err != nil || len(accounts) == 0 {
+		return fmt.Errorf("lnd wallet account %q not found under the "+
+			"taproot key scope: this daemon derives taproot "+
+			"addresses, and lnd resolves an account name within "+
+			"the key scope the requested address type implies, so "+
+			"the account must be created taproot-scoped (lookup "+
+			"error: %v)", account, err)
+	}
+
+	if accounts[0].GetWatchOnly() {
+		return fmt.Errorf("lnd wallet account %q is watch-only, so "+
+			"lnd cannot sign for it: coin selection would succeed "+
+			"and signing would fail after the inputs were "+
+			"already leased", account)
+	}
+
+	s.log.InfoS(ctx, "Using lnd wallet account",
+		"account", account)
 
 	return nil
 }
@@ -4099,6 +4156,9 @@ func (s *Server) initWalletActor(ctx context.Context,
 		lndSvc := s.lnd.UnsafeFromSome()
 		backend := lndbackend.NewBoardingBackend(
 			lndSvc.WalletKit, lndSvc.ChainKit,
+			lndbackend.WithAccount(
+				s.lndWalletAccount(),
+			),
 		)
 		backend.Log = fn.Some(s.subLogger(lndbackend.Subsystem))
 		boardingBackend = backend
@@ -5168,6 +5228,16 @@ func networkToLndclient(network string) (lndclient.Network, error) {
 	}
 }
 
+// lndWalletAccount returns the lnd wallet account this daemon spends from,
+// falling back to lnd's built-in account when none is configured.
+func (s *Server) lndWalletAccount() string {
+	if s.cfg.Lnd == nil || s.cfg.Lnd.Account == "" {
+		return lndbackend.DefaultWalletAccount
+	}
+
+	return s.cfg.Lnd.Account
+}
+
 // lndUnrollWallet composes the LND-backed signing/key-derivation wallet
 // with the boarding backend's ListUnspent to satisfy the
 // UnilateralExitWallet interface needed by the package executor.
@@ -5176,19 +5246,20 @@ type lndUnrollWallet struct {
 	boardingBackend *lndbackend.BoardingBackend
 }
 
-// ListUnspent returns UTXOs from LND's default wallet account only.
+// ListUnspent returns UTXOs from the boarding backend's configured LND wallet
+// account only.
 //
 // The boarding backend's unfiltered enumeration also surfaces imported
 // watch-only script outputs (boarding and exit scripts tracked via
 // ImportTaprootScript). Those are not signable by LND's FinalizePsbt, so
 // offering them as CPFP fee inputs makes the child PSBT unsignable and the
 // fee bump fails with "PSBT is not finalizable". Restricting fee selection
-// to the default account keeps selection aligned with what the finalize
+// to the wallet's own account keeps selection aligned with what the finalize
 // path can actually sign, mirroring the lwwallet and btcwallet adapters.
 func (w *lndUnrollWallet) ListUnspent(ctx context.Context, minConfs,
 	maxConfs int32) ([]*wallet.Utxo, error) {
 
-	return w.boardingBackend.ListUnspentDefaultAccount(
+	return w.boardingBackend.ListUnspentWalletAccount(
 		ctx, minConfs, maxConfs,
 	)
 }
@@ -5199,7 +5270,7 @@ func (w *lndUnrollWallet) NewWalletPkScript(ctx context.Context) ([]byte,
 	error) {
 
 	addr, err := w.boardingBackend.WalletKit().NextAddr(
-		ctx, lnwallet.DefaultAccountName,
+		ctx, w.boardingBackend.Account(),
 		walletrpc.AddressType_TAPROOT_PUBKEY, true,
 	)
 	if err != nil {
@@ -5226,7 +5297,7 @@ func (w *lndUnrollWallet) FinalizePsbt(ctx context.Context,
 	}
 
 	_, finalTx, err := w.boardingBackend.WalletKit().FinalizePsbt(
-		ctx, packet, "",
+		ctx, packet, w.boardingBackend.Account(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("LND FinalizePsbt: %w", err)
@@ -5240,24 +5311,35 @@ func (w *lndUnrollWallet) FundPsbt(ctx context.Context, packetBytes []byte,
 	feeRateSatPerVByte int64, lockID wallet.LockID,
 	lockExpiry time.Duration) (*wire.MsgTx, error) {
 
-	packet, _, _, err := w.boardingBackend.WalletKit().FundPsbt(
-		ctx, &walletrpc.FundPsbtRequest{
-			Template: &walletrpc.FundPsbtRequest_Psbt{
-				Psbt: packetBytes,
-			},
-			Fees: &walletrpc.FundPsbtRequest_SatPerVbyte{
-				SatPerVbyte: uint64(feeRateSatPerVByte),
-			},
-			Account:  lnwallet.DefaultAccountName,
-			MinConfs: 1,
-			ChangeType: walletrpc.
-				ChangeAddressType_CHANGE_ADDRESS_TYPE_P2TR,
-			CoinSelectionStrategy: lnrpc.
-				CoinSelectionStrategy_STRATEGY_LARGEST,
-			CustomLockId:          lockID[:],
-			LockExpirationSeconds: uint64(lockExpiry.Seconds()),
+	req := &walletrpc.FundPsbtRequest{
+		Template: &walletrpc.FundPsbtRequest_Psbt{
+			Psbt: packetBytes,
 		},
-	)
+		Fees: &walletrpc.FundPsbtRequest_SatPerVbyte{
+			SatPerVbyte: uint64(feeRateSatPerVByte),
+		},
+		Account:  w.boardingBackend.Account(),
+		MinConfs: 1,
+		CoinSelectionStrategy: lnrpc.
+			CoinSelectionStrategy_STRATEGY_LARGEST,
+		CustomLockId:          lockID[:],
+		LockExpirationSeconds: uint64(lockExpiry.Seconds()),
+	}
+
+	// The default account spans all key scopes, so LND needs to be told
+	// which one to take change from, and without an explicit type it
+	// defaults that account's change scope to BIP-0084. Asking for taproot
+	// keeps the change output P2TR, which matters because that output
+	// later becomes a fee input for a v3 CPFP child that needs a
+	// Schnorr-signable one. A custom account lives in exactly one key
+	// scope, which already fixes its change type, and LND rejects the
+	// request outright if a change type is supplied alongside one.
+	if w.boardingBackend.IsDefaultAccount() {
+		req.ChangeType =
+			walletrpc.ChangeAddressType_CHANGE_ADDRESS_TYPE_P2TR
+	}
+
+	packet, _, _, err := w.boardingBackend.WalletKit().FundPsbt(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("LND FundPsbt: %w", err)
 	}
@@ -5613,6 +5695,9 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 		)
 		boardingBackend := lndbackend.NewBoardingBackend(
 			lndSvc.WalletKit, lndSvc.ChainKit,
+			lndbackend.WithAccount(
+				s.lndWalletAccount(),
+			),
 		)
 		w := &lndUnrollWallet{
 			ClientWallet:    clientWallet,

--- a/waved/wallet_testhooks.go
+++ b/waved/wallet_testhooks.go
@@ -22,7 +22,7 @@ func (s *Server) NewWalletAddress(ctx context.Context) (string, error) {
 		lndSvc := s.lnd.UnsafeFromSome()
 
 		addr, err := lndSvc.WalletKit.NextAddr(
-			ctx, lnwallet.DefaultAccountName,
+			ctx, s.lndWalletAccount(),
 			walletrpc.AddressType_TAPROOT_PUBKEY, false,
 		)
 		if err != nil {
@@ -75,7 +75,7 @@ func (s *Server) ListWalletUnspent(ctx context.Context, minConfs,
 		return nil, fmt.Errorf("wallet is not ready")
 	}
 
-	utxos, err := s.listBackingWalletUnspent(ctx, minConfs, maxConfs)
+	utxos, err := s.listSpendableWalletUnspent(ctx, minConfs, maxConfs)
 	if err != nil {
 		return nil, err
 	}
@@ -88,10 +88,48 @@ func (s *Server) ListWalletUnspent(ctx context.Context, minConfs,
 	return filterBoardingScripts(utxos, boardingScripts), nil
 }
 
+// listSpendableWalletUnspent returns only the UTXOs this daemon can actually
+// spend, which on the LND path means restricting to its configured account.
+//
+// This is deliberately separate from listBackingWalletUnspent: the fee-input
+// and exit-preflight callers must not see coins the funding path cannot
+// select, while the boarding-observation callers must see imported watch-only
+// scripts that no account contains. Narrowing the shared dispatcher instead
+// would silently empty the pending-deposit balance and activity views.
+func (s *Server) listSpendableWalletUnspent(ctx context.Context, minConfs,
+	maxConfs int32) ([]*wallet.Utxo, error) {
+
+	if s.lnd.IsSome() {
+		lndSvc := s.lnd.UnsafeFromSome()
+		backend := lndbackend.NewBoardingBackend(
+			lndSvc.WalletKit, lndSvc.ChainKit,
+			lndbackend.WithAccount(
+				s.lndWalletAccount(),
+			),
+		)
+
+		utxos, err := backend.ListUnspentWalletAccount(
+			ctx, minConfs, maxConfs,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("LND list unspent: %w", err)
+		}
+
+		return utxos, nil
+	}
+
+	return s.listBackingWalletUnspent(ctx, minConfs, maxConfs)
+}
+
 // listBackingWalletUnspent dispatches to the active wallet backend's
 // raw unspent-output query without any filtering. Split from
 // ListWalletUnspent so the dispatch is independently testable and the
 // post-filter step is a one-liner at the public entry point.
+//
+// NOTE: this must stay unfiltered. fetchUnconfirmedBoardingBalance and
+// ListUnconfirmedBoardingUTXOs use it precisely to see imported boarding
+// scripts, which live in LND's watch-only account and belong to no wallet
+// account.
 func (s *Server) listBackingWalletUnspent(ctx context.Context, minConfs,
 	maxConfs int32) ([]*wallet.Utxo, error) {
 


### PR DESCRIPTION
### Motivation

When `waved` shares an lnd node with another daemon, every spend it makes comes
out of the same pool of coins the other one relies on: CPFP fee inputs for
unilateral exit, boarding sweeps, change, and the address operators deposit
into. A busy neighbour can leave this daemon unable to pay for an exit, and vice
versa.

This is the client-side half of giving each daemon that shares an lnd node its
own pocket of funds.

### Changes

- `lndbackend.BoardingBackend` gains an account (`WithAccount` option,
  defaulting to lnd's `default`), exposed via `Account()` / `IsDefaultAccount()`.
- `ListUnspentDefaultAccount` → `ListUnspentWalletAccount`, filtered on that
  account.
- `lndUnrollWallet` uses it for CPFP fee-input selection, fresh change scripts,
  `FundPsbt` and `FinalizePsbt` (which previously passed `""`, i.e. lnd's
  default account, while funding from a different one).
- The deposit address and the exit-funding UTXO accounting move onto it too.
- New `lnd.account` config option and `waved` flag, plus sample config and CLI
  guide entries.

Default behaviour is unchanged: an empty `lnd.account` keeps lnd's `default`
account, so existing deployments are unaffected.

### Notes for reviewers

- **Observation stays unscoped on purpose.** Imported boarding and exit taproot
  scripts live in lnd's separate watch-only account and must remain visible to
  boarding detection. Only spending, signing and change are narrowed.

- **Fee-input accounting *is* scoped**, unlike observation. It feeds the
  preflight that decides whether an exit can pay for itself, so counting coins
  the funding path cannot actually spend would green-light an exit that then
  cannot be funded.

- **The account must be taproot-scoped** — but not for the reason you might
  expect. It is not the CPFP witness type (the fee-bump code handles p2wkh,
  np2wkh and p2pkh fine). It is that every lnd address this daemon derives asks
  for a taproot address, and lnd resolves a custom account name within the key
  scope the requested address type implies, so an account under any other scope
  resolves as "account not found".

- `FundPsbt` only sets an explicit `ChangeType` on the default account. A custom
  account lives in exactly one key scope, which already fixes its change type,
  and lnd rejects a request that supplies both.

### Testing

Unit tests cover the account option, the empty-config fallback, and the scoped
versus unscoped enumerations.

**Known gap, flagged deliberately:** the custom-account path is not exercised at
runtime. Both harnesses give each client daemon its *own* lnd node, where the
default account is already correct, so no integration test sets `lnd.account`.
Closing this needs a harness change to put `waved` on a shared node, and I'd
suggest doing that before the option is enabled on any shared deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
