### PR TITLE
docs: nightly doc-gardening sweep 2026-08-18

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,7 +84,7 @@ package may import from a higher layer.
 | [`rpc/wavewalletrpc`](rpc/wavewalletrpc/) | Highest-level gRPC surface: `WalletService` with the seven core wallet verbs. Composes `waverpc` and `rpc/swapclientrpc` server-side via `swapwallet` |
 | [`rpc/restclient`](rpc/restclient/) | HTTP/protoJSON transport adapter: `Client`, `StreamClient[T]`, and per-service factory functions implementing the same gRPC stub interfaces over REST |
 | [`waverpc`](waverpc/) | Daemon gRPC API definitions |
-| [`swaprpc`](swaprpc/) | Generated gRPC/REST/mailbox-RPC stubs for the external `SwapService` |
+| [`swaprpc`](swaprpc/) | Generated gRPC/REST/mailbox-RPC stubs for the external `SwapService`, plus the hand-written canonical digest constructions (`out_swap_ack.go`, `credit_account_auth.go`) that client and server must derive identically |
 
 ### Layer 4: Testing & Tooling
 
@@ -233,11 +233,35 @@ once new ones are confirmed signed.
 ```
 Live → PendingForfeit → Forfeiting → Forfeited
 Live → Forfeiting → Forfeited  (fast path: ForfeitRequestEvent in LiveState)
-PendingForfeit → UnilateralExit  (critical expiry while pending)
-Live → UnilateralExit  (critical expiry)
+Live → Expired → (PendingForfeit | Forfeiting) → Forfeited  (round reclaim)
+Live | PendingForfeit | Spending | Forfeiting → UnilateralExit
 Live → Spent
 Any → Failed
 ```
+`Expired` is **not** terminal — the value is still reclaimable by forfeiting the
+VTXO in a round, so the actor stays alive holding the signing material. It is
+the one state that refuses a unilateral exit outright: past expiry the exit must
+confirm the whole ancestry and then wait out the exit CSV while racing an
+operator sweep that is already spendable.
+
+`UnilateralExit` is **non-terminal**: the actor survives to observe the exit
+and is reaped only on a terminal on-chain outcome. Every entry into it goes
+through the manager's admission gate (`ForceUnrollEvent`), which carries the
+trigger (critical expiry, manual `Unroll`, fraud spend, vHTLC recovery) and an
+optional exit policy. Two refusals are load-bearing rather than incidental:
+
+- From `Forfeiting`, once the forfeit signature has issued, a **critical-expiry**
+  trigger self-loops instead of escalating — the operator can spend the coin
+  into a connector immediately, so the exit would race a transaction that has
+  already won. Manual and fraud-spend triggers still escalate.
+- A second `PendingForfeitEvent` is refused in both `PendingForfeit` and
+  `Forfeiting`, so a leave or refresh racing an existing claim is reported as
+  refused rather than queued behind the claim that actually gets paid.
+
+`vtxo.CheckForfeitAdmission` is the advisory pre-check for the same question,
+used by `waved` to filter leave targets and to annotate exit plans. It is
+advisory only — the FSM above is the enforcement point. See
+[vtxo/CLAUDE.md](vtxo/CLAUDE.md) for the per-state detail.
 
 ### OOR FSM
 Manages outgoing/incoming transfer state through checkpoint signing with

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -173,8 +173,8 @@ waved \
 fee-estimate endpoint when left empty; set it explicitly only to point at a
 custom `fee_by_block_target` JSON endpoint.
 
-The Ark and swap connections resolve from the configured public test network
-unless explicitly overridden. See [`docs/signet.md`](docs/signet.md) for the
+The Ark and swap connections resolve from the configured public network unless
+explicitly overridden. See [`docs/signet.md`](docs/signet.md) for the mainnet,
 testnet3, testnet4, and signet gRPC and REST addresses.
 
 ### `lnd`

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ own `CLAUDE.md` / `AGENTS.md` with package-local context.
 |----------------------------------|-----------------------------------------------------------------------|
 | System architecture              | [`ARCHITECTURE.md`](ARCHITECTURE.md)                                  |
 | Install, configure, operate      | [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md)                |
-| Public test-network endpoints    | [`docs/signet.md`](docs/signet.md)                                    |
+| Public network endpoints         | [`docs/signet.md`](docs/signet.md)                                    |
 | Build-tag matrix                 | [`docs/wavewalletrpc_build.md`](docs/wavewalletrpc_build.md)                  |
 | Durable actor pattern            | [`docs/durable_actor_architecture.md`](docs/durable_actor_architecture.md) |
 | Mailbox transport                | [`docs/mailbox_architecture.md`](docs/mailbox_architecture.md)        |

--- a/cmd/waved/AGENTS.md
+++ b/cmd/waved/AGENTS.md
@@ -45,3 +45,10 @@ hands off to `waved.Main` to run the daemon.
 - `EagerRoundJoin`'s flag default comes from `waved.DefaultConfig()`,
   which is itself build-tag aware (true under `wavewalletrpc`, false
   otherwise); `--eagerroundjoin` still overrides it either way.
+- Several flags default to *empty* on purpose, because the meaning of "unset"
+  is resolved later against the network or the backend rather than here:
+  `--lnd.account` (empty = lnd's `default` account; set it to isolate spending
+  when two daemons share one lnd node) and `--server.host` /
+  `--swap.serveraddress` (empty = the selected network's public endpoint, via
+  `waved.defaultNetworkEndpoints`). Do not give these cosmetic non-empty
+  defaults in the flag registration — that would override the resolution.

--- a/cmd/waved/CLAUDE.md
+++ b/cmd/waved/CLAUDE.md
@@ -45,3 +45,10 @@ hands off to `waved.Main` to run the daemon.
 - `EagerRoundJoin`'s flag default comes from `waved.DefaultConfig()`,
   which is itself build-tag aware (true under `wavewalletrpc`, false
   otherwise); `--eagerroundjoin` still overrides it either way.
+- Several flags default to *empty* on purpose, because the meaning of "unset"
+  is resolved later against the network or the backend rather than here:
+  `--lnd.account` (empty = lnd's `default` account; set it to isolate spending
+  when two daemons share one lnd node) and `--server.host` /
+  `--swap.serveraddress` (empty = the selected network's public endpoint, via
+  `waved.defaultNetworkEndpoints`). Do not give these cosmetic non-empty
+  defaults in the flag registration — that would override the resolution.

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -147,8 +147,8 @@ waved \
 | `--swap.servertransport` | `grpc` | Swap server transport: `grpc` or `rest` |
 
 Empty Ark and swap addresses resolve from the selected network and transport.
-See [signet.md](signet.md) for the testnet3, testnet4, and signet endpoints and
-override examples.
+See [signet.md](signet.md) for the mainnet, testnet3, testnet4, and signet
+endpoints and override examples.
 
 There is no mailbox-ID flag: the client and compound server mailbox IDs are
 derived automatically from the client's identity key at connect time.

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ into specific topics below.
 | Document | Description |
 |----------|-------------|
 | [daemon_cli_guide.md](daemon_cli_guide.md) | waved/wavecli installation, configuration, CLI reference |
-| [signet.md](signet.md) | Public testnet3, testnet4, and signet Ark/swap endpoints, transport selection, and local overrides |
+| [signet.md](signet.md) | Public mainnet, testnet3, testnet4, and signet Ark/swap endpoints, transport selection, and local overrides |
 | [accounting_report.md](accounting_report.md) | Accounting report command: reading the fee ledger from SQLite or Postgres, text/JSON/CSV output, fiat conversion, read-only behavior |
 
 ## Plans

--- a/docs/signet.md
+++ b/docs/signet.md
@@ -1,11 +1,12 @@
-# Public Test Network Endpoints
+# Public Network Endpoints
 
-`waved` has built-in Ark and swap service endpoints for testnet3, testnet4,
-and signet. Leave `server.host` and `swap.serveraddress` empty to select the
-endpoint for the configured Bitcoin network and outbound transport.
+`waved` has built-in Ark and swap service endpoints for mainnet, testnet3,
+testnet4, and signet. Leave `server.host` and `swap.serveraddress` empty to
+select the endpoint for the configured Bitcoin network and outbound transport.
 
 | Network config | Ark gRPC | Ark REST | Swap gRPC | Swap REST |
 |----------------|----------|----------|-----------|-----------|
+| `mainnet` | `wavelength.lightning.finance:443` | `https://wavelength-rest.lightning.finance` (not live) | `swap.wavelength.lightning.finance:443` | `https://swapd-rest.lightning.finance` (not live) |
 | `testnet` | `test.wavelength.lightning.finance:443` | `https://test.wavelength-rest.lightning.finance` | `swap.test.wavelength.lightning.finance:443` | `https://test.swapd-rest.lightning.finance` |
 | `testnet4` | `lumosd-testnet4.testnet.lightningcluster.com:443` | `https://test4.wavelength-rest.lightning.finance` | `swapd-testnet4.testnet.lightningcluster.com:443` | `https://test4.swapd-rest.lightning.finance` |
 | `signet` | `signet.wavelength.lightning.finance:443` | `https://signet.wavelength-rest.lightning.finance` | `swap.signet.wavelength.lightning.finance:443` | `https://signet.swapd-rest.lightning.finance` |
@@ -76,7 +77,10 @@ waved \
 Regtest and simnet have no public service deployment in the default table, so
 empty address fields resolve to `localhost:10010` and `localhost:10030`.
 Mainnet resolves to the public operator, though its REST names are not live
-yet.
+yet: only the gRPC names are covered by the external load balancer and its
+certificates, so a mainnet daemon must stay on the default `grpc` transport
+until the REST ingress lands. Running on mainnet at all also requires the
+`--allow-mainnet` safety guard.
 
 ## wavewalletdk
 

--- a/lib/arkscript/AGENTS.md
+++ b/lib/arkscript/AGENTS.md
@@ -47,7 +47,11 @@ validated invariants.
 - `ValidatePolicy(nodes, opts)` — Structural admission check for any Ark policy
   shape (custom vHTLC, etc.). Enforces: collab leaf with operator key, exit
   leaf without operator key, no operator-unilateral leaf, CSV gating on exit
-  paths. `opts.MinExitDelay = 0` skips the CSV minimum check.
+  paths. `opts.MinExitDelay = 0` skips the CSV minimum check. It first rejects
+  nil leaves and **compiles** every leaf, so a direct caller that never calls
+  `PolicyTemplate.Compile()` still gets the compiler's `CSV` and `Condition`
+  safety checks (see Invariants) rather than validating a shape that could not
+  be built.
 - Decode budget constants: `MaxPolicyTemplateBytes` (64 KiB),
   `MaxLeafTemplateBytes` (16 KiB), `MaxPolicyLeaves` (32),
   `MaxPolicyDepth` (16), `MaxPolicyNodes` (256), `MaxMultisigKeys` (64) —
@@ -76,7 +80,18 @@ validated invariants.
   compare raw block counts against CSV lock values must convert accordingly.
 - CSV values are canonical non-zero block-mode encodings in `1..65535`.
   Time-mode, disable, and reserved high bits are rejected so structural delay
-  comparisons cannot diverge from the value enforced by consensus.
+  comparisons cannot diverge from the value enforced by consensus. The check
+  (`validateCSVLock`) runs in `CSV.Script()` and again at every entry point
+  that accepts a delay from a caller or a decoder:
+  `StandardVTXOTemplate`, `DecodeStandardVTXOParams`, and `VHTLCOpts.validate`
+  (all three unilateral delays).
+- `Condition.Predicate` is opaque to the AST walker but **not** unchecked.
+  `Condition.Script()` requires the predicate to tokenize as a complete script
+  fragment and rejects any tapscript `OP_SUCCESSx` opcode. Without those two
+  checks a raw prefix could consume the typed `Inner` clause as push data, or
+  make the leaf succeed before the inner signature checks ever execute — either
+  one turns "predicates only add restrictions" into a bypass, which is the
+  assumption `rejectOperatorUnilateral` and key extraction rely on.
 - Canonical leaf ordering: sorted by version then lexicographic script bytes.
 - All taproot outputs use the unspendable ARK NUMS key for key path (no
   key-path spend possible).

--- a/lib/arkscript/CLAUDE.md
+++ b/lib/arkscript/CLAUDE.md
@@ -47,7 +47,11 @@ validated invariants.
 - `ValidatePolicy(nodes, opts)` — Structural admission check for any Ark policy
   shape (custom vHTLC, etc.). Enforces: collab leaf with operator key, exit
   leaf without operator key, no operator-unilateral leaf, CSV gating on exit
-  paths. `opts.MinExitDelay = 0` skips the CSV minimum check.
+  paths. `opts.MinExitDelay = 0` skips the CSV minimum check. It first rejects
+  nil leaves and **compiles** every leaf, so a direct caller that never calls
+  `PolicyTemplate.Compile()` still gets the compiler's `CSV` and `Condition`
+  safety checks (see Invariants) rather than validating a shape that could not
+  be built.
 - Decode budget constants: `MaxPolicyTemplateBytes` (64 KiB),
   `MaxLeafTemplateBytes` (16 KiB), `MaxPolicyLeaves` (32),
   `MaxPolicyDepth` (16), `MaxPolicyNodes` (256), `MaxMultisigKeys` (64) —
@@ -76,7 +80,18 @@ validated invariants.
   compare raw block counts against CSV lock values must convert accordingly.
 - CSV values are canonical non-zero block-mode encodings in `1..65535`.
   Time-mode, disable, and reserved high bits are rejected so structural delay
-  comparisons cannot diverge from the value enforced by consensus.
+  comparisons cannot diverge from the value enforced by consensus. The check
+  (`validateCSVLock`) runs in `CSV.Script()` and again at every entry point
+  that accepts a delay from a caller or a decoder:
+  `StandardVTXOTemplate`, `DecodeStandardVTXOParams`, and `VHTLCOpts.validate`
+  (all three unilateral delays).
+- `Condition.Predicate` is opaque to the AST walker but **not** unchecked.
+  `Condition.Script()` requires the predicate to tokenize as a complete script
+  fragment and rejects any tapscript `OP_SUCCESSx` opcode. Without those two
+  checks a raw prefix could consume the typed `Inner` clause as push data, or
+  make the leaf succeed before the inner signature checks ever execute — either
+  one turns "predicates only add restrictions" into a bypass, which is the
+  assumption `rejectOperatorUnilateral` and key extraction rely on.
 - Canonical leaf ordering: sorted by version then lexicographic script bytes.
 - All taproot outputs use the unspendable ARK NUMS key for key path (no
   key-path spend possible).

--- a/waverpc/AGENTS.md
+++ b/waverpc/AGENTS.md
@@ -7,6 +7,22 @@ VHTLC-recovery operations. Proto source: `waverpc/daemon.proto`. Generated
 gRPC, REST-gateway, and mailbox-RPC stubs plus one hand-written helper file
 (`errors.go`) for structured wallet-lifecycle errors.
 
+`DaemonService` also carries a **delegated-signing family** —
+`SignReceiveAuthMessage`, `SignReceiveAuthMessageCompact`, `SignOORCustomInput`,
+`SignVTXOForfeit`, `SignOutSwapHtlcAck`, `SignCreditAccountAuthorization` —
+through which higher layers (`sdk/swaps`, `swapclientserver`, `swapwallet`)
+obtain signatures from keys the daemon holds without ever handling those keys
+themselves. The request shapes are deliberately narrow rather than
+"sign these bytes", so the daemon can bound what it authorizes:
+`SignVTXOForfeit` and `SignOORCustomInput` describe the transaction being
+signed, and `SignOutSwapHtlcAck` / `SignCreditAccountAuthorization` carry the
+authorization's committed fields (expiry, nonce, account key) alongside the
+digest so the daemon can refuse one that is not its own to grant — see
+[waved/CLAUDE.md](../waved/CLAUDE.md) for the checks each applies.
+`SignReceiveAuthMessage`(`Compact`) is the exception and is scoped by key
+instead: it signs a raw message under the per-swap receive-auth key selected by
+`payment_hash`, not under the daemon identity key.
+
 ## Key Types
 
 - `DaemonServiceClient` / `DaemonServiceServer` — Generated gRPC client and

--- a/waverpc/CLAUDE.md
+++ b/waverpc/CLAUDE.md
@@ -7,6 +7,22 @@ VHTLC-recovery operations. Proto source: `waverpc/daemon.proto`. Generated
 gRPC, REST-gateway, and mailbox-RPC stubs plus one hand-written helper file
 (`errors.go`) for structured wallet-lifecycle errors.
 
+`DaemonService` also carries a **delegated-signing family** —
+`SignReceiveAuthMessage`, `SignReceiveAuthMessageCompact`, `SignOORCustomInput`,
+`SignVTXOForfeit`, `SignOutSwapHtlcAck`, `SignCreditAccountAuthorization` —
+through which higher layers (`sdk/swaps`, `swapclientserver`, `swapwallet`)
+obtain signatures from keys the daemon holds without ever handling those keys
+themselves. The request shapes are deliberately narrow rather than
+"sign these bytes", so the daemon can bound what it authorizes:
+`SignVTXOForfeit` and `SignOORCustomInput` describe the transaction being
+signed, and `SignOutSwapHtlcAck` / `SignCreditAccountAuthorization` carry the
+authorization's committed fields (expiry, nonce, account key) alongside the
+digest so the daemon can refuse one that is not its own to grant — see
+[waved/CLAUDE.md](../waved/CLAUDE.md) for the checks each applies.
+`SignReceiveAuthMessage`(`Compact`) is the exception and is scoped by key
+instead: it signs a raw message under the per-swap receive-auth key selected by
+`payment_hash`, not under the daemon identity key.
+
 ## Key Types
 
 - `DaemonServiceClient` / `DaemonServiceServer` — Generated gRPC client and


### PR DESCRIPTION
Nightly documentation sweep via `.claude/skills/doc-gardening`, anchored to the last merged nightly (`7a88cb4e`) rather than to `main...HEAD`.

Workflow: https://github.com/lightninglabs/wavelength/actions/workflows/doc-gardening-nightly.yml

Most packages touched since the last sweep already had their docs updated in the feature PRs themselves, so this sweep is small and targets the gaps those PRs left behind:

- **`docs/signet.md`** — mainnet now resolves to the public operator (`f4da1c1a`), but the endpoint table still listed only the test networks while the prose below it said otherwise. Added the mainnet row, flagged the two REST names that are not routable yet, and noted the `--allow-mainnet` guard. Propagated the "test network" wording fix to `README.md`, `INSTALL.md`, `docs/index.md`, and `docs/daemon_cli_guide.md`.
- **`lib/arkscript`** — the CSV canonicality invariant was documented, but the sibling change in the same window was not: `Condition.Script()` now rejects incomplete script fragments and `OP_SUCCESSx`, and `ValidatePolicy` compiles every leaf (and rejects nil leaves) before its structural checks. Both are security invariants that the deep docs cover but the package doc did not.
- **`waverpc`** — documented the delegated-signing RPC family, which `SignCreditAccountAuthorization` just joined.
- **`cmd/waved`** — recorded why `--lnd.account`, `--server.host`, and `--swap.serveraddress` deliberately default to empty.
- **`ARCHITECTURE.md`** — `swaprpc` is no longer "fully generated" (it now carries the hand-written canonical digest constructions), and the VTXO FSM sketch predated `Expired`, `Spending`, and the two new exit/forfeit refusals.

Please review the updated `CLAUDE.md`/`AGENTS.md` and `ARCHITECTURE.md` diffs. `make doc-check` passes and every edited `CLAUDE.md` is byte-identical to its `AGENTS.md`.

Two notes on this run: the job's sandbox blocked reading `RUN_ID`/`RUN_NUMBER`, so the branch suffix and the workflow link are the collision-free/workflow-level fallbacks rather than the exact run. It also blocked `rm`, so two scratch files (`.doc-gardening-env.sh`, `.doc-gardening.mk`) were left untracked in the runner's worktree; they are not in this commit, which is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
