### PR TITLE
harness: allow an lnd wallet to be restored from its seed

### DIFF
--- a/harness/AGENTS.md
+++ b/harness/AGENTS.md
@@ -16,7 +16,8 @@ helpers for end-to-end tests.
   `GenerateAndWait`), funding (`Faucet`, `FundOperatorLND`), reorg
   (`Reorg`, `ReorgDepth`, `ReconsiderBlock`), and multi-node helpers
   (`StartAdditionalLND`, `StartAdditionalLNDWithBackend`,
-  `SetupChannelBetween`).
+  `SetupChannelBetween`), and seed recovery helpers
+  (`StartAdditionalLNDWithSeed`, `RestoreLNDFromSeed`, `RescanLND`).
 - `Options` — `NewHarness` configuration: image tags, `LNDRequireInterceptor`,
   `LNDBuildPath`, `ArtifactsBaseDir`, `GroupName`, log-to-stdout toggles,
   `StartTapd`, `AlwaysKeepArtifacts`. `DefaultOptions()` gives safe defaults.
@@ -48,6 +49,24 @@ helpers for end-to-end tests.
   primary LND node resyncs to the new tip.
 - `LNDRequireInterceptor` only applies to the primary LND node; additional
   nodes started via `StartAdditionalLND*` never set it.
+- Seed recovery helpers operate on instances from
+  `StartAdditionalLNDWithSeed`. Serialize their lifecycle and client use
+  with other harness lifecycle operations, including `Stop`.
+- `RestoreLNDFromSeed` requires removal of the old container before deleting
+  the wallet and macaroons under the chain-specific directory. TLS survives.
+  LND then performs default-account seed recovery and waits for chain sync.
+- Custom accounts require the original key scope and account index, a
+  matching xpub, and at least the original external AND internal address
+  counts. Reconstruct them before calling `RescanLND`. A rescan reaching
+  the chain tip does not prove complete recovery; assert expected outpoints
+  and spendability in the caller's test.
+- Restore and rescan replace the container and close the old harness RPC
+  connection. The instance pointer remains stable, but its ports and client
+  are refreshed. Rebuild any separately constructed clients.
+- `systest.TestLNDSeedRestore` tests real wallet deletion, both address
+  branches, incomplete custom-account reconstruction, and spending restored
+  default-account coins. The custom fixture is watch-only because the pinned
+  image predates native custom-account creation.
 - Container teardown (`Stop`) is guarded by `sync.Once`; a signal handler
   also calls `Stop` as a safety net against orphaned containers.
 

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -16,7 +16,8 @@ helpers for end-to-end tests.
   `GenerateAndWait`), funding (`Faucet`, `FundOperatorLND`), reorg
   (`Reorg`, `ReorgDepth`, `ReconsiderBlock`), and multi-node helpers
   (`StartAdditionalLND`, `StartAdditionalLNDWithBackend`,
-  `SetupChannelBetween`).
+  `SetupChannelBetween`), and seed recovery helpers
+  (`StartAdditionalLNDWithSeed`, `RestoreLNDFromSeed`, `RescanLND`).
 - `Options` — `NewHarness` configuration: image tags, `LNDRequireInterceptor`,
   `LNDBuildPath`, `ArtifactsBaseDir`, `GroupName`, log-to-stdout toggles,
   `StartTapd`, `AlwaysKeepArtifacts`. `DefaultOptions()` gives safe defaults.
@@ -48,6 +49,24 @@ helpers for end-to-end tests.
   primary LND node resyncs to the new tip.
 - `LNDRequireInterceptor` only applies to the primary LND node; additional
   nodes started via `StartAdditionalLND*` never set it.
+- Seed recovery helpers operate on instances from
+  `StartAdditionalLNDWithSeed`. Serialize their lifecycle and client use
+  with other harness lifecycle operations, including `Stop`.
+- `RestoreLNDFromSeed` requires removal of the old container before deleting
+  the wallet and macaroons under the chain-specific directory. TLS survives.
+  LND then performs default-account seed recovery and waits for chain sync.
+- Custom accounts require the original key scope and account index, a
+  matching xpub, and at least the original external AND internal address
+  counts. Reconstruct them before calling `RescanLND`. A rescan reaching
+  the chain tip does not prove complete recovery; assert expected outpoints
+  and spendability in the caller's test.
+- Restore and rescan replace the container and close the old harness RPC
+  connection. The instance pointer remains stable, but its ports and client
+  are refreshed. Rebuild any separately constructed clients.
+- `systest.TestLNDSeedRestore` tests real wallet deletion, both address
+  branches, incomplete custom-account reconstruction, and spending restored
+  default-account coins. The custom fixture is watch-only because the pinned
+  image predates native custom-account creation.
 - Container teardown (`Stop`) is guarded by `sync.Once`; a signal handler
   also calls `Stop` as a safety net against orphaned containers.
 

--- a/harness/lnd_seed_restore.go
+++ b/harness/lnd_seed_restore.go
@@ -1,0 +1,342 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+const (
+	// seedRestoreRecoveryWindow is the address look-ahead lnd uses when a
+	// wallet is restored from a seed.
+	//
+	// It only governs lnd's own scan of the default account. A custom
+	// account is invisible to that scan whatever the window, which is the
+	// reason a restore test exists at all — but the window still has to be
+	// non-zero to enable default-account address discovery.
+	seedRestoreRecoveryWindow = 250
+
+	// walletUnlockerTimeout bounds a single wallet unlocker RPC.
+	walletUnlockerTimeout = 30 * time.Second
+)
+
+// lndWalletPassword is the password every harness-managed lnd wallet uses.
+// It has to be stable across a restore, since the wallet is re-initialized
+// with it after the original database is destroyed.
+var lndWalletPassword = []byte("itestpassword")
+
+// StartAdditionalLNDWithSeed launches an extra lnd whose wallet is created
+// from a freshly generated aezeed, and returns the instance together with that
+// seed's mnemonic. Serialize calls with other harness lifecycle operations.
+//
+// The harness normally starts lnd with --noseedbackup, which auto-creates a
+// wallet whose seed is never surfaced. That is fine until a test needs to
+// destroy the wallet and bring it back, which is impossible without the
+// mnemonic — so this path initializes the wallet explicitly instead.
+func (h *Harness) StartAdditionalLNDWithSeed(name string) (*LndInstance,
+	[]string) {
+
+	h.T.Helper()
+
+	if name == "" {
+		name = fmt.Sprintf("lnd-seeded-%d", len(h.extraLNDs)+1)
+	}
+	if _, exists := h.extraLNDs[name]; exists {
+		h.T.Fatalf("LND instance %s already exists", name)
+	}
+
+	dataDir := filepath.Join(h.artifactsDir, name)
+	inst := h.startLNDInstanceWithOptions(
+		name, dataDir, false, LNDChainBackendBitcoind, true, nil,
+	)
+
+	// Register before initialization so Stop also cleans up a failed init.
+	h.extraLNDs[name] = inst
+	h.T.Cleanup(func() {
+		if inst.Client != nil {
+			_ = inst.Client.ClientConn.Close()
+		}
+	})
+	mnemonic := h.initLNDFromSeed(inst, nil)
+	h.initAndWaitLNDInstance(inst)
+
+	return inst, mnemonic
+}
+
+// RestoreLNDFromSeed destroys an instance's wallet and brings it back from the
+// given mnemonic.
+//
+// This is the failure the recovery procedure exists for: the seed survives and
+// nothing else does. The wallet database is deleted rather than merely reset
+// so that the restored node genuinely rediscovers its state from the chain.
+//
+// LND performs its normal default-account seed recovery and chain sync.
+// Custom accounts require the caller to reconstruct the original key scope
+// and account index, verify the account xpub, and re-derive at least the
+// original external AND internal address counts. Call RescanLND afterwards;
+// a synchronized wallet alone does not prove that all funds were recovered.
+//
+// The container is recreated, so its ports may change; the instance is
+// the same pointer with its fields refreshed, and any client built against the
+// old ports has to be rebuilt. The old harness RPC connection is closed.
+// Use only instances returned by StartAdditionalLNDWithSeed, with callers
+// quiesced. Lifecycle calls and use of inst must be serialized with Stop.
+func (h *Harness) RestoreLNDFromSeed(inst *LndInstance, mnemonic []string) {
+	h.T.Helper()
+
+	require.NotNil(h.T, inst, "instance is required")
+	require.Len(h.T, mnemonic, 24, "aezeed mnemonic must be 24 words")
+
+	h.Logf("Destroying %s wallet and restoring from seed...", inst.Name)
+
+	h.stopSeedLND(inst)
+
+	// Remove the chain-specific state, which is where the wallet database
+	// and the macaroons live. Everything under it is regenerated on
+	// re-init; the TLS material above it is deliberately kept so clients
+	// keep trusting the same certificate.
+	chainDir := filepath.Join(
+		inst.DataDir, "data", "chain", "bitcoin", "regtest",
+	)
+	require.NoError(
+		h.T, os.RemoveAll(chainDir),
+		"remove %s wallet state", inst.Name,
+	)
+
+	res := h.startLNDContainer(lndConfig{
+		name:             inst.Name,
+		dataDir:          inst.DataDir,
+		bitcoindName:     h.bitcoindName,
+		network:          h.network,
+		group:            h.group,
+		image:            imageRepo(h.opts.LNDImage),
+		tag:              imageTag(h.opts.LNDImage),
+		manualWalletInit: true,
+		chainBackend:     LNDChainBackendBitcoind,
+	})
+
+	inst.Resource = res
+	inst.GRPCPort = res.GetPort("10009/tcp")
+	inst.RESTPort = res.GetPort("8080/tcp")
+	inst.ContainerName = strings.TrimPrefix(res.Container.Name, "/")
+	inst.Client = nil
+
+	h.waitForLNDDial(inst)
+	h.initLNDFromSeed(inst, mnemonic)
+	h.initAndWaitLNDInstance(inst)
+
+	h.Logf("%s restored from seed", inst.Name)
+}
+
+// initLNDFromSeed initializes an instance's wallet, generating a fresh aezeed
+// when no mnemonic is supplied and restoring the given one otherwise. It
+// returns the mnemonic the wallet was created from.
+func (h *Harness) initLNDFromSeed(inst *LndInstance,
+	mnemonic []string) []string {
+
+	h.T.Helper()
+
+	tlsCert, err := loadClientTLSCredentials(inst.TLSCert)
+	require.NoError(h.T, err, "load %s TLS credentials", inst.Name)
+
+	addr := net.JoinHostPort("127.0.0.1", inst.GRPCPort)
+	conn, err := grpc.NewClient(
+		addr, grpc.WithTransportCredentials(tlsCert),
+	)
+	require.NoError(h.T, err, "connect to %s wallet unlocker", inst.Name)
+	defer conn.Close()
+
+	h.waitForWalletState(conn, inst, lnrpc.WalletState_NON_EXISTING)
+
+	unlocker := lnrpc.NewWalletUnlockerClient(conn)
+
+	// A restore reuses the caller's mnemonic; a fresh start asks lnd for
+	// one so the test has something to restore from later.
+	recoveryWindow := int32(seedRestoreRecoveryWindow)
+	if len(mnemonic) == 0 {
+		ctx, cancel := context.WithTimeout(
+			h.T.Context(), walletUnlockerTimeout,
+		)
+		defer cancel()
+
+		seed, err := unlocker.GenSeed(ctx, &lnrpc.GenSeedRequest{})
+		require.NoError(h.T, err, "generate %s seed", inst.Name)
+
+		mnemonic = seed.GetCipherSeedMnemonic()
+
+		// A brand new wallet has nothing to recover, and asking for a
+		// recovery on one makes lnd scan the chain for no reason.
+		recoveryWindow = 0
+	}
+
+	ctx, cancel := context.WithTimeout(
+		h.T.Context(), walletUnlockerTimeout,
+	)
+	defer cancel()
+
+	_, err = unlocker.InitWallet(ctx, &lnrpc.InitWalletRequest{
+		WalletPassword:     lndWalletPassword,
+		CipherSeedMnemonic: mnemonic,
+		RecoveryWindow:     recoveryWindow,
+	})
+	require.NoError(h.T, err, "initialize %s wallet", inst.Name)
+
+	return mnemonic
+}
+
+// waitForWalletState blocks until an instance's wallet reports the given state.
+func (h *Harness) waitForWalletState(conn *grpc.ClientConn, inst *LndInstance,
+	want lnrpc.WalletState) {
+
+	h.T.Helper()
+
+	stateClient := lnrpc.NewStateClient(conn)
+	require.Eventually(
+		h.T, func() bool {
+			const checkTimeout = 5 * time.Second
+
+			ctx, cancel := context.WithTimeout(
+				h.T.Context(), checkTimeout,
+			)
+			defer cancel()
+
+			resp, err := stateClient.GetState(
+				ctx, &lnrpc.GetStateRequest{},
+			)
+			if err != nil {
+				return false
+			}
+
+			return resp.State == want
+		},
+		lndStartupTimeout, time.Second,
+		fmt.Sprintf("%s wallet did not reach %v", inst.Name, want),
+	)
+}
+
+// waitForLNDDial blocks until an instance serves TLS and accepts a connection.
+func (h *Harness) waitForLNDDial(inst *LndInstance) {
+	h.T.Helper()
+
+	require.Eventually(
+		h.T, func() bool {
+			if !lndTLSReady(inst.TLSCert) {
+				return false
+			}
+
+			addr := net.JoinHostPort("127.0.0.1", inst.GRPCPort)
+			conn, err := net.DialTimeout("tcp", addr, time.Second)
+			if err != nil {
+				return false
+			}
+			_ = conn.Close()
+
+			return true
+		},
+		lndStartupTimeout, time.Second,
+		fmt.Sprintf("%s TLS/gRPC not ready", inst.Name),
+	)
+}
+
+// RescanLND restarts an instance with --reset-wallet-transactions, forcing it
+// to rescan the chain for every address its wallet currently knows.
+//
+// This is the last step of recovering a custom account, and the order matters:
+// a rescan searches only for addresses already present in the wallet database,
+// so running it before the account is recreated and its addresses re-derived
+// finds nothing and reports an empty balance for a funded account.
+//
+// The wallet already exists here, so the node comes back locked and is
+// unlocked rather than initialized. As with a restore, the container is
+// recreated and the instance's ports may change. The old harness RPC
+// connection is closed. Use only instances from StartAdditionalLNDWithSeed
+// and serialize lifecycle calls and use of inst with Stop. Returning means
+// chain sync is complete, not that the caller rebuilt every funded address.
+func (h *Harness) RescanLND(inst *LndInstance) {
+	h.T.Helper()
+
+	require.NotNil(h.T, inst, "instance is required")
+
+	h.Logf("Rescanning %s from genesis...", inst.Name)
+
+	h.stopSeedLND(inst)
+
+	res := h.startLNDContainer(lndConfig{
+		name:             inst.Name,
+		dataDir:          inst.DataDir,
+		bitcoindName:     h.bitcoindName,
+		network:          h.network,
+		group:            h.group,
+		image:            imageRepo(h.opts.LNDImage),
+		tag:              imageTag(h.opts.LNDImage),
+		manualWalletInit: true,
+		chainBackend:     LNDChainBackendBitcoind,
+		extraArgs:        []string{"--reset-wallet-transactions"},
+	})
+
+	inst.Resource = res
+	inst.GRPCPort = res.GetPort("10009/tcp")
+	inst.RESTPort = res.GetPort("8080/tcp")
+	inst.ContainerName = strings.TrimPrefix(res.Container.Name, "/")
+	inst.Client = nil
+
+	h.waitForLNDDial(inst)
+	h.unlockLND(inst)
+	h.initAndWaitLNDInstance(inst)
+
+	h.Logf("%s rescan complete", inst.Name)
+}
+
+// unlockLND unlocks an instance whose wallet already exists.
+func (h *Harness) unlockLND(inst *LndInstance) {
+	h.T.Helper()
+
+	tlsCert, err := loadClientTLSCredentials(inst.TLSCert)
+	require.NoError(h.T, err, "load %s TLS credentials", inst.Name)
+
+	addr := net.JoinHostPort("127.0.0.1", inst.GRPCPort)
+	conn, err := grpc.NewClient(
+		addr, grpc.WithTransportCredentials(tlsCert),
+	)
+	require.NoError(h.T, err, "connect to %s wallet unlocker", inst.Name)
+	defer conn.Close()
+
+	h.waitForWalletState(conn, inst, lnrpc.WalletState_LOCKED)
+
+	ctx, cancel := context.WithTimeout(
+		h.T.Context(), walletUnlockerTimeout,
+	)
+	defer cancel()
+
+	_, err = lnrpc.NewWalletUnlockerClient(conn).UnlockWallet(
+		ctx, &lnrpc.UnlockWalletRequest{
+			WalletPassword: lndWalletPassword,
+		},
+	)
+	require.NoError(h.T, err, "unlock %s wallet", inst.Name)
+}
+
+// stopSeedLND closes the old RPC connection and requires removal of the exact
+// container before its wallet files can be deleted or reopened by a restart.
+// Best-effort name cleanup is insufficient at this destructive boundary.
+func (h *Harness) stopSeedLND(inst *LndInstance) {
+	h.T.Helper()
+
+	if inst.Client != nil {
+		_ = inst.Client.ClientConn.Close()
+		inst.Client = nil
+	}
+
+	require.NoError(
+		h.T, h.pool.Purge(inst.Resource),
+		"remove %s before changing wallet state", inst.Name,
+	)
+}

--- a/systest/lnd_seed_restore_test.go
+++ b/systest/lnd_seed_restore_test.go
@@ -1,0 +1,236 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/wavelength/harness"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/connectivity"
+)
+
+// TestLNDSeedRestore proves that a deleted wallet recovers default-account
+// coins from its seed, while custom-account scanning requires both branches
+// to be reconstructed first. The custom fixture imports an xpub because the
+// pinned LND image predates native custom-account creation. It intentionally
+// remains watch-only; spendability is proved separately for the default
+// account, which has private keys from the restored seed.
+func TestLNDSeedRestore(t *testing.T) {
+	ParallelN(t)
+
+	opts := harness.DefaultOptions()
+	opts.GroupName = t.Name()
+	h := harness.NewHarness(t, &opts)
+	t.Cleanup(h.Stop)
+	h.Start()
+
+	inst, mnemonic := h.StartAdditionalLNDWithSeed("seed-recovery")
+	require.Len(t, mnemonic, 24)
+	require.Same(t, inst, h.GetAdditionalLND(inst.Name))
+
+	// Import a different node's account xpub to exercise custom-account
+	// rescan behavior with the stock harness image and public RPCs.
+	accounts, err := h.LND.WalletKit.ListAccounts(
+		t.Context(),
+		"default", walletrpc.AddressType_WITNESS_PUBKEY_HASH,
+	)
+	require.NoError(t, err)
+	require.Len(t, accounts, 1)
+	const custom = "recovery-custom"
+	xpub := accounts[0].ExtendedPublicKey
+	importSeedRestoreAccount(t, inst, custom, xpub)
+
+	// Fund non-first addresses so an off-by-one count or deriving only
+	// address zero cannot pass. Include both receive and change branches.
+	for _, change := range []bool{false, true} {
+		addr, err := inst.Client.WalletKit.NextAddr(
+			t.Context(),
+			"default", walletrpc.AddressType_WITNESS_PUBKEY_HASH,
+			change,
+		)
+		require.NoError(t, err)
+		h.Faucet(addr.String(), btcutil.Amount(100_000))
+
+		for range 3 {
+			addr, err = inst.Client.WalletKit.NextAddr(
+				t.Context(), custom,
+				walletrpc.AddressType_WITNESS_PUBKEY_HASH,
+				change,
+			)
+			require.NoError(t, err)
+		}
+		h.Faucet(addr.String(), btcutil.Amount(200_000))
+	}
+	h.GenerateAndWait(1)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for _, account := range []string{custom, "default"} {
+			coins, err := inst.Client.WalletKit.ListUnspent(
+				t.Context(), 1, 100000,
+				lndclient.WithUnspentAccount(account),
+			)
+			require.NoError(c, err)
+			require.Len(c, coins, 2)
+		}
+	}, 30*time.Second, 100*time.Millisecond)
+
+	before := seedRestoreCoins(t, inst, custom)
+	defaultBefore := seedRestoreCoins(t, inst, "default")
+	recorded := seedRestoreAccount(t, inst, custom)
+	require.NotNil(t, recorded)
+	require.EqualValues(t, 3, recorded.ExternalKeyCount)
+	require.EqualValues(t, 3, recorded.InternalKeyCount)
+
+	// A marker in the wallet directory must disappear. TLS outside it
+	// survives, and the old connection must not keep reconnecting.
+	marker := filepath.Join(filepath.Dir(inst.Macaroon), "restore-marker")
+	require.NoError(t, os.WriteFile(marker, []byte("old wallet"), 0o600))
+	cert, err := os.ReadFile(inst.TLSCert)
+	require.NoError(t, err)
+	oldConn := inst.Client.ClientConn
+	h.RestoreLNDFromSeed(inst, mnemonic)
+	require.Equal(t, connectivity.Shutdown, oldConn.GetState())
+	require.NoFileExists(t, marker)
+	restoredCert, err := os.ReadFile(inst.TLSCert)
+	require.NoError(t, err)
+	require.Equal(t, cert, restoredCert)
+	require.Same(t, inst, h.GetAdditionalLND(inst.Name))
+	require.Nil(t, seedRestoreAccount(t, inst, custom))
+	require.Equal(t, defaultBefore, seedRestoreCoins(t, inst, "default"))
+
+	// Account identity and issued addresses are separate prerequisites.
+	// Reimporting only the xpub must not rediscover its funded addresses.
+	importSeedRestoreAccount(t, inst, custom, xpub)
+	rebuilt := seedRestoreAccount(t, inst, custom)
+	require.NotNil(t, rebuilt)
+	require.Equal(t, recorded.DerivationPath, rebuilt.DerivationPath)
+	require.Equal(t, recorded.ExtendedPublicKey, rebuilt.ExtendedPublicKey)
+	h.RescanLND(inst)
+	require.Empty(t, seedRestoreCoins(t, inst, custom))
+
+	// Reconstructing only receive addresses recovers exactly one output.
+	// A successful rescan is therefore not proof of complete recovery.
+	deriveSeedRestoreBranch(
+		t, inst, custom, recorded.ExternalKeyCount, false,
+	)
+	h.RescanLND(inst)
+	partial := seedRestoreCoins(t, inst, custom)
+	require.Len(t, partial, 1)
+	for outpoint, amount := range partial {
+		require.Equal(t, before[outpoint], amount)
+	}
+
+	deriveSeedRestoreBranch(
+		t, inst, custom, recorded.InternalKeyCount, true,
+	)
+	oldConn = inst.Client.ClientConn
+	h.RescanLND(inst)
+	require.Equal(t, connectivity.Shutdown, oldConn.GetState())
+	require.Equal(t, before, seedRestoreCoins(t, inst, custom))
+	require.Equal(t, defaultBefore, seedRestoreCoins(t, inst, "default"))
+
+	// Spend every restored default-account output. Exact input membership
+	// proves the signature came from recovered keys for both branches.
+	dest, err := h.LND.WalletKit.NextAddr(
+		t.Context(),
+		"default", walletrpc.AddressType_WITNESS_PUBKEY_HASH, false,
+	)
+	require.NoError(t, err)
+	txid, err := inst.Client.Client.SendCoins(
+		t.Context(), dest, 0, true, 0, 2, "seed recovery proof",
+	)
+	require.NoError(t, err)
+	client, err := h.BitcoinRPCClient()
+	require.NoError(t, err)
+	defer client.Shutdown()
+	hash, err := chainhash.NewHashFromStr(txid)
+	require.NoError(t, err)
+	tx, err := client.GetRawTransaction(hash)
+	require.NoError(t, err)
+	require.Len(t, tx.MsgTx().TxIn, len(defaultBefore))
+	for _, input := range tx.MsgTx().TxIn {
+		require.Contains(
+			t, defaultBefore, input.PreviousOutPoint.String(),
+		)
+	}
+	blocks := h.GenerateAndWait(1)
+	require.Contains(t, blocks[0].TxIDs, txid)
+}
+
+// importSeedRestoreAccount recreates a watch-only custom account from its
+// recorded xpub using RPCs available in the pinned harness LND image.
+func importSeedRestoreAccount(t *testing.T, inst *harness.LndInstance, name,
+	xpub string) {
+
+	t.Helper()
+	ctx, timeout, client := inst.Client.WalletKit.RawClientWithMacAuth(
+		t.Context(),
+	)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	_, err := client.ImportAccount(ctx, &walletrpc.ImportAccountRequest{
+		Name: name, ExtendedPublicKey: xpub,
+		AddressType: walletrpc.AddressType_WITNESS_PUBKEY_HASH,
+	})
+	require.NoError(t, err)
+}
+
+// seedRestoreAccount distinguishes authoritative absence from an RPC error.
+func seedRestoreAccount(t *testing.T, inst *harness.LndInstance,
+	name string) *walletrpc.Account {
+
+	t.Helper()
+	accounts, err := inst.Client.WalletKit.ListAccounts(
+		t.Context(), "", walletrpc.AddressType_WITNESS_PUBKEY_HASH,
+	)
+	require.NoError(t, err)
+	for _, account := range accounts {
+		if account.Name == name {
+			return account
+		}
+	}
+
+	return nil
+}
+
+// seedRestoreCoins snapshots exact confirmed outpoints and amounts so equal
+// balances cannot hide missing or substituted recovered outputs.
+func seedRestoreCoins(t *testing.T, inst *harness.LndInstance,
+	account string) map[string]btcutil.Amount {
+
+	t.Helper()
+	coins, err := inst.Client.WalletKit.ListUnspent(
+		t.Context(), 1, 100000, lndclient.WithUnspentAccount(account),
+	)
+	require.NoError(t, err)
+	result := make(map[string]btcutil.Amount, len(coins))
+	for _, coin := range coins {
+		result[coin.OutPoint.String()] = coin.Value
+	}
+
+	return result
+}
+
+// deriveSeedRestoreBranch restores all recorded addresses on one branch,
+// including the final issued address where this test placed its funds.
+func deriveSeedRestoreBranch(t *testing.T, inst *harness.LndInstance,
+	account string, count uint32, change bool) {
+
+	t.Helper()
+	for range count {
+		_, err := inst.Client.WalletKit.NextAddr(
+			t.Context(), account,
+			walletrpc.AddressType_WITNESS_PUBKEY_HASH, change,
+		)
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
## What this enables

Tests can destroy an LND wallet and recover it from a known aezeed mnemonic. The usual harness startup uses `--noseedbackup`, so it cannot supply a mnemonic for this test.

`StartAdditionalLNDWithSeed` explicitly generates a seed and initializes the wallet. `RestoreLNDFromSeed` removes that node's container, deletes the chain-specific wallet and macaroon directory, and initializes a new wallet from the mnemonic. TLS material is preserved. LND performs default-account recovery with a look-ahead window of 250 and waits for chain sync.

## Recovery ordering

Custom accounts need separate reconstruction. The caller must reproduce the key scope and account index, verify the extended public key, and re-derive at least the original address count on **both receive and change branches**. `RescanLND` then restarts the wallet with `--reset-wallet-transactions` and waits for chain sync.

```mermaid
flowchart LR
    A[Capture seed and account metadata] --> B[Destroy and restore wallet]
    B --> C[Reconstruct accounts and both address branches]
    C --> D[Rescan known addresses]
    D --> E[Assert expected outpoints and spendability]
```

A completed rescan proves that the wallet reached the chain tip. It does not prove that the caller reconstructed every funded address.

## Lifecycle contract

Use restore and rescan on instances returned by `StartAdditionalLNDWithSeed`. Serialize lifecycle operations and client use, including teardown. Container removal must succeed before wallet files are deleted or reopened. Failed wallet initialization remains registered for harness cleanup.

The instance pointer remains stable, but its container, ports, and client are refreshed. The old harness RPC connection is closed; rebuild separately constructed clients after a restart.

## Tests and compatibility

`TestLNDSeedRestore` runs in the existing system-test suite with the stock LND image. It checks real wallet deletion, preserved TLS, retired RPC connections, exact recovered outpoints, and a confirmed spend using restored default-account receive and change outputs. Negative controls show that recreating a custom account without addresses finds no coins, and recreating only its receive branch leaves change missing.

The custom-account fixture imports an extended public key through existing public RPCs. It remains watch-only. The pinned image predates native custom-account creation, so this test does not claim to validate that newer RPC or private-key recovery for a native custom account. No dependency, protocol, schema, or deployment change is required.
