### PR TITLE
waved: make receive-script allocation idempotent

### DIFF
--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -65,7 +65,7 @@ who want direct access.
 |---------|-----|-------------|
 | `ark vtxos {list,refresh,leave}` | `ListVTXOs` / `RefreshVTXOs` / `LeaveVTXOs` | VTXO inventory and lifecycle |
 | `ark rounds {get,join,list,watch}` | `GetRound` / (join) / `ListRounds` / `WatchRounds` | Round FSM state; `join` commits queued intents into the next round (`vtxos refresh`/`leave` call it automatically); `watch --max-events`/`--for` bounds streams for machines |
-| `ark oor {receive,get,list}` | `NewReceiveScript` / `GetOORSession` / `ListOORSessions` | OOR session inspection |
+| `ark oor {receive,get,list}` | `NewReceiveScript` / `GetOORSession` / `ListOORSessions` | Receive-script allocation and OOR session inspection; `receive --idempotency-key` replays the allocation already made for that key |
 | `ark board` | `Board` | Trigger boarding with confirmed UTXOs |
 | `ark sweep [list]` | `SweepBoardingUTXOs` / `ListBoardingSweeps` | Boarding-timeout sweeps; broadcasting requires interactive approval or `--yes` |
 | `ark fees {estimate,history}` | `EstimateFee` / `GetFeeHistory` | Fee estimation and history |

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -65,7 +65,7 @@ who want direct access.
 |---------|-----|-------------|
 | `ark vtxos {list,refresh,leave}` | `ListVTXOs` / `RefreshVTXOs` / `LeaveVTXOs` | VTXO inventory and lifecycle |
 | `ark rounds {get,join,list,watch}` | `GetRound` / (join) / `ListRounds` / `WatchRounds` | Round FSM state; `join` commits queued intents into the next round (`vtxos refresh`/`leave` call it automatically); `watch --max-events`/`--for` bounds streams for machines |
-| `ark oor {receive,get,list}` | `NewReceiveScript` / `GetOORSession` / `ListOORSessions` | OOR session inspection |
+| `ark oor {receive,get,list}` | `NewReceiveScript` / `GetOORSession` / `ListOORSessions` | Receive-script allocation and OOR session inspection; `receive --idempotency-key` replays the allocation already made for that key |
 | `ark board` | `Board` | Trigger boarding with confirmed UTXOs |
 | `ark sweep [list]` | `SweepBoardingUTXOs` / `ListBoardingSweeps` | Boarding-timeout sweeps; broadcasting requires interactive approval or `--yes` |
 | `ark fees {estimate,history}` | `EstimateFee` / `GetFeeHistory` | Fee estimation and history |

--- a/cmd/wavecli/waveclicommands/cmd_oor.go
+++ b/cmd/wavecli/waveclicommands/cmd_oor.go
@@ -65,15 +65,17 @@ func newOORListCmd() *cobra.Command {
 func newOORReceiveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "receive",
-		Short: "Allocate a fresh receive script",
-		Long: "Allocates a fresh wallet key, registers the matching " +
-			"taproot receive script with the indexer, and " +
-			"prints the resulting destination details.",
+		Short: "Allocate or replay a receive script",
+		Long: "Allocates and registers a taproot receive script, " +
+			"or returns an exact allocation when an idempotency " +
+			"key is replayed.",
 		RunE: oorReceive,
 	}
 
 	cmd.Flags().String("label", "",
 		"optional label stored with the receive-script registration")
+	cmd.Flags().String("idempotency-key", "",
+		"retry key that returns the same receive script")
 
 	return cmd
 }
@@ -176,6 +178,8 @@ func oorReceive(cmd *cobra.Command, _ []string) error {
 	if err := parseRequest(cmd, req, func() error {
 		label, _ := cmd.Flags().GetString("label")
 		req.Label = label
+		idempotencyKey, _ := cmd.Flags().GetString("idempotency-key")
+		req.IdempotencyKey = idempotencyKey
 
 		return nil
 	}); err != nil {

--- a/cmd/wavecli/waveclicommands/devrpc/registry_generated.go
+++ b/cmd/wavecli/waveclicommands/devrpc/registry_generated.go
@@ -70,7 +70,7 @@ func generatedRegistry() []serviceSpec {
 					Aliases:  []string{"new-receive-script"},
 					Input:    "waverpc.NewReceiveScriptRequest",
 					Output:   "waverpc.NewReceiveScriptResponse",
-					Comments: "NewReceiveScript allocates a fresh wallet key, registers the\nmatching taproot receive script with the indexer, and returns the\nscript details needed to hand the destination to a sender.",
+					Comments: "NewReceiveScript allocates and registers a taproot receive script, or\nreturns the exact existing allocation for an idempotent retry.",
 				},
 				{
 					Name:     "ReceiveAuthKey",

--- a/cmd/wavecli/waveclicommands/oor_destination_test.go
+++ b/cmd/wavecli/waveclicommands/oor_destination_test.go
@@ -124,6 +124,20 @@ func TestMethodRegistryOORReceiveSchema(t *testing.T) {
 	method := findSchemaMethod(t, "ark.oor.receive")
 	require.Equal(t, "NewReceiveScriptRequest", method.RequestType)
 	require.Equal(t, "NewReceiveScriptResponse", method.ResponseType)
+	require.Equal(t, []schemaParam{
+		{
+			Name: "label",
+			Type: "string",
+			Description: "optional indexer registration " +
+				"label",
+		},
+		{
+			Name: "idempotency-key",
+			Type: "string",
+			Description: "retry key that returns same " +
+				"receive script",
+		},
+	}, method.Params)
 }
 
 // TestOORGetAcceptsSnakeCaseSessionID verifies the oor get command resolves

--- a/cmd/wavecli/waveclicommands/schema_registry.go
+++ b/cmd/wavecli/waveclicommands/schema_registry.go
@@ -816,6 +816,12 @@ func arkBaseMethodRegistry() []schemaMethod {
 					Description: "optional indexer " +
 						"registration label",
 				},
+				{
+					Name: "idempotency-key",
+					Type: "string",
+					Description: "retry key that returns " +
+						"same receive script",
+				},
 			},
 			RequestType:  "NewReceiveScriptRequest",
 			ResponseType: "NewReceiveScriptResponse",

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -33,6 +33,21 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   (`InsertClientVTXO`, `FetchByOutpoint`). Persists `ChainDepth`.
 - `OORArtifactStore`, `OwnedReceiveScriptStore` — OOR session state
   and locally owned receive-script metadata.
+- `OwnedReceiveScriptRecord` — one owned receive-script row. Its
+  `IdempotencyKey`, `RegistrationLabel`, `RegistrationExpiresAt`, and
+  `RegistrationRPCKey` fields define a retry-safe allocation;
+  `RegistrationCompletedAt` is set only after the indexer acknowledges that
+  remote request. Legacy rows and internal registrations leave the replay
+  identity empty, which keeps fresh allocation as the default.
+- Idempotent receive-script admission on `OORArtifactPersistenceStore`:
+  `AdmitIdempotentOwnedReceiveScript` selects the durable winner,
+  `LookupOwnedReceiveScriptByIdempotencyKey` loads it,
+  `RenewOwnedReceiveScriptRegistration` replaces an expired remote window by
+  compare-and-swap, and `MarkOwnedReceiveScriptRegistered` records remote
+  acknowledgement for the current request key. Bounds are
+  `MaxOwnedReceiveScriptIdempotencyKeyBytes = 128` and
+  `MaxOwnedReceiveScriptRegistrationTTL = 30 * 24h`. Reusing a key with a
+  different label fails with `ErrOwnedReceiveScriptReplayMismatch`.
 - `LedgerStoreDB` — implements `ledger.LedgerStore`. Wraps
   `sqlc.InsertClientLedgerEntry` (ON CONFLICT DO NOTHING for replay
   idempotency). Joins the outer actor transaction via
@@ -125,6 +140,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   `(outpoint_hash, outpoint_index)` WHERE status IN
   `('pending','published')`) prevents two concurrent sweeps from
   racing on the same boarding UTXO.
+- `idx_owned_receive_scripts_idempotency_key` (UNIQUE on `idempotency_key`
+  WHERE `idempotency_key IS NOT NULL`) admits exactly one durable receive-script
+  allocation per RPC retry key while leaving legacy and internal registrations
+  unconstrained.
 - Default retry logic: 10 retries with exponential backoff (40ms →
   3s cap).
 - SQLite `busy_timeout = 30 000 ms` under WAL mode tolerates
@@ -263,7 +282,7 @@ when adding one.
   policy: read-only Postgres transactions run at `REPEATABLE READ` with
   `READ ONLY` (no `SIRead` predicate locks, never a 40001), writers stay
   `SERIALIZABLE`. Also holds the write-path snapshot-isolation audit and the
-  inventory of the six partial unique indexes that any new `ON CONFLICT`
+  inventory of partial unique indexes that any new `ON CONFLICT`
   target has to be checked against, along with the caveat that a conflict
   target can also miss a plain unique constraint declared inline in a
   `CREATE TABLE`.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -71,7 +71,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   safety bounds enforced during `DeserializeTree`.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
-- `LatestMigrationVersion = 16` — current schema version.
+- `LatestMigrationVersion = 17` — current schema version.
 - `PendingIntentPersistenceStore` — implements `wallet.PendingIntentStore`,
   the persistence half of the generic restart-safe intent outbox (header
   `pending_intents` + per-kind detail tables + `pending_intent_anchors`).
@@ -251,6 +251,10 @@ when adding one.
   later checkpoint must not clear what an earlier one recorded. Rows
   predating the column read back zero, which the confirmation path treats
   as "unknown" and leaves the expiry unstamped rather than wrong.
+- `000017_idempotent_receive_scripts` — adds retry identity, immutable
+  registration terms, a stable remote RPC key, and completion evidence to
+  `owned_receive_scripts`. The partial unique index admits one durable
+  allocation per non-null idempotency key.
 
 ## Deep Docs
 

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -33,6 +33,21 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   (`InsertClientVTXO`, `FetchByOutpoint`). Persists `ChainDepth`.
 - `OORArtifactStore`, `OwnedReceiveScriptStore` — OOR session state
   and locally owned receive-script metadata.
+- `OwnedReceiveScriptRecord` — one owned receive-script row. Its
+  `IdempotencyKey`, `RegistrationLabel`, `RegistrationExpiresAt`, and
+  `RegistrationRPCKey` fields define a retry-safe allocation;
+  `RegistrationCompletedAt` is set only after the indexer acknowledges that
+  remote request. Legacy rows and internal registrations leave the replay
+  identity empty, which keeps fresh allocation as the default.
+- Idempotent receive-script admission on `OORArtifactPersistenceStore`:
+  `AdmitIdempotentOwnedReceiveScript` selects the durable winner,
+  `LookupOwnedReceiveScriptByIdempotencyKey` loads it,
+  `RenewOwnedReceiveScriptRegistration` replaces an expired remote window by
+  compare-and-swap, and `MarkOwnedReceiveScriptRegistered` records remote
+  acknowledgement for the current request key. Bounds are
+  `MaxOwnedReceiveScriptIdempotencyKeyBytes = 128` and
+  `MaxOwnedReceiveScriptRegistrationTTL = 30 * 24h`. Reusing a key with a
+  different label fails with `ErrOwnedReceiveScriptReplayMismatch`.
 - `LedgerStoreDB` — implements `ledger.LedgerStore`. Wraps
   `sqlc.InsertClientLedgerEntry` (ON CONFLICT DO NOTHING for replay
   idempotency). Joins the outer actor transaction via
@@ -125,6 +140,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   `(outpoint_hash, outpoint_index)` WHERE status IN
   `('pending','published')`) prevents two concurrent sweeps from
   racing on the same boarding UTXO.
+- `idx_owned_receive_scripts_idempotency_key` (UNIQUE on `idempotency_key`
+  WHERE `idempotency_key IS NOT NULL`) admits exactly one durable receive-script
+  allocation per RPC retry key while leaving legacy and internal registrations
+  unconstrained.
 - Default retry logic: 10 retries with exponential backoff (40ms →
   3s cap).
 - SQLite `busy_timeout = 30 000 ms` under WAL mode tolerates
@@ -263,7 +282,7 @@ when adding one.
   policy: read-only Postgres transactions run at `REPEATABLE READ` with
   `READ ONLY` (no `SIRead` predicate locks, never a 40001), writers stay
   `SERIALIZABLE`. Also holds the write-path snapshot-isolation audit and the
-  inventory of the six partial unique indexes that any new `ON CONFLICT`
+  inventory of partial unique indexes that any new `ON CONFLICT`
   target has to be checked against, along with the caveat that a conflict
   target can also miss a plain unique constraint declared inline in a
   `CREATE TABLE`.

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -71,7 +71,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   safety bounds enforced during `DeserializeTree`.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
-- `LatestMigrationVersion = 16` — current schema version.
+- `LatestMigrationVersion = 17` — current schema version.
 - `PendingIntentPersistenceStore` — implements `wallet.PendingIntentStore`,
   the persistence half of the generic restart-safe intent outbox (header
   `pending_intents` + per-kind detail tables + `pending_intent_anchors`).
@@ -251,6 +251,10 @@ when adding one.
   later checkpoint must not clear what an earlier one recorded. Rows
   predating the column read back zero, which the confirmation path treats
   as "unknown" and leaves the expiry unstamped rather than wrong.
+- `000017_idempotent_receive_scripts` — adds retry identity, immutable
+  registration terms, a stable remote RPC key, and completion evidence to
+  `owned_receive_scripts`. The partial unique index admits one durable
+  allocation per non-null idempotency key.
 
 ## Deep Docs
 

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 16
+	LatestMigrationVersion uint = 17
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
@@ -77,6 +78,56 @@ func TestMigrationSteps(t *testing.T) {
 	).Scan(&chainName)
 	require.NoError(t, err)
 	require.Equal(t, "testnet", chainName)
+}
+
+// TestIdempotentReceiveScriptsMigrationPreservesLegacyRows verifies migration
+// 17 adds nullable retry metadata without rewriting existing script ownership.
+func TestIdempotentReceiveScriptsMigrationPreservesLegacyRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	database := NewTestDBWithVersion(t, 16)
+	insert := transformByteLiterals(t, database.BaseDB, `
+		INSERT INTO owned_receive_scripts (
+			pk_script, client_key_id, operator_pubkey, exit_delay,
+			source, created_at, last_used_at
+		) VALUES (
+			X'512001', NULL, X'020101', 144, 0, 1700000000,
+			NULL
+		)
+	`)
+	_, err := database.ExecContext(ctx, insert)
+	require.NoError(t, err)
+
+	err = database.ExecuteMigrations(TargetLatest)
+	require.NoError(t, err)
+
+	var (
+		pkScript                []byte
+		idempotencyKey          sql.NullString
+		registrationLabel       sql.NullString
+		registrationExpiresAt   sql.NullInt64
+		registrationRPCKey      sql.NullString
+		registrationCompletedAt sql.NullInt64
+	)
+	err = database.QueryRowContext(ctx, `
+		SELECT pk_script, idempotency_key, registration_label,
+		       registration_expires_at, registration_rpc_key,
+		       registration_completed_at
+		FROM owned_receive_scripts
+		WHERE pk_script = $1
+	`, []byte{0x51, 0x20, 0x01}).Scan(
+		&pkScript, &idempotencyKey, &registrationLabel,
+		&registrationExpiresAt, &registrationRPCKey,
+		&registrationCompletedAt,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x51, 0x20, 0x01}, pkScript)
+	require.False(t, idempotencyKey.Valid)
+	require.False(t, registrationLabel.Valid)
+	require.False(t, registrationExpiresAt.Valid)
+	require.False(t, registrationRPCKey.Valid)
+	require.False(t, registrationCompletedAt.Valid)
 }
 
 // TestMigrationDowngrade tests that downgrading the database is prevented.

--- a/db/oor_artifact_store.go
+++ b/db/oor_artifact_store.go
@@ -6,7 +6,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -192,6 +194,14 @@ type OORArtifactStore interface {
 	// allocation.
 	GetOwnedReceiveScriptByIdempotencyKey(ctx context.Context,
 		idempotencyKey sql.NullString) (sqlc.OwnedReceiveScript, error)
+
+	// RenewOwnedReceiveScriptRegistration atomically replaces one expired
+	// remote registration window without changing script ownership.
+	RenewOwnedReceiveScriptRegistration(ctx context.Context,
+		arg sqlc.RenewOwnedReceiveScriptRegistrationParams) (
+		int64,
+		error,
+	)
 
 	// MarkOwnedReceiveScriptRegistered records remote
 	// acknowledgement for one allocation and stable RPC key.
@@ -1136,6 +1146,132 @@ func (s *OORArtifactPersistenceStore) AdmitIdempotentOwnedReceiveScript(
 	return result, created, nil
 }
 
+// RenewOwnedReceiveScriptRegistration atomically replaces an expired indexer
+// registration window while preserving the allocation's wallet key, script,
+// label, and operator terms. A concurrent winner is returned so every retry
+// resumes the same new remote request key.
+func (s *OORArtifactPersistenceStore) RenewOwnedReceiveScriptRegistration(
+	ctx context.Context, existing OwnedReceiveScriptRecord,
+	nextExpiresAt time.Time, nextRPCKey string) (*OwnedReceiveScriptRecord,
+	error) {
+
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("store must be provided")
+	}
+
+	if err := validateOwnedReceiveScriptReplay(
+		existing, existing.RegistrationLabel,
+	); err != nil {
+		return nil, err
+	}
+
+	now := s.clock.Now()
+	switch {
+	case nextRPCKey == "":
+		return nil, fmt.Errorf("next registration RPC key must be " +
+			"provided")
+
+	case !nextExpiresAt.After(now):
+		return nil, fmt.Errorf("next registration expiry must be in " +
+			"the future")
+
+	case nextExpiresAt.After(
+		now.Add(MaxOwnedReceiveScriptRegistrationTTL),
+	):
+		return nil, fmt.Errorf("next registration expiry exceeds %v",
+			MaxOwnedReceiveScriptRegistrationTTL)
+	}
+
+	var result *OwnedReceiveScriptRecord
+	err := s.db.ExecTx(
+		ctx, WriteTxOption(),
+		func(q OORArtifactStore) error {
+			expectedRPCKey := existing.RegistrationRPCKey
+			expectedExpiry := existing.RegistrationExpiresAt.Unix()
+			params :=
+				sqlc.RenewOwnedReceiveScriptRegistrationParams{
+					NextExpiresAt: sql.NullInt64{
+						Int64: nextExpiresAt.Unix(),
+						Valid: true,
+					},
+					NextRpcKey: sql.NullString{
+						String: nextRPCKey,
+						Valid:  true,
+					},
+					IdempotencyKey: sql.NullString{
+						String: existing.IdempotencyKey,
+						Valid:  true,
+					},
+					ExpectedRpcKey: sql.NullString{
+						String: expectedRPCKey,
+						Valid:  true,
+					},
+					ExpectedExpiresAt: sql.NullInt64{
+						Int64: expectedExpiry,
+						Valid: true,
+					},
+					NowUnix: sql.NullInt64{
+						Int64: now.Unix(),
+						Valid: true,
+					},
+				}
+			rows, err := q.RenewOwnedReceiveScriptRegistration(
+				ctx, params,
+			)
+			if err != nil {
+				return err
+			}
+
+			row, err := q.GetOwnedReceiveScriptByIdempotencyKey(
+				ctx, sql.NullString{
+					String: existing.IdempotencyKey,
+					Valid:  true,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("load renewed receive "+
+					"script: %w", err)
+			}
+
+			result, err = ownedReceiveScriptRowToRecord(ctx, q, row)
+			if err != nil {
+				return err
+			}
+
+			if err := validateOwnedReceiveScriptReplay(
+				*result, existing.RegistrationLabel,
+			); err != nil {
+				return err
+			}
+
+			stillExpired := !result.RegistrationExpiresAt.After(now)
+			if rows == 0 && stillExpired {
+				return fmt.Errorf("expired receive script " +
+					"registration renewal invariant failed")
+			}
+
+			nextExpiry := unixTimeUTC(nextExpiresAt.Unix())
+			rpcKeyMatches := result.RegistrationRPCKey == nextRPCKey
+			expiryMatches := result.RegistrationExpiresAt.Equal(
+				nextExpiry,
+			)
+			matchesRenewal := rpcKeyMatches && expiryMatches &&
+				result.RegistrationCompletedAt.IsNone()
+			if rows == 1 && !matchesRenewal {
+				return fmt.Errorf("renewed receive script " +
+					"registration invariant failed")
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // MarkOwnedReceiveScriptRegistered records an acknowledged indexer
 // registration. Repeating it succeeds only when the durable row already
 // proves that the same remote request completed.
@@ -1303,6 +1439,9 @@ func validateIdempotentOwnedReceiveScript(rec OwnedReceiveScriptRecord,
 		MaxOwnedReceiveScriptIdempotencyKeyBytes:
 		return fmt.Errorf("idempotency key exceeds %d bytes",
 			MaxOwnedReceiveScriptIdempotencyKeyBytes)
+
+	case strings.IndexFunc(rec.IdempotencyKey, unicode.IsControl) >= 0:
+		return fmt.Errorf("idempotency key contains control characters")
 
 	case len(rec.PkScript) == 0:
 		return fmt.Errorf("pk script must be provided")

--- a/db/oor_artifact_store.go
+++ b/db/oor_artifact_store.go
@@ -1032,6 +1032,9 @@ func (s *OORArtifactPersistenceStore) AdmitIdempotentOwnedReceiveScript(
 
 	writeTx := WriteTxOption()
 	err := s.db.ExecTx(ctx, writeTx, func(q OORArtifactStore) error {
+		// ExecTx may retry this closure after a serialization failure.
+		created = false
+
 		row, err := q.GetOwnedReceiveScriptByIdempotencyKey(
 			ctx, sql.NullString{
 				String: candidate.IdempotencyKey,

--- a/db/oor_artifact_store.go
+++ b/db/oor_artifact_store.go
@@ -21,6 +21,14 @@ import (
 )
 
 const (
+	// MaxOwnedReceiveScriptIdempotencyKeyBytes bounds durable indexed
+	// replay keys at the registry owning boundary.
+	MaxOwnedReceiveScriptIdempotencyKeyBytes = 128
+
+	// MaxOwnedReceiveScriptRegistrationTTL bounds how far an idempotent
+	// allocation can extend the indexer's durable registration lifetime.
+	MaxOwnedReceiveScriptRegistrationTTL = 30 * 24 * time.Hour
+
 	// Direction codes persisted in oor_packages.direction.
 	oorPackageDirectionIncomingCode int32 = 0
 	oorPackageDirectionOutgoingCode int32 = 1
@@ -28,6 +36,20 @@ const (
 	// Link-kind codes persisted in oor_vtxo_bindings.link_kind.
 	oorPackageLinkKindCreatedOutputCode int32 = 0
 	oorPackageLinkKindConsumedInputCode int32 = 1
+)
+
+var (
+	// ErrOwnedReceiveScriptReplayMismatch is returned when an idempotency
+	// key is reused with a different immutable request fingerprint.
+	ErrOwnedReceiveScriptReplayMismatch = errors.New("owned receive " +
+		"script replay fingerprint mismatch")
+
+	// errOwnedReceiveScriptAdmissionRace asks the public admission method
+	// to resolve the durable winner after a concurrent insert. Returning it
+	// from the transaction body rolls back the unused internal key
+	// registration.
+	errOwnedReceiveScriptAdmissionRace = errors.New("owned receive " +
+		"script admission race")
 )
 
 // OORPackageDirection is the typed package direction enum.
@@ -155,8 +177,26 @@ type OORArtifactStore interface {
 	UpsertOwnedReceiveScript(ctx context.Context,
 		arg sqlc.UpsertOwnedReceiveScriptParams) error
 
+	// InsertIdempotentOwnedReceiveScript inserts one retry-safe allocation
+	// without replacing a durable winner.
+	InsertIdempotentOwnedReceiveScript(ctx context.Context,
+		arg sqlc.InsertIdempotentOwnedReceiveScriptParams) (
+		int64,
+		error,
+	)
+
 	GetOwnedReceiveScript(ctx context.Context,
 		pkScript []byte) (sqlc.OwnedReceiveScript, error)
+
+	// GetOwnedReceiveScriptByIdempotencyKey loads one durable retry
+	// allocation.
+	GetOwnedReceiveScriptByIdempotencyKey(ctx context.Context,
+		idempotencyKey sql.NullString) (sqlc.OwnedReceiveScript, error)
+
+	// MarkOwnedReceiveScriptRegistered records remote
+	// acknowledgement for one allocation and stable RPC key.
+	MarkOwnedReceiveScriptRegistered(ctx context.Context,
+		arg sqlc.MarkOwnedReceiveScriptRegisteredParams) (int64, error)
 
 	ListOwnedReceiveScripts(ctx context.Context) (
 		[]sqlc.OwnedReceiveScript,
@@ -249,6 +289,26 @@ type OwnedReceiveScriptRecord struct {
 
 	// LastUsedAt tracks the last usage timestamp when available.
 	LastUsedAt fn.Option[time.Time]
+
+	// IdempotencyKey identifies a retry-safe RPC allocation. It is empty
+	// for legacy and internal registrations that allocate a fresh script.
+	IdempotencyKey string
+
+	// RegistrationLabel is the immutable indexer label for an idempotent
+	// allocation.
+	RegistrationLabel string
+
+	// RegistrationExpiresAt is the immutable absolute indexer expiry for an
+	// idempotent allocation.
+	RegistrationExpiresAt time.Time
+
+	// RegistrationRPCKey is the stable mailbox idempotency key used for all
+	// attempts to register this script with the indexer.
+	RegistrationRPCKey string
+
+	// RegistrationCompletedAt is set after the indexer acknowledges the
+	// registration. An absent value means retry must resume registration.
+	RegistrationCompletedAt fn.Option[time.Time]
 }
 
 // OORArtifactPersistenceStore persists OOR artifacts and query surfaces needed
@@ -896,6 +956,253 @@ func (s *OORArtifactPersistenceStore) UpsertOwnedReceiveScript(
 	})
 }
 
+// LookupOwnedReceiveScriptByIdempotencyKey loads a retry-safe receive-script
+// allocation by its durable request key.
+func (s *OORArtifactPersistenceStore) LookupOwnedReceiveScriptByIdempotencyKey(
+	ctx context.Context, idempotencyKey string) (*OwnedReceiveScriptRecord,
+	error) {
+
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("store must be provided")
+	}
+
+	if idempotencyKey == "" {
+		return nil, fmt.Errorf("idempotency key must be provided")
+	}
+	if len(idempotencyKey) > MaxOwnedReceiveScriptIdempotencyKeyBytes {
+		return nil, fmt.Errorf("idempotency key exceeds %d bytes",
+			MaxOwnedReceiveScriptIdempotencyKeyBytes)
+	}
+
+	var result *OwnedReceiveScriptRecord
+	readTx := ReadTxOption()
+	err := s.db.ExecTx(ctx, readTx, func(q OORArtifactStore) error {
+		row, err := q.GetOwnedReceiveScriptByIdempotencyKey(
+			ctx, sql.NullString{
+				String: idempotencyKey,
+				Valid:  true,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		result, err = ownedReceiveScriptRowToRecord(ctx, q, row)
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// AdmitIdempotentOwnedReceiveScript atomically selects one durable receive
+// script for an idempotency key. An existing allocation wins over a newly
+// derived candidate when its normalized label matches.
+func (s *OORArtifactPersistenceStore) AdmitIdempotentOwnedReceiveScript(
+	ctx context.Context, candidate OwnedReceiveScriptRecord) (
+	*OwnedReceiveScriptRecord, bool, error) {
+
+	if s == nil || s.db == nil {
+		return nil, false, fmt.Errorf("store must be provided")
+	}
+
+	if err := validateIdempotentOwnedReceiveScript(
+		candidate, s.clock.Now(),
+	); err != nil {
+		return nil, false, err
+	}
+
+	var (
+		result  *OwnedReceiveScriptRecord
+		created bool
+	)
+
+	writeTx := WriteTxOption()
+	err := s.db.ExecTx(ctx, writeTx, func(q OORArtifactStore) error {
+		row, err := q.GetOwnedReceiveScriptByIdempotencyKey(
+			ctx, sql.NullString{
+				String: candidate.IdempotencyKey,
+				Valid:  true,
+			},
+		)
+		switch {
+		case err == nil:
+			result, err = ownedReceiveScriptRowToRecord(ctx, q, row)
+			if err != nil {
+				return err
+			}
+
+			return validateOwnedReceiveScriptReplay(
+				*result, candidate.RegistrationLabel,
+			)
+
+		case !errors.Is(err, sql.ErrNoRows):
+			return err
+		}
+
+		now := s.clock.Now().Unix()
+		createdAt := candidate.CreatedAt.Unix()
+		if candidate.CreatedAt.IsZero() {
+			createdAt = now
+		}
+
+		clientKeyID, err := RegisterInternalKeyTx(
+			ctx, q, now, candidate.ClientKey,
+		)
+		if err != nil {
+			return fmt.Errorf("register client key: %w", err)
+		}
+
+		source, err := ownedReceiveScriptSourceCode(candidate.Source)
+		if err != nil {
+			return err
+		}
+
+		rows, err := q.InsertIdempotentOwnedReceiveScript(
+			ctx, sqlc.InsertIdempotentOwnedReceiveScriptParams{
+				PkScript: candidate.PkScript,
+				ClientKeyID: sql.NullInt64{
+					Int64: clientKeyID,
+					Valid: true,
+				},
+				OperatorPubkey: candidate.OperatorPubKey.
+					SerializeCompressed(),
+				ExitDelay: candidate.ExitDelay,
+				Source:    source,
+				CreatedAt: createdAt,
+				LastUsedAt: nullUnixFromOptionTime(
+					candidate.LastUsedAt,
+				),
+				IdempotencyKey: sql.NullString{
+					String: candidate.IdempotencyKey,
+					Valid:  true,
+				},
+				RegistrationLabel: sql.NullString{
+					String: candidate.RegistrationLabel,
+					Valid:  true,
+				},
+				RegistrationExpiresAt: sql.NullInt64{
+					Int64: candidate.RegistrationExpiresAt.
+						Unix(),
+					Valid: true,
+				},
+				RegistrationRpcKey: sql.NullString{
+					String: candidate.RegistrationRPCKey,
+					Valid:  true,
+				},
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		if rows == 0 {
+			return errOwnedReceiveScriptAdmissionRace
+		}
+
+		candidate.CreatedAt = unixTimeUTC(createdAt)
+		candidate.RegistrationExpiresAt = unixTimeUTC(
+			candidate.RegistrationExpiresAt.Unix(),
+		)
+		result = &candidate
+		created = true
+
+		return nil
+	})
+	if errors.Is(err, errOwnedReceiveScriptAdmissionRace) {
+		winner, lookupErr := s.LookupOwnedReceiveScriptByIdempotencyKey(
+			ctx, candidate.IdempotencyKey,
+		)
+		if lookupErr != nil {
+			return nil, false, fmt.Errorf("resolve receive script "+
+				"admission race: %w", lookupErr)
+		}
+
+		if matchErr := validateOwnedReceiveScriptReplay(
+			*winner, candidate.RegistrationLabel,
+		); matchErr != nil {
+			return nil, false, matchErr
+		}
+
+		return winner, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	return result, created, nil
+}
+
+// MarkOwnedReceiveScriptRegistered records an acknowledged indexer
+// registration. Repeating it succeeds only when the durable row already
+// proves that the same remote request completed.
+func (s *OORArtifactPersistenceStore) MarkOwnedReceiveScriptRegistered(
+	ctx context.Context, idempotencyKey, registrationRPCKey string) error {
+
+	if s == nil || s.db == nil {
+		return fmt.Errorf("store must be provided")
+	}
+
+	if idempotencyKey == "" || registrationRPCKey == "" {
+		return fmt.Errorf("idempotency and registration RPC keys " +
+			"must be provided")
+	}
+	if len(idempotencyKey) > MaxOwnedReceiveScriptIdempotencyKeyBytes {
+		return fmt.Errorf("idempotency key exceeds %d bytes",
+			MaxOwnedReceiveScriptIdempotencyKeyBytes)
+	}
+
+	writeTx := WriteTxOption()
+
+	return s.db.ExecTx(ctx, writeTx, func(q OORArtifactStore) error {
+		rows, err := q.MarkOwnedReceiveScriptRegistered(
+			ctx, sqlc.MarkOwnedReceiveScriptRegisteredParams{
+				IdempotencyKey: sql.NullString{
+					String: idempotencyKey,
+					Valid:  true,
+				},
+				RegistrationRpcKey: sql.NullString{
+					String: registrationRPCKey,
+					Valid:  true,
+				},
+				RegistrationCompletedAt: sql.NullInt64{
+					Int64: s.clock.Now().Unix(),
+					Valid: true,
+				},
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		if rows == 1 {
+			return nil
+		}
+
+		row, err := q.GetOwnedReceiveScriptByIdempotencyKey(
+			ctx, sql.NullString{
+				String: idempotencyKey,
+				Valid:  true,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("verify completed registration: %w",
+				err)
+		}
+
+		if row.RegistrationRpcKey.String != registrationRPCKey ||
+			!row.RegistrationCompletedAt.Valid {
+			return fmt.Errorf("receive script registration " +
+				"completion invariant failed")
+		}
+
+		return nil
+	})
+}
+
 // LookupOwnedReceiveScript loads one owned receive script metadata row by
 // pkScript.
 //
@@ -956,14 +1263,100 @@ func ownedReceiveScriptRowToRecord(ctx context.Context, q OORArtifactStore,
 	}
 
 	return &OwnedReceiveScriptRecord{
-		PkScript:       row.PkScript,
-		ClientKey:      clientKey,
-		OperatorPubKey: operatorPubKey,
-		ExitDelay:      row.ExitDelay,
-		Source:         source,
-		CreatedAt:      unixTimeUTC(row.CreatedAt),
-		LastUsedAt:     optionTimeFromNullUnix(row.LastUsedAt),
+		PkScript:              row.PkScript,
+		ClientKey:             clientKey,
+		OperatorPubKey:        operatorPubKey,
+		ExitDelay:             row.ExitDelay,
+		Source:                source,
+		CreatedAt:             unixTimeUTC(row.CreatedAt),
+		LastUsedAt:            optionTimeFromNullUnix(row.LastUsedAt),
+		IdempotencyKey:        row.IdempotencyKey.String,
+		RegistrationLabel:     row.RegistrationLabel.String,
+		RegistrationExpiresAt: nullUnixTime(row.RegistrationExpiresAt),
+		RegistrationRPCKey:    row.RegistrationRpcKey.String,
+		RegistrationCompletedAt: optionTimeFromNullUnix(
+			row.RegistrationCompletedAt,
+		),
 	}, nil
+}
+
+// nullUnixTime maps a nullable unix timestamp to UTC, returning the zero time
+// for legacy rows without the field.
+func nullUnixTime(value sql.NullInt64) time.Time {
+	if !value.Valid {
+		return time.Time{}
+	}
+
+	return unixTimeUTC(value.Int64)
+}
+
+// validateIdempotentOwnedReceiveScript checks the all-or-none replay metadata
+// and the ownership fields required before durable admission.
+func validateIdempotentOwnedReceiveScript(rec OwnedReceiveScriptRecord,
+	now time.Time) error {
+
+	switch {
+	case rec.IdempotencyKey == "":
+		return fmt.Errorf("idempotency key must be provided")
+
+	case len(rec.IdempotencyKey) >
+		MaxOwnedReceiveScriptIdempotencyKeyBytes:
+		return fmt.Errorf("idempotency key exceeds %d bytes",
+			MaxOwnedReceiveScriptIdempotencyKeyBytes)
+
+	case len(rec.PkScript) == 0:
+		return fmt.Errorf("pk script must be provided")
+
+	case rec.ClientKey.PubKey == nil:
+		return fmt.Errorf("client key pubkey must be provided")
+
+	case rec.OperatorPubKey == nil:
+		return fmt.Errorf("operator pubkey must be provided")
+
+	case rec.RegistrationLabel == "":
+		return fmt.Errorf("registration label must be provided")
+
+	case rec.RegistrationExpiresAt.IsZero():
+		return fmt.Errorf("registration expiry must be provided")
+
+	case !rec.RegistrationExpiresAt.After(now):
+		return fmt.Errorf("registration expiry must be in the future")
+
+	case rec.RegistrationExpiresAt.After(
+		now.Add(MaxOwnedReceiveScriptRegistrationTTL),
+	):
+		return fmt.Errorf("registration expiry exceeds %v",
+			MaxOwnedReceiveScriptRegistrationTTL)
+
+	case rec.RegistrationRPCKey == "":
+		return fmt.Errorf("registration RPC key must be provided")
+
+	case rec.RegistrationCompletedAt.IsSome():
+		return fmt.Errorf("new registration must not be complete")
+	}
+
+	return nil
+}
+
+// validateOwnedReceiveScriptReplay checks the caller-controlled immutable
+// fingerprint. Server-selected key, script, terms, expiry, and remote request
+// key always come from the first durable winner.
+func validateOwnedReceiveScriptReplay(existing OwnedReceiveScriptRecord,
+	label string) error {
+
+	if existing.RegistrationLabel != label {
+		return fmt.Errorf("%w: label differs",
+			ErrOwnedReceiveScriptReplayMismatch)
+	}
+
+	if existing.IdempotencyKey == "" ||
+		existing.RegistrationRPCKey == "" ||
+		existing.RegistrationExpiresAt.IsZero() {
+		return fmt.Errorf("idempotent receive script metadata " +
+			"incomplete")
+	}
+
+	return nil
 }
 
 // ListOwnedReceiveScripts returns all owned receive script registrations.

--- a/db/oor_artifact_store_test.go
+++ b/db/oor_artifact_store_test.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"database/sql"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -56,6 +58,36 @@ func newOORArtifactStoreForTest(t *testing.T) (*OORArtifactPersistenceStore,
 	)
 
 	return NewOORArtifactPersistenceStore(artifactDB, clk), roundStore
+}
+
+// newOORArtifactStoreFromBaseDB creates an artifact store over an existing
+// test database handle.
+func newOORArtifactStoreFromBaseDB(
+	baseDB *BaseDB) *OORArtifactPersistenceStore {
+
+	artifactDB := NewTransactionExecutor(
+		baseDB,
+		func(tx *sql.Tx) OORArtifactStore {
+			return baseDB.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+
+	return NewOORArtifactPersistenceStore(
+		artifactDB, clock.NewDefaultClock(),
+	)
+}
+
+// newOORArtifactStoreForTestPath opens an artifact store at a stable test
+// database path so callers can close and reopen it to model restart.
+func newOORArtifactStoreForTestPath(t *testing.T,
+	dbPath string) (*OORArtifactPersistenceStore, *BaseDB) {
+
+	t.Helper()
+
+	testDB := NewTestDBHandleFromPath(t, dbPath)
+
+	return newOORArtifactStoreFromBaseDB(testDB.BaseDB), testDB.BaseDB
 }
 
 func seedBindingOutpoint(t *testing.T, ctx context.Context,
@@ -599,6 +631,294 @@ func TestOORArtifactStoreOwnedReceiveScriptCRUD(t *testing.T) {
 
 	require.Equal(t, recB.PkScript, rows[0].PkScript)
 	require.Equal(t, recA.PkScript, rows[1].PkScript)
+}
+
+// testIdempotentOwnedReceiveScript builds deterministic ownership metadata for
+// one retry-safe receive-script admission.
+func testIdempotentOwnedReceiveScript(t *testing.T, seed byte, idempotencyKey,
+	label string) OwnedReceiveScriptRecord {
+
+	t.Helper()
+
+	clientKey, _ := btcec.PrivKeyFromBytes([]byte{seed, 0x01})
+	operatorKey, _ := btcec.PrivKeyFromBytes([]byte{seed, 0x02})
+	createdAt := time.Unix(1_700_000_000+int64(seed), 0).UTC()
+	lastUsedAt := time.Unix(1_700_001_000+int64(seed), 0).UTC()
+
+	return OwnedReceiveScriptRecord{
+		PkScript: []byte{
+			0x51, 0x20, seed,
+		},
+		ClientKey: keychain.KeyDescriptor{
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamily(seed),
+				Index:  uint32(seed) + 10,
+			},
+			PubKey: clientKey.PubKey(),
+		},
+		OperatorPubKey:    operatorKey.PubKey(),
+		ExitDelay:         int64(seed) + 20,
+		Source:            OwnedReceiveScriptSourceRPC,
+		CreatedAt:         createdAt,
+		LastUsedAt:        fn.Some(lastUsedAt),
+		IdempotencyKey:    idempotencyKey,
+		RegistrationLabel: label,
+		RegistrationExpiresAt: time.Now().UTC().Add(
+			4 * time.Hour,
+		).Truncate(time.Second),
+		RegistrationRPCKey: "register-" + idempotencyKey,
+	}
+}
+
+// requireOwnedReceiveScriptEqual compares every persisted receive-script
+// ownership and retry field without relying on public-key pointer identity.
+func requireOwnedReceiveScriptEqual(t *testing.T, want,
+	got OwnedReceiveScriptRecord) {
+
+	t.Helper()
+
+	require.Equal(t, want.PkScript, got.PkScript)
+	require.Equal(t, want.ClientKey.Family, got.ClientKey.Family)
+	require.Equal(t, want.ClientKey.Index, got.ClientKey.Index)
+	require.True(t, want.ClientKey.PubKey.IsEqual(got.ClientKey.PubKey))
+	require.True(t, want.OperatorPubKey.IsEqual(got.OperatorPubKey))
+	require.Equal(t, want.ExitDelay, got.ExitDelay)
+	require.Equal(t, want.Source, got.Source)
+	require.Equal(t, want.CreatedAt, got.CreatedAt)
+	require.Equal(t, want.LastUsedAt, got.LastUsedAt)
+	require.Equal(t, want.IdempotencyKey, got.IdempotencyKey)
+	require.Equal(t, want.RegistrationLabel, got.RegistrationLabel)
+	require.Equal(
+		t, want.RegistrationExpiresAt, got.RegistrationExpiresAt,
+	)
+	require.Equal(t, want.RegistrationRPCKey, got.RegistrationRPCKey)
+	require.Equal(
+		t, want.RegistrationCompletedAt, got.RegistrationCompletedAt,
+	)
+}
+
+// TestOORArtifactStoreAdmitIdempotentOwnedReceiveScriptExactReplay verifies a
+// repeated admission returns the first durable allocation and round-trips all
+// ownership and registration metadata.
+func TestOORArtifactStoreAdmitIdempotentOwnedReceiveScriptExactReplay(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newOORArtifactStoreForTest(t)
+	winner := testIdempotentOwnedReceiveScript(
+		t, 0x41, "receive-replay", "credit-topup",
+	)
+
+	admitted, created, err := store.AdmitIdempotentOwnedReceiveScript(
+		ctx, winner,
+	)
+	require.NoError(t, err)
+	require.True(t, created)
+	requireOwnedReceiveScriptEqual(t, winner, *admitted)
+
+	replay := testIdempotentOwnedReceiveScript(
+		t, 0x42, winner.IdempotencyKey, winner.RegistrationLabel,
+	)
+	replayed, created, err := store.AdmitIdempotentOwnedReceiveScript(
+		ctx, replay,
+	)
+	require.NoError(t, err)
+	require.False(t, created)
+	requireOwnedReceiveScriptEqual(t, winner, *replayed)
+
+	lookedUp, err := store.LookupOwnedReceiveScriptByIdempotencyKey(
+		ctx, winner.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	requireOwnedReceiveScriptEqual(t, winner, *lookedUp)
+}
+
+// TestOORArtifactStoreAdmitIdempotentOwnedReceiveScriptChangedLabel verifies
+// reusing an idempotency key for a different caller-controlled label is
+// rejected without rewriting the durable winner.
+func TestOORArtifactStoreAdmitIdempotentOwnedReceiveScriptChangedLabel(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newOORArtifactStoreForTest(t)
+	winner := testIdempotentOwnedReceiveScript(
+		t, 0x51, "receive-label", "first-label",
+	)
+
+	_, created, err := store.AdmitIdempotentOwnedReceiveScript(ctx, winner)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	mismatch := testIdempotentOwnedReceiveScript(
+		t, 0x52, winner.IdempotencyKey, "second-label",
+	)
+	_, created, err = store.AdmitIdempotentOwnedReceiveScript(
+		ctx, mismatch,
+	)
+	require.ErrorIs(t, err, ErrOwnedReceiveScriptReplayMismatch)
+	require.False(t, created)
+
+	lookedUp, err := store.LookupOwnedReceiveScriptByIdempotencyKey(
+		ctx, winner.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	requireOwnedReceiveScriptEqual(t, winner, *lookedUp)
+}
+
+// TestOORArtifactStoreAdmitIdempotentOwnedReceiveScriptConcurrentWinner
+// verifies concurrent first admissions converge on one durable allocation.
+func TestOORArtifactStoreAdmitIdempotentOwnedReceiveScriptConcurrentWinner(
+	t *testing.T) {
+
+	t.Parallel()
+
+	type admissionResult struct {
+		record  *OwnedReceiveScriptRecord
+		created bool
+		err     error
+	}
+
+	ctx := t.Context()
+	store, _ := newOORArtifactStoreForTest(t)
+	candidates := []OwnedReceiveScriptRecord{
+		testIdempotentOwnedReceiveScript(
+			t, 0x61, "receive-concurrent", "shared-label",
+		),
+		testIdempotentOwnedReceiveScript(
+			t, 0x62, "receive-concurrent", "shared-label",
+		),
+	}
+
+	start := make(chan struct{})
+	results := make(chan admissionResult, len(candidates))
+	var workers sync.WaitGroup
+	for i := range candidates {
+		candidate := candidates[i]
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+
+			record, created, err :=
+				store.AdmitIdempotentOwnedReceiveScript(
+					ctx, candidate,
+				)
+			results <- admissionResult{
+				record:  record,
+				created: created,
+				err:     err,
+			}
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(results)
+
+	var admissions []admissionResult
+	for result := range results {
+		require.NoError(t, result.err)
+		require.NotNil(t, result.record)
+		admissions = append(admissions, result)
+	}
+	require.Len(t, admissions, 2)
+	require.NotEqual(t, admissions[0].created, admissions[1].created)
+	requireOwnedReceiveScriptEqual(
+		t, *admissions[0].record, *admissions[1].record,
+	)
+
+	winner := *admissions[0].record
+	require.True(
+		t, string(winner.PkScript) == string(candidates[0].PkScript) ||
+			string(winner.PkScript) == string(
+				candidates[1].PkScript,
+			),
+	)
+}
+
+// TestOORArtifactStoreIdempotentOwnedReceiveScriptPendingAcrossRestart
+// verifies an admitted but unregistered allocation survives a database-handle
+// restart and remains the exact replay winner.
+func TestOORArtifactStoreIdempotentOwnedReceiveScriptPendingAcrossRestart(
+	t *testing.T) {
+
+	dbPath := filepath.Join(t.TempDir(), "receive-script.db")
+	store, baseDB := newOORArtifactStoreForTestPath(t, dbPath)
+	winner := testIdempotentOwnedReceiveScript(
+		t, 0x71, "receive-restart", "restart-label",
+	)
+
+	_, created, err := store.AdmitIdempotentOwnedReceiveScript(
+		t.Context(), winner,
+	)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(t, baseDB.DB.Close())
+
+	restarted, _ := newOORArtifactStoreForTestPath(t, dbPath)
+	pending, err := restarted.LookupOwnedReceiveScriptByIdempotencyKey(
+		t.Context(), winner.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	require.True(t, pending.RegistrationCompletedAt.IsNone())
+	requireOwnedReceiveScriptEqual(t, winner, *pending)
+
+	replay := testIdempotentOwnedReceiveScript(
+		t, 0x72, winner.IdempotencyKey, winner.RegistrationLabel,
+	)
+	replayed, created, err :=
+		restarted.AdmitIdempotentOwnedReceiveScript(t.Context(), replay)
+	require.NoError(t, err)
+	require.False(t, created)
+	requireOwnedReceiveScriptEqual(t, winner, *replayed)
+}
+
+// TestOORArtifactStoreOwnedReceiveScriptCompletionIdempotency verifies the
+// registration completion transition is retry-safe for the exact remote key
+// and rejects a different remote request identity.
+func TestOORArtifactStoreOwnedReceiveScriptCompletionIdempotency(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newOORArtifactStoreForTest(t)
+	winner := testIdempotentOwnedReceiveScript(
+		t, 0x81, "receive-complete", "completion-label",
+	)
+
+	_, created, err := store.AdmitIdempotentOwnedReceiveScript(ctx, winner)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	err = store.MarkOwnedReceiveScriptRegistered(
+		ctx, winner.IdempotencyKey, winner.RegistrationRPCKey,
+	)
+	require.NoError(t, err)
+	completed, err := store.LookupOwnedReceiveScriptByIdempotencyKey(
+		ctx, winner.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	require.True(t, completed.RegistrationCompletedAt.IsSome())
+	completedAt := completed.RegistrationCompletedAt
+
+	err = store.MarkOwnedReceiveScriptRegistered(
+		ctx, winner.IdempotencyKey, winner.RegistrationRPCKey,
+	)
+	require.NoError(t, err)
+	completed, err = store.LookupOwnedReceiveScriptByIdempotencyKey(
+		ctx, winner.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	require.Equal(t, completedAt, completed.RegistrationCompletedAt)
+
+	err = store.MarkOwnedReceiveScriptRegistered(
+		ctx, winner.IdempotencyKey, "different-registration-key",
+	)
+	require.ErrorContains(
+		t, err, "registration completion invariant failed",
+	)
 }
 
 // buildTestOORPackage constructs a deterministic incoming-style OOR package

--- a/db/oor_artifact_store_test.go
+++ b/db/oor_artifact_store_test.go
@@ -697,6 +697,61 @@ func requireOwnedReceiveScriptEqual(t *testing.T, want,
 	)
 }
 
+// TestOORArtifactStoreUpsertPreservesIdempotentReplayMetadata verifies a
+// wallet or recovery upsert can refresh script ownership without clearing the
+// retry identity and remote-registration evidence owned by admission.
+func TestOORArtifactStoreUpsertPreservesIdempotentReplayMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newOORArtifactStoreForTest(t)
+	winner := testIdempotentOwnedReceiveScript(
+		t, 0x39, "receive-recovery-upsert", "recovery-label",
+	)
+
+	_, created, err := store.AdmitIdempotentOwnedReceiveScript(ctx, winner)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(
+		t, store.MarkOwnedReceiveScriptRegistered(
+			ctx, winner.IdempotencyKey, winner.RegistrationRPCKey,
+		),
+	)
+
+	before, err := store.LookupOwnedReceiveScriptByIdempotencyKey(
+		ctx, winner.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	require.True(t, before.RegistrationCompletedAt.IsSome())
+
+	recovery := winner
+	recovery.Source = OwnedReceiveScriptSourceSync
+	recovery.IdempotencyKey = ""
+	recovery.RegistrationLabel = ""
+	recovery.RegistrationExpiresAt = time.Time{}
+	recovery.RegistrationRPCKey = ""
+	recovery.RegistrationCompletedAt = fn.None[time.Time]()
+	require.NoError(t, store.UpsertOwnedReceiveScript(ctx, recovery))
+
+	after, err := store.LookupOwnedReceiveScriptByIdempotencyKey(
+		ctx, winner.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	require.Equal(t, OwnedReceiveScriptSourceSync, after.Source)
+	require.Equal(t, before.IdempotencyKey, after.IdempotencyKey)
+	require.Equal(t, before.RegistrationLabel, after.RegistrationLabel)
+	require.Equal(
+		t, before.RegistrationExpiresAt, after.RegistrationExpiresAt,
+	)
+	require.Equal(
+		t, before.RegistrationRPCKey, after.RegistrationRPCKey,
+	)
+	require.Equal(
+		t, before.RegistrationCompletedAt,
+		after.RegistrationCompletedAt,
+	)
+}
+
 // TestOORArtifactStoreAdmitIdempotentOwnedReceiveScriptExactReplay verifies a
 // repeated admission returns the first durable allocation and round-trips all
 // ownership and registration metadata.

--- a/db/oor_artifact_store_test.go
+++ b/db/oor_artifact_store_test.go
@@ -769,6 +769,33 @@ func TestOORArtifactStoreAdmitIdempotentOwnedReceiveScriptChangedLabel(
 	requireOwnedReceiveScriptEqual(t, winner, *lookedUp)
 }
 
+// TestOORArtifactStoreIdempotentAdmissionSurfacesScriptCollision verifies the
+// idempotency conflict clause does not hide a distinct pk_script owner.
+func TestOORArtifactStoreIdempotentAdmissionSurfacesScriptCollision(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newOORArtifactStoreForTest(t)
+	candidate := testIdempotentOwnedReceiveScript(
+		t, 0x59, "receive-script-collision", "collision-label",
+	)
+	require.NoError(t, store.UpsertOwnedReceiveScript(ctx, candidate))
+
+	_, created, err := store.AdmitIdempotentOwnedReceiveScript(
+		ctx, candidate,
+	)
+	require.Error(t, err)
+	require.False(t, created)
+	require.NotErrorIs(t, err, errOwnedReceiveScriptAdmissionRace)
+
+	_, err = store.LookupOwnedReceiveScriptByIdempotencyKey(
+		ctx, candidate.IdempotencyKey,
+	)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+}
+
 // TestOORArtifactStoreAdmitIdempotentOwnedReceiveScriptConcurrentWinner
 // verifies concurrent first admissions converge on one durable allocation.
 func TestOORArtifactStoreAdmitIdempotentOwnedReceiveScriptConcurrentWinner(
@@ -874,6 +901,71 @@ func TestOORArtifactStoreIdempotentOwnedReceiveScriptPendingAcrossRestart(
 	require.NoError(t, err)
 	require.False(t, created)
 	requireOwnedReceiveScriptEqual(t, winner, *replayed)
+}
+
+// TestOORArtifactStoreRenewExpiredOwnedReceiveScriptRegistration verifies an
+// expired completed allocation keeps its ownership identity while one new
+// durable registration window wins across stale concurrent retries.
+func TestOORArtifactStoreRenewExpiredOwnedReceiveScriptRegistration(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	clk := clock.NewTestClock(now)
+	testDB := NewTestDB(t)
+	artifactDB := NewTransactionExecutor(
+		testDB.BaseDB,
+		func(tx *sql.Tx) OORArtifactStore {
+			return testDB.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	store := NewOORArtifactPersistenceStore(artifactDB, clk)
+	winner := testIdempotentOwnedReceiveScript(
+		t, 0x79, "receive-renew", "renew-label",
+	)
+	winner.RegistrationExpiresAt = now.Add(time.Hour)
+
+	_, created, err := store.AdmitIdempotentOwnedReceiveScript(ctx, winner)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(
+		t, store.MarkOwnedReceiveScriptRegistered(
+			ctx, winner.IdempotencyKey, winner.RegistrationRPCKey,
+		),
+	)
+
+	clk.SetTime(now.Add(2 * time.Hour))
+	nextExpiry := clk.Now().Add(4 * time.Hour)
+	renewed, err :=
+		store.RenewOwnedReceiveScriptRegistration(
+			ctx, winner, nextExpiry, "renewed-registration-key",
+		)
+	require.NoError(t, err)
+	require.Equal(t, winner.PkScript, renewed.PkScript)
+	require.Equal(t, winner.ClientKey, renewed.ClientKey)
+	require.True(t, winner.OperatorPubKey.IsEqual(renewed.OperatorPubKey))
+	require.Equal(t, winner.ExitDelay, renewed.ExitDelay)
+	require.Equal(t, winner.RegistrationLabel, renewed.RegistrationLabel)
+	require.Equal(t, nextExpiry, renewed.RegistrationExpiresAt)
+	require.Equal(t, "renewed-registration-key", renewed.RegistrationRPCKey)
+	require.True(t, renewed.RegistrationCompletedAt.IsNone())
+
+	staleReplay, err :=
+		store.RenewOwnedReceiveScriptRegistration(
+			ctx, winner, clk.Now().Add(5*time.Hour),
+			"losing-registration-key",
+		)
+	require.NoError(t, err)
+	require.Equal(
+		t, renewed.RegistrationExpiresAt,
+		staleReplay.RegistrationExpiresAt,
+	)
+	require.Equal(
+		t, renewed.RegistrationRPCKey, staleReplay.RegistrationRPCKey,
+	)
 }
 
 // TestOORArtifactStoreOwnedReceiveScriptCompletionIdempotency verifies the

--- a/db/sqlc/migrations/000017_idempotent_receive_scripts.down.sql
+++ b/db/sqlc/migrations/000017_idempotent_receive_scripts.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_owned_receive_scripts_idempotency_key;
+
+ALTER TABLE owned_receive_scripts DROP COLUMN registration_expires_at;
+ALTER TABLE owned_receive_scripts DROP COLUMN registration_completed_at;
+ALTER TABLE owned_receive_scripts DROP COLUMN registration_rpc_key;
+ALTER TABLE owned_receive_scripts DROP COLUMN registration_label;
+ALTER TABLE owned_receive_scripts DROP COLUMN idempotency_key;

--- a/db/sqlc/migrations/000017_idempotent_receive_scripts.up.sql
+++ b/db/sqlc/migrations/000017_idempotent_receive_scripts.up.sql
@@ -1,0 +1,18 @@
+ALTER TABLE owned_receive_scripts
+    ADD COLUMN idempotency_key TEXT;
+
+ALTER TABLE owned_receive_scripts
+    ADD COLUMN registration_label TEXT;
+
+ALTER TABLE owned_receive_scripts
+    ADD COLUMN registration_expires_at BIGINT;
+
+ALTER TABLE owned_receive_scripts
+    ADD COLUMN registration_rpc_key TEXT;
+
+ALTER TABLE owned_receive_scripts
+    ADD COLUMN registration_completed_at BIGINT;
+
+CREATE UNIQUE INDEX idx_owned_receive_scripts_idempotency_key
+    ON owned_receive_scripts(idempotency_key)
+    WHERE idempotency_key IS NOT NULL;

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -253,13 +253,18 @@ type OorVtxoBindingLinkKind struct {
 }
 
 type OwnedReceiveScript struct {
-	PkScript       []byte
-	ClientKeyID    sql.NullInt64
-	OperatorPubkey []byte
-	ExitDelay      int64
-	Source         int32
-	CreatedAt      int64
-	LastUsedAt     sql.NullInt64
+	PkScript                []byte
+	ClientKeyID             sql.NullInt64
+	OperatorPubkey          []byte
+	ExitDelay               int64
+	Source                  int32
+	CreatedAt               int64
+	LastUsedAt              sql.NullInt64
+	IdempotencyKey          sql.NullString
+	RegistrationLabel       sql.NullString
+	RegistrationExpiresAt   sql.NullInt64
+	RegistrationRpcKey      sql.NullString
+	RegistrationCompletedAt sql.NullInt64
 }
 
 type OwnedReceiveScriptSource struct {

--- a/db/sqlc/oor_artifacts.sql.go
+++ b/db/sqlc/oor_artifacts.sql.go
@@ -302,7 +302,7 @@ INSERT INTO owned_receive_scripts (
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL
 )
-ON CONFLICT DO NOTHING
+ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING
 `
 
 type InsertIdempotentOwnedReceiveScriptParams struct {
@@ -622,6 +622,41 @@ type MarkOwnedReceiveScriptRegisteredParams struct {
 
 func (q *Queries) MarkOwnedReceiveScriptRegistered(ctx context.Context, arg MarkOwnedReceiveScriptRegisteredParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, MarkOwnedReceiveScriptRegistered, arg.IdempotencyKey, arg.RegistrationRpcKey, arg.RegistrationCompletedAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const RenewOwnedReceiveScriptRegistration = `-- name: RenewOwnedReceiveScriptRegistration :execrows
+UPDATE owned_receive_scripts
+SET registration_expires_at = $1,
+    registration_rpc_key = $2,
+    registration_completed_at = NULL
+WHERE idempotency_key = $3
+  AND registration_rpc_key = $4
+  AND registration_expires_at = $5
+  AND registration_expires_at <= $6
+`
+
+type RenewOwnedReceiveScriptRegistrationParams struct {
+	NextExpiresAt     sql.NullInt64
+	NextRpcKey        sql.NullString
+	IdempotencyKey    sql.NullString
+	ExpectedRpcKey    sql.NullString
+	ExpectedExpiresAt sql.NullInt64
+	NowUnix           sql.NullInt64
+}
+
+func (q *Queries) RenewOwnedReceiveScriptRegistration(ctx context.Context, arg RenewOwnedReceiveScriptRegistrationParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, RenewOwnedReceiveScriptRegistration,
+		arg.NextExpiresAt,
+		arg.NextRpcKey,
+		arg.IdempotencyKey,
+		arg.ExpectedRpcKey,
+		arg.ExpectedExpiresAt,
+		arg.NowUnix,
+	)
 	if err != nil {
 		return 0, err
 	}

--- a/db/sqlc/oor_artifacts.sql.go
+++ b/db/sqlc/oor_artifacts.sql.go
@@ -244,7 +244,7 @@ func (q *Queries) GetOORVTXOBindingByOutpointAndKind(ctx context.Context, arg Ge
 }
 
 const GetOwnedReceiveScript = `-- name: GetOwnedReceiveScript :one
-SELECT pk_script, client_key_id, operator_pubkey, exit_delay, source, created_at, last_used_at FROM owned_receive_scripts
+SELECT pk_script, client_key_id, operator_pubkey, exit_delay, source, created_at, last_used_at, idempotency_key, registration_label, registration_expires_at, registration_rpc_key, registration_completed_at FROM owned_receive_scripts
 WHERE pk_script = $1
 `
 
@@ -259,8 +259,84 @@ func (q *Queries) GetOwnedReceiveScript(ctx context.Context, pkScript []byte) (O
 		&i.Source,
 		&i.CreatedAt,
 		&i.LastUsedAt,
+		&i.IdempotencyKey,
+		&i.RegistrationLabel,
+		&i.RegistrationExpiresAt,
+		&i.RegistrationRpcKey,
+		&i.RegistrationCompletedAt,
 	)
 	return i, err
+}
+
+const GetOwnedReceiveScriptByIdempotencyKey = `-- name: GetOwnedReceiveScriptByIdempotencyKey :one
+SELECT pk_script, client_key_id, operator_pubkey, exit_delay, source, created_at, last_used_at, idempotency_key, registration_label, registration_expires_at, registration_rpc_key, registration_completed_at FROM owned_receive_scripts
+WHERE idempotency_key = $1
+`
+
+func (q *Queries) GetOwnedReceiveScriptByIdempotencyKey(ctx context.Context, idempotencyKey sql.NullString) (OwnedReceiveScript, error) {
+	row := q.db.QueryRowContext(ctx, GetOwnedReceiveScriptByIdempotencyKey, idempotencyKey)
+	var i OwnedReceiveScript
+	err := row.Scan(
+		&i.PkScript,
+		&i.ClientKeyID,
+		&i.OperatorPubkey,
+		&i.ExitDelay,
+		&i.Source,
+		&i.CreatedAt,
+		&i.LastUsedAt,
+		&i.IdempotencyKey,
+		&i.RegistrationLabel,
+		&i.RegistrationExpiresAt,
+		&i.RegistrationRpcKey,
+		&i.RegistrationCompletedAt,
+	)
+	return i, err
+}
+
+const InsertIdempotentOwnedReceiveScript = `-- name: InsertIdempotentOwnedReceiveScript :execrows
+INSERT INTO owned_receive_scripts (
+    pk_script, client_key_id, operator_pubkey, exit_delay, source,
+    created_at, last_used_at, idempotency_key, registration_label,
+    registration_expires_at, registration_rpc_key,
+    registration_completed_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL
+)
+ON CONFLICT DO NOTHING
+`
+
+type InsertIdempotentOwnedReceiveScriptParams struct {
+	PkScript              []byte
+	ClientKeyID           sql.NullInt64
+	OperatorPubkey        []byte
+	ExitDelay             int64
+	Source                int32
+	CreatedAt             int64
+	LastUsedAt            sql.NullInt64
+	IdempotencyKey        sql.NullString
+	RegistrationLabel     sql.NullString
+	RegistrationExpiresAt sql.NullInt64
+	RegistrationRpcKey    sql.NullString
+}
+
+func (q *Queries) InsertIdempotentOwnedReceiveScript(ctx context.Context, arg InsertIdempotentOwnedReceiveScriptParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, InsertIdempotentOwnedReceiveScript,
+		arg.PkScript,
+		arg.ClientKeyID,
+		arg.OperatorPubkey,
+		arg.ExitDelay,
+		arg.Source,
+		arg.CreatedAt,
+		arg.LastUsedAt,
+		arg.IdempotencyKey,
+		arg.RegistrationLabel,
+		arg.RegistrationExpiresAt,
+		arg.RegistrationRpcKey,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const InsertOORPackageCheckpoint = `-- name: InsertOORPackageCheckpoint :exec
@@ -490,7 +566,7 @@ func (q *Queries) ListOORVTXOBindingsBySession(ctx context.Context, sessionID []
 }
 
 const ListOwnedReceiveScripts = `-- name: ListOwnedReceiveScripts :many
-SELECT pk_script, client_key_id, operator_pubkey, exit_delay, source, created_at, last_used_at FROM owned_receive_scripts
+SELECT pk_script, client_key_id, operator_pubkey, exit_delay, source, created_at, last_used_at, idempotency_key, registration_label, registration_expires_at, registration_rpc_key, registration_completed_at FROM owned_receive_scripts
 ORDER BY created_at DESC
 `
 
@@ -511,6 +587,11 @@ func (q *Queries) ListOwnedReceiveScripts(ctx context.Context) ([]OwnedReceiveSc
 			&i.Source,
 			&i.CreatedAt,
 			&i.LastUsedAt,
+			&i.IdempotencyKey,
+			&i.RegistrationLabel,
+			&i.RegistrationExpiresAt,
+			&i.RegistrationRpcKey,
+			&i.RegistrationCompletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -523,6 +604,28 @@ func (q *Queries) ListOwnedReceiveScripts(ctx context.Context) ([]OwnedReceiveSc
 		return nil, err
 	}
 	return items, nil
+}
+
+const MarkOwnedReceiveScriptRegistered = `-- name: MarkOwnedReceiveScriptRegistered :execrows
+UPDATE owned_receive_scripts
+SET registration_completed_at = $3
+WHERE idempotency_key = $1
+  AND registration_rpc_key = $2
+  AND registration_completed_at IS NULL
+`
+
+type MarkOwnedReceiveScriptRegisteredParams struct {
+	IdempotencyKey          sql.NullString
+	RegistrationRpcKey      sql.NullString
+	RegistrationCompletedAt sql.NullInt64
+}
+
+func (q *Queries) MarkOwnedReceiveScriptRegistered(ctx context.Context, arg MarkOwnedReceiveScriptRegisteredParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, MarkOwnedReceiveScriptRegistered, arg.IdempotencyKey, arg.RegistrationRpcKey, arg.RegistrationCompletedAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const UpsertOORPackage = `-- name: UpsertOORPackage :execrows
@@ -632,9 +735,11 @@ func (q *Queries) UpsertOORVTXOBinding(ctx context.Context, arg UpsertOORVTXOBin
 const UpsertOwnedReceiveScript = `-- name: UpsertOwnedReceiveScript :exec
 INSERT INTO owned_receive_scripts (
     pk_script, client_key_id, operator_pubkey, exit_delay, source,
-    created_at, last_used_at
+    created_at, last_used_at, idempotency_key, registration_label,
+    registration_expires_at, registration_rpc_key,
+    registration_completed_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7
+    $1, $2, $3, $4, $5, $6, $7, NULL, NULL, NULL, NULL, NULL
 )
 ON CONFLICT (pk_script) DO UPDATE SET
     client_key_id = EXCLUDED.client_key_id,

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -375,6 +375,7 @@ type Querier interface {
 	// PullActivityEvents returns transition rows strictly after the cursor in
 	// event_seq order, the resumable-subscribe replay primitive.
 	PullActivityEvents(ctx context.Context, arg PullActivityEventsParams) ([]ActivityEvent, error)
+	RenewOwnedReceiveScriptRegistration(ctx context.Context, arg RenewOwnedReceiveScriptRegistrationParams) (int64, error)
 	SumBoardingIntentAmountsByStatus(ctx context.Context, status string) (interface{}, error)
 	SumUnspentVTXOAmounts(ctx context.Context) (interface{}, error)
 	UpdateBoardingIntentStatus(ctx context.Context, arg UpdateBoardingIntentStatusParams) error

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -103,6 +103,7 @@ type Querier interface {
 	GetOORVTXOBindingByOutpoint(ctx context.Context, arg GetOORVTXOBindingByOutpointParams) (OorVtxoBinding, error)
 	GetOORVTXOBindingByOutpointAndKind(ctx context.Context, arg GetOORVTXOBindingByOutpointAndKindParams) (OorVtxoBinding, error)
 	GetOwnedReceiveScript(ctx context.Context, pkScript []byte) (OwnedReceiveScript, error)
+	GetOwnedReceiveScriptByIdempotencyKey(ctx context.Context, idempotencyKey sql.NullString) (OwnedReceiveScript, error)
 	// Fetch one intent header by id, exposing the terminal-failure columns so
 	// callers (and tests) can assert send-failure state without raw SQL.
 	GetPendingIntentByID(ctx context.Context, intentID []byte) (GetPendingIntentByIDRow, error)
@@ -153,6 +154,7 @@ type Querier interface {
 	// Client tree txids queries.
 	InsertClientTreeTxid(ctx context.Context, arg InsertClientTreeTxidParams) error
 	InsertExitFundingAddress(ctx context.Context, arg InsertExitFundingAddressParams) error
+	InsertIdempotentOwnedReceiveScript(ctx context.Context, arg InsertIdempotentOwnedReceiveScriptParams) (int64, error)
 	InsertMacaroonRootKey(ctx context.Context, arg InsertMacaroonRootKeyParams) error
 	InsertOORPackageCheckpoint(ctx context.Context, arg InsertOORPackageCheckpointParams) error
 	// Round queries.
@@ -344,6 +346,7 @@ type Querier interface {
 	MarkBoardingSweepInputStatus(ctx context.Context, arg MarkBoardingSweepInputStatusParams) error
 	MarkBoardingSweepInputsStatus(ctx context.Context, arg MarkBoardingSweepInputsStatusParams) error
 	MarkBoardingSweepStatus(ctx context.Context, arg MarkBoardingSweepStatusParams) error
+	MarkOwnedReceiveScriptRegistered(ctx context.Context, arg MarkOwnedReceiveScriptRegisteredParams) (int64, error)
 	// Terminally fail the pending send intent anchored to the given outpoint,
 	// recording the reason and typed failure code. Idempotent: the status guard
 	// makes a repeat call (e.g. a second forfeit outpoint of the same intent) a

--- a/db/sqlc/queries/oor_artifacts.sql
+++ b/db/sqlc/queries/oor_artifacts.sql
@@ -173,7 +173,17 @@ INSERT INTO owned_receive_scripts (
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL
 )
-ON CONFLICT DO NOTHING;
+ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
+
+-- name: RenewOwnedReceiveScriptRegistration :execrows
+UPDATE owned_receive_scripts
+SET registration_expires_at = sqlc.arg(next_expires_at),
+    registration_rpc_key = sqlc.arg(next_rpc_key),
+    registration_completed_at = NULL
+WHERE idempotency_key = sqlc.arg(idempotency_key)
+  AND registration_rpc_key = sqlc.arg(expected_rpc_key)
+  AND registration_expires_at = sqlc.arg(expected_expires_at)
+  AND registration_expires_at <= sqlc.arg(now_unix);
 
 -- name: MarkOwnedReceiveScriptRegistered :execrows
 UPDATE owned_receive_scripts

--- a/db/sqlc/queries/oor_artifacts.sql
+++ b/db/sqlc/queries/oor_artifacts.sql
@@ -151,9 +151,11 @@ ORDER BY updated_at DESC;
 -- name: UpsertOwnedReceiveScript :exec
 INSERT INTO owned_receive_scripts (
     pk_script, client_key_id, operator_pubkey, exit_delay, source,
-    created_at, last_used_at
+    created_at, last_used_at, idempotency_key, registration_label,
+    registration_expires_at, registration_rpc_key,
+    registration_completed_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7
+    $1, $2, $3, $4, $5, $6, $7, NULL, NULL, NULL, NULL, NULL
 )
 ON CONFLICT (pk_script) DO UPDATE SET
     client_key_id = EXCLUDED.client_key_id,
@@ -162,9 +164,31 @@ ON CONFLICT (pk_script) DO UPDATE SET
     source = EXCLUDED.source,
     last_used_at = EXCLUDED.last_used_at;
 
+-- name: InsertIdempotentOwnedReceiveScript :execrows
+INSERT INTO owned_receive_scripts (
+    pk_script, client_key_id, operator_pubkey, exit_delay, source,
+    created_at, last_used_at, idempotency_key, registration_label,
+    registration_expires_at, registration_rpc_key,
+    registration_completed_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL
+)
+ON CONFLICT DO NOTHING;
+
+-- name: MarkOwnedReceiveScriptRegistered :execrows
+UPDATE owned_receive_scripts
+SET registration_completed_at = $3
+WHERE idempotency_key = $1
+  AND registration_rpc_key = $2
+  AND registration_completed_at IS NULL;
+
 -- name: GetOwnedReceiveScript :one
 SELECT * FROM owned_receive_scripts
 WHERE pk_script = $1;
+
+-- name: GetOwnedReceiveScriptByIdempotencyKey :one
+SELECT * FROM owned_receive_scripts
+WHERE idempotency_key = $1;
 
 -- name: ListOwnedReceiveScripts :many
 SELECT * FROM owned_receive_scripts

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -556,6 +556,10 @@ CREATE INDEX idx_outbox_messages_pending
     ON outbox_messages(status, created_at)
     WHERE status = 'pending';
 
+CREATE UNIQUE INDEX idx_owned_receive_scripts_idempotency_key
+    ON owned_receive_scripts(idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
 CREATE INDEX idx_pending_intent_anchors_intent_id
 ON pending_intent_anchors (intent_id);
 
@@ -1044,7 +1048,7 @@ CREATE TABLE owned_receive_scripts (
     created_at BIGINT NOT NULL,
 
     -- last_used_at is an optional unix timestamp of latest usage.
-    last_used_at BIGINT,
+    last_used_at BIGINT, idempotency_key TEXT, registration_label TEXT, registration_expires_at BIGINT, registration_rpc_key TEXT, registration_completed_at BIGINT,
 
     -- Source enum foreign key.
     FOREIGN KEY (source) REFERENCES owned_receive_script_sources(source)

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -407,9 +407,11 @@ key locator.
 | Flag | Type | Description |
 |------|------|-------------|
 | `--label` | string | Optional indexer registration label |
+| `--idempotency-key` | string | Return the same allocation on exact retry |
 
 ```bash
 wavecli ark oor receive
+wavecli ark oor receive --idempotency-key durable-operation-42
 ```
 
 ### `ark vtxos list`

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -400,9 +400,10 @@ wavecli ark board --target-vtxo-count 4
 
 ### `ark oor receive` — incoming OOR pubkey
 
-Allocate a fresh out-of-round receive script backed by a newly derived
-wallet key. Returns `pk_script_hex`, `pubkey_xonly_hex`, and the wallet
-key locator.
+Allocate an out-of-round receive script backed by a newly derived wallet key,
+or replay the exact allocation for a previously used idempotency key. Returns
+`pk_script_hex`, `pubkey_xonly_hex`, the wallet key locator, and the absolute
+indexer registration expiry.
 
 | Flag | Type | Description |
 |------|------|-------------|
@@ -411,8 +412,11 @@ key locator.
 
 ```bash
 wavecli ark oor receive
-wavecli ark oor receive --idempotency-key durable-operation-42
+wavecli ark oor receive --idempotency-key my-app:durable-operation-42
 ```
+
+Idempotency keys share one daemon-wide namespace. Prefix them with an
+application or tenant identity when several callers use the same daemon.
 
 ### `ark vtxos list`
 

--- a/docs/idempotent-receive-scripts-execplan.md
+++ b/docs/idempotent-receive-scripts-execplan.md
@@ -1,0 +1,282 @@
+# Make receive-script allocation retry-safe
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises &
+Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must stay current
+while the work proceeds. Maintain this document according to `PLANS.md` in the
+repository root.
+
+## Purpose / Big Picture
+
+After this change, a caller can attach an idempotency key to
+`NewReceiveScript`. Repeating the same request, including after the daemon
+restarts, returns the same wallet key, taproot script, label, and absolute
+registration expiry. A retry never silently extends the registration lifetime.
+Calls without an idempotency key keep the existing behavior and allocate a
+fresh destination each time.
+
+This matters when a client persists a durable operation before asking
+Wavelength for a destination. If the RPC response is lost, the client can retry
+without creating another indexer registration. The behavior is demonstrated by
+unit tests for exact replay, changed-request rejection, concurrent replay,
+registration failure, and restart, plus shared SQLite and PostgreSQL store
+tests and migration tests.
+
+## Progress
+
+- [x] (2026-08-17 09:18Z) Audited the existing RPC, key derivation, indexer
+  registration, owned-script persistence, transaction layer, and migration
+  scheme.
+- [x] (2026-08-17 09:40Z) Chose an additive request and persistence contract
+  that preserves calls with no idempotency key.
+- [x] (2026-08-17 09:29Z) Added protocol fields and migration 17, then
+  regenerated RPC and SQL code.
+- [x] (2026-08-17 09:38Z) Implemented atomic durable admission and exact replay
+  at the artifact-store boundary.
+- [x] (2026-08-17 09:53Z) Reordered the RPC path to persist the allocation
+  before indexer
+  registration and resume incomplete registrations on retry.
+- [x] (2026-08-17 09:57Z) Added SQLite, PostgreSQL, restart, concurrency, and
+  failure-shape tests.
+- [x] (2026-08-17 10:18Z) Ran full SQLite and PostgreSQL-tagged unit suites,
+  generation checks, formatting, lint, module checks, documentation audit,
+  funds-safety review, and compatibility review.
+- [ ] Refresh upstream and recheck migration numbering before push.
+
+## Surprises & Discoveries
+
+- Observation: the current path registers with the indexer before persisting
+  local ownership.
+  Evidence: `waved/receive_script.go` calls
+  `RegisterReceiveScriptTaproot` before `UpsertOwnedReceiveScript` in
+  `RegisterOwnedOORReceiveScript`.
+
+- Observation: the current request has only a label, and each call derives the
+  next wallet key.
+  Evidence: `waverpc/daemon.proto` defines `NewReceiveScriptRequest.label`, and
+  `CreateOORReceiveScript` calls `deriveNextKey` before any durable write.
+
+- Observation: all read-write store transactions already use serializable
+  isolation and retry serialization failures.
+  Evidence: `db/interfaces.go` maps write transactions to
+  `sql.LevelSerializable` and `TransactionExecutor.ExecTx` retries recognized
+  serialization and deadlock errors.
+
+- Observation: mailbox replay needs one stable key per logical remote
+  registration, and two live callers must not share that key.
+  Evidence: `mailbox/rpc/AGENTS.md` states both invariants, while
+  `serverconn/unary_facade.go` mints a fresh key when callers omit one.
+
+- Observation: the changed-file linter loads all supported build tags and
+  therefore checks the SQLite and PostgreSQL variants together.
+  Evidence: `make lint-changed-local base=origin/main workers=4` completed
+  with zero findings on 2026-08-17 after loading `test_postgres`,
+  `test_sqlite`, and `systest`.
+
+## Decision Log
+
+- Decision: keep the idempotency key optional. Empty keys retain the existing
+  allocate-on-every-call contract.
+  Rationale: existing CLI, SDK, and embedded callers do not need coordination
+  with the new durable replay contract.
+  Date/Author: 2026-08-17, Codex.
+
+- Decision: treat the normalized label as the caller-controlled immutable
+  fingerprint. The daemon selects and persists one absolute expiry.
+  Rationale: concurrent first calls can accept the same durable winner without
+  comparing independently resolved default expiries. Replay still never
+  extends the stored lifetime.
+  Date/Author: 2026-08-17, Codex.
+
+- Decision: store the allocation before indexer registration, and retain it if
+  registration fails.
+  Rationale: retry can safely re-register the exact script. Deleting the row
+  would lose the wallet-key evidence and could allocate a second destination.
+  Date/Author: 2026-08-17, Codex.
+
+- Decision: derive at most one persisted allocation per idempotency key by
+  resolving the unique-key winner in the serializable store transaction.
+  Rationale: two concurrent callers may derive local wallet keys, but only one
+  key and script become the durable and remotely registered result. The local
+  derivation is not a fund-bearing remote registration. Avoiding even that
+  unused local key would require a durable lease around an external wallet
+  operation and would add recovery states without improving funds safety.
+  Date/Author: 2026-08-17, Codex.
+
+- Decision: persist a random mailbox RPC key and registration-completion time.
+  Serialize only callers sharing one local idempotency key.
+  Rationale: ambiguous remote results retry one logical request, completed
+  replay does not depend on the indexer, and unrelated allocations remain
+  concurrent.
+  Date/Author: 2026-08-17, Codex.
+
+## Outcomes & Retrospective
+
+The implementation now persists one immutable allocation and remote mailbox
+key before registration. Completed replay does not contact the indexer.
+Pending replay reuses the original script, expiry, label, and mailbox key.
+
+Focused SQLite store, RPC, restart, concurrency, and failure-shape tests pass.
+Focused race tests pass. The full unit suite and full PostgreSQL-tagged suite
+pass, including the shared store and migration tests. Generated RPC and SQL
+outputs are current. Formatting, diff checks, changed-file lint, module tidy,
+SQL generation, and commit-message checks pass. An independent funds-safety
+and compatibility review found no concrete blocker. Upstream refresh and the
+external review remain.
+
+## Context and Orientation
+
+`waverpc/daemon.proto` owns the public daemon RPC. `make rpc` regenerates its
+Go, REST, mailbox, CLI schema, and SDK-facing artifacts. The current
+`NewReceiveScriptRequest` contains only an optional label.
+
+`waved/rpc_oor_receive.go` implements the RPC. It fetches the current operator
+taproot key and exit delay, derives the next wallet key, calls the indexer, and
+returns the resulting script. `waved/receive_script.go` contains that derivation
+and registration logic. An indexer registration is a server-side binding from a
+taproot output script to this wallet. Its absolute expiry controls how long the
+server may retain that binding.
+
+`db/oor_artifact_store.go` owns local metadata for wallet-controlled receive
+scripts. The SQL schema and queries live under `db/sqlc/migrations` and
+`db/sqlc/queries`. `make sqlc` regenerates `db/sqlc/*.go` and
+`db/sqlc/schemas/generated_schema.sql`. The current schema version is 16 in
+`db/migrations.go`; this plan proposes migration 17, subject to a fresh
+upstream check before push.
+
+An exact replay means a request with the same non-empty idempotency key and
+normalized label. It returns the same key locator and script even when the
+open request count or process state changed. A fingerprint mismatch means the
+same key was reused with a different label and must return
+`InvalidArgument` rather than silently returning old terms.
+
+## Plan of Work
+
+Add `idempotency_key` to `NewReceiveScriptRequest`, and return the daemon's
+resolved `expires_at_unix_s` in the response. Bound non-empty keys to 128 bytes
+before database, wallet, terms, or indexer work.
+
+Add nullable replay columns to `owned_receive_scripts`: idempotency key,
+registration label, absolute expiry, stable mailbox RPC key, and remote
+completion time. Add a unique partial index on
+non-null idempotency keys. Old rows and non-idempotent callers leave these
+columns null. Add SQL queries for lookup by idempotency key and an insert that
+does not overwrite an existing key.
+
+Extend `OwnedReceiveScriptRecord` with optional replay metadata. Add a store
+method that runs one serializable transaction. It first looks up an existing
+idempotency key. Exact matches return that row. Mismatches return a typed
+fingerprint error. If no row exists, it registers the internal wallet key and
+inserts the owned script. A unique-conflict race is resolved by loading and
+validating the winner. This method is the owning boundary for replay identity.
+
+In the RPC, keep the existing path for empty idempotency keys. For a non-empty
+key, first look up the exact durable allocation. If none exists, derive a wallet
+key, build the script, mint one mailbox request key, and admit it through the
+store. Then register the stored script with the indexer using its stored
+expiry, label, and mailbox key. Mark completion only after acknowledgement.
+Pending state remains if registration fails. A completed replay returns from
+storage without calling the indexer. Return fields from the stored allocation.
+
+Keep the general-purpose `RegisterOwnedOORReceiveScript` behavior compatible
+for the daemon's existing default-script and recovery paths. Add a narrow
+idempotent allocation helper instead of changing unrelated callers.
+
+## Concrete Steps
+
+Work from `/Users/bhandras/work/ark/wavelength-idempotent-receive-scripts`.
+
+Edit `waverpc/daemon.proto`, add migration
+`db/sqlc/migrations/000017_idempotent_receive_scripts.{up,down}.sql`, update
+`db/migrations.go`, and extend `db/sqlc/queries/oor_artifacts.sql`. Run:
+
+    make rpc
+    make sqlc
+
+Implement the store and RPC changes, then format changed Go files:
+
+    make fmt-changed
+
+Run focused tests while iterating:
+
+    go test ./waved ./db
+    go test -race ./waved ./db
+
+Run the PostgreSQL-tagged shared tests when the repository fixture is
+available:
+
+    go test -tags=test_postgres ./db
+
+Before proposing the change, run the repository checks from
+`docs/testing-guide.md`, the Go documentation audit from the product-work
+skill, and the full unit suite. Record exact results in this plan.
+
+## Validation and Acceptance
+
+The new store tests must prove that an exact replay returns the same key and
+script; a changed label is rejected; two concurrent first calls
+select one durable winner on SQLite and PostgreSQL; and reopening the database
+preserves the winner.
+
+The RPC tests must prove that a first registration failure leaves the durable
+allocation intact and a retry registers that same script; an exact replay does
+not derive another key; a changed fingerprint does not call the indexer; and a
+call without an idempotency key still derives a fresh key each time.
+
+Migration tests must prove a version-16 database upgrades to version 17 without
+changing existing owned-script rows and that both supported backends enforce
+the unique replay key.
+
+Acceptance requires generated-code checks, focused tests, race tests, full unit
+tests, formatting, lint, documentation audit, and an explicit funds-safety and
+backward-compatibility review to pass.
+
+## Idempotence and Recovery
+
+RPC and SQL generation are deterministic and may be rerun. Migrations are
+additive. The down migration removes only the new index and columns.
+
+If the process stops after durable admission but before indexer registration,
+the next exact request loads the stored allocation and retries registration.
+If registration succeeds but the response or local completion write is lost,
+the same request reuses the same script and mailbox key. Remote deduplication
+collapses the retry to the original logical registration. The stored absolute
+expiry never moves forward. A failed or ambiguous indexer call never deletes
+the allocation.
+
+The canonical repository checkout and every pre-existing worktree remain
+untouched. This work is isolated on branch `agent/idempotent-receive-scripts`
+in its dedicated worktree.
+
+## Artifacts and Notes
+
+Initial base:
+
+    origin/main 3c0672d26e144e1d481fc8be06bcca23bcb09fbc
+    schema version 16
+
+The public change is an independent retry-safety primitive. Its documentation,
+commits, and pull request must not refer to any private downstream repository or
+incident.
+
+## Interfaces and Dependencies
+
+At completion, `waverpc.NewReceiveScriptRequest` has an optional
+`idempotency_key` field. The response reports the daemon-resolved absolute
+`expires_at_unix_s`.
+
+`db.OwnedReceiveScriptRecord` carries optional registration replay metadata.
+`db.OORArtifactPersistenceStore` exposes lookup and atomic admission by
+idempotency key. A typed fingerprint error allows the RPC layer to map a reused
+key with changed immutable terms to gRPC `InvalidArgument`.
+
+The implementation adds no new external dependency. It uses the existing
+serializable transaction executor, internal-key registry, indexer client, and
+clock seams.
+
+Plan revision note: created 2026-08-17 after the initial source and funds-safety
+audit. The plan records the chosen backward-compatible API and persist-before-
+registration ordering.
+
+Plan revision note: updated 2026-08-17 after mailbox-contract review. The plan
+now records the stable remote request key, completion evidence, keyed local
+serialization, daemon-owned expiry, and correct PostgreSQL test tag.

--- a/docs/idempotent-receive-scripts-execplan.md
+++ b/docs/idempotent-receive-scripts-execplan.md
@@ -9,8 +9,10 @@ repository root.
 
 After this change, a caller can attach an idempotency key to
 `NewReceiveScript`. Repeating the same request, including after the daemon
-restarts, returns the same wallet key, taproot script, label, and absolute
-registration expiry. A retry never silently extends the registration lifetime.
+restarts, returns the same wallet key, taproot script, and label. Replay within
+an active indexer window returns its absolute expiry unchanged. Replay after
+expiry atomically persists and resumes one new registration window for the
+same script before contacting the indexer.
 Calls without an idempotency key keep the existing behavior and allocate a
 fresh destination each time.
 
@@ -40,7 +42,14 @@ tests and migration tests.
 - [x] (2026-08-17 10:18Z) Ran full SQLite and PostgreSQL-tagged unit suites,
   generation checks, formatting, lint, module checks, documentation audit,
   funds-safety review, and compatibility review.
-- [ ] Refresh upstream and recheck migration numbering before push.
+- [x] (2026-08-17 12:00Z) Gateway found expired replay, broad SQL conflict,
+  canceled-waiter, PostgreSQL key-validation, namespace-documentation, and
+  RPC-level failure-coverage gaps.
+- [x] (2026-08-17 12:45Z) Rebased onto fresh upstream and addressed all five
+  findings with durable expired-window renewal, targeted conflict handling,
+  context-aware keyed locking, portable key validation, documentation, and
+  public RPC regression tests.
+- [ ] Re-run full verification and Gateway review on the new exact head.
 
 ## Surprises & Discoveries
 
@@ -83,8 +92,10 @@ tests and migration tests.
 - Decision: treat the normalized label as the caller-controlled immutable
   fingerprint. The daemon selects and persists one absolute expiry.
   Rationale: concurrent first calls can accept the same durable winner without
-  comparing independently resolved default expiries. Replay still never
-  extends the stored lifetime.
+  comparing independently resolved default expiries. Replay keeps that expiry
+  while it is active; after expiry, one exact durable CAS replaces only the
+  registration window and remote request key so the same allocation remains
+  usable.
   Date/Author: 2026-08-17, Codex.
 
 - Decision: store the allocation before indexer registration, and retain it if
@@ -105,15 +116,26 @@ tests and migration tests.
 - Decision: persist a random mailbox RPC key and registration-completion time.
   Serialize only callers sharing one local idempotency key.
   Rationale: ambiguous remote results retry one logical request, completed
-  replay does not depend on the indexer, and unrelated allocations remain
-  concurrent.
+  replay within its active window does not depend on the indexer, expired
+  replay starts one new durable remote operation, and unrelated allocations
+  remain concurrent.
+  Date/Author: 2026-08-17, Codex.
+
+- Decision: renew an expired registration in place instead of rejecting the
+  durable key or allocating a new script.
+  Rationale: callers may retain possible-funded value after the first indexer
+  window. Changing the wallet key or permanently rejecting replay would strand
+  recovery evidence. The renewal changes only expiry, remote request key, and
+  completion evidence before the remote call.
   Date/Author: 2026-08-17, Codex.
 
 ## Outcomes & Retrospective
 
 The implementation now persists one immutable allocation and remote mailbox
-key before registration. Completed replay does not contact the indexer.
-Pending replay reuses the original script, expiry, label, and mailbox key.
+key before registration. Completed replay within the active window does not
+contact the indexer. Pending replay reuses the original script, expiry, label,
+and mailbox key. Expired replay persists one fresh window and mailbox key,
+then registers the same script.
 
 Focused SQLite store, RPC, restart, concurrency, and failure-shape tests pass.
 Focused race tests pass. The full unit suite and full PostgreSQL-tagged suite
@@ -174,8 +196,11 @@ key, first look up the exact durable allocation. If none exists, derive a wallet
 key, build the script, mint one mailbox request key, and admit it through the
 store. Then register the stored script with the indexer using its stored
 expiry, label, and mailbox key. Mark completion only after acknowledgement.
-Pending state remains if registration fails. A completed replay returns from
-storage without calling the indexer. Return fields from the stored allocation.
+Pending state remains if registration fails. A completed replay within its
+active registration window returns from storage without calling the indexer.
+An expired replay atomically stores one replacement expiry and mailbox key,
+clears completion, and re-registers the same allocation. Return fields from
+the stored allocation.
 
 Keep the general-purpose `RegisterOwnedOORReceiveScript` behavior compatible
 for the daemon's existing default-script and recovery paths. Add a narrow
@@ -280,3 +305,8 @@ registration ordering.
 Plan revision note: updated 2026-08-17 after mailbox-contract review. The plan
 now records the stable remote request key, completion evidence, keyed local
 serialization, daemon-owned expiry, and correct PostgreSQL test tag.
+
+Plan revision note: updated 2026-08-17 after Gateway review. Expired replay now
+renews the same durable allocation through a persisted CAS before remote work;
+the plan also records targeted SQL conflicts, cancelable key locking, portable
+key validation, the global key namespace, and RPC-level ambiguous retry tests.

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,3 +65,4 @@ into specific topics below.
 | Document | Description |
 |----------|-------------|
 | [PLANS.md](../PLANS.md) | ExecPlan specification for complex features |
+| [idempotent-receive-scripts-execplan.md](idempotent-receive-scripts-execplan.md) | Retry-safe `NewReceiveScript` allocation: durable identity, exact replay, and expiry renewal |

--- a/docs/postgres_isolation.md
+++ b/docs/postgres_isolation.md
@@ -163,8 +163,8 @@ subquery selected, which stays safe under `REPEATABLE READ`.
 ### Partial unique indexes
 
 A conflict target that does not match a partial index predicate will not fire,
-and the upsert silently degrades to a plain insert. The schema has six partial
-unique indexes, so any new `ON CONFLICT` needs checking against this list.
+and the upsert silently degrades to a plain insert. Any new `ON CONFLICT` needs
+checking against this list of partial unique indexes.
 
 | Index | Table | Predicate |
 |-------|-------|-----------|
@@ -174,6 +174,7 @@ unique indexes, so any new `ON CONFLICT` needs checking against this list.
 | `idx_client_ledger_idempotent_session` | `ledger_entries` | `session_id IS NOT NULL` |
 | `idx_client_ledger_idempotent_key` | `ledger_entries` | `idempotency_key IS NOT NULL` |
 | `idx_credit_operations_op_key` | `credit_operations` | `status != 2` |
+| `idx_owned_receive_scripts_idempotency_key` | `owned_receive_scripts` | `idempotency_key IS NOT NULL` |
 
 A targetless `ON CONFLICT DO NOTHING` arbitrates over every unique index,
 partial ones included, which is why the ledger insert in

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -199,6 +199,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   that never fired. The distinction is not cosmetic: `ForfeitingState`
   suppresses a critical-expiry exit once the forfeit signature has issued but
   still honours a manual one.
+- `NewReceiveScript` treats a non-empty idempotency key as one durable
+  allocation. The owned-script store records the key locator, script, operator
+  terms, absolute expiry, stable mailbox RPC key, and completion evidence
+  before indexer registration. Pending retry reuses those artifacts; completed
+  replay returns without the indexer. Empty keys preserve fresh allocation.
 - `SignCreditAccountAuthorization` (and the internal
   `RPCServer.SignCreditAccountAuth` behind it) signs a canonical swap
   credit-account request digest with the daemon identity key. It validates

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -203,7 +203,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   allocation. The owned-script store records the key locator, script, operator
   terms, absolute expiry, stable mailbox RPC key, and completion evidence
   before indexer registration. Pending retry reuses those artifacts; completed
-  replay returns without the indexer. Empty keys preserve fresh allocation.
+  replay returns without the indexer while its window is active. Expired replay
+  atomically persists a new window and remote key before re-registering the
+  same script. Empty keys preserve fresh allocation.
 - `SignCreditAccountAuthorization` (and the internal
   `RPCServer.SignCreditAccountAuth` behind it) signs a canonical swap
   credit-account request digest with the daemon identity key. It validates

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -205,7 +205,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   before indexer registration. Pending retry reuses those artifacts; completed
   replay returns without the indexer while its window is active. Expired replay
   atomically persists a new window and remote key before re-registering the
-  same script. Empty keys preserve fresh allocation.
+  same script. Empty keys preserve fresh allocation. Concurrent callers on one
+  key serialize on `RPCServer.receiveScriptLocks`, a refcounted in-process
+  keyed lock, so two retries never drive the same mailbox correlation ID at
+  once; the entry is dropped when its last holder or waiter leaves.
+  `NewReceiveScriptResponse.expires_at_unix_s` reports the absolute indexer
+  registration expiry on both fresh and replayed paths.
 - `SignCreditAccountAuthorization` (and the internal
   `RPCServer.SignCreditAccountAuth` behind it) signs a canonical swap
   credit-account request digest with the daemon identity key. It validates

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -199,6 +199,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   that never fired. The distinction is not cosmetic: `ForfeitingState`
   suppresses a critical-expiry exit once the forfeit signature has issued but
   still honours a manual one.
+- `NewReceiveScript` treats a non-empty idempotency key as one durable
+  allocation. The owned-script store records the key locator, script, operator
+  terms, absolute expiry, stable mailbox RPC key, and completion evidence
+  before indexer registration. Pending retry reuses those artifacts; completed
+  replay returns without the indexer. Empty keys preserve fresh allocation.
 - `SignCreditAccountAuthorization` (and the internal
   `RPCServer.SignCreditAccountAuth` behind it) signs a canonical swap
   credit-account request digest with the daemon identity key. It validates

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -203,7 +203,14 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   allocation. The owned-script store records the key locator, script, operator
   terms, absolute expiry, stable mailbox RPC key, and completion evidence
   before indexer registration. Pending retry reuses those artifacts; completed
-  replay returns without the indexer. Empty keys preserve fresh allocation.
+  replay returns without the indexer while its window is active. Expired replay
+  atomically persists a new window and remote key before re-registering the
+  same script. Empty keys preserve fresh allocation. Concurrent callers on one
+  key serialize on `RPCServer.receiveScriptLocks`, a refcounted in-process
+  keyed lock, so two retries never drive the same mailbox correlation ID at
+  once; the entry is dropped when its last holder or waiter leaves.
+  `NewReceiveScriptResponse.expires_at_unix_s` reports the absolute indexer
+  registration expiry on both fresh and replayed paths.
 - `SignCreditAccountAuthorization` (and the internal
   `RPCServer.SignCreditAccountAuth` behind it) signs a canonical swap
   credit-account request digest with the daemon identity key. It validates

--- a/waved/receive_script.go
+++ b/waved/receive_script.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultOORReceiveScriptRegistrationTTL = 30 * 24 * time.Hour
+	defaultOORRegistrationTTL = db.MaxOwnedReceiveScriptRegistrationTTL
 
 	// oorReceiveKeyFamily is the key family used for OOR receive
 	// keys. It is distinct from the identity key family (and the
@@ -418,6 +418,23 @@ func CreateOORReceiveScript(ctx context.Context, idx *indexer.Client,
 	operatorKey *btcec.PublicKey, exitDelay uint32, label string) (
 	*keychain.KeyDescriptor, []byte, error) {
 
+	expiresAt := time.Now().Add(defaultOORRegistrationTTL)
+
+	return CreateOORReceiveScriptWithExpiry(
+		ctx, idx, store, deriveNextKey, signerFactory, operatorKey,
+		exitDelay, label, expiresAt,
+	)
+}
+
+// CreateOORReceiveScriptWithExpiry derives a fresh wallet key and registers
+// its receive script until the supplied absolute expiry.
+func CreateOORReceiveScriptWithExpiry(ctx context.Context, idx *indexer.Client,
+	store ownedReceiveScriptStore,
+	deriveNextKey DeriveDefaultOORReceiveKeyFunc,
+	signerFactory OORReceiveScriptSignerFactory,
+	operatorKey *btcec.PublicKey, exitDelay uint32, label string,
+	expiresAt time.Time) (*keychain.KeyDescriptor, []byte, error) {
+
 	if deriveNextKey == nil {
 		return nil, nil, fmt.Errorf("derive next key func must be " +
 			"provided")
@@ -433,9 +450,9 @@ func CreateOORReceiveScript(ctx context.Context, idx *indexer.Client,
 			"pubkey")
 	}
 
-	pkScript, err := RegisterOwnedOORReceiveScript(
+	pkScript, err := RegisterOwnedOORReceiveScriptWithExpiry(
 		ctx, idx, store, *keyDesc, signerFactory, operatorKey,
-		exitDelay, label,
+		exitDelay, label, expiresAt,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -451,6 +468,23 @@ func RegisterOwnedOORReceiveScript(ctx context.Context, idx *indexer.Client,
 	signerFactory OORReceiveScriptSignerFactory,
 	operatorKey *btcec.PublicKey, exitDelay uint32,
 	label string) ([]byte, error) {
+
+	expiresAt := time.Now().Add(defaultOORRegistrationTTL)
+
+	return RegisterOwnedOORReceiveScriptWithExpiry(
+		ctx, idx, store, clientKey, signerFactory, operatorKey,
+		exitDelay, label, expiresAt,
+	)
+}
+
+// RegisterOwnedOORReceiveScriptWithExpiry registers and persists one
+// wallet-owned receive script with a caller-selected absolute expiry.
+func RegisterOwnedOORReceiveScriptWithExpiry(ctx context.Context,
+	idx *indexer.Client, store ownedReceiveScriptStore,
+	clientKey keychain.KeyDescriptor,
+	signerFactory OORReceiveScriptSignerFactory,
+	operatorKey *btcec.PublicKey, exitDelay uint32, label string,
+	expiresAt time.Time) ([]byte, error) {
 
 	switch {
 	case idx == nil:
@@ -473,7 +507,6 @@ func RegisterOwnedOORReceiveScript(ctx context.Context, idx *indexer.Client,
 
 	registerClient := idx.WithSigner(signerFactory(clientKey))
 
-	expiresAt := time.Now().Add(defaultOORReceiveScriptRegistrationTTL)
 	_, err = registerClient.RegisterReceiveScriptTaproot(
 		ctx, pkScript, expiresAt, label,
 	)

--- a/waved/receive_script_test.go
+++ b/waved/receive_script_test.go
@@ -375,12 +375,13 @@ func (s *testOwnedReceiveScriptSigner) ProofPubKey(_ []byte) (*btcec.PublicKey,
 // testReceiveScriptRPCClient records mailbox RPC requests for registration.
 type testReceiveScriptRPCClient struct {
 	registerReqs []*arkrpc.RegisterReceiveScriptRequest
+	registerOpts []mailboxrpc.RPCOptions
 }
 
 // SendRPC records RegisterReceiveScript requests and returns a fixed result.
 func (c *testReceiveScriptRPCClient) SendRPC(_ context.Context,
 	method mailboxrpc.ServiceMethod, req proto.Message,
-	_ mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
+	opts mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
 
 	if method.Service == "arkrpc.IndexerService" &&
 		method.Method == "RegisterReceiveScript" {
@@ -392,6 +393,7 @@ func (c *testReceiveScriptRPCClient) SendRPC(_ context.Context,
 		}
 
 		c.registerReqs = append(c.registerReqs, regReq)
+		c.registerOpts = append(c.registerOpts, opts)
 	}
 
 	return mailboxrpc.SendResult{

--- a/waved/receive_script_test.go
+++ b/waved/receive_script_test.go
@@ -376,6 +376,8 @@ func (s *testOwnedReceiveScriptSigner) ProofPubKey(_ []byte) (*btcec.PublicKey,
 type testReceiveScriptRPCClient struct {
 	registerReqs []*arkrpc.RegisterReceiveScriptRequest
 	registerOpts []mailboxrpc.RPCOptions
+	awaitErrors  []error
+	awaitCalls   int
 }
 
 // SendRPC records RegisterReceiveScript requests and returns a fixed result.
@@ -405,6 +407,14 @@ func (c *testReceiveScriptRPCClient) SendRPC(_ context.Context,
 // AwaitRPC populates the response expected by the generated mailbox client.
 func (c *testReceiveScriptRPCClient) AwaitRPC(_ context.Context, _ string,
 	resp proto.Message) error {
+
+	if c.awaitCalls < len(c.awaitErrors) {
+		err := c.awaitErrors[c.awaitCalls]
+		c.awaitCalls++
+		if err != nil {
+			return err
+		}
+	}
 
 	registerResp, ok := resp.(*arkrpc.RegisterReceiveScriptResponse)
 	if !ok {

--- a/waved/rpc_oor_receive.go
+++ b/waved/rpc_oor_receive.go
@@ -2,13 +2,19 @@ package waved
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/indexer"
+	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
 	"github.com/lightninglabs/wavelength/waverpc"
-	"github.com/lightningnetwork/lnd/clock"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -18,9 +24,23 @@ const (
 	defaultOORChangeScriptLabel  = "oor change"
 )
 
-// NewReceiveScript allocates a fresh wallet key, registers the matching
-// taproot receive script with the indexer, and returns the script details
-// needed to hand this one-shot destination to a sender.
+// receiveScriptLock serializes callers for one receive-script idempotency key.
+type receiveScriptLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+// receiveScriptRegistrationCompleter persists acknowledged remote
+// registration for one idempotent allocation.
+type receiveScriptRegistrationCompleter interface {
+	// MarkOwnedReceiveScriptRegistered records acknowledged
+	// remote registration for one allocation and stable RPC key.
+	MarkOwnedReceiveScriptRegistered(ctx context.Context, idempotencyKey,
+		registrationRPCKey string) error
+}
+
+// NewReceiveScript allocates and registers a taproot receive script, or returns
+// the exact existing allocation for an idempotent retry.
 func (r *RPCServer) NewReceiveScript(ctx context.Context,
 	req *waverpc.NewReceiveScriptRequest) (
 	*waverpc.NewReceiveScriptResponse, error) {
@@ -33,14 +53,40 @@ func (r *RPCServer) NewReceiveScript(ctx context.Context,
 		req = &waverpc.NewReceiveScriptRequest{}
 	}
 
-	if r.server.indexer == nil {
-		return nil, status.Errorf(codes.Internal, "indexer client "+
-			"not initialized")
+	label := req.Label
+	if label == "" {
+		label = defaultOORReceiveScriptLabel
+	}
+
+	if req.IdempotencyKey != "" {
+		if len(req.IdempotencyKey) >
+			db.MaxOwnedReceiveScriptIdempotencyKeyBytes {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"idempotency_key exceeds %d bytes",
+				db.MaxOwnedReceiveScriptIdempotencyKeyBytes)
+		}
+
+		if r.server.db == nil {
+			return nil, status.Errorf(codes.Internal, "database "+
+				"not initialized")
+		}
+
+		release := r.acquireReceiveScriptLock(req.IdempotencyKey)
+		defer release()
+
+		return r.newIdempotentReceiveScript(
+			ctx, req.IdempotencyKey, label,
+		)
 	}
 
 	if r.server.db == nil {
 		return nil, status.Errorf(codes.Internal, "database not "+
 			"initialized")
+	}
+
+	if r.server.indexer == nil {
+		return nil, status.Errorf(codes.Internal, "indexer client "+
+			"not initialized")
 	}
 
 	terms, err := r.server.fetchOperatorTerms(ctx)
@@ -61,14 +107,12 @@ func (r *RPCServer) NewReceiveScript(ctx context.Context,
 			"initialize OOR receive key ops: %v", err)
 	}
 
-	label := req.Label
-	if label == "" {
-		label = defaultOORReceiveScriptLabel
-	}
-
-	keyDesc, pkScript, err := CreateOORReceiveScript(
+	expiresAt := r.server.clk.Now().Add(
+		defaultOORRegistrationTTL,
+	)
+	keyDesc, pkScript, err := CreateOORReceiveScriptWithExpiry(
 		ctx, r.server.indexer, store, deriveNextKey, signerFactory,
-		terms.PubKey, terms.VTXOExitDelay, label,
+		terms.PubKey, terms.VTXOExitDelay, label, expiresAt,
 	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to create "+
@@ -85,10 +129,250 @@ func (r *RPCServer) NewReceiveScript(ctx context.Context,
 		PubkeyXonlyHex: hex.EncodeToString(
 			schnorr.SerializePubKey(keyDesc.PubKey),
 		),
-		KeyFamily: uint32(keyDesc.KeyLocator.Family),
-		KeyIndex:  keyDesc.KeyLocator.Index,
-		Label:     label,
+		KeyFamily:      uint32(keyDesc.KeyLocator.Family),
+		KeyIndex:       keyDesc.KeyLocator.Index,
+		Label:          label,
+		ExpiresAtUnixS: uint64(expiresAt.Unix()),
 	}, nil
+}
+
+// newIdempotentReceiveScript admits or resumes one retry-safe allocation.
+func (r *RPCServer) newIdempotentReceiveScript(ctx context.Context,
+	idempotencyKey, label string) (*waverpc.NewReceiveScriptResponse,
+	error) {
+
+	store, err := r.newOORReceiveScriptStore()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to "+
+			"initialize OOR receive-script store: %v", err)
+	}
+
+	rec, err := store.LookupOwnedReceiveScriptByIdempotencyKey(
+		ctx, idempotencyKey,
+	)
+	switch {
+	case err == nil:
+		if rec.RegistrationLabel != label {
+			return nil, status.Error(
+				codes.InvalidArgument, "idempotency_key "+
+					"was already used with a different "+
+					"label",
+			)
+		}
+
+	case !errors.Is(err, sql.ErrNoRows):
+		return nil, status.Errorf(codes.Internal, "unable to look up "+
+			"OOR receive script: %v", err)
+
+	default:
+		rec, err = r.admitIdempotentReceiveScript(
+			ctx, store, idempotencyKey, label,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if rec.RegistrationCompletedAt.IsSome() {
+		return newReceiveScriptResponse(rec), nil
+	}
+
+	if r.server.indexer == nil {
+		return nil, status.Errorf(codes.Internal, "indexer client "+
+			"not initialized")
+	}
+
+	_, signerFactory, err := r.oorReceiveKeyOps()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to "+
+			"initialize OOR receive key ops: %v", err)
+	}
+
+	registerClient := r.server.indexer.WithSigner(
+		signerFactory(rec.ClientKey),
+	)
+	err = registerIdempotentReceiveScript(
+		ctx, registerClient, store, rec,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to register "+
+			"OOR receive script: %v", err)
+	}
+
+	completedAt := r.server.clk.Now()
+	rec.RegistrationCompletedAt = fn.Some(completedAt)
+
+	return newReceiveScriptResponse(rec), nil
+}
+
+// registerIdempotentReceiveScript resumes a pending remote registration with
+// its durable mailbox request key, then records acknowledged completion.
+func registerIdempotentReceiveScript(ctx context.Context,
+	registerClient *indexer.Client,
+	store receiveScriptRegistrationCompleter,
+	rec *db.OwnedReceiveScriptRecord) error {
+
+	if rec.RegistrationCompletedAt.IsSome() {
+		return nil
+	}
+
+	if registerClient == nil {
+		return fmt.Errorf("indexer client must be provided")
+	}
+
+	if store == nil {
+		return fmt.Errorf("registration store must be provided")
+	}
+
+	if rec.RegistrationRPCKey == "" {
+		return fmt.Errorf("registration RPC key must be provided")
+	}
+
+	_, err := registerClient.RegisterReceiveScriptTaproot(
+		ctx, rec.PkScript, rec.RegistrationExpiresAt,
+		rec.RegistrationLabel, mailboxrpc.RPCOptions{
+			IdempotencyKey: rec.RegistrationRPCKey,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return store.MarkOwnedReceiveScriptRegistered(
+		ctx, rec.IdempotencyKey, rec.RegistrationRPCKey,
+	)
+}
+
+// admitIdempotentReceiveScript derives a candidate only after lookup proves no
+// durable allocation exists, then lets the serializable store select a winner.
+func (r *RPCServer) admitIdempotentReceiveScript(ctx context.Context,
+	store *db.OORArtifactPersistenceStore, idempotencyKey, label string) (
+	*db.OwnedReceiveScriptRecord, error) {
+
+	if r.server.indexer == nil {
+		return nil, status.Errorf(codes.Internal, "indexer client "+
+			"not initialized")
+	}
+
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to fetch "+
+			"operator terms: %v", err)
+	}
+
+	deriveNextKey, _, err := r.oorReceiveKeyOps()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to "+
+			"initialize OOR receive key ops: %v", err)
+	}
+
+	keyDesc, err := deriveNextKey(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to derive "+
+			"OOR receive key: %v", err)
+	}
+
+	if keyDesc == nil || keyDesc.PubKey == nil {
+		return nil, status.Error(
+			codes.Internal, "missing receive key descriptor",
+		)
+	}
+
+	pkScript, err := BuildPubKeyVTXOReceiveScript(
+		keyDesc.PubKey, terms.PubKey, terms.VTXOExitDelay,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to build "+
+			"OOR receive script: %v", err)
+	}
+
+	registrationRPCKey, err := mailboxrpc.NewIdempotencyKey()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to allocate "+
+			"registration request key: %v", err)
+	}
+
+	now := r.server.clk.Now()
+	candidate := db.OwnedReceiveScriptRecord{
+		PkScript:          pkScript,
+		ClientKey:         *keyDesc,
+		OperatorPubKey:    terms.PubKey,
+		ExitDelay:         int64(terms.VTXOExitDelay),
+		Source:            db.OwnedReceiveScriptSourceWallet,
+		CreatedAt:         now,
+		LastUsedAt:        fn.None[time.Time](),
+		IdempotencyKey:    idempotencyKey,
+		RegistrationLabel: label,
+		RegistrationExpiresAt: now.Add(
+			defaultOORRegistrationTTL,
+		),
+		RegistrationRPCKey: registrationRPCKey,
+	}
+
+	rec, _, err := store.AdmitIdempotentOwnedReceiveScript(
+		ctx, candidate,
+	)
+	if errors.Is(err, db.ErrOwnedReceiveScriptReplayMismatch) {
+		return nil, status.Error(
+			codes.InvalidArgument, "idempotency_key was "+
+				"already used with a different label",
+		)
+	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to admit "+
+			"OOR receive script: %v", err)
+	}
+
+	return rec, nil
+}
+
+// newReceiveScriptResponse reconstructs the public response from durable
+// allocation data.
+func newReceiveScriptResponse(
+	rec *db.OwnedReceiveScriptRecord) *waverpc.NewReceiveScriptResponse {
+
+	return &waverpc.NewReceiveScriptResponse{
+		PkScriptHex: hex.EncodeToString(rec.PkScript),
+		PubkeyXonlyHex: hex.EncodeToString(
+			schnorr.SerializePubKey(rec.ClientKey.PubKey),
+		),
+		KeyFamily: uint32(rec.ClientKey.KeyLocator.Family),
+		KeyIndex:  rec.ClientKey.KeyLocator.Index,
+		Label:     rec.RegistrationLabel,
+		ExpiresAtUnixS: uint64(
+			rec.RegistrationExpiresAt.Unix(),
+		),
+	}
+}
+
+// acquireReceiveScriptLock locks one idempotency key and returns its release
+// function. The registry entry is removed after the final waiter exits.
+func (r *RPCServer) acquireReceiveScriptLock(key string) func() {
+	r.receiveScriptLocksMu.Lock()
+	if r.receiveScriptLocks == nil {
+		r.receiveScriptLocks = make(map[string]*receiveScriptLock)
+	}
+
+	entry, ok := r.receiveScriptLocks[key]
+	if !ok {
+		entry = &receiveScriptLock{}
+		r.receiveScriptLocks[key] = entry
+	}
+	entry.refs++
+	r.receiveScriptLocksMu.Unlock()
+
+	entry.mu.Lock()
+
+	return func() {
+		entry.mu.Unlock()
+
+		r.receiveScriptLocksMu.Lock()
+		entry.refs--
+		if entry.refs == 0 {
+			delete(r.receiveScriptLocks, key)
+		}
+		r.receiveScriptLocksMu.Unlock()
+	}
 }
 
 // newOORReceiveScriptStore returns the artifact store used to persist owned
@@ -105,7 +389,11 @@ func (r *RPCServer) newOORReceiveScriptStore() (*db.OORArtifactPersistenceStore,
 		r.server.subLogger(db.Subsystem),
 	)
 
-	return dbStore.NewOORArtifactStore(clock.NewDefaultClock()), nil
+	if r.server.clk == nil {
+		return nil, fmt.Errorf("server clock not initialized")
+	}
+
+	return dbStore.NewOORArtifactStore(r.server.clk), nil
 }
 
 // oorReceiveKeyOps returns the fresh-key derivation function and signer

--- a/waved/rpc_oor_receive.go
+++ b/waved/rpc_oor_receive.go
@@ -6,8 +6,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"sync"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/wavelength/db"
@@ -26,8 +27,8 @@ const (
 
 // receiveScriptLock serializes callers for one receive-script idempotency key.
 type receiveScriptLock struct {
-	mu   sync.Mutex
-	refs int
+	token chan struct{}
+	refs  int
 }
 
 // receiveScriptRegistrationCompleter persists acknowledged remote
@@ -65,13 +66,27 @@ func (r *RPCServer) NewReceiveScript(ctx context.Context,
 				"idempotency_key exceeds %d bytes",
 				db.MaxOwnedReceiveScriptIdempotencyKeyBytes)
 		}
+		hasControl := strings.IndexFunc(
+			req.IdempotencyKey, unicode.IsControl,
+		) >= 0
+		if hasControl {
+			return nil, status.Error(
+				codes.InvalidArgument,
+				"idempotency_key contains control characters",
+			)
+		}
 
 		if r.server.db == nil {
 			return nil, status.Errorf(codes.Internal, "database "+
 				"not initialized")
 		}
 
-		release := r.acquireReceiveScriptLock(req.IdempotencyKey)
+		release, err := r.acquireReceiveScriptLock(
+			ctx, req.IdempotencyKey,
+		)
+		if err != nil {
+			return nil, status.FromContextError(err).Err()
+		}
 		defer release()
 
 		return r.newIdempotentReceiveScript(
@@ -170,6 +185,25 @@ func (r *RPCServer) newIdempotentReceiveScript(ctx context.Context,
 		)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	now := r.server.clk.Now()
+	if !rec.RegistrationExpiresAt.After(now) {
+		nextRPCKey, err := mailboxrpc.NewIdempotencyKey()
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "unable to "+
+				"allocate renewal request key: %v", err)
+		}
+
+		rec, err = store.RenewOwnedReceiveScriptRegistration(
+			ctx, *rec, now.Add(defaultOORRegistrationTTL),
+			nextRPCKey,
+		)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "unable to "+
+				"renew OOR receive script registration: %v",
+				err)
 		}
 	}
 
@@ -346,8 +380,11 @@ func newReceiveScriptResponse(
 }
 
 // acquireReceiveScriptLock locks one idempotency key and returns its release
-// function. The registry entry is removed after the final waiter exits.
-func (r *RPCServer) acquireReceiveScriptLock(key string) func() {
+// function. A canceled waiter leaves promptly, and the registry entry is
+// removed after the final holder or waiter exits.
+func (r *RPCServer) acquireReceiveScriptLock(ctx context.Context, key string) (
+	func(), error) {
+
 	r.receiveScriptLocksMu.Lock()
 	if r.receiveScriptLocks == nil {
 		r.receiveScriptLocks = make(map[string]*receiveScriptLock)
@@ -355,17 +392,16 @@ func (r *RPCServer) acquireReceiveScriptLock(key string) func() {
 
 	entry, ok := r.receiveScriptLocks[key]
 	if !ok {
-		entry = &receiveScriptLock{}
+		entry = &receiveScriptLock{
+			token: make(chan struct{}, 1),
+		}
+		entry.token <- struct{}{}
 		r.receiveScriptLocks[key] = entry
 	}
 	entry.refs++
 	r.receiveScriptLocksMu.Unlock()
 
-	entry.mu.Lock()
-
-	return func() {
-		entry.mu.Unlock()
-
+	releaseRef := func() {
 		r.receiveScriptLocksMu.Lock()
 		entry.refs--
 		if entry.refs == 0 {
@@ -373,6 +409,20 @@ func (r *RPCServer) acquireReceiveScriptLock(key string) func() {
 		}
 		r.receiveScriptLocksMu.Unlock()
 	}
+
+	select {
+	case <-ctx.Done():
+		releaseRef()
+
+		return nil, ctx.Err()
+
+	case <-entry.token:
+	}
+
+	return func() {
+		entry.token <- struct{}{}
+		releaseRef()
+	}, nil
 }
 
 // newOORReceiveScriptStore returns the artifact store used to persist owned

--- a/waved/rpc_oor_receive.go
+++ b/waved/rpc_oor_receive.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 	"unicode"
@@ -190,6 +191,7 @@ func (r *RPCServer) newIdempotentReceiveScript(ctx context.Context,
 
 	now := r.server.clk.Now()
 	if !rec.RegistrationExpiresAt.After(now) {
+		oldExpiresAt := rec.RegistrationExpiresAt
 		nextRPCKey, err := mailboxrpc.NewIdempotencyKey()
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to "+
@@ -205,6 +207,16 @@ func (r *RPCServer) newIdempotentReceiveScript(ctx context.Context,
 				"renew OOR receive script registration: %v",
 				err)
 		}
+
+		r.server.log.DebugS(ctx, "Renewed expired OOR receive-script "+
+			"registration window",
+			slog.String("idempotency_key", idempotencyKey),
+			slog.Int64("old_expires_at_unix_s", oldExpiresAt.Unix()),
+			slog.Int64(
+				"new_expires_at_unix_s",
+				rec.RegistrationExpiresAt.Unix(),
+			),
+		)
 	}
 
 	if rec.RegistrationCompletedAt.IsSome() {

--- a/waved/rpc_oor_receive_sqlite_test.go
+++ b/waved/rpc_oor_receive_sqlite_test.go
@@ -3,17 +3,54 @@
 package waved
 
 import (
+	"context"
+	"encoding/hex"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/indexer"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// testReceiveScriptProofBackend provides deterministic receive keys and proof
+// signers without starting a wallet backend.
+type testReceiveScriptProofBackend struct {
+	nextKey *keychain.KeyDescriptor
+}
+
+// DeriveKey returns the configured wallet key.
+func (b *testReceiveScriptProofBackend) DeriveKey(_ context.Context,
+	_ keychain.KeyLocator) (*keychain.KeyDescriptor, error) {
+
+	return b.nextKey, nil
+}
+
+// DeriveNextKey returns the configured fresh receive key.
+func (b *testReceiveScriptProofBackend) DeriveNextKey(_ context.Context,
+	_ keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
+
+	return b.nextKey, nil
+}
+
+// ProofSigner returns a deterministic signer for the requested wallet key.
+func (b *testReceiveScriptProofBackend) ProofSigner(
+	keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+
+	return &testOwnedReceiveScriptSigner{
+		keyDesc: keyDesc,
+		tagSig:  []byte("test-tag-signature"),
+	}
+}
 
 // TestNewReceiveScriptCompletedReplayUsesDurableResult verifies exact replay
 // returns a completed allocation without current operator terms or an indexer.
@@ -87,4 +124,173 @@ func TestNewReceiveScriptCompletedReplayUsesDurableResult(t *testing.T) {
 		},
 	)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestNewReceiveScriptRetryPreservesPendingAllocation verifies the public RPC
+// persists one allocation before registration and resumes its exact remote
+// request after an ambiguous first response.
+func TestNewReceiveScriptRetryPreservesPendingAllocation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	walletReady := make(chan struct{})
+	close(walletReady)
+	receiveKey := testKeyDescriptor(t, 93)
+	operatorKey := testKeyDescriptor(t, 94)
+	rpcClient := &testReceiveScriptRPCClient{
+		awaitErrors: []error{
+			errors.New("ambiguous indexer response"),
+		},
+	}
+	idx := indexer.New(
+		rpcClient, nil, "test-server", "client:test",
+		fn.None[btclog.Logger](),
+	)
+	server := &Server{
+		walletReady: walletReady,
+		clk:         clock.NewTestClock(now),
+		db:          db.NewTestDB(t),
+		indexer:     idx,
+		proofKeyBackend: &testReceiveScriptProofBackend{
+			nextKey: &receiveKey,
+		},
+		serverConn: newBufconnClient(t, &fakeArkService{
+			getInfoResponse: &arkrpc.GetInfoResponse{
+				Pubkey:        operatorKey.PubKey.SerializeCompressed(),
+				VtxoExitDelay: 144,
+			},
+		}),
+	}
+	rpcServer := NewRPCServer(server)
+	req := &waverpc.NewReceiveScriptRequest{
+		Label:          "credit top-up",
+		IdempotencyKey: "consumer:operation-1",
+	}
+
+	_, err := rpcServer.NewReceiveScript(t.Context(), req)
+	require.Equal(t, codes.Internal, status.Code(err))
+	store, err := rpcServer.newOORReceiveScriptStore()
+	require.NoError(t, err)
+	pending, err := store.LookupOwnedReceiveScriptByIdempotencyKey(
+		t.Context(), req.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	require.True(t, pending.RegistrationCompletedAt.IsNone())
+
+	resp, err := rpcServer.NewReceiveScript(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(pending.PkScript), resp.PkScriptHex)
+	require.Equal(
+		t,
+		uint64(
+			pending.RegistrationExpiresAt.Unix(),
+		),
+		resp.ExpiresAtUnixS,
+	)
+	require.Len(t, rpcClient.registerOpts, 2)
+	require.Equal(
+		t, pending.RegistrationRPCKey,
+		rpcClient.registerOpts[0].IdempotencyKey,
+	)
+	require.Equal(
+		t, rpcClient.registerOpts[0].IdempotencyKey,
+		rpcClient.registerOpts[1].IdempotencyKey,
+	)
+	completed, err := store.LookupOwnedReceiveScriptByIdempotencyKey(
+		t.Context(), req.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	require.True(t, completed.RegistrationCompletedAt.IsSome())
+}
+
+// TestNewReceiveScriptRenewsExpiredRegistration verifies completed replay
+// persists a fresh registration window and remote request key before
+// re-registering the exact same owned script.
+func TestNewReceiveScriptRenewsExpiredRegistration(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	clk := clock.NewTestClock(now)
+	walletReady := make(chan struct{})
+	close(walletReady)
+	clientKey := testKeyDescriptor(t, 95)
+	operatorKey := testKeyDescriptor(t, 96)
+	rpcClient := &testReceiveScriptRPCClient{}
+	server := &Server{
+		walletReady: walletReady,
+		clk:         clk,
+		db:          db.NewTestDB(t),
+		indexer: indexer.New(
+			rpcClient, nil, "test-server", "client:test",
+			fn.None[btclog.Logger](),
+		),
+		proofKeyBackend: &testReceiveScriptProofBackend{
+			nextKey: &clientKey,
+		},
+	}
+	rpcServer := NewRPCServer(server)
+	store, err := rpcServer.newOORReceiveScriptStore()
+	require.NoError(t, err)
+	pkScript, err := BuildPubKeyVTXOReceiveScript(
+		clientKey.PubKey, operatorKey.PubKey, 144,
+	)
+	require.NoError(t, err)
+	candidate := db.OwnedReceiveScriptRecord{
+		PkScript:              pkScript,
+		ClientKey:             clientKey,
+		OperatorPubKey:        operatorKey.PubKey,
+		ExitDelay:             144,
+		Source:                db.OwnedReceiveScriptSourceWallet,
+		CreatedAt:             now,
+		LastUsedAt:            fn.None[time.Time](),
+		IdempotencyKey:        "consumer:operation-expired",
+		RegistrationLabel:     "credit top-up",
+		RegistrationExpiresAt: now.Add(time.Second),
+		RegistrationRPCKey:    "expired-remote-key",
+	}
+	_, created, err := store.AdmitIdempotentOwnedReceiveScript(
+		t.Context(), candidate,
+	)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(
+		t,
+		store.MarkOwnedReceiveScriptRegistered(
+			t.Context(), candidate.IdempotencyKey,
+			candidate.RegistrationRPCKey,
+		),
+	)
+	clk.SetTime(now.Add(2 * time.Second))
+
+	resp, err := rpcServer.NewReceiveScript(t.Context(),
+		&waverpc.NewReceiveScriptRequest{
+			Label:          candidate.RegistrationLabel,
+			IdempotencyKey: candidate.IdempotencyKey,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, hex.EncodeToString(candidate.PkScript), resp.PkScriptHex,
+	)
+	require.Greater(
+		t, resp.ExpiresAtUnixS,
+		uint64(
+			candidate.RegistrationExpiresAt.Unix(),
+		),
+	)
+	require.Len(t, rpcClient.registerOpts, 1)
+	require.NotEqual(
+		t, candidate.RegistrationRPCKey,
+		rpcClient.registerOpts[0].IdempotencyKey,
+	)
+	renewed, err := store.LookupOwnedReceiveScriptByIdempotencyKey(
+		t.Context(), candidate.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	require.Equal(t, candidate.PkScript, renewed.PkScript)
+	require.Equal(
+		t, rpcClient.registerOpts[0].IdempotencyKey,
+		renewed.RegistrationRPCKey,
+	)
+	require.True(t, renewed.RegistrationCompletedAt.IsSome())
 }

--- a/waved/rpc_oor_receive_sqlite_test.go
+++ b/waved/rpc_oor_receive_sqlite_test.go
@@ -1,0 +1,90 @@
+//go:build !test_postgres
+
+package waved
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/clock"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestNewReceiveScriptCompletedReplayUsesDurableResult verifies exact replay
+// returns a completed allocation without current operator terms or an indexer.
+func TestNewReceiveScriptCompletedReplayUsesDurableResult(t *testing.T) {
+	t.Parallel()
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+	now := time.Unix(1_700_000_000, 0)
+	sqliteDB := db.NewTestDB(t)
+	rpcServer := NewRPCServer(&Server{
+		walletReady: walletReady,
+		clk:         clock.NewTestClock(now),
+		db:          sqliteDB,
+	})
+
+	store, err := rpcServer.newOORReceiveScriptStore()
+	require.NoError(t, err)
+	clientKey := testKeyDescriptor(t, 101)
+	operatorKey := testKeyDescriptor(t, 102)
+	pkScript, err := BuildPubKeyVTXOReceiveScript(
+		clientKey.PubKey, operatorKey.PubKey, 144,
+	)
+	require.NoError(t, err)
+	candidate := db.OwnedReceiveScriptRecord{
+		PkScript:              pkScript,
+		ClientKey:             clientKey,
+		OperatorPubKey:        operatorKey.PubKey,
+		ExitDelay:             144,
+		Source:                db.OwnedReceiveScriptSourceWallet,
+		CreatedAt:             now,
+		LastUsedAt:            fn.None[time.Time](),
+		IdempotencyKey:        "completed-allocation",
+		RegistrationLabel:     "durable-label",
+		RegistrationExpiresAt: now.Add(time.Hour),
+		RegistrationRPCKey:    "stable-remote-key",
+	}
+	_, created, err := store.AdmitIdempotentOwnedReceiveScript(
+		t.Context(), candidate,
+	)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(
+		t,
+		store.MarkOwnedReceiveScriptRegistered(
+			t.Context(), candidate.IdempotencyKey,
+			candidate.RegistrationRPCKey,
+		),
+	)
+
+	resp, err := rpcServer.NewReceiveScript(t.Context(),
+		&waverpc.NewReceiveScriptRequest{
+			Label:          candidate.RegistrationLabel,
+			IdempotencyKey: candidate.IdempotencyKey,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, candidate.RegistrationLabel, resp.Label)
+	require.Equal(
+		t,
+		uint64(
+			candidate.RegistrationExpiresAt.Unix(),
+		),
+		resp.ExpiresAtUnixS,
+	)
+
+	_, err = rpcServer.NewReceiveScript(t.Context(),
+		&waverpc.NewReceiveScriptRequest{
+			Label:          "changed-label",
+			IdempotencyKey: candidate.IdempotencyKey,
+		},
+	)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/waved/rpc_oor_receive_sqlite_test.go
+++ b/waved/rpc_oor_receive_sqlite_test.go
@@ -219,6 +219,7 @@ func TestNewReceiveScriptRenewsExpiredRegistration(t *testing.T) {
 	server := &Server{
 		walletReady: walletReady,
 		clk:         clk,
+		log:         btclog.Disabled,
 		db:          db.NewTestDB(t),
 		indexer: indexer.New(
 			rpcClient, nil, "test-server", "client:test",

--- a/waved/rpc_oor_receive_test.go
+++ b/waved/rpc_oor_receive_test.go
@@ -1,0 +1,137 @@
+package waved
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/indexer"
+	"github.com/lightninglabs/wavelength/waverpc"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// testRegistrationCompleter records completion attempts and can inject one
+// durable write error after the indexer acknowledges registration.
+type testRegistrationCompleter struct {
+	keys []string
+	err  error
+}
+
+// MarkOwnedReceiveScriptRegistered records the durable completion
+// identity and returns the configured error.
+func (s *testRegistrationCompleter) MarkOwnedReceiveScriptRegistered(
+	_ context.Context, idempotencyKey, registrationRPCKey string) error {
+
+	s.keys = append(s.keys, idempotencyKey+":"+registrationRPCKey)
+
+	return s.err
+}
+
+// TestRegisterIdempotentReceiveScriptReusesRemoteKey verifies an ambiguous
+// completion-write failure retries the same logical indexer registration.
+func TestRegisterIdempotentReceiveScriptReusesRemoteKey(t *testing.T) {
+	t.Parallel()
+
+	key := testKeyDescriptor(t, 91)
+	operator := testKeyDescriptor(t, 92)
+	pkScript, err := BuildPubKeyVTXOReceiveScript(
+		key.PubKey, operator.PubKey, 144,
+	)
+	require.NoError(t, err)
+
+	rpcClient := &testReceiveScriptRPCClient{}
+	idx := indexer.New(
+		rpcClient, nil, "test-server", "client:test",
+		fn.None[btclog.Logger](),
+	).WithSigner(&testOwnedReceiveScriptSigner{
+		keyDesc: key,
+		tagSig:  []byte("test-tag-signature"),
+	})
+
+	rec := &db.OwnedReceiveScriptRecord{
+		PkScript:              pkScript,
+		ClientKey:             key,
+		OperatorPubKey:        operator.PubKey,
+		ExitDelay:             144,
+		Source:                db.OwnedReceiveScriptSourceWallet,
+		IdempotencyKey:        "allocation-1",
+		RegistrationLabel:     "retry-safe",
+		RegistrationExpiresAt: time.Now().Add(time.Hour),
+		RegistrationRPCKey:    "stable-remote-key",
+	}
+
+	markErr := errors.New("completion write failed")
+	store := &testRegistrationCompleter{err: markErr}
+	err = registerIdempotentReceiveScript(t.Context(), idx, store, rec)
+	require.ErrorIs(t, err, markErr)
+
+	store.err = nil
+	err = registerIdempotentReceiveScript(t.Context(), idx, store, rec)
+	require.NoError(t, err)
+
+	require.Len(t, rpcClient.registerOpts, 2)
+	require.Equal(
+		t, "stable-remote-key",
+		rpcClient.registerOpts[0].IdempotencyKey,
+	)
+	require.Equal(
+		t, rpcClient.registerOpts[0].IdempotencyKey,
+		rpcClient.registerOpts[1].IdempotencyKey,
+	)
+	require.Equal(t, []string{
+		"allocation-1:stable-remote-key",
+		"allocation-1:stable-remote-key",
+	}, store.keys)
+}
+
+// TestRegisterIdempotentReceiveScriptCompletedReplay verifies completed replay
+// returns without requiring an indexer client or completion store.
+func TestRegisterIdempotentReceiveScriptCompletedReplay(t *testing.T) {
+	t.Parallel()
+
+	rec := &db.OwnedReceiveScriptRecord{
+		RegistrationCompletedAt: fn.Some(time.Unix(100, 0)),
+	}
+
+	err := registerIdempotentReceiveScript(
+		t.Context(), nil, nil, rec,
+	)
+	require.NoError(t, err)
+}
+
+// TestNewReceiveScriptRejectsOversizeIdempotencyKey verifies the durable text
+// bound is enforced before database or indexer initialization is consulted.
+func TestNewReceiveScriptRejectsOversizeIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+	rpcServer := NewRPCServer(&Server{walletReady: walletReady})
+	keyBytes := db.MaxOwnedReceiveScriptIdempotencyKeyBytes + 1
+
+	_, err := rpcServer.NewReceiveScript(t.Context(),
+		&waverpc.NewReceiveScriptRequest{
+			IdempotencyKey: string(make([]byte, keyBytes)),
+		},
+	)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestAcquireReceiveScriptLockCleansRegistry verifies keyed lock entries do not
+// accumulate after the last caller releases them.
+func TestAcquireReceiveScriptLockCleansRegistry(t *testing.T) {
+	t.Parallel()
+
+	rpcServer := NewRPCServer(&Server{})
+	release := rpcServer.acquireReceiveScriptLock("allocation-1")
+	require.Len(t, rpcServer.receiveScriptLocks, 1)
+
+	release()
+	require.Empty(t, rpcServer.receiveScriptLocks)
+}

--- a/waved/rpc_oor_receive_test.go
+++ b/waved/rpc_oor_receive_test.go
@@ -123,13 +123,60 @@ func TestNewReceiveScriptRejectsOversizeIdempotencyKey(t *testing.T) {
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+// TestNewReceiveScriptRejectsControlIdempotencyKey verifies keys invalid in a
+// PostgreSQL text column fail consistently before backend selection matters.
+func TestNewReceiveScriptRejectsControlIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+	rpcServer := NewRPCServer(&Server{walletReady: walletReady})
+
+	_, err := rpcServer.NewReceiveScript(t.Context(),
+		&waverpc.NewReceiveScriptRequest{
+			IdempotencyKey: "allocation\x00one",
+		},
+	)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 // TestAcquireReceiveScriptLockCleansRegistry verifies keyed lock entries do not
 // accumulate after the last caller releases them.
 func TestAcquireReceiveScriptLockCleansRegistry(t *testing.T) {
 	t.Parallel()
 
 	rpcServer := NewRPCServer(&Server{})
-	release := rpcServer.acquireReceiveScriptLock("allocation-1")
+	release, err := rpcServer.acquireReceiveScriptLock(
+		t.Context(),
+		"allocation-1",
+	)
+	require.NoError(t, err)
+	require.Len(t, rpcServer.receiveScriptLocks, 1)
+
+	release()
+	require.Empty(t, rpcServer.receiveScriptLocks)
+}
+
+// TestAcquireReceiveScriptLockHonorsCancellation verifies a retry does not
+// retain its goroutine after its own deadline while the first remote call is
+// still holding the same-key registration lock.
+func TestAcquireReceiveScriptLockHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	rpcServer := NewRPCServer(&Server{})
+	release, err := rpcServer.acquireReceiveScriptLock(
+		t.Context(),
+		"allocation-1",
+	)
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	secondRelease, err := rpcServer.acquireReceiveScriptLock(
+		waitCtx, "allocation-1",
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, secondRelease)
 	require.Len(t, rpcServer.receiveScriptLocks, 1)
 
 	release()

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -102,6 +102,16 @@ type RPCServer struct {
 	// currently reserved by an in-flight SendOOR call.
 	customInputLocks map[wire.OutPoint]struct{}
 
+	// receiveScriptLocksMu guards receiveScriptLocks. The keyed locks keep
+	// two exact NewReceiveScript retries from using the same mailbox
+	// correlation id concurrently.
+	receiveScriptLocksMu sync.Mutex
+
+	// receiveScriptLocks contains only idempotency keys with active
+	// callers. Entries are removed when their last caller releases the
+	// lock.
+	receiveScriptLocks map[string]*receiveScriptLock
+
 	// oorSignerOverride lets focused RPC tests exercise custom-input
 	// signing without booting a full wallet backend.
 	oorSignerOverride input.Signer
@@ -110,8 +120,9 @@ type RPCServer struct {
 // NewRPCServer creates a new RPCServer backed by the given Server.
 func NewRPCServer(server *Server) *RPCServer {
 	return &RPCServer{
-		server:           server,
-		customInputLocks: make(map[wire.OutPoint]struct{}),
+		server:             server,
+		customInputLocks:   make(map[wire.OutPoint]struct{}),
+		receiveScriptLocks: make(map[string]*receiveScriptLock),
 	}
 }
 

--- a/waved/wallet_recovery.go
+++ b/waved/wallet_recovery.go
@@ -260,7 +260,7 @@ func (r *RPCServer) recoverIndexedVTXOs(ctx context.Context,
 			r.server.proofKeyBackend.ProofSigner(*keyDesc),
 		)
 		expiresAt := r.server.clk.Now().Add(
-			defaultOORReceiveScriptRegistrationTTL,
+			defaultOORRegistrationTTL,
 		)
 		err = retryRecoveryIndexerRPC(ctx, func(
 			opts mailboxrpc.RPCOptions) error {

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -2345,7 +2345,9 @@ type NewReceiveScriptRequest struct {
 	// non-empty key with the same normalized label returns the original
 	// receive script and expiry. Reusing it with a different label is
 	// rejected. An empty key preserves the legacy behavior and allocates a
-	// fresh script.
+	// fresh script. The key namespace is global to this daemon; callers must
+	// prefix keys with an application or tenant identity when they share one
+	// daemon.
 	IdempotencyKey string `protobuf:"bytes,2,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -2340,9 +2340,15 @@ type NewReceiveScriptRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// label is an optional human-readable label stored with the
 	// registration on the indexer.
-	Label         string `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Label string `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"`
+	// idempotency_key makes allocation retry-safe. Repeating the same
+	// non-empty key with the same normalized label returns the original
+	// receive script and expiry. Reusing it with a different label is
+	// rejected. An empty key preserves the legacy behavior and allocates a
+	// fresh script.
+	IdempotencyKey string `protobuf:"bytes,2,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *NewReceiveScriptRequest) Reset() {
@@ -2382,6 +2388,13 @@ func (x *NewReceiveScriptRequest) GetLabel() string {
 	return ""
 }
 
+func (x *NewReceiveScriptRequest) GetIdempotencyKey() string {
+	if x != nil {
+		return x.IdempotencyKey
+	}
+	return ""
+}
+
 type NewReceiveScriptResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// pk_script_hex is the raw taproot output script encoded as hex.
@@ -2393,9 +2406,12 @@ type NewReceiveScriptResponse struct {
 	// key_index is the wallet key index used to derive the receive key.
 	KeyIndex uint32 `protobuf:"varint,4,opt,name=key_index,json=keyIndex,proto3" json:"key_index,omitempty"`
 	// label is the registration label stored with the indexer.
-	Label         string `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Label string `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
+	// expires_at_unix_s is the absolute indexer registration expiry used for
+	// this receive script.
+	ExpiresAtUnixS uint64 `protobuf:"varint,6,opt,name=expires_at_unix_s,json=expiresAtUnixS,proto3" json:"expires_at_unix_s,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *NewReceiveScriptResponse) Reset() {
@@ -2461,6 +2477,13 @@ func (x *NewReceiveScriptResponse) GetLabel() string {
 		return x.Label
 	}
 	return ""
+}
+
+func (x *NewReceiveScriptResponse) GetExpiresAtUnixS() uint64 {
+	if x != nil {
+		return x.ExpiresAtUnixS
+	}
+	return 0
 }
 
 type ReceiveAuthKeyRequest struct {
@@ -10530,16 +10553,18 @@ const file_daemon_proto_rawDesc = "" +
 	"\x05vtxos\x18\x01 \x03(\v2\r.waverpc.VTXOR\x05vtxos\"\x13\n" +
 	"\x11NewAddressRequest\".\n" +
 	"\x12NewAddressResponse\x12\x18\n" +
-	"\aaddress\x18\x01 \x01(\tR\aaddress\"/\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\"X\n" +
 	"\x17NewReceiveScriptRequest\x12\x14\n" +
-	"\x05label\x18\x01 \x01(\tR\x05label\"\xba\x01\n" +
+	"\x05label\x18\x01 \x01(\tR\x05label\x12'\n" +
+	"\x0fidempotency_key\x18\x02 \x01(\tR\x0eidempotencyKey\"\xe5\x01\n" +
 	"\x18NewReceiveScriptResponse\x12\"\n" +
 	"\rpk_script_hex\x18\x01 \x01(\tR\vpkScriptHex\x12(\n" +
 	"\x10pubkey_xonly_hex\x18\x02 \x01(\tR\x0epubkeyXonlyHex\x12\x1d\n" +
 	"\n" +
 	"key_family\x18\x03 \x01(\rR\tkeyFamily\x12\x1b\n" +
 	"\tkey_index\x18\x04 \x01(\rR\bkeyIndex\x12\x14\n" +
-	"\x05label\x18\x05 \x01(\tR\x05label\":\n" +
+	"\x05label\x18\x05 \x01(\tR\x05label\x12)\n" +
+	"\x11expires_at_unix_s\x18\x06 \x01(\x04R\x0eexpiresAtUnixS\":\n" +
 	"\x15ReceiveAuthKeyRequest\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\"0\n" +
 	"\x16ReceiveAuthKeyResponse\x12\x16\n" +

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -41,9 +41,8 @@ service DaemonService {
     // on-chain funds for use in the Ark protocol.
     rpc NewAddress (NewAddressRequest) returns (NewAddressResponse);
 
-    // NewReceiveScript allocates a fresh wallet key, registers the
-    // matching taproot receive script with the indexer, and returns the
-    // script details needed to hand the destination to a sender.
+    // NewReceiveScript allocates and registers a taproot receive script, or
+    // returns the exact existing allocation for an idempotent retry.
     rpc NewReceiveScript (NewReceiveScriptRequest)
         returns (NewReceiveScriptResponse);
 
@@ -786,6 +785,13 @@ message NewReceiveScriptRequest {
     // label is an optional human-readable label stored with the
     // registration on the indexer.
     string label = 1;
+
+    // idempotency_key makes allocation retry-safe. Repeating the same
+    // non-empty key with the same normalized label returns the original
+    // receive script and expiry. Reusing it with a different label is
+    // rejected. An empty key preserves the legacy behavior and allocates a
+    // fresh script.
+    string idempotency_key = 2;
 }
 
 message NewReceiveScriptResponse {
@@ -803,6 +809,10 @@ message NewReceiveScriptResponse {
 
     // label is the registration label stored with the indexer.
     string label = 5;
+
+    // expires_at_unix_s is the absolute indexer registration expiry used for
+    // this receive script.
+    uint64 expires_at_unix_s = 6;
 }
 
 message ReceiveAuthKeyRequest {

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -790,7 +790,9 @@ message NewReceiveScriptRequest {
     // non-empty key with the same normalized label returns the original
     // receive script and expiry. Reusing it with a different label is
     // rejected. An empty key preserves the legacy behavior and allocates a
-    // fresh script.
+    // fresh script. The key namespace is global to this daemon; callers must
+    // prefix keys with an application or tenant identity when they share one
+    // daemon.
     string idempotency_key = 2;
 }
 

--- a/waverpc/daemon_grpc.pb.go
+++ b/waverpc/daemon_grpc.pb.go
@@ -102,9 +102,8 @@ type DaemonServiceClient interface {
 	// NewAddress generates a new boarding address that can receive
 	// on-chain funds for use in the Ark protocol.
 	NewAddress(ctx context.Context, in *NewAddressRequest, opts ...grpc.CallOption) (*NewAddressResponse, error)
-	// NewReceiveScript allocates a fresh wallet key, registers the
-	// matching taproot receive script with the indexer, and returns the
-	// script details needed to hand the destination to a sender.
+	// NewReceiveScript allocates and registers a taproot receive script, or
+	// returns the exact existing allocation for an idempotent retry.
 	NewReceiveScript(ctx context.Context, in *NewReceiveScriptRequest, opts ...grpc.CallOption) (*NewReceiveScriptResponse, error)
 	// ReceiveAuthKey returns the per-payment receive-auth public key.
 	ReceiveAuthKey(ctx context.Context, in *ReceiveAuthKeyRequest, opts ...grpc.CallOption) (*ReceiveAuthKeyResponse, error)
@@ -790,9 +789,8 @@ type DaemonServiceServer interface {
 	// NewAddress generates a new boarding address that can receive
 	// on-chain funds for use in the Ark protocol.
 	NewAddress(context.Context, *NewAddressRequest) (*NewAddressResponse, error)
-	// NewReceiveScript allocates a fresh wallet key, registers the
-	// matching taproot receive script with the indexer, and returns the
-	// script details needed to hand the destination to a sender.
+	// NewReceiveScript allocates and registers a taproot receive script, or
+	// returns the exact existing allocation for an idempotent retry.
 	NewReceiveScript(context.Context, *NewReceiveScriptRequest) (*NewReceiveScriptResponse, error)
 	// ReceiveAuthKey returns the per-payment receive-auth public key.
 	ReceiveAuthKey(context.Context, *ReceiveAuthKeyRequest) (*ReceiveAuthKeyResponse, error)


### PR DESCRIPTION
## What changed

`NewReceiveScript` now accepts an optional idempotency key. Repeating the same keyed request returns the original wallet key, taproot script, and normalized label.

The daemon persists the allocation before it contacts the indexer. The durable row contains the wallet key locator, script terms, absolute registration expiry, a stable mailbox request key, and registration completion evidence. A retry after a crash or ambiguous remote result resumes the same logical registration.

When a stored registration window expires, replay keeps the owned wallet key and script but atomically renews the remote expiry and mailbox request key before re-registering. Concurrent renewals load the same canonical winner. Calls without an idempotency key keep the existing fresh-allocation behavior.

The CLI exposes the new request field. The response reports the active absolute expiry.

## Why

The old sequence derived and registered a new script before it persisted local ownership. If the process stopped or the RPC response was lost after remote success, a retry derived and registered another destination. Concurrent retries could do the same work more than once.

Persisting one immutable allocation and one remote request identity first makes the operation restart-safe. Pending ownership evidence survives remote errors. Renewing only an expired remote registration window lets a durable caller recover without replacing its published script.

## Safety and compatibility

- Idempotency keys are optional, bounded to 128 bytes, and reject control characters.
- The key namespace is daemon-global. Shared callers must prefix keys with an application or tenant identity.
- Exact replay is independent of current operator terms and indexer availability while the registration remains active.
- Reusing a key with a changed normalized label returns `InvalidArgument`.
- Same-key remote calls are serialized. A canceled waiter exits promptly. Different keys remain concurrent.
- Admission targets only idempotency-key conflicts. Primary-script collisions remain visible.
- Existing owned-script rows migrate with null replay metadata.
- Recovery upserts cannot clear replay metadata.
- Pending or possibly registered ownership evidence is never deleted.
- Expiry renewal changes only the remote expiry and mailbox request key. The wallet key, script, label, and operator terms remain immutable.

## Verification

- Full `make unit`
- Full `make unit tags=test_postgres`
- Full `make unit-race`
- `make sqlc-check`
- `make fmt-changed-check`
- `make tidy-module-check`
- `make ast-lint`
- `make lint-local` with 0 issues
- Focused SQLite and PostgreSQL renewal, primary-script collision, restart, concurrency, ambiguous-result, RPC retry, and cancellation tests

Both commits are signed. A funds-safety and compatibility review found no remaining concrete blocker. The previous Gateway findings are addressed on the current head and are being re-reviewed.
