### PR TITLE
sdk: Add external-seed wallet startup

### DIFF
--- a/cmd/wavewalletdk-wasm/AGENTS.md
+++ b/cmd/wavewalletdk-wasm/AGENTS.md
@@ -40,6 +40,7 @@ VM with no separate gateway.
   `os.MkdirAll` at the filesystem root and fail with `EROFS`/`EACCES`. A Node
   caller must set `data_dir` explicitly and gets a rejected promise if it
   does not.
+- External-seed startup always requires an explicit final directory.
 - The `executor` `js.Func` passed to `Promise.New` must be released right
   after construction (the executor runs synchronously), otherwise every
   wallet call leaks a Go callback handle for the life of the page.

--- a/cmd/wavewalletdk-wasm/CLAUDE.md
+++ b/cmd/wavewalletdk-wasm/CLAUDE.md
@@ -40,6 +40,7 @@ VM with no separate gateway.
   `os.MkdirAll` at the filesystem root and fail with `EROFS`/`EACCES`. A Node
   caller must set `data_dir` explicitly and gets a rejected promise if it
   does not.
+- External-seed startup always requires an explicit final directory.
 - The `executor` `js.Func` passed to `Promise.New` must be released right
   after construction (the executor runs synchronously), otherwise every
   wallet call leaks a Go callback handle for the life of the page.

--- a/cmd/wavewalletdk-wasm/main.go
+++ b/cmd/wavewalletdk-wasm/main.go
@@ -1,13 +1,15 @@
 //go:build js && wasm
 
-// Command wavewalletdk-wasm exposes the embedded wavewalletdk runtime to
-// browser JavaScript. It is a thin syscall/js adapter over the
+// Command wavewalletdk-wasm exposes the embedded wavewalletdk runtime through
+// a private browser transport ABI. It is a thin syscall/js adapter over the
 // sdk/wavewalletdk/mobile JSON facade: every verb takes a JS request object and
 // resolves a JS response object, so the daemon, swap, and OOR machinery all run
-// in-process in the one browser VM with no separate gateway. The facade is the
-// single source of truth shared with the gomobile bindings, so this bridge
-// never reaches into the wavewalletdk.Client API directly and cannot drift from
-// it.
+// in-process in the one browser VM with no separate gateway. A typed host SDK
+// invokes this ABI from its Worker and owns lifecycle serialization and
+// cross-tab locking; application code must not call the global directly. The
+// facade is the single source of truth shared with the gomobile bindings, so
+// this bridge never reaches into the wavewalletdk.Client API directly and
+// cannot drift from it.
 //
 //	Build with: GOOS=js GOARCH=wasm go build \
 //		-tags "mobile wavewalletrpc swapruntime" ./cmd/wavewalletdk-wasm
@@ -22,8 +24,8 @@ import (
 	"github.com/lightninglabs/wavelength/sdk/wavewalletdk/mobile"
 )
 
-// main installs the browser entry point and then parks the Go runtime so the
-// exported callbacks stay live for the lifetime of the page.
+// main installs the private browser transport entry point and then parks the Go
+// runtime so the exported callbacks stay live for the lifetime of the page.
 func main() {
 	js.Global().Set("wavewalletdkCall", js.FuncOf(walletCall))
 	js.Global().Call("dispatchEvent", js.Global().Get("CustomEvent").New(
@@ -33,9 +35,11 @@ func main() {
 	select {}
 }
 
-// walletCall is the single JS entry point. It takes a method name and an
-// optional request object and returns a Promise that resolves with the verb's
-// JSON response decoded into a JS value (or rejects with an Error).
+// walletCall is the private JS transport dispatcher used by a typed host SDK.
+// It takes a method name and an optional request object and returns a Promise
+// that resolves with the verb's JSON response decoded into a JS value (or
+// rejects with an Error). Calling it directly would bypass the host SDK's
+// lifecycle queue and runtime lock.
 func walletCall(_ js.Value, args []js.Value) any {
 	if len(args) == 0 {
 		return rejected(errors.New("method is required"))
@@ -49,7 +53,8 @@ func walletCall(_ js.Value, args []js.Value) any {
 	}
 
 	switch method {
-	// Lifecycle.
+	// Private lifecycle transport verbs. The typed host SDK serializes them
+	// with stop and owns the runtime lock.
 	case "start":
 		cfg, err := startConfig(req)
 		if err != nil {
@@ -58,6 +63,21 @@ func walletCall(_ js.Value, args []js.Value) any {
 
 		return promise(func() (any, error) {
 			return js.Null(), mobile.Start(cfg)
+		})
+
+	case "startExternalSeedWallet":
+		body, err := externalSeedWalletStartRequest(req)
+		if err != nil {
+			return rejected(err)
+		}
+
+		return promise(func() (any, error) {
+			out, err := mobile.StartExternalSeedWallet(body)
+			if err != nil {
+				return nil, err
+			}
+
+			return parse(out), nil
 		})
 
 	case "stop":
@@ -309,17 +329,49 @@ func startConfig(req js.Value) (string, error) {
 		req = js.Global().Get("Object").New()
 	}
 
-	if v := req.Get("data_dir"); v.IsUndefined() || v.IsNull() ||
-		v.String() == "" {
-
-		if wasmhost.UnderNode() {
-			return "", errNodeDataDirRequired
-		}
-
-		req.Set("data_dir", browserDataDir)
+	if err := ensureDataDir(req); err != nil {
+		return "", err
 	}
 
 	return stringify(req), nil
+}
+
+// externalSeedWalletStartRequest renders the typed SDK's private external-seed
+// transport request. Its nested config must already select the final wallet
+// data directory; unlike legacy Start, this path cannot safely guess one.
+func externalSeedWalletStartRequest(req js.Value) ([]byte, error) {
+	if req.IsUndefined() || req.IsNull() || req.Type() != js.TypeObject {
+		req = js.Global().Get("Object").New()
+	}
+
+	cfg := req.Get("config")
+	if cfg.IsUndefined() || cfg.IsNull() || cfg.Type() != js.TypeObject {
+		return nil, errors.New("config must be an object")
+	}
+	dataDir := cfg.Get("data_dir")
+	if dataDir.IsUndefined() || dataDir.IsNull() || dataDir.String() == "" {
+		return nil, errors.New("config.data_dir must select the " +
+			"final wallet directory")
+	}
+
+	return jsonBytes(req), nil
+}
+
+// ensureDataDir fills the browser-safe data directory or requires an explicit
+// host-filesystem path under Node for legacy Start.
+func ensureDataDir(cfg js.Value) error {
+	if v := cfg.Get("data_dir"); !v.IsUndefined() && !v.IsNull() &&
+		v.String() != "" {
+		return nil
+	}
+
+	if wasmhost.UnderNode() {
+		return errNodeDataDirRequired
+	}
+
+	cfg.Set("data_dir", browserDataDir)
+
+	return nil
 }
 
 // stringify renders a JS request value as a JSON string, or "" when absent.

--- a/docs/wavewalletdk_integration.md
+++ b/docs/wavewalletdk_integration.md
@@ -106,6 +106,48 @@ if err != nil {
 fmt.Println("identity:", unlocked.IdentityPubKey)
 ```
 
+### Externally derived wallet entropy
+
+`StartExternalSeedWallet` imports or unlocks a self-managed wallet from exactly
+16 bytes of already-derived aezeed entropy. The host owns mnemonic, derivation,
+account, and directory conventions and must pass the final `Config.DataDir`.
+Legacy startup and its data-directory behavior are unchanged.
+
+```go
+cfg.DataDir = finalWalletDataDir
+defer clear(derivedEntropy)
+
+openReq := wavewalletdk.ExternalSeedWalletRequest{
+	SeedEntropy:           derivedEntropy, // exactly 16 bytes
+	ExpectedIdentityPubKey: previouslyPinnedIdentity,
+}
+
+client, opened, err := wavewalletdk.StartExternalSeedWallet(
+	ctx, cfg, openReq,
+)
+if err != nil {
+	panic(err)
+}
+defer client.Stop()
+
+fmt.Println("identity:", opened.IdentityPubKey)
+```
+
+The method supports `lwwallet` and `btcwallet`. It rejects custom state, log,
+and password-file paths that could escape the selected directory. It returns
+after wallet-dependent services are ready and stops the daemon if startup
+fails.
+
+The result contains the wallet identity and recovery counters, never an
+internal mnemonic. Persist the identity and supply it as
+`ExpectedIdentityPubKey` when reopening the directory. `RecoverState` is a
+per-start request that runs only after this identity check; a partial scan is
+safe to retry but may scan from Bitcoin genesis.
+
+`Client.Deposit` returns a Wavelength boarding address. It is not a BIP84
+address; expose a separately named Bitcoin-address API if the host also needs
+that conventional account model.
+
 ## Wallet Operations
 
 Fetch readiness and balances:
@@ -275,6 +317,7 @@ Keep host-language bindings thin:
 - Expose explicit `Start` or `Connect`, `Stop`, `CreateWallet`,
   `UnlockWallet`, `Status`, `Balance`, `Deposit`, `Receive`, `PrepareSend`,
   `SendPrepared`, `List`, and `Subscribe` methods.
+- Expose `StartExternalSeedWallet` when the host owns wallet derivation.
 - Convert SDK structs into plain host DTOs. Do not expose protobuf messages to
   mobile or JavaScript callers.
 - Accept caller-provided timeouts or cancellation handles for every operation.
@@ -283,9 +326,8 @@ Keep host-language bindings thin:
   security decisions owned by the host app.
 
 For gomobile or React Native bridges, prefer a small manager object with string
-or JSON DTO methods. For browser WASM, prefer the `Connect` shape against a
-remote or host-provided daemon until the embedded daemon storage and transport
-stack is browser-ready.
+or JSON DTO methods. For browser WASM, route lifecycle calls through a Worker
+so blocking Go calls do not run on the application thread.
 
 ## LLM Integration Checklist
 
@@ -305,3 +347,4 @@ When generating wallet code against `wavewalletdk`, follow this checklist:
 10. Call `Stop` during app shutdown.
 11. Never log wallet passwords, seed passphrases, mnemonics, or full invoices
     unless the product explicitly asks for that debug behavior.
+12. Never log external seed entropy.

--- a/docs/wavewalletdk_mobile.md
+++ b/docs/wavewalletdk_mobile.md
@@ -6,6 +6,9 @@ facade over the wallet SDK. It lets an Android (Kotlin/Java) or iOS
 separate daemon binary, no open socket — by reusing the private `bufconn` gRPC
 transport that [`wavewalletdk.Start`](../sdk/wavewalletdk/embedded.go) already sets up.
 
+The exported functions and browser global are low-level binding APIs. Host SDKs
+should wrap them with typed lifecycle methods.
+
 It borrows the *bytes-out* idea from `lightninglabs/falafel` and `lnd/mobile`
 **without** the protoc generator or their callback interfaces, because the
 `wavewalletdk` facade already owns the wiring and `wavewalletdk.Start` returns once gRPC
@@ -29,6 +32,7 @@ The package is gated behind three build tags — `mobile`, `wavewalletrpc`, and
 | Shape | Convention | Verbs |
 |-------|-----------|-------|
 | RPC verbs | **JSON `[]byte` in / out** (throwing) | `GetInfo`, `CreateWallet`, `UnlockWallet`, `OpenWalletFromPasskey`, `Balance`, `Deposit`, `Receive`, `PrepareSend`, `SendPrepared`, `List`, `Exit`, `ExitStatus`, `ExitSummary`, `GetExitPlan`, `SweepWallet`, `Status` |
+| Lifecycle JSON | **JSON `[]byte` in / out** (throwing) | `StartExternalSeedWallet` |
 | Streaming | **pull handle** `Subscription{ next() []byte; close() }` | `Subscribe` |
 | Hot-path scalars | **plain `int64`/`bool`** | `ConfirmedBalanceSat`, `PendingInboundSat`, `WalletReady`, `IsRunning` |
 
@@ -50,12 +54,26 @@ request is a small camelCase-tagged struct (`prfOutput`). Every other request
 decodes into the matching `wavewalletdk.*Request` DTO, so it follows the
 PascalCase rule.
 
+`StartExternalSeedWallet` is another explicit exception in the private binding
+ABI. Its startup envelope is snake_case (`config`, `seed_entropy`,
+`expected_identity_pubkey`, `recover_state`, and `recovery_window`). In JSON,
+`seed_entropy` is standard base64 because the Go field is `[]byte`. The response
+is the PascalCase `ExternalSeedWalletOpenResult`. Typed SDKs map their public
+request types onto this wire shape.
+
 ## Lifecycle
+
+These signatures document the generated binding:
 
 ```go
 // Start boots the daemon and blocks until gRPC is serving (or errors).
 // Call it off the main thread.
 func Start(cfgJSON string) error
+
+// StartExternalSeedWallet starts at a host-selected final data directory, then
+// imports or unlocks exactly 16 bytes of already-derived entropy. It returns
+// ExternalSeedWalletOpenResult JSON.
+func StartExternalSeedWallet(reqJSON []byte) ([]byte, error)
 
 // Stop tears down the daemon. Idempotent; resets the singleton so a host can
 // restart after the OS suspends/resumes the app.
@@ -75,6 +93,40 @@ func Stop() error
 - The wrapper owns an internal `context.Context` created in `Start` and
   cancelled by `Stop`, so the mobile API never has to express a `context.Context`
   and in-flight RPCs / subscriptions unwind on shutdown.
+- The startup deadline bounds daemon readiness only. External-seed opening and
+  recovery use the lifecycle context cancelled by `Stop`.
+
+### External seed wallets
+
+`StartExternalSeedWallet` accepts a nested config and exactly 16 bytes of
+already-derived entropy. The host owns seed derivation and account directories;
+`config.data_dir` is the final wallet directory. The method supports
+`lwwallet` and `btcwallet`, while legacy `Start` remains unchanged.
+
+The request uses snake_case keys and standard base64 for `seed_entropy`:
+
+```json
+{
+  "config": {
+    "data_dir": "/data/user/0/<app>/files/wavelength/wallets/<id>",
+    "network": "signet",
+    "wallet_type": "lwwallet"
+  },
+  "seed_entropy": "ABEiM0RVZneImaq7zN3u/w==",
+  "expected_identity_pubkey": "optional identity pinned after first use",
+  "recover_state": false,
+  "recovery_window": 0
+}
+```
+
+The client becomes active only after wallet services are ready; an earlier
+failure stops the daemon and resets the singleton. `recover_state` is a
+per-start request and runs only after `expected_identity_pubkey` matches. A
+partial recovery is safe to retry. The response contains identity and recovery
+counters, not an internal mnemonic.
+
+Mobile and WASM expose one active client per binding instance. Call `Stop`
+before reusing that instance for another final directory.
 
 ### Streaming
 

--- a/lwwallet/AGENTS.md
+++ b/lwwallet/AGENTS.md
@@ -126,6 +126,8 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
   UTXO set, because btcwallet does not credit-mark non-default scope outputs.
 - `Stop()` explicitly closes btcwallet's internal database to prevent resource
   leaks.
+- Shutdown and startup rollback cancel `EsploraChainService` before stopping
+  btcwallet so an active recovery can drain.
 
 ### js/wasm wallet store (`walletdb_wasm.go`)
 

--- a/lwwallet/CLAUDE.md
+++ b/lwwallet/CLAUDE.md
@@ -126,6 +126,8 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
   UTXO set, because btcwallet does not credit-mark non-default scope outputs.
 - `Stop()` explicitly closes btcwallet's internal database to prevent resource
   leaks.
+- Shutdown and startup rollback cancel `EsploraChainService` before stopping
+  btcwallet so an active recovery can drain.
 
 ### js/wasm wallet store (`walletdb_wasm.go`)
 

--- a/lwwallet/esplora_chain.go
+++ b/lwwallet/esplora_chain.go
@@ -58,6 +58,12 @@ type EsploraChainService struct {
 	// whose methods do not accept a context parameter.
 	runCtx context.Context //nolint:containedctx
 
+	// runCancel cancels runCtx before btcwallet waits for its recovery
+	// goroutine. Without this explicit cancellation, a first-start recovery
+	// can remain blocked in an Esplora request while wallet shutdown waits
+	// for that same recovery to finish.
+	runCancel context.CancelFunc
+
 	// maxGapFillPerTipEvent caps the number of missed heights that a
 	// single processTipEvent invocation will walk before yielding
 	// back to the handleTipEvents loop. Initialized from
@@ -124,13 +130,16 @@ func (s *EsploraChainService) Start(ctx context.Context) error {
 		return fmt.Errorf("subscribe to tip poller: %w", err)
 	}
 
+	runCtx, runCancel := context.WithCancel(ctx)
+
 	s.mu.Lock()
 	s.bestBlock = waddrmgr.BlockStamp{
 		Height:    tipHeight,
 		Hash:      tipHash,
 		Timestamp: tipTime,
 	}
-	s.runCtx = ctx
+	s.runCtx = runCtx
+	s.runCancel = runCancel
 	s.mu.Unlock()
 
 	// Send ClientConnected so btcwallet knows the chain backend
@@ -138,9 +147,9 @@ func (s *EsploraChainService) Start(ctx context.Context) error {
 	s.notifications <- chain.ClientConnected{}
 
 	s.wg.Add(1)
-	go s.handleChainEvents(ctx, chainSub)
+	go s.handleChainEvents(runCtx, chainSub)
 
-	s.log.InfoS(ctx, "Esplora chain service started",
+	s.log.InfoS(runCtx, "Esplora chain service started",
 		slog.Int("tip_height", int(tipHeight)),
 		slog.String("tip_hash", tipHash.String()),
 	)
@@ -154,10 +163,18 @@ func (s *EsploraChainService) Start(ctx context.Context) error {
 // both reach close(s.quit) and panic on a double close.
 func (s *EsploraChainService) Stop() {
 	s.stopOnce.Do(func() {
+		ctx := s.requestContext()
 		s.log.InfoS(
-			s.requestContext(),
+			ctx,
 			"Stopping Esplora chain service",
 		)
+
+		s.mu.Lock()
+		cancel := s.runCancel
+		s.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
 
 		close(s.quit)
 	})

--- a/lwwallet/esplora_chain_test.go
+++ b/lwwallet/esplora_chain_test.go
@@ -2,10 +2,12 @@ package lwwallet
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -18,6 +20,92 @@ import (
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/stretchr/testify/require"
 )
+
+// TestEsploraChainServiceStopCancelsRequestContext verifies that Stop cancels
+// the context used by chain.Interface methods. Btcwallet waits for its recovery
+// goroutine before it stops the chain client, so lwwallet must be able to
+// cancel an in-flight recovery request before entering that wait.
+func TestEsploraChainServiceStopCancelsRequestContext(t *testing.T) {
+	t.Parallel()
+
+	chainStub := newRawBlockStubChain(100)
+	srv := mockEsploraServer(t, chainStub.handler(t))
+	esplora := NewEsploraClient(srv.URL, btclog.Disabled)
+	tipPoller := NewTipPoller(
+		esplora, 5*time.Millisecond, btclog.Disabled,
+	)
+	require.NoError(t, tipPoller.Start())
+	t.Cleanup(tipPoller.Stop)
+
+	service := NewEsploraChainService(
+		esplora, tipPoller, btclog.Disabled,
+	)
+	require.NoError(t, service.Start(context.Background()))
+	t.Cleanup(func() {
+		service.Stop()
+		service.WaitForShutdown()
+	})
+
+	requestCtx := service.requestContext()
+	require.NoError(t, requestCtx.Err())
+
+	service.Stop()
+	require.ErrorIs(t, requestCtx.Err(), context.Canceled)
+}
+
+// TestEsploraChainServiceStopCancelsInFlightRequest pins the first-create
+// shutdown failure seen in the WASM integration: btcwallet recovery was
+// waiting inside a chain.Interface HTTP call while Stop waited for recovery.
+func TestEsploraChainServiceStopCancelsInFlightRequest(t *testing.T) {
+	t.Parallel()
+
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(_ http.ResponseWriter, req *http.Request) {
+				close(requestStarted)
+				select {
+				case <-req.Context().Done():
+				case <-releaseRequest:
+				}
+			},
+		),
+	)
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(releaseRequest) })
+
+	service := NewEsploraChainService(
+		NewEsploraClient(server.URL, btclog.Disabled), nil,
+		btclog.Disabled,
+	)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	service.mu.Lock()
+	service.runCtx = runCtx
+	service.runCancel = runCancel
+	service.mu.Unlock()
+
+	requestErr := make(chan error, 1)
+	go func() {
+		_, err := service.GetBlockHash(100)
+		requestErr <- err
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Esplora request did not start")
+	}
+
+	service.Stop()
+	select {
+	case err := <-requestErr:
+		require.ErrorIs(t, err, context.Canceled)
+
+	case <-time.After(time.Second):
+		t.Fatal("Esplora request did not observe service shutdown")
+	}
+}
 
 // rawBlockStubChain is a tip+block fixture richer than stubChain: it
 // builds real wire.MsgBlock values per height (so /block/:hash/raw

--- a/lwwallet/wallet.go
+++ b/lwwallet/wallet.go
@@ -292,7 +292,11 @@ func (w *Wallet) Start() error {
 	if err := w.BtcWallet.Start(); err != nil {
 		return fmt.Errorf("start btcwallet: %w", err)
 	}
-	rollback = append(rollback, func() { _ = w.BtcWallet.Stop() })
+	rollback = append(rollback, func() {
+		w.chainSvc.Stop()
+		_ = w.BtcWallet.Stop()
+		w.chainSvc.WaitForShutdown()
+	})
 
 	// Start the chainsource ChainBackend used by the actor system.
 	// It also subscribes to the wallet's TipPoller; it does not
@@ -311,30 +315,27 @@ func (w *Wallet) Start() error {
 	return nil
 }
 
-// Stop shuts down the wallet, chain service, chain backend, and
-// shared tip poller. The teardown order mirrors Start in reverse:
-// btcwallet first (so it stops draining notifications), then the
-// chain backend (which unsubscribes from the poller), and finally
-// the tip poller itself once nobody else can be observing it.
+// Stop shuts down the wallet, chain service, chain backend, and shared tip
+// poller. The chain service is signaled first so its lifecycle context cancels
+// any Esplora request made by btcwallet's recovery goroutine. Btcwallet can
+// then finish that recovery and drain its own goroutines before the shared tip
+// poller stops.
 func (w *Wallet) Stop() {
 	ctx := context.Background()
 
 	w.Logger(ctx).InfoS(ctx, "Stopping lightweight wallet")
 
+	// btcwallet waits for an active recovery before it stops its chain
+	// client. Cancel the chain-service context first so a recovery blocked
+	// in an Esplora request can observe shutdown and return.
+	w.chainSvc.Stop()
 	_ = w.BtcWallet.Stop()
 	if err := w.BtcWallet.InternalWallet().Database().Close(); err != nil {
 		w.Logger(ctx).WarnS(ctx, "Failed to close btcwallet DB", err)
 	}
 
-	// Explicitly Stop the chain service before waiting on its
-	// goroutine. btcwallet.Stop will transitively call
-	// chainClient.Stop today, but relying on that is brittle —
-	// any future fast-shutdown path that bypasses
-	// btcwallet.Stop would leave handleTipEvents blocked on its
-	// quit channel and deadlock WaitForShutdown. The Stop is
-	// idempotent (sync.Once), so the duplicate-close path is
-	// safe even if btcwallet's Stop already fired it.
-	w.chainSvc.Stop()
+	// Stop is idempotent, so btcwallet's own chain-client shutdown and the
+	// explicit signal above safely converge before this wait.
 	w.chainSvc.WaitForShutdown()
 	_ = w.chainBackend.Stop()
 	w.tipPoller.Stop()

--- a/sdk/wavewalletdk/AGENTS.md
+++ b/sdk/wavewalletdk/AGENTS.md
@@ -29,10 +29,18 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/wave
   value, zero defers to `DaemonConfig` (no tri-state). To force a
   `false`, set `DaemonConfig` directly or use the matching `Option`.
 - `DefaultConfig` — `Config` populated from `waved.DefaultConfig()`.
+- `ExternalSeedWalletRequest` / `ExternalSeedWalletOpenResult` — 16 bytes of
+  already-derived aezeed entropy with optional identity and recovery inputs,
+  and the resulting identity and recovery counters. No mnemonic is returned.
 - `Start(ctx, cfg, opts...)` — boots the embedded daemon, dials it,
   waits for gRPC readiness, and returns a ready `*Client`. The daemon
   lifetime is owned by wavewalletdk's `runCtx`, not the caller's `ctx`, so
   a tight startup deadline cancels dialing only.
+- `StartExternalSeedWallet(ctx, cfg, req, opts...)` /
+  `StartExternalSeedWalletWithContexts(startCtx, openCtx, cfg, req, opts...)`
+  — starts at an explicit `Config.DataDir`, imports or unlocks the wallet, and
+  returns the ready client and open result. The two-context form separates the
+  daemon boot deadline from wallet opening and recovery.
 - `Connect(ctx, ConnectConfig)` — dials an already-running external
   daemon instead of embedding one. `ConnectConfig.Transport` selects
   `TransportGRPC` (default) or `TransportREST`; `Insecure`,
@@ -167,10 +175,16 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/wave
   after the convenience merge and `configureWalletRPC` so the
   disable wins over the build-tag default and any `DaemonConfig`
   value.
-- Secret-bearing slices (`SeedPassphrase`, `WalletPassword`,
+- Secret-bearing slices (`SeedEntropy`, `SeedPassphrase`, `WalletPassword`,
   `Mnemonic`) are cloned at the SDK boundary via `bytes.Clone` /
   `append` before being handed to the RPC layer, so host apps can zero
   their copies on return without racing the marshaller.
+- External-seed startup leaves `Start` unchanged. It accepts only `lwwallet` or
+  `btcwallet`, requires the final `Config.DataDir`, and assigns no derivation,
+  account, or directory semantics to the entropy.
+- The client is published only after wallet-dependent actors and mailbox
+  ingress start. Earlier failure stops the new daemon. Optional recovery runs
+  only after identity verification and may retry a partial scan.
 - Wallet methods fail with `ErrWalletRPCUnavailable` synchronously at
   the wrapper boundary on builds without the `wavewalletrpc` tag, before
   any RPC is attempted. `ErrSwapRuntimeUnavailable` is an alias for

--- a/sdk/wavewalletdk/CLAUDE.md
+++ b/sdk/wavewalletdk/CLAUDE.md
@@ -29,10 +29,18 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/wave
   value, zero defers to `DaemonConfig` (no tri-state). To force a
   `false`, set `DaemonConfig` directly or use the matching `Option`.
 - `DefaultConfig` — `Config` populated from `waved.DefaultConfig()`.
+- `ExternalSeedWalletRequest` / `ExternalSeedWalletOpenResult` — 16 bytes of
+  already-derived aezeed entropy with optional identity and recovery inputs,
+  and the resulting identity and recovery counters. No mnemonic is returned.
 - `Start(ctx, cfg, opts...)` — boots the embedded daemon, dials it,
   waits for gRPC readiness, and returns a ready `*Client`. The daemon
   lifetime is owned by wavewalletdk's `runCtx`, not the caller's `ctx`, so
   a tight startup deadline cancels dialing only.
+- `StartExternalSeedWallet(ctx, cfg, req, opts...)` /
+  `StartExternalSeedWalletWithContexts(startCtx, openCtx, cfg, req, opts...)`
+  — starts at an explicit `Config.DataDir`, imports or unlocks the wallet, and
+  returns the ready client and open result. The two-context form separates the
+  daemon boot deadline from wallet opening and recovery.
 - `Connect(ctx, ConnectConfig)` — dials an already-running external
   daemon instead of embedding one. `ConnectConfig.Transport` selects
   `TransportGRPC` (default) or `TransportREST`; `Insecure`,
@@ -167,10 +175,16 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/wave
   after the convenience merge and `configureWalletRPC` so the
   disable wins over the build-tag default and any `DaemonConfig`
   value.
-- Secret-bearing slices (`SeedPassphrase`, `WalletPassword`,
+- Secret-bearing slices (`SeedEntropy`, `SeedPassphrase`, `WalletPassword`,
   `Mnemonic`) are cloned at the SDK boundary via `bytes.Clone` /
   `append` before being handed to the RPC layer, so host apps can zero
   their copies on return without racing the marshaller.
+- External-seed startup leaves `Start` unchanged. It accepts only `lwwallet` or
+  `btcwallet`, requires the final `Config.DataDir`, and assigns no derivation,
+  account, or directory semantics to the entropy.
+- The client is published only after wallet-dependent actors and mailbox
+  ingress start. Earlier failure stops the new daemon. Optional recovery runs
+  only after identity verification and may retry a partial scan.
 - Wallet methods fail with `ErrWalletRPCUnavailable` synchronously at
   the wrapper boundary on builds without the `wavewalletrpc` tag, before
   any RPC is attempted. `ErrSwapRuntimeUnavailable` is an alias for

--- a/sdk/wavewalletdk/account_backend_test.go
+++ b/sdk/wavewalletdk/account_backend_test.go
@@ -1,0 +1,130 @@
+//go:build !js
+
+package wavewalletdk
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/btcwbackend"
+	"github.com/lightninglabs/wavelength/lwwallet"
+	"github.com/lightninglabs/wavelength/walletcore"
+	"github.com/lightninglabs/wavelength/waved"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExternalSeedIdentityMatchesSelfManagedBackends verifies the same
+// externally derived entropy produces the same Wavelength identity through
+// both supported self-managed wallet implementations. The chain transports
+// differ, but their m/1017' key-family contract must not.
+func TestExternalSeedIdentityMatchesSelfManagedBackends(t *testing.T) {
+	entropy := testExternalSeedEntropy()
+
+	var rawSeed [walletcore.SeedLen]byte
+	copy(rawSeed[:], entropy[:])
+	password := deriveExternalSeedDBPassword(entropy)
+
+	genesisHash := chaincfg.RegressionNetParams.GenesisHash.String()
+
+	// Serve a static genesis-only Esplora chain and a minimal fee response.
+	// No external service is involved in the backend compatibility check.
+	httpServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/blocks/tip/height":
+				_, _ = w.Write([]byte("0"))
+
+			case "/block-height/0":
+				_, _ = w.Write([]byte(genesisHash))
+
+			case "/block/" + genesisHash:
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":        genesisHash,
+					"height":    0,
+					"timestamp": 1,
+				})
+
+			case "/fee":
+				_, _ = w.Write([]byte(
+					`{"fee_by_block_target":{"2":1000}}`,
+				))
+
+			default:
+				http.NotFound(w, r)
+			}
+		},
+	))
+	t.Cleanup(httpServer.Close)
+
+	lw, err := lwwallet.New(lwwallet.Config{
+		Seed:           rawSeed[:],
+		WalletPassword: password,
+		EsploraURL:     httpServer.URL,
+		ChainParams:    &chaincfg.RegressionNetParams,
+		PollInterval:   time.Hour,
+		RecoveryWindow: 1,
+		DBDir:          t.TempDir(),
+		Log:            fn.None[btclog.Logger](),
+	})
+	require.NoError(t, err)
+	t.Cleanup(lw.Stop)
+	require.NoError(t, lw.Start())
+
+	btc, err := btcwbackend.New(btcwbackend.Config{
+		Config: walletcore.Config{
+			Seed:           rawSeed[:],
+			WalletPassword: password,
+			ChainParams:    &chaincfg.RegressionNetParams,
+			RecoveryWindow: 1,
+			DBDir:          t.TempDir(),
+			Log:            fn.None[btclog.Logger](),
+		},
+		NeutrinoDataDir:      t.TempDir(),
+		ConnectPeers:         []string{},
+		FeeURL:               httpServer.URL + "/fee",
+		DisableGlobalLoggers: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, btc.ChainBackend().Stop())
+		btc.Stop()
+	})
+
+	// Start btcwallet's common wallet layer so it creates and unlocks the
+	// m/1017' key scope. The neutrino chain service is already running; we
+	// intentionally leave the higher chain notifier stopped because this is
+	// a key-derivation test, not a synchronization test.
+	require.NoError(t, btc.BtcWallet.Start())
+
+	locator := keychain.KeyLocator{
+		Family: keychain.KeyFamilyNodeKey,
+		Index:  0,
+	}
+	lwIdentity, err := lw.DeriveKey(t.Context(), locator)
+	require.NoError(t, err, "derive lwwallet identity")
+	btcIdentity, err := btc.DeriveKey(t.Context(), locator)
+	require.NoError(t, err, "derive btcwallet identity")
+	require.Equal(
+		t, lwIdentity.PubKey.SerializeCompressed(),
+		btcIdentity.PubKey.SerializeCompressed(),
+	)
+
+	expectedIdentity, err := waved.WalletIdentityPubKeyFromSeed(
+		rawSeed, "regtest",
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, expectedIdentity,
+		hex.EncodeToString(
+			lwIdentity.PubKey.SerializeCompressed(),
+		),
+	)
+}

--- a/sdk/wavewalletdk/client.go
+++ b/sdk/wavewalletdk/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightninglabs/wavelength/rpc/swapclientrpc"
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
 	"github.com/lightninglabs/wavelength/rpcauth"
+	"github.com/lightninglabs/wavelength/waved"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"google.golang.org/grpc"
 )
@@ -32,6 +33,17 @@ type Client struct {
 
 	canWallet bool
 	waitCh    <-chan error
+
+	// waitWalletServicesReady is installed only by Start. It waits until
+	// wallet-dependent actors and mailbox ingress are online, and returns
+	// the first startup error before that boundary. Remote clients
+	// intentionally leave it nil.
+	waitWalletServicesReady func(context.Context) error
+
+	// recoverWalletState is installed only by Start, which owns a waved
+	// Server in this process. Remote clients intentionally leave it nil.
+	recoverWalletState func(context.Context, uint32) (
+		*waved.WalletRecoveryResult, error)
 
 	closeFn   func(context.Context) error
 	closeOnce sync.Once

--- a/sdk/wavewalletdk/embedded.go
+++ b/sdk/wavewalletdk/embedded.go
@@ -204,7 +204,7 @@ func Start(ctx context.Context, cfg Config, opts ...Option) (*Client, error) {
 			errors.Join(err, closeErr, runErr, listenerErr))
 	}
 
-	return newClient(conn, true, waitErrChan,
+	client := newClient(conn, true, waitErrChan,
 		func(closeCtx context.Context) error {
 			closeErr := conn.Close()
 			cancel()
@@ -213,7 +213,11 @@ func Start(ctx context.Context, cfg Config, opts ...Option) (*Client, error) {
 
 			return errors.Join(closeErr, runErr, listenerErr)
 		},
-	), nil
+	)
+	client.waitWalletServicesReady = server.WaitForWalletServicesReady
+	client.recoverWalletState = server.RecoverWalletState
+
+	return client, nil
 }
 
 // requireEmbeddedWalletRuntime makes Start fail before booting a daemon when

--- a/sdk/wavewalletdk/external_seed.go
+++ b/sdk/wavewalletdk/external_seed.go
@@ -1,0 +1,454 @@
+package wavewalletdk
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/lightninglabs/wavelength/waved"
+	"github.com/lightningnetwork/lnd/aezeed"
+	"golang.org/x/crypto/hkdf"
+)
+
+const (
+	externalSeedDBKeyInfo = "wavewalletdk:external-seed:dbpw:v1"
+
+	wavedSeedEnvVar     = "WAVED_LWWALLET_SEED"
+	wavedPasswordEnvVar = "WAVED_WALLET_PASSWORD" //nolint:gosec
+)
+
+// ExternalSeedWalletRequest opens the wallet at an explicit daemon data
+// directory from already-derived aezeed entropy. SeedEntropy must contain
+// exactly aezeed.EntropySize bytes. Wavelength does not assign BIP39, BIP32,
+// account-index, network, or storage-path semantics to those bytes; the host
+// SDK owns that versioned derivation and selects Config.DataDir.
+//
+// ExpectedIdentityPubKey optionally binds the selected directory to a
+// previously persisted Wavelength identity. RecoverState is an explicit
+// per-open operation: setting it on an existing wallet reruns the idempotent
+// recovery scan, including after a prior scan failed. Callers should leave it
+// false for ordinary starts after recovery has succeeded.
+type ExternalSeedWalletRequest struct {
+	SeedEntropy            []byte
+	ExpectedIdentityPubKey string
+	RecoverState           bool
+	RecoveryWindow         uint32
+}
+
+// StartExternalSeedWallet atomically starts an embedded daemon at the explicit
+// Config.DataDir, then imports a fresh wallet or unlocks its existing wallet
+// from externally derived entropy. If opening fails, the newly started daemon
+// is stopped before the error returns.
+func StartExternalSeedWallet(ctx context.Context, cfg Config,
+	req ExternalSeedWalletRequest, opts ...Option) (*Client,
+	*ExternalSeedWalletOpenResult, error) {
+
+	return StartExternalSeedWalletWithContexts(
+		ctx, ctx, cfg, req, opts...,
+	)
+}
+
+// StartExternalSeedWalletWithContexts starts an embedded daemon with startCtx,
+// then imports or unlocks its wallet with openCtx. It returns only after
+// wallet-dependent actors and mailbox ingress are ready, so the first wallet
+// operation cannot race their initialization. Authenticated terms refreshes
+// and wallet-ready hooks are outside this success boundary. The split lets
+// hosts keep a short daemon-boot deadline without imposing that deadline on
+// wallet opening, service initialization, or an optional state-recovery scan.
+// If opening or pre-readiness service startup fails, the newly started daemon
+// is stopped before the error returns.
+func StartExternalSeedWalletWithContexts(startCtx, openCtx context.Context,
+	cfg Config, req ExternalSeedWalletRequest, opts ...Option) (*Client,
+	*ExternalSeedWalletOpenResult, error) {
+
+	seedEntropy := bytes.Clone(req.SeedEntropy)
+	defer clear(seedEntropy)
+
+	if err := validateExternalSeedWalletRequest(seedEntropy); err != nil {
+		return nil, nil, err
+	}
+	if err := validateExternalSeedWalletConfig(cfg); err != nil {
+		return nil, nil, err
+	}
+
+	// The seed and password environment hooks are process-global and take
+	// precedence during daemon startup. Reject them before Start can create
+	// an unrelated wallet or auto-unlock one without proving this request's
+	// derived password.
+	for _, envVar := range []string{wavedSeedEnvVar, wavedPasswordEnvVar} {
+		if value, ok := os.LookupEnv(envVar); ok && value != "" {
+			return nil, nil, fmt.Errorf("%s must be unset when "+
+				"starting an external-seed wallet", envVar)
+		}
+	}
+	if err := verifyExpectedExternalSeedWalletIdentity(
+		cfg, seedEntropy, req.ExpectedIdentityPubKey,
+	); err != nil {
+		return nil, nil, err
+	}
+
+	client, err := Start(startCtx, cfg, opts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("start external-seed wallet: %w",
+			err)
+	}
+
+	result, err := openStartedExternalSeedWallet(
+		openCtx, client, req, seedEntropy,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, result, nil
+}
+
+// openStartedExternalSeedWallet opens the wallet on an already-started
+// embedded client and rolls the daemon back on either open or readiness
+// failure. Keeping both post-Start failure paths here lets tests pin the
+// atomic stop-and-join contract without replacing the production starter.
+func openStartedExternalSeedWallet(ctx context.Context, client *Client,
+	req ExternalSeedWalletRequest,
+	seedEntropy []byte) (*ExternalSeedWalletOpenResult, error) {
+
+	openReq := req
+	openReq.SeedEntropy = seedEntropy
+	result, err := client.openWalletFromExternalSeed(ctx, openReq)
+	if err != nil {
+		// Stop owns its own bounded daemon-shutdown context.
+		//nolint:contextcheck
+		stopErr := client.Stop()
+
+		return nil, fmt.Errorf("open external-seed wallet: %w",
+			errors.Join(err, stopErr))
+	}
+
+	if err := waitForExternalSeedWalletReady(ctx, client); err != nil {
+		// Stop owns its own bounded daemon-shutdown context.
+		//nolint:contextcheck
+		stopErr := client.Stop()
+
+		return nil, fmt.Errorf("wait for external-seed wallet "+
+			"ready: %w", errors.Join(err, stopErr))
+	}
+
+	return result, nil
+}
+
+// waitForExternalSeedWalletReady waits for the embedded daemon's
+// wallet-services signal, which succeeds after wallet-dependent actors and
+// mailbox ingress have started. WalletStateReady alone is too early for calls
+// such as Deposit because the wallet backend publishes that state before those
+// services finish initializing.
+func waitForExternalSeedWalletReady(ctx context.Context, client *Client) error {
+	if client == nil || client.waitWalletServicesReady == nil {
+		return errors.New("external-seed wallet readiness requires " +
+			"an embedded client")
+	}
+
+	return client.waitWalletServicesReady(ctx)
+}
+
+// openWalletFromExternalSeed converts exactly 16 externally derived bytes to
+// fixed-birthday aezeed entropy and either imports it into an empty daemon or
+// unlocks the existing local wallet. RecoverState is honored on both first
+// import and existing-wallet unlock. It remains private so remote clients
+// cannot inject seed material through a generic wallet RPC.
+func (c *Client) openWalletFromExternalSeed(ctx context.Context,
+	req ExternalSeedWalletRequest) (*ExternalSeedWalletOpenResult, error) {
+
+	if err := validateExternalSeedWalletRequest(
+		req.SeedEntropy,
+	); err != nil {
+		return nil, err
+	}
+
+	var entropy [aezeed.EntropySize]byte
+	copy(entropy[:], req.SeedEntropy)
+	defer clear(entropy[:])
+
+	dbPassword := deriveExternalSeedDBPassword(entropy)
+	defer clear(dbPassword)
+
+	info, err := c.GetInfo(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read wallet state: %w", err)
+	}
+
+	switch info.WalletState {
+	case WalletStateNone:
+		return c.createWalletFromExternalSeed(
+			ctx, entropy, dbPassword, req,
+		)
+
+	case WalletStateLocked:
+		if req.RecoverState && c.recoverWalletState == nil {
+			return nil, errors.New("wallet state recovery " +
+				"requires an embedded client")
+		}
+
+		unlock, err := c.UnlockWallet(ctx, UnlockWalletRequest{
+			WalletPassword: dbPassword,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := verifyExternalSeedWalletIdentity(
+			req.ExpectedIdentityPubKey, unlock.IdentityPubKey,
+		); err != nil {
+			return nil, err
+		}
+
+		result := &ExternalSeedWalletOpenResult{
+			Imported:       false,
+			IdentityPubKey: unlock.IdentityPubKey,
+		}
+		if !req.RecoverState {
+			return result, nil
+		}
+		if err := c.recoverExternalSeedWalletState(
+			ctx, req.RecoveryWindow, result,
+		); err != nil {
+			return nil, err
+		}
+
+		return result, nil
+
+	case WalletStateReady, WalletStateSyncing:
+		// Without an unlock attempt, the daemon cannot prove that its
+		// open wallet came from the supplied entropy. Match the
+		// existing passkey behavior and refuse to claim that
+		// association.
+		return nil, errors.New("wallet is already unlocked")
+
+	default:
+		return nil, fmt.Errorf("unexpected wallet state %v: cannot "+
+			"open wallet", info.WalletState)
+	}
+}
+
+// createWalletFromExternalSeed converts fixed entropy into the daemon's
+// existing aezeed import format and initializes the empty local wallet.
+func (c *Client) createWalletFromExternalSeed(ctx context.Context,
+	entropy [aezeed.EntropySize]byte, dbPassword []byte,
+	req ExternalSeedWalletRequest) (*ExternalSeedWalletOpenResult, error) {
+
+	defer clear(entropy[:])
+	if req.RecoverState && c.recoverWalletState == nil {
+		return nil, errors.New("wallet state recovery requires an " +
+			"embedded client")
+	}
+
+	mnemonic, err := entropyToMnemonic(entropy)
+	if err != nil {
+		return nil, fmt.Errorf("derive aezeed mnemonic: %w", err)
+	}
+	defer clear(mnemonic[:])
+
+	created, err := c.CreateWallet(ctx, CreateWalletRequest{
+		Mnemonic:       mnemonic[:],
+		WalletPassword: dbPassword,
+		// Identity must be verified before recovery can register or
+		// persist state for this new profile. Run the same explicit,
+		// idempotent recovery operation used by locked-wallet retries
+		// only after the check below succeeds.
+		RecoverState: false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("initialize wallet from external "+
+			"entropy: %w", err)
+	}
+	defer clear(created.Mnemonic)
+	defer clear(created.EncipheredSeed)
+
+	if err := verifyExternalSeedWalletIdentity(
+		req.ExpectedIdentityPubKey, created.IdentityPubKey,
+	); err != nil {
+		return nil, err
+	}
+
+	result := &ExternalSeedWalletOpenResult{
+		Imported:       true,
+		IdentityPubKey: created.IdentityPubKey,
+	}
+	if !req.RecoverState {
+		return result, nil
+	}
+	if err := c.recoverExternalSeedWalletState(
+		ctx, req.RecoveryWindow, result,
+	); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// recoverExternalSeedWalletState runs the private embedded recovery operation
+// after the selected profile's identity has been verified and copies its
+// counters into the public open result.
+func (c *Client) recoverExternalSeedWalletState(ctx context.Context,
+	recoveryWindow uint32, result *ExternalSeedWalletOpenResult) error {
+
+	if c.recoverWalletState == nil {
+		return errors.New("wallet state recovery requires an " +
+			"embedded client")
+	}
+
+	recovery, err := c.recoverWalletState(ctx, recoveryWindow)
+	if err != nil {
+		return fmt.Errorf("recover wallet state: %w", err)
+	}
+	if recovery == nil {
+		return errors.New("recover wallet state: empty result")
+	}
+
+	result.RecoveryRan = true
+	result.RecoveredBoardingAddresses = recovery.BoardingAddresses
+	result.RecoveredBoardingUTXOs = recovery.BoardingUTXOs
+	result.RecoveredVTXOs = recovery.VTXOs
+	result.RecoveredOORReceiveScripts = recovery.OORReceiveScripts
+	result.RecoveredOORRecipientEvents = recovery.OOREvents
+
+	return nil
+}
+
+// deriveExternalSeedDBPassword derives a domain-separated password for the
+// local encrypted wallet DB. It is deliberately not the seed entropy itself.
+func deriveExternalSeedDBPassword(entropy [aezeed.EntropySize]byte) []byte {
+	defer clear(entropy[:])
+
+	rawPassword := make([]byte, 32)
+	reader := hkdf.New(
+		sha256.New, entropy[:], nil, []byte(externalSeedDBKeyInfo),
+	)
+	_, _ = io.ReadFull(reader, rawPassword)
+	defer clear(rawPassword)
+
+	password := make([]byte, hex.EncodedLen(len(rawPassword)))
+	hex.Encode(password, rawPassword)
+
+	return password
+}
+
+// verifyExpectedExternalSeedWalletIdentity proves an optional identity pin
+// directly from the requested entropy before Start can create a directory or
+// initialize a wallet database. The post-open check remains as a defense
+// against future drift between this derivation and the wallet backend.
+func verifyExpectedExternalSeedWalletIdentity(cfg Config, entropy []byte,
+	expected string) error {
+
+	if expected == "" {
+		return nil
+	}
+
+	daemonCfg, err := daemonConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("resolve external-seed wallet network: %w",
+			err)
+	}
+
+	var rawSeed [32]byte
+	copy(rawSeed[:], entropy)
+	defer clear(rawSeed[:])
+
+	actual, err := waved.WalletIdentityPubKeyFromSeed(
+		rawSeed, daemonCfg.Network,
+	)
+	if err != nil {
+		return fmt.Errorf("derive external-seed wallet identity: %w",
+			err)
+	}
+
+	return verifyExternalSeedWalletIdentity(expected, actual)
+}
+
+// validateExternalSeedWalletRequest requires the complete aezeed entropy
+// boundary. Accepting any other size would require an undocumented transform
+// and make host implementations derive different wallets from the same input.
+func validateExternalSeedWalletRequest(seedEntropy []byte) error {
+	if len(seedEntropy) != aezeed.EntropySize {
+		return fmt.Errorf("external seed entropy must be exactly %d "+
+			"bytes: got %d", aezeed.EntropySize, len(seedEntropy))
+	}
+
+	return nil
+}
+
+// validateExternalSeedWalletConfig checks the storage and wallet-backend
+// boundary before Start performs any filesystem or network I/O. The host owns
+// path derivation, so it must supply the final DataDir explicitly. Alternate
+// state and auto-unlock paths could escape that selected directory or bypass
+// proof that the existing DB belongs to this request, so they are rejected.
+func validateExternalSeedWalletConfig(cfg Config) error {
+	if cfg.DataDir == "" {
+		return errors.New("external-seed wallet requires an explicit " +
+			"final data directory")
+	}
+
+	walletType := cfg.WalletType
+	if walletType == "" && cfg.DaemonConfig != nil &&
+		cfg.DaemonConfig.Wallet != nil {
+
+		walletType = cfg.DaemonConfig.Wallet.Type
+	}
+	if walletType == "" {
+		walletType = waved.DefaultConfig().Wallet.Type
+	}
+	switch walletType {
+	case waved.WalletTypeLwwallet, waved.WalletTypeBtcwallet:
+	default:
+		return fmt.Errorf("wallet type %q cannot be initialized from "+
+			"external seed entropy", walletType)
+	}
+
+	if cfg.WalletPasswordFile != "" {
+		return errors.New("wallet password file is incompatible with " +
+			"external-seed wallets")
+	}
+	if cfg.SwapDatabaseFileName != "" {
+		return errors.New("custom swap database path is incompatible " +
+			"with external-seed wallets")
+	}
+	if cfg.DaemonConfig == nil {
+		return nil
+	}
+	if cfg.DaemonConfig.LogDirPath != "" {
+		return errors.New("daemon custom log directory is " +
+			"incompatible with external-seed wallets")
+	}
+
+	if cfg.DaemonConfig.Wallet != nil {
+		walletCfg := cfg.DaemonConfig.Wallet
+		if walletCfg.PasswordFile != "" {
+			return errors.New("daemon wallet password file is " +
+				"incompatible with external-seed wallets")
+		}
+		if walletCfg.BtcwalletDataDir != "" {
+			return errors.New("custom btcwallet datadir is " +
+				"incompatible with external-seed wallets")
+		}
+	}
+	if cfg.DaemonConfig.Swap != nil &&
+		cfg.DaemonConfig.Swap.DatabaseFileName != "" {
+		return errors.New("daemon custom swap database path is " +
+			"incompatible with external-seed wallets")
+	}
+
+	return nil
+}
+
+// verifyExternalSeedWalletIdentity checks an optional caller-persisted
+// identity before returning a newly imported or unlocked wallet to the host.
+func verifyExternalSeedWalletIdentity(expected, actual string) error {
+	if expected == "" || expected == actual {
+		return nil
+	}
+
+	return fmt.Errorf("external-seed wallet identity mismatch: expected "+
+		"%s, got %s", expected, actual)
+}

--- a/sdk/wavewalletdk/external_seed_compat_test.go
+++ b/sdk/wavewalletdk/external_seed_compat_test.go
@@ -1,0 +1,431 @@
+package wavewalletdk
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lightninglabs/wavelength/waved"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/aezeed"
+	"github.com/stretchr/testify/require"
+)
+
+type seedHarness struct {
+	entropy       [aezeed.EntropySize]byte
+	stub          *stubDaemonServer
+	client        *Client
+	recoveryErr   error
+	recoveryCalls int
+}
+
+// newSeedHarness wires a stub wallet and optional recovery bridge.
+func newSeedHarness(t *testing.T, state waverpc.WalletState, identity string,
+	withRecovery bool) *seedHarness {
+
+	stub := &stubDaemonServer{
+		state:    state,
+		identity: identity,
+		initResp: &waverpc.InitWalletResponse{
+			IdentityPubkey: identity,
+		},
+	}
+	h := &seedHarness{
+		entropy: testExternalSeedEntropy(),
+		stub:    stub,
+		client:  newStubClient(t, stub),
+	}
+	if !withRecovery {
+		return h
+	}
+
+	h.client.recoverWalletState = func(_ context.Context, window uint32) (
+		*waved.WalletRecoveryResult, error) {
+
+		h.recoveryCalls++
+		require.Equal(t, uint32(144), window)
+		require.True(t, stub.initCalled || stub.unlockCalled)
+		if h.recoveryErr != nil {
+			return nil, h.recoveryErr
+		}
+
+		return &waved.WalletRecoveryResult{
+			BoardingAddresses: 1,
+			BoardingUTXOs:     2,
+			VTXOs:             3,
+			OORReceiveScripts: 4,
+			OOREvents:         5,
+		}, nil
+	}
+
+	return h
+}
+
+// open sends the harness entropy through the private external-seed opener.
+func (h *seedHarness) open(t *testing.T, expected string, runRecovery bool) (
+	*ExternalSeedWalletOpenResult, error) {
+
+	t.Helper()
+
+	return h.client.openWalletFromExternalSeed(
+		t.Context(), ExternalSeedWalletRequest{
+			SeedEntropy:            h.entropy[:],
+			ExpectedIdentityPubKey: expected,
+			RecoverState:           runRecovery,
+			RecoveryWindow:         144,
+		},
+	)
+}
+
+// recoveredResult returns the result expected from the recovery fixture.
+func recoveredResult(imported bool,
+	identity string) *ExternalSeedWalletOpenResult {
+
+	return &ExternalSeedWalletOpenResult{
+		Imported:                    imported,
+		IdentityPubKey:              identity,
+		RecoveryRan:                 true,
+		RecoveredBoardingAddresses:  1,
+		RecoveredBoardingUTXOs:      2,
+		RecoveredVTXOs:              3,
+		RecoveredOORReceiveScripts:  4,
+		RecoveredOORRecipientEvents: 5,
+	}
+}
+
+// requireSeedStartError checks validation before filesystem writes.
+func requireSeedStartError(t *testing.T, dataDir string, seed []byte,
+	want string) {
+
+	t.Helper()
+	cfg := Config{DataDir: dataDir}
+	client, result, err := StartExternalSeedWallet(
+		t.Context(), cfg, ExternalSeedWalletRequest{
+			SeedEntropy: seed,
+		},
+	)
+	require.ErrorContains(t, err, want)
+	require.Nil(t, client)
+	require.Nil(t, result)
+	if dataDir == "" {
+		return
+	}
+
+	entries, err := os.ReadDir(dataDir)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+// TestOpenWalletFromExternalSeed verifies import, unlock, and recovery.
+func TestOpenWalletFromExternalSeed(t *testing.T) {
+	t.Parallel()
+	t.Run("fresh import and recovery", testExternalSeedImport)
+	t.Run("existing wallet unlock", testExternalSeedUnlock)
+}
+
+// testExternalSeedImport verifies the fresh-wallet import contract.
+func testExternalSeedImport(t *testing.T) {
+	t.Parallel()
+	h := newSeedHarness(
+		t, waverpc.WalletState_WALLET_STATE_NONE, "init-id", true,
+	)
+	result, err := h.open(t, "init-id", true)
+	require.NoError(t, err)
+	require.True(t, h.stub.initCalled)
+	require.False(t, h.stub.unlockCalled)
+	require.Equal(t, 1, h.recoveryCalls)
+	require.Equal(t, recoveredResult(true, "init-id"), result)
+
+	password := deriveExternalSeedDBPassword(h.entropy)
+	require.False(t, h.stub.lastInitReq.RecoverState)
+	require.Zero(t, h.stub.lastInitReq.RecoveryWindow)
+	require.Empty(t, h.stub.lastInitReq.SeedPassphrase)
+	require.Equal(t, password, h.stub.lastInitReq.WalletPassword)
+
+	var mnemonic aezeed.Mnemonic
+	copy(mnemonic[:], h.stub.lastInitReq.Mnemonic)
+	cipherSeed, err := mnemonic.ToCipherSeed(nil)
+	require.NoError(t, err)
+	require.Equal(t, h.entropy, cipherSeed.Entropy)
+	require.Zero(t, cipherSeed.Birthday)
+}
+
+// testExternalSeedUnlock verifies deterministic existing-wallet unlock.
+func testExternalSeedUnlock(t *testing.T) {
+	t.Parallel()
+	h := newSeedHarness(
+		t, waverpc.WalletState_WALLET_STATE_LOCKED, "unlock-id", true,
+	)
+	result, err := h.open(t, "unlock-id", false)
+	require.NoError(t, err)
+	require.False(t, h.stub.initCalled)
+	require.True(t, h.stub.unlockCalled)
+	require.Zero(t, h.recoveryCalls)
+	require.Equal(t, &ExternalSeedWalletOpenResult{
+		IdentityPubKey: "unlock-id",
+	}, result)
+	require.Equal(
+		t, deriveExternalSeedDBPassword(h.entropy),
+		h.stub.lastUnlockReq.WalletPassword,
+	)
+}
+
+// TestOpenWalletFromExternalSeedRetriesRecoveryAfterFailedImport tests retry.
+func TestOpenWalletFromExternalSeedRetriesRecoveryAfterFailedImport(
+	t *testing.T) {
+
+	t.Parallel()
+	first := newSeedHarness(
+		t, waverpc.WalletState_WALLET_STATE_NONE, "unlock-id", true,
+	)
+	first.recoveryErr = errors.New("state recovery failed")
+	_, err := first.open(t, "unlock-id", true)
+	require.ErrorContains(t, err, "state recovery failed")
+	require.True(t, first.stub.initCalled)
+	require.False(t, first.stub.lastInitReq.RecoverState)
+
+	retry := newSeedHarness(
+		t, waverpc.WalletState_WALLET_STATE_LOCKED, "unlock-id", true,
+	)
+	result, err := retry.open(t, "unlock-id", true)
+	require.NoError(t, err)
+	require.Equal(t, 1, retry.recoveryCalls)
+	require.Equal(t, recoveredResult(false, "unlock-id"), result)
+}
+
+type externalSeedOpenGuard uint8
+
+const (
+	seedNone    = waverpc.WalletState_WALLET_STATE_NONE
+	seedLocked  = waverpc.WalletState_WALLET_STATE_LOCKED
+	seedReady   = waverpc.WalletState_WALLET_STATE_READY
+	seedSyncing = waverpc.WalletState_WALLET_STATE_SYNCING
+)
+
+const (
+	needsBridge externalSeedOpenGuard = iota
+	identityMismatch
+	identityBeforeRecovery
+	alreadyUnlocked
+	invalidEntropy
+)
+
+// TestOpenWalletFromExternalSeedRejectsUnsafeOpens covers open guards.
+func TestOpenWalletFromExternalSeedRejectsUnsafeOpens(t *testing.T) {
+	t.Parallel()
+	testExternalSeedGuard(t, "fresh needs bridge", seedNone, needsBridge)
+	testExternalSeedGuard(
+		t, "restart needs bridge", seedLocked, needsBridge,
+	)
+	testExternalSeedGuard(
+		t, "fresh identity before recovery", seedNone,
+		identityBeforeRecovery,
+	)
+	testExternalSeedGuard(
+		t, "restart identity before recovery", seedLocked,
+		identityBeforeRecovery,
+	)
+	testExternalSeedGuard(
+		t, "fresh identity mismatch", seedNone, identityMismatch,
+	)
+	testExternalSeedGuard(
+		t, "restart identity mismatch", seedLocked, identityMismatch,
+	)
+	testExternalSeedGuard(t, "ready wallet", seedReady, alreadyUnlocked)
+	testExternalSeedGuard(t, "syncing wallet", seedSyncing, alreadyUnlocked)
+	testExternalSeedGuard(t, "wrong entropy size", seedNone, invalidEntropy)
+}
+
+// testExternalSeedGuard verifies one unsafe-open scenario.
+func testExternalSeedGuard(t *testing.T, name string, state waverpc.WalletState,
+	guard externalSeedOpenGuard) {
+
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		t.Parallel()
+		runRecovery := guard == identityBeforeRecovery
+		h := newSeedHarness(t, state, "actual-id", runRecovery)
+		var err error
+		var want string
+		switch guard {
+		case needsBridge:
+			_, err = h.open(t, "", true)
+			want = "requires an embedded client"
+
+		case identityMismatch, identityBeforeRecovery:
+			_, err = h.open(t, "wrong-id", runRecovery)
+			want = "identity"
+
+		case alreadyUnlocked:
+			_, err = h.open(t, "actual-id", false)
+			want = "already unlocked"
+
+		case invalidEntropy:
+			_, err = h.client.openWalletFromExternalSeed(
+				t.Context(), ExternalSeedWalletRequest{
+					SeedEntropy: bytes.Repeat(
+						[]byte{1}, aezeed.EntropySize+1,
+					),
+				},
+			)
+			want = "exactly 16 bytes"
+		}
+
+		require.ErrorContains(t, err, want)
+		identityGuard := guard == identityMismatch || runRecovery
+		require.Equal(
+			t, identityGuard && state == seedNone,
+			h.stub.initCalled,
+		)
+		require.Equal(
+			t, identityGuard && state == seedLocked,
+			h.stub.unlockCalled,
+		)
+		require.Zero(t, h.recoveryCalls)
+		if h.stub.initCalled {
+			require.False(t, h.stub.lastInitReq.RecoverState)
+		}
+	})
+}
+
+// TestStartExternalSeedWalletValidatesBeforeStartup tests early validation.
+func TestStartExternalSeedWalletValidatesBeforeStartup(t *testing.T) {
+	t.Setenv(wavedSeedEnvVar, "")
+	t.Setenv(wavedPasswordEnvVar, "")
+	requireSeedStartError(
+		t, t.TempDir(), make([]byte, aezeed.EntropySize-1),
+		"exactly 16 bytes",
+	)
+	entropy := testExternalSeedEntropy()
+	requireSeedStartError(
+		t, "", entropy[:], "explicit final data directory",
+	)
+}
+
+// TestExternalSeedWalletConfigUsesExactDataDir tests caller-owned paths.
+func TestExternalSeedWalletConfigUsesExactDataDir(t *testing.T) {
+	t.Parallel()
+	legacy, err := daemonConfig(Config{})
+	require.NoError(t, err)
+	require.Equal(t, waved.DefaultConfig().DataDir, legacy.DataDir)
+
+	daemonCfg := waved.DefaultConfig()
+	daemonCfg.DataDir = t.TempDir()
+	originalDir, originalType := daemonCfg.DataDir, daemonCfg.Wallet.Type
+	finalDir := filepath.Join(t.TempDir(), "sdk-selected-wallet")
+	cfg := Config{
+		DaemonConfig: daemonCfg,
+		DataDir:      finalDir,
+		Network:      "regtest",
+		WalletType:   waved.WalletTypeBtcwallet,
+	}
+	require.NoError(t, validateExternalSeedWalletConfig(cfg))
+	resolved, err := daemonConfig(cfg)
+	require.NoError(t, err)
+	require.Equal(t, finalDir, resolved.DataDir)
+	require.Equal(t, waved.WalletTypeBtcwallet, resolved.Wallet.Type)
+	require.Equal(t, originalDir, daemonCfg.DataDir)
+	require.Equal(t, originalType, daemonCfg.Wallet.Type)
+
+	missingDir := Config{DaemonConfig: daemonCfg}
+	require.ErrorContains(
+		t, validateExternalSeedWalletConfig(missingDir),
+		"explicit final data directory",
+	)
+}
+
+// TestStartExternalSeedWalletRejectsProcessGlobals tests legacy hook guards.
+func TestStartExternalSeedWalletRejectsProcessGlobals(t *testing.T) {
+	entropy := testExternalSeedEntropy()
+	original := bytes.Clone(entropy[:])
+	testSeedProcessGlobal(
+		t, wavedSeedEnvVar, "000102030405060708090a0b0c0d0e0f1011121"+
+			"31415161718191a1b1c1d1e1f", entropy[:],
+	)
+	testSeedProcessGlobal(
+		t, wavedPasswordEnvVar, "process-global-password", entropy[:],
+	)
+	require.Equal(t, original, entropy[:])
+}
+
+// testSeedProcessGlobal verifies one process-global guard.
+func testSeedProcessGlobal(t *testing.T, envVar, value string, entropy []byte) {
+	t.Helper()
+	t.Run(envVar, func(t *testing.T) {
+		t.Setenv(wavedSeedEnvVar, "")
+		t.Setenv(wavedPasswordEnvVar, "")
+		t.Setenv(envVar, value)
+		requireSeedStartError(
+			t, t.TempDir(), entropy, envVar,
+		)
+	})
+}
+
+type externalSeedConfigOverride uint8
+
+const (
+	overrideWalletPassword externalSeedConfigOverride = iota
+	overrideSwapDatabase
+	overrideLogDirectory
+	overrideDaemonPassword
+	overrideBtcwalletDatabase
+	overrideDaemonSwapDatabase
+)
+
+// TestExternalSeedWalletConfigRejectsStateOverrides tests path isolation.
+func TestExternalSeedWalletConfigRejectsStateOverrides(t *testing.T) {
+	t.Parallel()
+	for override := overrideWalletPassword; override <=
+		overrideDaemonSwapDatabase; override++ {
+
+		testExternalSeedConfigOverride(t, override)
+	}
+}
+
+// testExternalSeedConfigOverride verifies one alternate state path is rejected.
+func testExternalSeedConfigOverride(t *testing.T,
+	override externalSeedConfigOverride) {
+
+	t.Helper()
+	cfg := Config{
+		DaemonConfig: waved.DefaultConfig(),
+		DataDir:      "wallet",
+	}
+	var name, want string
+	switch override {
+	case overrideWalletPassword:
+		name, want = "wallet password file", "password file"
+		cfg.WalletPasswordFile = "wallet.pw"
+
+	case overrideSwapDatabase:
+		name, want = "swap database", "database"
+		cfg.SwapDatabaseFileName = "swaps.db"
+
+	case overrideLogDirectory:
+		name, want = "daemon log directory", "log directory"
+		cfg.DaemonConfig.LogDirPath = "logs"
+
+	case overrideDaemonPassword:
+		name, want = "daemon wallet password file", "password file"
+		cfg.DaemonConfig.Wallet.PasswordFile = "wallet.pw"
+
+	case overrideBtcwalletDatabase:
+		name, want = "btcwallet database", "datadir"
+		cfg.WalletType = waved.WalletTypeBtcwallet
+		cfg.DaemonConfig.Wallet.BtcwalletDataDir = "btcwallet"
+
+	case overrideDaemonSwapDatabase:
+		name, want = "daemon swap database", "database"
+		cfg.DaemonConfig.Swap.DatabaseFileName = "swaps.db"
+	}
+
+	t.Run(name, func(t *testing.T) {
+		t.Parallel()
+		require.ErrorContains(
+			t, validateExternalSeedWalletConfig(cfg), want,
+		)
+	})
+}

--- a/sdk/wavewalletdk/external_seed_test.go
+++ b/sdk/wavewalletdk/external_seed_test.go
@@ -1,0 +1,245 @@
+package wavewalletdk
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/lightninglabs/wavelength/waved"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/aezeed"
+	"github.com/stretchr/testify/require"
+)
+
+// testExternalSeedEntropy returns the fixed, already-derived entropy shared by
+// the external-seed unit and backend compatibility tests.
+func testExternalSeedEntropy() [aezeed.EntropySize]byte {
+	return [aezeed.EntropySize]byte{
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+		0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+	}
+}
+
+// TestWaitForExternalSeedWalletReady verifies external-seed startup delegates
+// to the embedded wallet-services waiter and surfaces cancellation or startup
+// errors.
+func TestWaitForExternalSeedWalletReady(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ready", func(t *testing.T) {
+		t.Parallel()
+
+		client := &Client{
+			waitWalletServicesReady: func(context.Context) error {
+				return nil
+			},
+		}
+
+		require.NoError(
+			t,
+			waitForExternalSeedWalletReady(
+				t.Context(), client,
+			),
+		)
+	})
+
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		client := &Client{
+			waitWalletServicesReady: func(
+				ctx context.Context) error {
+
+				<-ctx.Done()
+
+				return ctx.Err()
+			},
+		}
+
+		require.ErrorIs(
+			t, waitForExternalSeedWalletReady(ctx, client),
+			context.Canceled,
+		)
+	})
+
+	t.Run("startup error", func(t *testing.T) {
+		t.Parallel()
+
+		runErr := errors.New("run failed")
+		client := &Client{
+			waitWalletServicesReady: func(context.Context) error {
+				return runErr
+			},
+		}
+
+		require.ErrorIs(
+			t,
+			waitForExternalSeedWalletReady(
+				t.Context(), client,
+			),
+			runErr,
+		)
+	})
+
+	t.Run("remote client", func(t *testing.T) {
+		t.Parallel()
+
+		err := waitForExternalSeedWalletReady(t.Context(), &Client{})
+		require.ErrorContains(t, err, "requires an embedded client")
+	})
+}
+
+// TestOpenStartedExternalSeedWalletStopsOnFailure pins both rollback branches
+// after Start has already returned an embedded client. The original open or
+// readiness error and any shutdown error must all remain observable.
+func TestOpenStartedExternalSeedWalletStopsOnFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("open failure", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &stubDaemonServer{
+			state:   seedNone,
+			initErr: errors.New("initialize failed"),
+		}
+		client := newStubClient(t, stub)
+		assertExternalSeedStartRollback(
+			t, client, "initialize failed",
+		)
+	})
+
+	t.Run("readiness failure", func(t *testing.T) {
+		t.Parallel()
+
+		readyErr := errors.New("wallet services failed")
+		stub := &stubDaemonServer{
+			state: seedNone,
+			initResp: &waverpc.InitWalletResponse{
+				IdentityPubkey: "init-id",
+			},
+		}
+		client := newStubClient(t, stub)
+		client.waitWalletServicesReady = func(context.Context) error {
+			return readyErr
+		}
+		assertExternalSeedStartRollback(
+			t, client, "wallet services failed",
+		)
+	})
+}
+
+// assertExternalSeedStartRollback verifies one post-Start failure stops the
+// embedded client and joins the shutdown error with the triggering failure.
+func assertExternalSeedStartRollback(t *testing.T, client *Client,
+	wantMessage string) {
+
+	t.Helper()
+
+	stopErr := errors.New("stop failed")
+	stopCalls := 0
+	client.closeFn = func(context.Context) error {
+		stopCalls++
+
+		return stopErr
+	}
+
+	entropy := testExternalSeedEntropy()
+	result, err := openStartedExternalSeedWallet(
+		t.Context(), client, ExternalSeedWalletRequest{}, entropy[:],
+	)
+	require.Nil(t, result)
+	require.ErrorContains(t, err, wantMessage)
+	require.ErrorIs(t, err, stopErr)
+	require.Equal(t, 1, stopCalls)
+}
+
+// TestExternalSeedDBPasswordGoldenVector pins the password-domain version and
+// HKDF transform used to reopen an existing encrypted wallet database.
+func TestExternalSeedDBPasswordGoldenVector(t *testing.T) {
+	t.Parallel()
+
+	entropy := testExternalSeedEntropy()
+	password := deriveExternalSeedDBPassword(entropy)
+	defer clear(password)
+
+	require.Len(t, password, 64)
+	_, err := hex.DecodeString(string(password))
+	require.NoError(t, err)
+	require.Equal(
+		t, "550ff1a159e3142b1c3b442b02e7ef2a19e780e1889dea704ce9c3d6"+
+			"603189ec", string(password),
+	)
+}
+
+// TestValidateExternalSeedWalletRequestRequiresAezeedEntropy rejects any
+// undocumented padding, truncation, or hashing at the Go boundary.
+func TestValidateExternalSeedWalletRequestRequiresAezeedEntropy(t *testing.T) {
+	t.Parallel()
+
+	require.ErrorContains(
+		t, validateExternalSeedWalletRequest(nil),
+		"exactly 16 bytes",
+	)
+	require.ErrorContains(
+		t,
+		validateExternalSeedWalletRequest(
+			make([]byte, 15),
+		),
+		"exactly 16 bytes",
+	)
+	require.NoError(
+		t,
+		validateExternalSeedWalletRequest(
+			make([]byte, 16),
+		),
+	)
+	require.ErrorContains(
+		t,
+		validateExternalSeedWalletRequest(
+			make([]byte, 17),
+		),
+		"exactly 16 bytes",
+	)
+}
+
+// TestValidateExternalSeedWalletConfigRejectsExternalWallet verifies entropy
+// is offered only to the two self-managed wallet backends that consume it.
+func TestValidateExternalSeedWalletConfigRejectsExternalWallet(t *testing.T) {
+	t.Parallel()
+
+	err := validateExternalSeedWalletConfig(Config{
+		DataDir:    t.TempDir(),
+		WalletType: waved.WalletTypeLnd,
+	})
+	require.ErrorContains(t, err, "wallet type")
+}
+
+// TestStartExternalSeedWalletRejectsIdentityBeforeStartup verifies an
+// identity mismatch is rejected before Start can create daemon state.
+func TestStartExternalSeedWalletRejectsIdentityBeforeStartup(t *testing.T) {
+	t.Setenv(wavedSeedEnvVar, "")
+	t.Setenv(wavedPasswordEnvVar, "")
+
+	dataDir := t.TempDir()
+	entropy := testExternalSeedEntropy()
+	client, result, err := StartExternalSeedWallet(
+		t.Context(), Config{
+			DataDir: dataDir,
+			Network: "regtest",
+		}, ExternalSeedWalletRequest{
+			SeedEntropy:            entropy[:],
+			ExpectedIdentityPubKey: "wrong-id",
+		},
+	)
+	require.ErrorContains(t, err, "identity mismatch")
+	require.Nil(t, client)
+	require.Nil(t, result)
+
+	entries, err := os.ReadDir(dataDir)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}

--- a/sdk/wavewalletdk/mobile/AGENTS.md
+++ b/sdk/wavewalletdk/mobile/AGENTS.md
@@ -9,6 +9,8 @@ bytes-in/bytes-out RPC verbs plus a few scalar convenience methods. Built only
 via `gomobile bind` under the `mobile`, `wavewalletrpc`, and `swapruntime` build
 tags; without those tags this package has no exported API at all (there is no
 committed stub source in this directory, unlike `cmd/wavewalletdk-wasm/stub.go`).
+The exported functions are a binding ABI for typed host SDKs, not the
+application-facing wallet API.
 
 ## Key Types
 
@@ -16,6 +18,9 @@ committed stub source in this directory, unlike `cmd/wavewalletdk-wasm/stub.go`)
   embedded daemon; a four-state machine (`stopped`/`starting`/`started`/
   `stopping`) plus a generation counter guards a `Stop` racing an in-progress
   `Start`.
+- `StartExternalSeedWallet(reqJSON []byte) ([]byte, error)` — starts at the
+  final data directory, imports or unlocks 16 bytes of already-derived entropy,
+  and returns the marshalled open result through the same lifecycle.
 - `Subscription` — pull-based handle (`Next`/`Close`) over a wallet activity
   stream, replacing the callback interfaces gomobile would otherwise require.
 - `mobileConfig` — unexported flat JSON config decoded by `parseConfig`/
@@ -44,12 +49,17 @@ committed stub source in this directory, unlike `cmd/wavewalletdk-wasm/stub.go`)
 
 - All package state lives in the unexported singleton `state`; a second
   `Start` before `Stop` returns an error instead of booting a second daemon.
+- `StartExternalSeedWallet` shares the same singleton guard.
+- `StartExternalSeedWallet` accepts nested `config` and standard-base64
+  `seed_entropy`. `config.data_dir` is the final wallet directory; this package
+  derives no account, seed, or path namespace.
 - `Stop` is idempotent and always resets the singleton so a subsequent `Start`
   can succeed (e.g. after OS suspend/resume).
-- Only `Start` (mobile.go:98) and `Subscription.Next` (wallet.go:365-371)
-  recover panics into a returned `error`; those are the two entry points
-  documented to survive a panic without crossing the gomobile boundary and
-  killing the host process.
+- `startEmbedded` separates its daemon-readiness deadline from the lifecycle
+  context used to open or recover the wallet. `Stop` cancels both.
+- Startup through `startEmbedded` and `Subscription.Next` recover panics into
+  a returned `error`; those are the entry points documented to survive a panic
+  without crossing the gomobile boundary and killing the host process.
 - `Subscribe`'s updates/close path is driven by a context derived from the
   wrapper-owned call context, not the caller's; `Stop` cancelling that context
   is what unblocks an in-flight `Subscription.Next`.

--- a/sdk/wavewalletdk/mobile/CLAUDE.md
+++ b/sdk/wavewalletdk/mobile/CLAUDE.md
@@ -9,6 +9,8 @@ bytes-in/bytes-out RPC verbs plus a few scalar convenience methods. Built only
 via `gomobile bind` under the `mobile`, `wavewalletrpc`, and `swapruntime` build
 tags; without those tags this package has no exported API at all (there is no
 committed stub source in this directory, unlike `cmd/wavewalletdk-wasm/stub.go`).
+The exported functions are a binding ABI for typed host SDKs, not the
+application-facing wallet API.
 
 ## Key Types
 
@@ -16,6 +18,9 @@ committed stub source in this directory, unlike `cmd/wavewalletdk-wasm/stub.go`)
   embedded daemon; a four-state machine (`stopped`/`starting`/`started`/
   `stopping`) plus a generation counter guards a `Stop` racing an in-progress
   `Start`.
+- `StartExternalSeedWallet(reqJSON []byte) ([]byte, error)` — starts at the
+  final data directory, imports or unlocks 16 bytes of already-derived entropy,
+  and returns the marshalled open result through the same lifecycle.
 - `Subscription` — pull-based handle (`Next`/`Close`) over a wallet activity
   stream, replacing the callback interfaces gomobile would otherwise require.
 - `mobileConfig` — unexported flat JSON config decoded by `parseConfig`/
@@ -44,12 +49,17 @@ committed stub source in this directory, unlike `cmd/wavewalletdk-wasm/stub.go`)
 
 - All package state lives in the unexported singleton `state`; a second
   `Start` before `Stop` returns an error instead of booting a second daemon.
+- `StartExternalSeedWallet` shares the same singleton guard.
+- `StartExternalSeedWallet` accepts nested `config` and standard-base64
+  `seed_entropy`. `config.data_dir` is the final wallet directory; this package
+  derives no account, seed, or path namespace.
 - `Stop` is idempotent and always resets the singleton so a subsequent `Start`
   can succeed (e.g. after OS suspend/resume).
-- Only `Start` (mobile.go:98) and `Subscription.Next` (wallet.go:365-371)
-  recover panics into a returned `error`; those are the two entry points
-  documented to survive a panic without crossing the gomobile boundary and
-  killing the host process.
+- `startEmbedded` separates its daemon-readiness deadline from the lifecycle
+  context used to open or recover the wallet. `Stop` cancels both.
+- Startup through `startEmbedded` and `Subscription.Next` recover panics into
+  a returned `error`; those are the entry points documented to survive a panic
+  without crossing the gomobile boundary and killing the host process.
 - `Subscribe`'s updates/close path is driven by a context derived from the
   wrapper-owned call context, not the caller's; `Stop` cancelling that context
   is what unblocks an in-flight `Subscription.Next`.

--- a/sdk/wavewalletdk/mobile/doc.go
+++ b/sdk/wavewalletdk/mobile/doc.go
@@ -9,10 +9,11 @@
 // gRPC is serving (lnd.Main blocks forever, so lnd needs a callback; we do
 // not). RPC verbs use a JSON bytes-in / bytes-out convention (the host decodes
 // with kotlinx.serialization / Codable, no protobuf runtime needed), with a
-// handful of scalar convenience methods for the hottest paths. Start is
-// synchronous (call it off the main thread), and the one streaming verb,
-// Subscribe, hands back a pull-based Subscription handle (Next / Close) instead
-// of a callback, since a Go channel cannot cross the gomobile boundary.
+// handful of scalar convenience methods for the hottest paths. Start and
+// StartExternalSeedWallet are synchronous and share one active-client
+// lifecycle. The one streaming verb, Subscribe, hands back a pull-based
+// Subscription handle (Next / Close) instead of a callback, since a Go channel
+// cannot cross the gomobile boundary.
 //
 // Everything is gated behind the mobile, wavewalletrpc, and swapruntime build
 // tags so the package only compiles into a gomobile bind output; ordinary

--- a/sdk/wavewalletdk/mobile/external_seed_wallet.go
+++ b/sdk/wavewalletdk/mobile/external_seed_wallet.go
@@ -1,0 +1,146 @@
+//go:build mobile && wavewalletrpc && swapruntime
+
+package mobile
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/lightninglabs/wavelength/sdk/wavewalletdk"
+	"github.com/lightningnetwork/lnd/aezeed"
+)
+
+// externalSeedWalletStartRequest is the private mobile/WASM transport envelope
+// used by typed host SDKs. Config is the final daemon configuration, including
+// its already-selected data directory. SeedEntropy is standard base64 in JSON,
+// matching encoding/json's []byte representation.
+type externalSeedWalletStartRequest struct {
+	Config json.RawMessage `json:"config"`
+
+	SeedEntropy      []byte `json:"seed_entropy"`
+	ExpectedIdentity string `json:"expected_identity_pubkey,omitempty"`
+	RecoverState     bool   `json:"recover_state,omitempty"`
+	RecoveryWindow   uint32 `json:"recovery_window,omitempty"`
+}
+
+// StartExternalSeedWallet is the private binding ABI for atomically booting an
+// embedded daemon at a host-selected data directory and importing or unlocking
+// its internal wallet from already-derived entropy. Typed host SDKs must route
+// it through the same lifecycle queue and runtime lock as Start and Stop;
+// application code should use that typed API instead of constructing this JSON
+// request directly. The request accepts only a nested final config and exactly
+// 16 bytes of seed_entropy encoded as standard base64. Wavelength assigns no
+// BIP39, derivation-path, account-index, network, or storage-path semantics to
+// the entropy.
+//
+// Only one mobile wallet may be active at a time; call Stop before selecting
+// another wallet directory. A successful response means wallet-dependent
+// actors and mailbox ingress are online, so the first wallet operation does not
+// need a separate readiness poll. Later authenticated terms refreshes and
+// wallet-ready hooks are outside this transport's success boundary.
+//
+// Existing Start callers are unaffected. After this path claims a stopped
+// lifecycle, a startup, import, unlock, recovery, or identity-check failure
+// resets it to stopped. A call rejected because another wallet is already
+// active leaves that wallet running. RecoverState is a per-start restore
+// request; after a successful recovery, ordinary starts should leave it false.
+func StartExternalSeedWallet(reqJSON []byte) ([]byte, error) {
+	var result *wavewalletdk.ExternalSeedWalletOpenResult
+	err := startEmbedded(func(startCtx, operationCtx context.Context) (
+		*wavewalletdk.Client, error) {
+
+		cfg, req, err := parseExternalSeedWalletStartRequest(reqJSON)
+		if err != nil {
+			return nil, fmt.Errorf("parse external-seed wallet "+
+				"request: %w", err)
+		}
+		defer clear(req.SeedEntropy)
+
+		client, openResult, err :=
+			wavewalletdk.StartExternalSeedWalletWithContexts(
+				startCtx, operationCtx, cfg, req,
+			)
+		if err != nil {
+			return nil, fmt.Errorf("start external-seed wallet: %w",
+				err)
+		}
+
+		result = openResult
+
+		return client, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(result)
+}
+
+// parseExternalSeedWalletStartRequest separates the final startup config from
+// the secret wallet entropy. Only the nested config shape is accepted so the
+// selected state directory cannot be confused with transport-level fields.
+func parseExternalSeedWalletStartRequest(reqJSON []byte) (wavewalletdk.Config,
+	wavewalletdk.ExternalSeedWalletRequest, error) {
+
+	var envelope externalSeedWalletStartRequest
+	parseFailed := true
+	defer func() {
+		if parseFailed {
+			clear(envelope.SeedEntropy)
+		}
+	}()
+
+	if err := json.Unmarshal(reqJSON, &envelope); err != nil {
+		return wavewalletdk.Config{},
+			wavewalletdk.ExternalSeedWalletRequest{}, fmt.Errorf(
+				"decode "+
+					"request: %w", err)
+	}
+
+	nested := bytes.TrimSpace(envelope.Config)
+	if len(nested) == 0 || bytes.Equal(nested, []byte("null")) {
+		return wavewalletdk.Config{},
+			wavewalletdk.ExternalSeedWalletRequest{},
+			errors.New("config must be a nested object")
+	}
+
+	var mobileCfg mobileConfig
+	if err := json.Unmarshal(nested, &mobileCfg); err != nil {
+		return wavewalletdk.Config{},
+			wavewalletdk.ExternalSeedWalletRequest{}, fmt.Errorf(
+				"decode nested "+
+					"config: %w", err)
+	}
+	if mobileCfg.DataDir == "" {
+		return wavewalletdk.Config{},
+			wavewalletdk.ExternalSeedWalletRequest{}, errors.New(
+				"config.data_dir must select the final " +
+					"wallet directory")
+	}
+
+	cfg, err := parseConfig(string(nested))
+	if err != nil {
+		return wavewalletdk.Config{},
+			wavewalletdk.ExternalSeedWalletRequest{}, err
+	}
+	if len(envelope.SeedEntropy) != aezeed.EntropySize {
+		return wavewalletdk.Config{},
+			wavewalletdk.ExternalSeedWalletRequest{}, fmt.Errorf(
+				"seed_entropy must decode to exactly %d "+
+					"bytes: got %d", aezeed.EntropySize,
+				len(envelope.SeedEntropy))
+	}
+
+	req := wavewalletdk.ExternalSeedWalletRequest{
+		SeedEntropy:            envelope.SeedEntropy,
+		ExpectedIdentityPubKey: envelope.ExpectedIdentity,
+		RecoverState:           envelope.RecoverState,
+		RecoveryWindow:         envelope.RecoveryWindow,
+	}
+	parseFailed = false
+
+	return cfg, req, nil
+}

--- a/sdk/wavewalletdk/mobile/external_seed_wallet_test.go
+++ b/sdk/wavewalletdk/mobile/external_seed_wallet_test.go
@@ -1,0 +1,159 @@
+//go:build mobile && wavewalletrpc && swapruntime
+
+package mobile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/wavelength/sdk/wavewalletdk"
+	"github.com/stretchr/testify/require"
+)
+
+// resetMobileState isolates tests that exercise the package singleton.
+func resetMobileState(t *testing.T) {
+	t.Helper()
+	require.NoError(t, Stop())
+	t.Cleanup(func() { _ = Stop() })
+}
+
+// requireContextDone checks a synchronous context cancellation boundary.
+func requireContextDone(t *testing.T, ctx context.Context, want bool) {
+	t.Helper()
+
+	select {
+	case <-ctx.Done():
+		require.True(t, want, "context unexpectedly cancelled")
+
+	default:
+		require.False(t, want, "context was not cancelled")
+	}
+}
+
+// TestParseExternalSeedWalletStartRequest verifies the private wire contract.
+func TestParseExternalSeedWalletStartRequest(t *testing.T) {
+	cfg, req, err := parseExternalSeedWalletStartRequest([]byte(`{
+		"config": {
+			"data_dir": "/tmp/wavelength-wallet",
+			"network": "regtest",
+			"wallet_type": "btcwallet"
+		},
+		"seed_entropy": "ABEiM0RVZneImaq7zN3u/w==",
+		"expected_identity_pubkey": "02abcdef",
+		"recover_state": true,
+		"recovery_window": 144
+	}`))
+	require.NoError(t, err)
+	defer clear(req.SeedEntropy)
+	require.Equal(t, "/tmp/wavelength-wallet", cfg.DataDir)
+	require.Equal(t, "regtest", cfg.Network)
+	require.Equal(t, "btcwallet", cfg.WalletType)
+	require.Equal(t, []byte{
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+		0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+	}, req.SeedEntropy)
+	require.Equal(t, "02abcdef", req.ExpectedIdentityPubKey)
+	require.True(t, req.RecoverState)
+	require.Equal(t, uint32(144), req.RecoveryWindow)
+}
+
+// TestParseExternalSeedWalletStartRequestRejectsInvalid tests its wire shape.
+func TestParseExternalSeedWalletStartRequestRejectsInvalid(t *testing.T) {
+	tests := []struct{ name, request string }{
+		{"flat config", `{
+			"data_dir":"/flat",
+			"seed_entropy":"ABEiM0RVZneImaq7zN3u/w=="
+		}`},
+		{"non-base64 entropy", `{
+			"config":{"data_dir":"/tmp/wavelength-wallet"},
+			"seed_entropy":"not_base64"
+		}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := parseExternalSeedWalletStartRequest(
+				[]byte(test.request),
+			)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestStartExternalSeedWalletRejectsBadRequestAndResets tests lifecycle reset.
+func TestStartExternalSeedWalletRejectsBadRequestAndResets(t *testing.T) {
+	resetMobileState(t)
+	_, err := StartExternalSeedWallet([]byte(`{
+		"config":{"data_dir":"/tmp/external-seed-test"},
+		"seed_entropy":"AQ=="
+	}`))
+	require.Error(t, err)
+	require.False(t, IsRunning())
+}
+
+// TestStartEmbeddedSeparatesLifecycleContexts tests context ownership.
+func TestStartEmbeddedSeparatesLifecycleContexts(t *testing.T) {
+	resetMobileState(t)
+
+	var startCtx, operationCtx context.Context
+	err := startEmbedded(func(start, operation context.Context) (
+		*wavewalletdk.Client, error) {
+
+		startCtx, operationCtx = start, operation
+
+		return &wavewalletdk.Client{}, nil
+	})
+	require.NoError(t, err)
+	_, startHasDeadline := startCtx.Deadline()
+	_, operationHasDeadline := operationCtx.Deadline()
+	require.True(t, startHasDeadline)
+	require.False(t, operationHasDeadline)
+	requireContextDone(t, startCtx, true)
+	requireContextDone(t, operationCtx, false)
+
+	_, activeCtx, err := activeClient()
+	require.NoError(t, err)
+	require.True(t, activeCtx == operationCtx)
+	require.NoError(t, Stop())
+	requireContextDone(t, operationCtx, true)
+}
+
+// TestStopCancelsStartupContexts tests cancellation during startup.
+func TestStopCancelsStartupContexts(t *testing.T) {
+	resetMobileState(t)
+
+	type startupContexts struct {
+		start, operation context.Context
+	}
+	returned := make(chan error, 1)
+	published := make(chan startupContexts, 1)
+	go func() {
+		returned <- startEmbedded(
+			func(start, operation context.Context) (
+				*wavewalletdk.Client, error) {
+
+				published <- startupContexts{start, operation}
+				<-operation.Done()
+
+				return nil, operation.Err()
+			},
+		)
+	}()
+
+	var contexts startupContexts
+	select {
+	case contexts = <-published:
+	case <-t.Context().Done():
+		t.Fatal("startup callback was not entered")
+	}
+	require.NoError(t, Stop())
+	select {
+	case err := <-returned:
+		require.ErrorIs(t, err, context.Canceled)
+
+	case <-t.Context().Done():
+		t.Fatal("cancelled startup did not return")
+	}
+	requireContextDone(t, contexts.start, true)
+	requireContextDone(t, contexts.operation, true)
+	require.False(t, IsRunning())
+}

--- a/sdk/wavewalletdk/mobile/mobile.go
+++ b/sdk/wavewalletdk/mobile/mobile.go
@@ -14,10 +14,10 @@ import (
 	"github.com/lightninglabs/wavelength/sdk/wavewalletdk"
 )
 
-// startTimeout bounds how long Start will wait for the embedded daemon's gRPC
-// transport to report readiness before giving up. The daemon lifetime itself
-// is owned by wavewalletdk's internal runCtx, so this deadline only cancels
-// dialing, never the running daemon.
+// startTimeout bounds how long either startup path waits for the embedded
+// daemon's gRPC transport to report readiness. Wallet opening and recovery use
+// a separate lifecycle context, while the running daemon is owned by
+// wavewalletdk's internal runCtx.
 const startTimeout = 90 * time.Second
 
 // lifecycleStatus is the explicit state of the embedded daemon. A plain CAS on
@@ -73,7 +73,34 @@ var state = struct {
 // Start then tears down any client it produced instead of publishing it. A
 // panic in the boot path is recovered into the returned error so it never
 // crosses the gomobile boundary as a process kill.
-func Start(cfgJSON string) (err error) {
+func Start(cfgJSON string) error {
+	return startEmbedded(func(startCtx, _ context.Context) (
+		*wavewalletdk.Client, error) {
+
+		cfg, err := parseConfig(cfgJSON)
+		if err != nil {
+			return nil, fmt.Errorf("parse config: %w", err)
+		}
+
+		client, err := wavewalletdk.Start(startCtx, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("start embedded wallet: %w", err)
+		}
+
+		return client, nil
+	})
+}
+
+// startEmbedded owns the singleton lifecycle shared by Start and the additive
+// account-aware startup paths. startCtx has the bounded daemon-readiness
+// deadline. operationCtx has no deadline and remains valid for wallet opening,
+// recovery, and later mobile calls until Stop cancels it. The supplied function
+// must either return a fully initialized client or clean up any client it
+// started before returning an error.
+func startEmbedded(
+	start func(context.Context, context.Context) (*wavewalletdk.Client, error)) (
+	err error) {
+
 	state.mu.Lock()
 	if state.status != statusStopped {
 		state.mu.Unlock()
@@ -84,9 +111,14 @@ func Start(cfgJSON string) (err error) {
 	state.gen++
 	gen := state.gen
 
-	startCtx, startCancel := context.WithTimeout(
-		context.Background(), startTimeout,
+	operationCtx, operationCancel := context.WithCancel(
+		context.Background(),
 	)
+	startCtx, bootCancel := context.WithTimeout(operationCtx, startTimeout)
+	startCancel := func() {
+		bootCancel()
+		operationCancel()
+	}
 	state.startCancel = startCancel
 	state.mu.Unlock()
 
@@ -113,17 +145,10 @@ func Start(cfgJSON string) (err error) {
 		state.mu.Unlock()
 	}()
 
-	cfg, err := parseConfig(cfgJSON)
+	client, err := start(startCtx, operationCtx)
 	if err != nil {
-		return fmt.Errorf("parse config: %w", err)
+		return err
 	}
-
-	client, err := wavewalletdk.Start(startCtx, cfg)
-	if err != nil {
-		return fmt.Errorf("start embedded wallet: %w", err)
-	}
-
-	callCtx, callCancel := context.WithCancel(context.Background())
 
 	state.mu.Lock()
 	// A Stop raced this boot: it cancelled startCtx and moved us out of the
@@ -131,16 +156,23 @@ func Start(cfgJSON string) (err error) {
 	// it under a reset guard.
 	if state.status != statusStarting || state.gen != gen {
 		state.mu.Unlock()
+		startCancel()
 		_ = client.Stop()
 
 		return errors.New("wavewalletdk mobile start cancelled by Stop")
 	}
 	state.client = client
-	state.callCtx = callCtx
-	state.callCancel = callCancel
+	// The lifecycle context intentionally spans later RPC calls.
+	//nolint:fatcontext
+	state.callCtx = operationCtx
+	state.callCancel = operationCancel
 	state.startCancel = nil
 	state.status = statusStarted
 	state.mu.Unlock()
+
+	// The readiness deadline is no longer needed. Keep only the Stop-owned
+	// operation context for wallet calls and subscriptions.
+	bootCancel()
 
 	return nil
 }

--- a/sdk/wavewalletdk/passkey.go
+++ b/sdk/wavewalletdk/passkey.go
@@ -153,10 +153,13 @@ func deriveSeedAndPassword(passkeyPRFOutput []byte) ([aezeed.EntropySize]byte,
 func entropyToMnemonic(entropy [aezeed.EntropySize]byte) (aezeed.Mnemonic,
 	error) {
 
+	defer clear(entropy[:])
+
 	cipherSeed, err := aezeed.New(0, &entropy, aezeed.BitcoinGenesisDate)
 	if err != nil {
 		return aezeed.Mnemonic{}, err
 	}
+	defer clear(cipherSeed.Entropy[:])
 
 	return cipherSeed.ToMnemonic(nil)
 }

--- a/sdk/wavewalletdk/passkey_test.go
+++ b/sdk/wavewalletdk/passkey_test.go
@@ -25,6 +25,7 @@ type stubDaemonServer struct {
 	identity      string
 	freeWindow    uint32
 	initErr       error
+	initResp      *waverpc.InitWalletResponse
 	unlockErr     error
 	initCalled    bool
 	unlockCalled  bool
@@ -73,6 +74,9 @@ func (s *stubDaemonServer) InitWallet(_ context.Context,
 	s.lastInitReq = req
 	if s.initErr != nil {
 		return nil, s.initErr
+	}
+	if s.initResp != nil {
+		return s.initResp, nil
 	}
 
 	return &waverpc.InitWalletResponse{IdentityPubkey: "init-id"}, nil

--- a/sdk/wavewalletdk/types.go
+++ b/sdk/wavewalletdk/types.go
@@ -152,6 +152,21 @@ type OpenWalletResult struct {
 	IdentityPubKey string
 }
 
+// ExternalSeedWalletOpenResult reports an external-seed wallet import or
+// unlock and the optional state-recovery scan performed for that operation.
+// It deliberately omits the transient internal aezeed mnemonic: the host-owned
+// external root and derivation contract are the wallet's backup boundary.
+type ExternalSeedWalletOpenResult struct {
+	Imported                    bool
+	IdentityPubKey              string
+	RecoveryRan                 bool
+	RecoveredBoardingAddresses  uint32
+	RecoveredBoardingUTXOs      uint32
+	RecoveredVTXOs              uint32
+	RecoveredOORReceiveScripts  uint32
+	RecoveredOORRecipientEvents uint32
+}
+
 // Balance is the wallet-level balance view.
 type Balance struct {
 	ConfirmedSat       int64

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -29,6 +29,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   `MaxOperatorFeeSat` (the #270 seal-time fee-cap validated in
   `Config.Validate()`).
 - `WalletState` — `None` / `Locked` / `Ready` wallet lifecycle.
+- `WalletRecoveryResult` — counters returned by the in-process,
+  post-unlock recovery hook.
 - `UnrollConfig` / `OORConfig` — subsystem tunables; see `Config.Validate()`
   for the invariants each enforces.
 
@@ -65,6 +67,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 - Wallet transitions `None → Locked → Ready` (or direct to `Ready` if a seed
   is provided). Three wallet backends: LND, lightweight (`lwwallet`), or
   neutrino-backed (`btcwallet` via `btcwbackend`).
+- `WaitForWalletServicesReady` resolves after wallet-dependent actors and
+  mailbox ingress start, or with the first error before that boundary.
+  `DaemonReady` remains the later full-startup signal.
+- `Server.RecoverWalletState` is an in-process, post-unlock retry seam. It
+  keeps the supplied context through the scan; idempotent writes make a partial
+  scan safe to retry.
 - Mailbox IDs are derived from identity pubkeys via
   `serverconn.PubKeyMailboxID`, not config strings. The operator's remote
   mailbox ID and pubkey are fetched via direct gRPC (`fetchCurrentOperatorPubKey`)

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -29,6 +29,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   `MaxOperatorFeeSat` (the #270 seal-time fee-cap validated in
   `Config.Validate()`).
 - `WalletState` — `None` / `Locked` / `Ready` wallet lifecycle.
+- `WalletRecoveryResult` — counters returned by the in-process,
+  post-unlock recovery hook.
 - `UnrollConfig` / `OORConfig` — subsystem tunables; see `Config.Validate()`
   for the invariants each enforces.
 
@@ -65,6 +67,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 - Wallet transitions `None → Locked → Ready` (or direct to `Ready` if a seed
   is provided). Three wallet backends: LND, lightweight (`lwwallet`), or
   neutrino-backed (`btcwallet` via `btcwbackend`).
+- `WaitForWalletServicesReady` resolves after wallet-dependent actors and
+  mailbox ingress start, or with the first error before that boundary.
+  `DaemonReady` remains the later full-startup signal.
+- `Server.RecoverWalletState` is an in-process, post-unlock retry seam. It
+  keeps the supplied context through the scan; idempotent writes make a partial
+  scan safe to retry.
 - Mailbox IDs are derived from identity pubkeys via
   `serverconn.PubKeyMailboxID`, not config strings. The operator's remote
   mailbox ID and pubkey are fetched via direct gRPC (`fetchCurrentOperatorPubKey`)

--- a/waved/rpc_wallet.go
+++ b/waved/rpc_wallet.go
@@ -524,7 +524,7 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 	// failures are reported as such: the caller must not retry
 	// InitWallet (the daemon is already unlocked), only the
 	// post-start step that failed.
-	var recoveryResult *walletRecoveryResult
+	var recoveryResult *WalletRecoveryResult
 	if req.GetRecoverState() {
 		recoveryResult, err = r.recoverWalletState(
 			ctx, req.GetRecoveryWindow(),

--- a/waved/server.go
+++ b/waved/server.go
@@ -255,6 +255,14 @@ type Server struct {
 	// handlers that require wallet access select on this channel.
 	walletReady chan struct{}
 
+	// walletServicesReady is resolved after wallet-dependent actors and
+	// mailbox ingress have started. The first result is sticky: failures
+	// before that boundary are published to waiters, while later startup
+	// failures cannot replace a successful result.
+	walletServicesReady     chan struct{}
+	walletServicesReadyErr  error
+	walletServicesReadyOnce sync.Once
+
 	// daemonReady is closed when all startup steps have
 	// completed: wallet initialized, mailbox transport
 	// connected, and wallet-dependent actors started. Test
@@ -432,18 +440,19 @@ type Server struct {
 	forfeitSignatures *forfeitSignatureBroker
 }
 
-// NewServer allocates a Server from a validated Config. The server is
-// inert until RunUntilShutdown is called. The walletReady channel and
-// recovery preimage registry are initialized here so RPC handlers can use
-// them immediately.
+// NewServer allocates a Server from a validated Config. The server is inert
+// until RunUntilShutdown is called. The wallet and wallet-services readiness
+// signals and recovery preimage registry are initialized here so RPC handlers
+// and embedded clients can use them immediately.
 func NewServer(cfg *Config) (*Server, error) {
 	return &Server{
-		cfg:               cfg,
-		clk:               clock.NewDefaultClock(),
-		walletReady:       make(chan struct{}),
-		daemonReady:       make(chan struct{}),
-		vhtlcPreimages:    &unrollpolicy.PreimageResolverRegistry{},
-		forfeitSignatures: newForfeitSignatureBroker(),
+		cfg:                 cfg,
+		clk:                 clock.NewDefaultClock(),
+		walletReady:         make(chan struct{}),
+		walletServicesReady: make(chan struct{}),
+		daemonReady:         make(chan struct{}),
+		vhtlcPreimages:      &unrollpolicy.PreimageResolverRegistry{},
+		forfeitSignatures:   newForfeitSignatureBroker(),
 	}, nil
 }
 
@@ -513,6 +522,61 @@ func (s *Server) markWalletReady() {
 	s.walletReadyOnce.Do(func() {
 		close(s.walletReady)
 	})
+}
+
+// markWalletServicesReady publishes the first wallet-services startup result.
+// A nil error means wallet-dependent actors and mailbox ingress are online.
+// Once that boundary is crossed, authenticated terms refreshes and wallet-ready
+// hooks cannot replace success with their later errors.
+func (s *Server) markWalletServicesReady(err error) {
+	s.walletServicesReadyOnce.Do(func() {
+		s.walletServicesReadyErr = err
+		close(s.walletServicesReady)
+	})
+}
+
+// markWalletServicesStopped resolves an unfinished readiness wait when the
+// daemon run loop exits before wallet-dependent services come online. A prior
+// readiness result remains sticky and cannot be replaced during shutdown.
+func (s *Server) markWalletServicesStopped(runErr, contextErr error) {
+	if runErr == nil {
+		runErr = contextErr
+	}
+	if runErr == nil {
+		runErr = errors.New("daemon stopped")
+	}
+
+	s.markWalletServicesReady(
+		fmt.Errorf("daemon exited before wallet services were "+
+			"ready: %w", runErr),
+	)
+}
+
+// WaitForWalletServicesReady waits until wallet-dependent actors and mailbox
+// ingress are online, or returns the first error encountered before that
+// boundary. It intentionally does not wait for authenticated terms refreshes,
+// pending-intent replay, or wallet-ready hooks.
+func (s *Server) WaitForWalletServicesReady(ctx context.Context) error {
+	if s == nil || s.walletServicesReady == nil {
+		return errors.New("wallet services readiness signal " +
+			"unavailable")
+	}
+
+	select {
+	case <-s.walletServicesReady:
+		return s.walletServicesReadyErr
+
+	case <-ctx.Done():
+		// Prefer a result published concurrently with cancellation so a
+		// completed startup is not reported as cancelled.
+		select {
+		case <-s.walletServicesReady:
+			return s.walletServicesReadyErr
+
+		default:
+			return ctx.Err()
+		}
+	}
 }
 
 // markDaemonReady closes the daemonReady channel, signaling that all
@@ -1030,9 +1094,21 @@ func (s *Server) RunWithContext(ctx context.Context) error {
 // run is the shared core startup logic for both RunUntilShutdown
 // and RunWithContext. The shutdownFn is wired into the logging
 // subsystem so critical log events can trigger daemon shutdown.
+func (s *Server) run(ctx context.Context, shutdownFn func()) error {
+	var runErr error
+	defer func() {
+		s.markWalletServicesStopped(runErr, ctx.Err())
+	}()
+
+	runErr = s.runInner(ctx, shutdownFn)
+
+	return runErr
+}
+
+// runInner performs the daemon startup, service, and shutdown sequence.
 //
 //nolint:funlen
-func (s *Server) run(ctx context.Context, shutdownFn func()) error {
+func (s *Server) runInner(ctx context.Context, shutdownFn func()) error {
 	// Store the run context so background goroutines (like the
 	// btcwallet sync poller) can outlive individual RPC
 	// handlers but still shut down with the daemon.
@@ -1531,6 +1607,10 @@ func (s *Server) run(ctx context.Context, shutdownFn func()) error {
 				ctx, chainSourceRef, timeoutRef,
 			)
 			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+
 				s.log.ErrorS(
 					ctx,
 					"Failed to start wallet-ready services",
@@ -1569,18 +1649,26 @@ func (s *Server) startWalletReadyServices(ctx context.Context,
 	], timeoutRef actor.TellOnlyRef[timeout.Msg]) error {
 
 	if err := s.connectAndBootstrapMailbox(ctx); err != nil {
+		s.markWalletServicesReady(err)
+
 		return err
 	}
 
 	if err := s.startWalletDependentActors(
 		ctx, chainSourceRef, timeoutRef,
 	); err != nil {
+
+		s.markWalletServicesReady(err)
+
 		return err
 	}
 
 	if err := s.startMailboxIngress(ctx); err != nil {
+		s.markWalletServicesReady(err)
+
 		return err
 	}
+	s.markWalletServicesReady(nil)
 
 	// The bootstrap GetInfo call cannot use the mailbox identity because
 	// the runtime does not exist yet. Refresh the cached terms now that

--- a/waved/wallet_ops.go
+++ b/waved/wallet_ops.go
@@ -9,11 +9,13 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/oor"
 	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightninglabs/wavelength/walletcore"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/lightningnetwork/lnd/aezeed"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -52,6 +54,58 @@ func WalletSeedFromMnemonic(mnemonic []string, seedPassphrase,
 	}
 
 	return seed, birthday, nil
+}
+
+// WalletIdentityPubKeyFromSeed derives the self-managed wallet identity at
+// m/1017'/coinType'/6'/0/0 without creating or opening a wallet database. It
+// deliberately uses btcwallet's legacy-compatible BIP32 derivation so the
+// result matches both lwwallet and btcwallet exactly.
+func WalletIdentityPubKeyFromSeed(seed [rawSeedLen]byte,
+	network string) (string, error) {
+
+	defer zeroBytes(seed[:])
+
+	chainParams, err := networkToChainParams(network)
+	if err != nil {
+		return "", err
+	}
+
+	coinType := walletcore.CoinTypeForNet(chainParams)
+	key, err := hdkeychain.NewMaster(seed[:], chainParams)
+	if err != nil {
+		return "", fmt.Errorf("derive identity master key: %w", err)
+	}
+	defer func() {
+		key.Zero()
+	}()
+
+	path := []uint32{
+		keychain.BIP0043Purpose + hdkeychain.HardenedKeyStart,
+		coinType + hdkeychain.HardenedKeyStart,
+		uint32(keychain.KeyFamilyNodeKey) +
+			hdkeychain.HardenedKeyStart,
+		0,
+		0,
+	}
+	for _, childIndex := range path {
+		child, err := key.DeriveNonStandard(
+			childIndex,
+		)
+		if err != nil {
+			return "", fmt.Errorf("derive identity child %d: %w",
+				childIndex, err)
+		}
+
+		key.Zero()
+		key = child
+	}
+
+	pubKey, err := key.ECPubKey()
+	if err != nil {
+		return "", fmt.Errorf("derive identity public key: %w", err)
+	}
+
+	return fmt.Sprintf("%x", pubKey.SerializeCompressed()), nil
 }
 
 // ValidateWalletPassword enforces the daemon-wide minimum wallet

--- a/waved/wallet_recovery.go
+++ b/waved/wallet_recovery.go
@@ -41,12 +41,31 @@ const (
 	recoveryIndexerRetryMax      = 5 * time.Second
 )
 
-type walletRecoveryResult struct {
+// WalletRecoveryResult reports the state discovered by one idempotent wallet
+// recovery scan. Counters describe artifacts found and persisted during that
+// scan; on a retry, some artifacts may already have existed locally.
+type WalletRecoveryResult struct {
 	BoardingAddresses uint32
 	BoardingUTXOs     uint32
 	VTXOs             uint32
 	OORReceiveScripts uint32
 	OOREvents         uint32
+}
+
+// RecoverWalletState reruns the daemon's idempotent seed-recovery scan. It is
+// intended for in-process embedders that need to retry recovery after wallet
+// initialization succeeded but the original scan did not.
+func (s *Server) RecoverWalletState(ctx context.Context, window uint32) (
+	*WalletRecoveryResult, error) {
+
+	if s == nil {
+		return nil, fmt.Errorf("wallet server is nil")
+	}
+	if s.rpcServer == nil {
+		return nil, fmt.Errorf("wallet RPC server is not running")
+	}
+
+	return s.rpcServer.recoverWalletState(ctx, window)
 }
 
 // retryRecoveryIndexerRPC retries recovery-local indexer calls that hit the
@@ -74,7 +93,7 @@ func retryRecoveryIndexerRPC(ctx context.Context,
 	)
 }
 
-func (r walletRecoveryResult) apply(resp *waverpc.InitWalletResponse) {
+func (r WalletRecoveryResult) apply(resp *waverpc.InitWalletResponse) {
 	resp.RecoveryRan = true
 	resp.RecoveredBoardingAddresses = r.BoardingAddresses
 	resp.RecoveredBoardingUtxos = r.BoardingUTXOs
@@ -84,7 +103,7 @@ func (r walletRecoveryResult) apply(resp *waverpc.InitWalletResponse) {
 }
 
 func (r *RPCServer) recoverWalletState(ctx context.Context, window uint32) (
-	*walletRecoveryResult, error) {
+	*WalletRecoveryResult, error) {
 
 	if window == 0 {
 		window = r.server.cfg.Wallet.RecoveryWindow
@@ -99,12 +118,12 @@ func (r *RPCServer) recoverWalletState(ctx context.Context, window uint32) (
 
 	// InitWallet stores the seed before this point, which lets the daemon
 	// start wallet-backed services on a separate goroutine. Recovery needs
-	// those services, so wait for that async startup before scanning.
-	select {
-	case <-r.server.DaemonReady():
-	case <-ctx.Done():
+	// the actors and mailbox ingress, but not the later authenticated terms
+	// refresh or wallet-ready hooks, so wait on the precise service
+	// boundary.
+	if err := r.server.WaitForWalletServicesReady(ctx); err != nil {
 		return nil, fmt.Errorf("wait for wallet-ready services: %w",
-			ctx.Err())
+			err)
 	}
 
 	if r.server.indexer == nil {
@@ -116,7 +135,7 @@ func (r *RPCServer) recoverWalletState(ctx context.Context, window uint32) (
 		return nil, err
 	}
 
-	var result walletRecoveryResult
+	var result WalletRecoveryResult
 	if err := r.recoverBoardingKeys(
 		ctx, terms, window, &result,
 	); err != nil {
@@ -138,7 +157,7 @@ func (r *RPCServer) recoverWalletState(ctx context.Context, window uint32) (
 
 func (r *RPCServer) recoverBoardingKeys(ctx context.Context,
 	terms *libtypes.OperatorTerms, window uint32,
-	result *walletRecoveryResult) error {
+	result *WalletRecoveryResult) error {
 
 	backend, err := r.server.recoveryBoardingBackend()
 	if err != nil {
@@ -236,7 +255,7 @@ func (s *Server) recoveryBoardingBackend() (wallet.BoardingBackend, error) {
 
 func (r *RPCServer) recoverIndexedVTXOs(ctx context.Context,
 	terms *libtypes.OperatorTerms, window uint32,
-	result *walletRecoveryResult) error {
+	result *WalletRecoveryResult) error {
 
 	for i := uint32(0); i < window; i++ {
 		keyDesc, err := r.server.proofKeyBackend.DeriveKey(
@@ -531,7 +550,7 @@ func (r *RPCServer) notifyRecoveredVTXOs(ctx context.Context,
 
 func (r *RPCServer) recoverOORReceiveScripts(ctx context.Context,
 	terms *libtypes.OperatorTerms, window uint32,
-	result *walletRecoveryResult) error {
+	result *WalletRecoveryResult) error {
 
 	var registered *arkrpc.ListMyReceiveScriptsResponse
 	err := retryRecoveryIndexerRPC(ctx, func(
@@ -674,7 +693,7 @@ func (r *RPCServer) recoveryOORHandler(
 func (r *RPCServer) recoverOOREventsForScript(ctx context.Context,
 	idx *indexer.Client, pkScript []byte, ensureScript func() error,
 	handler *oor.LocalPersistenceOutboxHandler,
-	result *walletRecoveryResult) error {
+	result *WalletRecoveryResult) error {
 
 	var afterEventID uint64
 	for {

--- a/waved/wallet_recovery_test.go
+++ b/waved/wallet_recovery_test.go
@@ -10,6 +10,22 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// TestRecoverWalletStateRequiresRunningServer verifies the in-process retry
+// hook reports lifecycle misuse instead of dereferencing an unavailable RPC
+// server. Legacy startup still owns when that server becomes available.
+func TestRecoverWalletStateRequiresRunningServer(t *testing.T) {
+	t.Parallel()
+
+	var nilServer *Server
+	_, err := nilServer.RecoverWalletState(t.Context(), 1)
+	require.ErrorContains(t, err, "server is nil")
+
+	server, err := NewServer(DefaultConfig())
+	require.NoError(t, err)
+	_, err = server.RecoverWalletState(t.Context(), 1)
+	require.ErrorContains(t, err, "not running")
+}
+
 // TestRetryRecoveryIndexerRPCRetriesResourceExhausted verifies seed recovery
 // backs off and retries when the operator query limiter rejects a scan request.
 func TestRetryRecoveryIndexerRPCRetriesResourceExhausted(t *testing.T) {

--- a/waved/wallet_services_ready_test.go
+++ b/waved/wallet_services_ready_test.go
@@ -1,0 +1,122 @@
+package waved
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWaitForWalletServicesReady verifies the readiness result is broadcast to
+// every waiter and that the first success or pre-ready failure remains final.
+func TestWaitForWalletServicesReady(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success ignores later error", func(t *testing.T) {
+		t.Parallel()
+
+		server := &Server{
+			walletServicesReady: make(chan struct{}),
+		}
+		ctx := t.Context()
+		results := make(chan error, 2)
+		for range 2 {
+			go func() {
+				results <- server.WaitForWalletServicesReady(
+					ctx,
+				)
+			}()
+		}
+
+		server.markWalletServicesReady(nil)
+		server.markWalletServicesReady(errors.New("late hook failed"))
+
+		require.NoError(t, <-results)
+		require.NoError(t, <-results)
+	})
+
+	t.Run("failure remains final", func(t *testing.T) {
+		t.Parallel()
+
+		wantErr := errors.New("mailbox ingress failed")
+		server := &Server{
+			walletServicesReady: make(chan struct{}),
+		}
+		server.markWalletServicesReady(wantErr)
+		server.markWalletServicesReady(nil)
+
+		require.ErrorIs(
+			t,
+			server.WaitForWalletServicesReady(
+				t.Context(),
+			),
+			wantErr,
+		)
+		require.ErrorIs(
+			t,
+			server.WaitForWalletServicesReady(
+				t.Context(),
+			),
+			wantErr,
+		)
+	})
+
+	t.Run("context cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		server := &Server{
+			walletServicesReady: make(chan struct{}),
+		}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		require.ErrorIs(
+			t, server.WaitForWalletServicesReady(ctx),
+			context.Canceled,
+		)
+	})
+
+	t.Run("daemon exits before ready", func(t *testing.T) {
+		t.Parallel()
+
+		runErr := errors.New("run failed")
+		server := &Server{
+			walletServicesReady: make(chan struct{}),
+		}
+		server.markWalletServicesStopped(runErr, nil)
+
+		require.ErrorIs(
+			t,
+			server.WaitForWalletServicesReady(
+				t.Context(),
+			),
+			runErr,
+		)
+	})
+
+	t.Run("shutdown before ready", func(t *testing.T) {
+		t.Parallel()
+
+		server := &Server{
+			walletServicesReady: make(chan struct{}),
+		}
+		server.markWalletServicesStopped(nil, context.Canceled)
+
+		require.ErrorIs(
+			t,
+			server.WaitForWalletServicesReady(
+				t.Context(),
+			),
+			context.Canceled,
+		)
+	})
+
+	t.Run("signal unavailable", func(t *testing.T) {
+		t.Parallel()
+
+		var server *Server
+		err := server.WaitForWalletServicesReady(t.Context())
+		require.ErrorContains(t, err, "readiness signal unavailable")
+	})
+}


### PR DESCRIPTION
## Summary

Add a narrow, opt-in external-seed startup primitive for embedded Wavelength.

- accept exactly 16 bytes of already-derived seed entropy and an explicit final
  `Config.DataDir`
- start either self-managed wallet backend (`lwwallet` or `btcwallet`) from
  that entropy
- bind a profile to an optional expected Wavelength identity before recovery
  runs
- expose the primitive through Go, gomobile, and the private WASM ABI
- wait for wallet actors and mailbox ingress before reporting startup success

Wavelength deliberately does **not** accept BIP39 mnemonics or define network,
account-index, derivation-path, root-ID, or profile-directory policy. The
consuming WDK owns those choices and passes only the derived entropy and final
directory. The paired wavelength-sdk change is typed transport only.

## Boundary and lifecycle

`StartExternalSeedWallet` is embedded-only. It converts the 16-byte entropy to
the existing aezeed wallet representation, derives a domain-separated database
password, and opens one complete daemon identity in the caller-selected
directory. There is no protobuf startup method and no seed is sent over gRPC.

When `ExpectedIdentityPubKey` is set, Wavelength derives the identity from the
supplied entropy before daemon startup or filesystem writes. On a new profile,
it then imports without recovery and verifies the backend-reported identity
again before an explicitly requested recovery scan. On a locked profile, it
unlocks with the deterministic database password, verifies the same identity,
and then runs recovery. A failed scan is retryable
on the next start without allowing an identity mismatch to register or persist
recovered state.

The mobile/WASM singleton is claimed atomically. A failure before wallet-service
readiness stops any daemon started by the operation and releases the lifecycle
for a retry.

The two-account integration also exposed a first-start shutdown problem:
btcwallet waited for recovery before stopping its Esplora chain source, while
the in-flight recovery request needed that source to be cancelled. The final
lwwallet commit gives the chain source a cancellable run context and cancels it
before btcwallet shutdown, including startup rollback.

## Compatibility and safety

- Existing `Start`, passkey, aezeed, `OpenWalletResult`, and data-directory
  behavior is unchanged.
- Existing wallets are never moved, re-derived, or implicitly selected.
- No protobuf or database schema migration is introduced.
- The externally owned `lnd` backend is rejected because Wavelength cannot seed
  it.
- Unsafe process-global seed/password hooks and state-path overrides are
  rejected on this path.
- The result does not expose a mnemonic.
- `Deposit` continues to return a Wavelength boarding address, not a BIP84
  receive address.
- `RecoverState` remains an explicit per-start operation and should be cleared
  after success.

## Live two-account proof

The current WASM build was exercised through the WDK Bare CLI with fresh signet
profiles for indices 0 and 1:

- both daemons ran concurrently in separate worker/WASM instances
- both logged `gRPC server listening addr=bufconn`; no TCP ports were allocated
- their final directories, daemon identities, and boarding addresses were
  distinct
- reopening the same two directories reproduced the same two identities
- the second run loaded prior boarding rows and skipped migrations and backups
- both stopped within the existing five-second deadline after the Esplora
  cancellation fix
- all six SQLite databases passed `quick_check`; no nodefs lock or open holder
  remained after daemon shutdown

## Commit story

1. `lwwallet: Cancel recovery before wallet shutdown`
2. `multi: Expose embedded wallet lifecycle hooks`
3. `sdk: Add external-seed wallet startup`
4. `mobile: Bridge external-seed wallet startup`
5. `docs: Document external-seed wallet startup`

## Validation

- `make fmt-changed`
- `make lint-changed-local` (0 issues)
- `make doc-check`
- `make commitmsg-lint range='origin/main..HEAD'`
- `make tidy-module-check`
- `go test ./lwwallet -count=1`
- focused lwwallet race tests
- `go test ./sdk/wavewalletdk -count=1`
- tagged mobile tests and focused mobile race tests
- `make wasm-wallet`
- live fresh-profile two-account WDK/Bare CLI run
- `git diff --check origin/main..HEAD`

Coverage includes both internal wallet backends, deterministic keyring identity,
fresh and locked profiles, identity-mismatch ordering, failed-recovery retry,
unsafe configuration rejection, lifecycle cancellation, readiness races, and
bounded recovery shutdown.

## Paired rollout

- Typed transport: [lightninglabs/wavelength-sdk#73](https://github.com/lightninglabs/wavelength-sdk/pull/73)
- WDK derivation and account integration: [rbndg/wavelength-wdk#1](https://github.com/rbndg/wavelength-wdk/pull/1)

Land this PR first and publish matching WASM, AAR, and XCFramework artifacts in
a new Wavelength release. The SDK draft must then update its runtime version,
digests, generated daemon types, and native bindings and exercise those released
artifacts. WDK can update its SDK pins and rebuild native addon prebuilds after
that synchronized release.
