### PR TITLE
docs: nightly doc-gardening sweep 2026-08-19

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,14 +16,16 @@ This file is a **map**, not a manual. Follow links for details.
 | `make fmt-changed-check` | Verify changed Go source files are formatted |
 | `make unit pkg=<pkg> case=<test>` | Run unit tests |
 | `make unit log="stdlog trace" pkg=<pkg> case=<test>` | Unit tests with debug logs |
-| `make systest` | System integration tests (use `db=postgres` for PostgreSQL) |
+| `make systest` | Run system integration tests (sqlite) |
+| `make systest db=postgres` | Run system integration tests (postgres) |
 | `make tidy-module-check` | Verify module files are tidy |
 | `make rpc` | Regenerate protobuf stubs |
 | `make sqlc` | Regenerate type-safe DB queries |
 | `make ast-lint` | Check ast-grep style rules |
+| `make doc-check` | Verify documentation cross-links (CI canonical) |
+| `make schema-check` | Verify schema registry, MCP tools, and cobra commands agree |
+| `make sample-conf-check` | Verify `sample-waved.conf` matches daemon config options |
 | `make commitmsg-lint range="origin/main..HEAD"` | Lint commit messages on the current branch |
-| `make systest` | Run system integration tests (sqlite) |
-| `make systest db=postgres` | Run system integration tests (postgres) |
 
 ## Code Style (Summary)
 
@@ -72,13 +74,20 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 9. Do not batch actor messages without backpressure.
 10. Comments explain WHY and HOW, not WHAT.
 
-## Review Skills
+## Skills
 
 - [`.claude/skills/context-lifecycle/SKILL.md`](.claude/skills/context-lifecycle/SKILL.md)
   — Review goroutines, timers, callbacks, actor handoffs, and async cleanup
   for context lifetime bugs where short-lived request cancellation is captured
   by work that should be owned by a daemon, actor, registration, or bounded
   cleanup path.
+- [`.claude/skills/doc-gardening/SKILL.md`](.claude/skills/doc-gardening/SKILL.md)
+  — Maintain this documentation graph: per-package `CLAUDE.md`/`AGENTS.md`,
+  `docs/`, and `ARCHITECTURE.md`. Run it after adding a package, changing
+  types or dependencies significantly, or when `make doc-check` fails.
+- [`.claude/skills/bug-report/SKILL.md`](.claude/skills/bug-report/SKILL.md)
+  — File a structured GitHub issue from a test session, collecting daemon
+  logs, config, build commit, and chain-backend reachability.
 
 ## Efficient Code Lookup (save tokens)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,14 +16,16 @@ This file is a **map**, not a manual. Follow links for details.
 | `make fmt-changed-check` | Verify changed Go source files are formatted |
 | `make unit pkg=<pkg> case=<test>` | Run unit tests |
 | `make unit log="stdlog trace" pkg=<pkg> case=<test>` | Unit tests with debug logs |
-| `make systest` | System integration tests (use `db=postgres` for PostgreSQL) |
+| `make systest` | Run system integration tests (sqlite) |
+| `make systest db=postgres` | Run system integration tests (postgres) |
 | `make tidy-module-check` | Verify module files are tidy |
 | `make rpc` | Regenerate protobuf stubs |
 | `make sqlc` | Regenerate type-safe DB queries |
 | `make ast-lint` | Check ast-grep style rules |
+| `make doc-check` | Verify documentation cross-links (CI canonical) |
+| `make schema-check` | Verify schema registry, MCP tools, and cobra commands agree |
+| `make sample-conf-check` | Verify `sample-waved.conf` matches daemon config options |
 | `make commitmsg-lint range="origin/main..HEAD"` | Lint commit messages on the current branch |
-| `make systest` | Run system integration tests (sqlite) |
-| `make systest db=postgres` | Run system integration tests (postgres) |
 
 ## Code Style (Summary)
 
@@ -72,13 +74,20 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 9. Do not batch actor messages without backpressure.
 10. Comments explain WHY and HOW, not WHAT.
 
-## Review Skills
+## Skills
 
 - [`.claude/skills/context-lifecycle/SKILL.md`](.claude/skills/context-lifecycle/SKILL.md)
   — Review goroutines, timers, callbacks, actor handoffs, and async cleanup
   for context lifetime bugs where short-lived request cancellation is captured
   by work that should be owned by a daemon, actor, registration, or bounded
   cleanup path.
+- [`.claude/skills/doc-gardening/SKILL.md`](.claude/skills/doc-gardening/SKILL.md)
+  — Maintain this documentation graph: per-package `CLAUDE.md`/`AGENTS.md`,
+  `docs/`, and `ARCHITECTURE.md`. Run it after adding a package, changing
+  types or dependencies significantly, or when `make doc-check` fails.
+- [`.claude/skills/bug-report/SKILL.md`](.claude/skills/bug-report/SKILL.md)
+  — File a structured GitHub issue from a test session, collecting daemon
+  logs, config, build commit, and chain-backend reachability.
 
 ## Efficient Code Lookup (save tokens)
 

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -146,6 +146,14 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   unconstrained.
 - Default retry logic: 10 retries with exponential backoff (40ms →
   3s cap).
+- An `ExecTx` closure may run **more than once**, so any variable it
+  captures from the enclosing function is per-attempt state, not
+  per-call state. Reset every captured out-parameter at the top of the
+  closure rather than at the call site. Otherwise a serialization
+  failure late in one attempt leaves that attempt's partial result in
+  place, and the retry that succeeds returns the durable row alongside a
+  stale flag — `AdmitIdempotentOwnedReceiveScript` reset `created` this
+  way after reporting a replayed allocation as freshly created.
 - SQLite `busy_timeout = 30 000 ms` under WAL mode tolerates
   multi-actor contention bursts.
 - `ledger_entries.entry_id` and `wallet_utxo_log.entry_id` use

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -146,6 +146,14 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   unconstrained.
 - Default retry logic: 10 retries with exponential backoff (40ms →
   3s cap).
+- An `ExecTx` closure may run **more than once**, so any variable it
+  captures from the enclosing function is per-attempt state, not
+  per-call state. Reset every captured out-parameter at the top of the
+  closure rather than at the call site. Otherwise a serialization
+  failure late in one attempt leaves that attempt's partial result in
+  place, and the retry that succeeds returns the durable row alongside a
+  stale flag — `AdmitIdempotentOwnedReceiveScript` reset `created` this
+  way after reporting a replayed allocation as freshly created.
 - SQLite `busy_timeout = 30 000 ms` under WAL mode tolerates
   multi-actor contention bursts.
 - `ledger_entries.entry_id` and `wallet_utxo_log.entry_id` use

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ into specific topics below.
 | [commit-tooling.md](commit-tooling.md) | commit_message.py workflows for linting and rewording |
 | [testing-guide.md](testing-guide.md) | Coverage targets, test approaches, pre-commit checklist |
 | [go_workspace.md](go_workspace.md) | Multi-module Go workspace setup |
-| [postgres_isolation.md](postgres_isolation.md) | Postgres isolation policy: why read-only transactions run at `REPEATABLE READ` and writers stay `SERIALIZABLE`, operator notes on long-lived read transactions, the write-path snapshot-isolation audit, and the partial unique index inventory |
+| [postgres_isolation.md](postgres_isolation.md) | Postgres isolation policy: why read-only transactions run at `REPEATABLE READ` and writers stay `SERIALIZABLE`, operator notes on long-lived read transactions, the write-path snapshot-isolation audit, the partial unique index inventory, and why a retried `ExecTx` closure must reset its own captured out-parameters |
 | [policy_arkscript_review_guide.md](policy_arkscript_review_guide.md) | Policy-first arkscript reviewer guide |
 | [dev_rpc_cli_builder.md](dev_rpc_cli_builder.md) | Generated `wavecli dev` command builder and request flag rules |
 

--- a/docs/postgres_isolation.md
+++ b/docs/postgres_isolation.md
@@ -99,6 +99,17 @@ Separately, a lost creation race can stop being a retryable `40001` and become
 a `23505` unique violation that the retry loop correctly refuses to retry.
 Several write paths perform a plain insert that can lose such a race.
 
+A retry loop also changes what a closure's captured variables mean. Where
+`ExecTx` does retry, the closure body is per-attempt but anything it captures
+from the enclosing function is per-call, so a closure that assigns an
+out-parameter has to clear it on entry rather than relying on the caller's
+initialization. A serialization failure raised after that assignment otherwise
+carries the abandoned attempt's answer into the attempt that commits.
+`AdmitIdempotentOwnedReceiveScript` in
+[`db/oor_artifact_store.go`](../db/oor_artifact_store.go) hit exactly this and
+now resets its `created` flag inside the closure. The more retries a level
+change induces, the more this shape matters.
+
 That last point only applies to half of them, and the distinction decides
 whether a given site is exposed today or only after a move. SSI promotes a
 creation race to `40001` only when the losing transaction read the contested


### PR DESCRIPTION
Nightly documentation-graph sweep via `.claude/skills/doc-gardening` (scope: `all`), anchored to the last merged sweep (`7a88cb4e`, 2026-08-10).

Workflow run: https://github.com/lightninglabs/wavelength/actions

## What changed

The per-package docs for this window's feature work (retry-safe receive scripts, lnd account isolation) were already updated by their own PRs, so this sweep records the one invariant that fell through the gaps plus two map corrections:

- **`db/CLAUDE.md`** — new invariant: an `ExecTx` closure may run more than once, so variables it captures from the enclosing function are per-attempt, not per-call, and captured out-parameters must be reset inside the closure. This is the shape `cd9596eb` fixed in `AdmitIdempotentOwnedReceiveScript`, where a serialization retry returned the durable winner alongside the failed attempt's `created` flag.
- **`docs/postgres_isolation.md`** — same rule written up against the write-path audit, since a relaxed isolation level induces more retries and so makes the shape more reachable. `docs/index.md` entry updated to match.
- **`CLAUDE.md`** (root) — Quick Commands gained the three verification targets that exist in the `Makefile` but were unlisted (`doc-check`, `schema-check`, `sample-conf-check`); the duplicate `make systest` row is collapsed. The skills section now also points at `doc-gardening` and `bug-report`, which closes the loop from a failing `make doc-check` to the skill that fixes it.

`ARCHITECTURE.md` needed no change: no new packages and no layer moves this window, and every changed package is already in the layer tables.

## Review notes

Please review the updated **`CLAUDE.md`/`AGENTS.md`** and **`docs/`** diffs. The `db` and root `CLAUDE.md`/`AGENTS.md` pairs are byte-identical mirrors, so read one of each.

Verified before commit:
- `make doc-check` passes.
- Every symbol named in the new prose exists in the tree (`AdmitIdempotentOwnedReceiveScript`, `created` reset at `db/oor_artifact_store.go`; all three `make` targets present in the `Makefile`).
- No leaked tool/formatting artifacts in any `.md`.
- Staged with `git add -- '*.md'`, so the commit is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
