### PR TITLE
build: bump version to v0.1.2-rc1

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -15,11 +15,11 @@ const (
 	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 1
+	AppPatch uint = 2
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = ""
+	AppPreRelease = "rc1"
 )
 
 var (


### PR DESCRIPTION
## Summary

Bump the v0.1.x release line from v0.1.1 to v0.1.2-rc1.

This changes only `build/version.go`:

- `AppPatch`: `1` to `2`
- `AppPreRelease`: `""` to `"rc1"`

## Impact

Release binaries now report `0.1.2-rc1`. There are no runtime or dependency changes.

## Validation

- `make fmt-changed`
- `go test ./build`
- `make build`
- `make lint-changed-local`
- `./bin/waved --version`
- `./bin/wavecli --version`
- `make commitmsg-lint range='origin/v0.1.x-branch..HEAD'`
- `git diff --check`
