### PR TITLE
build: Isolate Docker release caches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,10 +184,15 @@ else
 DOCKER_RELEASE_USER_ARGS = --user $(shell id -u):$(shell id -g)
 endif
 
+# Keep the Go caches inside the release container. The release script clears
+# the build cache between platforms, so mounting the host cache would delete
+# host entries and race with Go commands running outside the container.
+# Trust only the checkout's fixed container path without changing host config.
 DOCKER_RELEASE_ARGS = --rm $(DOCKER_RELEASE_USER_ARGS) \
-  -v $(shell bash -c "$(GOCC) env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
-  -v $(shell bash -c "$(GOCC) env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
-  -e SKIP_VERSION_CHECK
+  -e SKIP_VERSION_CHECK \
+  -e GIT_CONFIG_COUNT=1 \
+  -e GIT_CONFIG_KEY_0=safe.directory \
+  -e GIT_CONFIG_VALUE_0=/tmp/build/wavelength
 
 # ============
 # DEPENDENCIES

--- a/docs/release.md
+++ b/docs/release.md
@@ -35,6 +35,10 @@ finished archives back to the host. Its Go build and module caches stay inside
 the container and are discarded with it. The release build never reads,
 writes, or clears the host's Go caches.
 
+Allow at least 5 GB of free space in Docker's storage for these temporary
+caches. The release clears its build cache between target platforms, and
+Docker removes the remaining cache data when the container exits.
+
 ### Linux/Windows (WSL)
 
 No prior set up beyond a pinned `go` toolchain (see `GO_VERSION` in the

--- a/docs/release.md
+++ b/docs/release.md
@@ -30,6 +30,11 @@ $  make docker-release tag=<TAG>
 Where `<TAG>` is the name of the next release of `wavelength`, e.g.
 `v0.1.0-rc2`.
 
+The release container only mounts the source checkout, which lets it write the
+finished archives back to the host. Its Go build and module caches stay inside
+the container and are discarded with it. The release build never reads,
+writes, or clears the host's Go caches.
+
 ### Linux/Windows (WSL)
 
 No prior set up beyond a pinned `go` toolchain (see `GO_VERSION` in the

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -9,10 +9,8 @@ LABEL maintainer="Olaoluwa Osuntokun <laolu32@gmail.com>"
 ENV GODEBUG=netdns=cgo
 ENV CGO_ENABLED=0
 
-# Set up cache directories. Those will be mounted from the host system to
-# speed up builds. If go isn't installed on the host system, those will fall
-# back to temp directories during the build (see the docker-release target in
-# the Makefile).
+# Keep Go caches in the container so release cache cleanup cannot modify or
+# race with the host's Go caches.
 ENV GOCACHE=/tmp/build/.cache
 ENV GOMODCACHE=/tmp/build/.modcache
 


### PR DESCRIPTION
## The problem

`make docker-release` bind-mounts the host Go build and module caches into the release container. The release script runs `go clean -cache` between target platforms. A host Go command can recreate a cache entry while the container removes it, which aborts the release with `unlinkat ... directory not empty`. The cleanup can also clear the user's normal host build cache.

Docker Desktop can also report the mounted checkout as unsafe, which forces callers to replace `DOCKER_RELEASE_ARGS` with host-specific Git configuration.

## The fix

Keep both Go caches in the container's writable layer. The source checkout remains the only host bind mount because the build must write release artifacts back to the caller.

Pass a scoped Git configuration that trusts only `/tmp/build/wavelength`. This handles Docker Desktop ownership mapping without changing host Git configuration.

Document the cache boundary in the release guide.

## What does not change

The pinned builder image, release script, artifacts, reproducibility flags, platform list, and host user mapping are unchanged. Docker still discards the container and its caches after the build.

## Tests

- `make fmt-changed`
- `make lint-changed-local`
- `make doc-check`
- `make commitmsg-lint range="origin/main..HEAD"`
- Built the release helper image.
- Ran `SKIP_VERSION_CHECK=1 make docker-release tag=isolation-test sys=linux-amd64` from a clean normal clone. The release completed through cache cleanup, archive generation, and manifest hashing without host cache mounts.