### PR TITLE
swapwallet: hide internal OOR activity rows

### DIFF
--- a/db/activity_store.go
+++ b/db/activity_store.go
@@ -16,30 +16,47 @@ import (
 // activity log: the current-state activity_entries projection and the
 // append-only activity_events transition log.
 type ActivityStore interface {
+	// UpsertActivityEntry inserts or advances one current-state projection.
 	UpsertActivityEntry(ctx context.Context,
 		arg sqlc.UpsertActivityEntryParams) (int64, error)
 
+	// AppendActivityEvent records one immutable activity transition.
 	AppendActivityEvent(ctx context.Context,
 		arg sqlc.AppendActivityEventParams) (int64, error)
 
+	// GetActivityEntry loads one projection by its canonical identity.
 	GetActivityEntry(ctx context.Context,
 		canonicalID string) (sqlc.ActivityEntry, error)
 
+	// DeleteActivityEventsByCanonicalID removes the replay history for an
+	// erroneous projection before its foreign-key parent is removed.
+	DeleteActivityEventsByCanonicalID(ctx context.Context,
+		canonicalID string) error
+
+	// DeleteActivityEntry removes one current-state projection.
+	DeleteActivityEntry(ctx context.Context,
+		canonicalID string) (int64, error)
+
+	// CountActivityEntriesByStatus counts the full current-state set for
+	// one lifecycle status.
 	CountActivityEntriesByStatus(ctx context.Context,
 		status int64) (int64, error)
 
+	// ListActivityEntries reads one newest-first keyset page.
 	ListActivityEntries(ctx context.Context,
 		arg sqlc.ListActivityEntriesParams) (
 		[]sqlc.ActivityEntry,
 		error,
 	)
 
+	// ListEntriesByKindStatus reads a canonical-id page for rehydration.
 	ListEntriesByKindStatus(ctx context.Context,
 		arg sqlc.ListEntriesByKindStatusParams) (
 		[]sqlc.ActivityEntry,
 		error,
 	)
 
+	// PullActivityEvents reads replay events strictly after a cursor.
 	PullActivityEvents(ctx context.Context,
 		arg sqlc.PullActivityEventsParams) ([]sqlc.ActivityEvent, error)
 }
@@ -266,6 +283,27 @@ func (s *ActivityPersistenceStore) GetEntry(ctx context.Context,
 	})
 
 	return entry, err
+}
+
+// RemoveEntry atomically removes a current-state activity row and its event
+// history after the wallet projection proves that the row represents an
+// internal implementation detail. The accounting ledger remains untouched.
+// Deleting the events first preserves the activity_events foreign key, and a
+// missing row is an idempotent success so startup reconciliation can retry.
+func (s *ActivityPersistenceStore) RemoveEntry(ctx context.Context,
+	canonicalID string) error {
+
+	return s.db.ExecTx(ctx, WriteTxOption(), func(q ActivityStore) error {
+		if err := q.DeleteActivityEventsByCanonicalID(
+			ctx, canonicalID,
+		); err != nil {
+			return err
+		}
+
+		_, err := q.DeleteActivityEntry(ctx, canonicalID)
+
+		return err
+	})
 }
 
 // CountByStatus returns the number of current-state rows in the given status.

--- a/db/activity_store_test.go
+++ b/db/activity_store_test.go
@@ -91,6 +91,49 @@ func TestActivityStoreProjectInsertsEntryAndEvent(t *testing.T) {
 	require.EqualValues(t, 1, events[0].Status)
 }
 
+// TestActivityStoreRemoveEntry verifies reconciliation can atomically remove
+// an erroneous wallet projection and its replay events without changing an
+// unrelated activity row.
+func TestActivityStoreRemoveEntry(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActivityStoreForTest(t)
+
+	require.NoError(
+		t,
+		projected(
+			store.ProjectEntry(
+				ctx, sampleProjection("ledger-3"),
+			),
+		),
+	)
+	require.NoError(
+		t,
+		projected(
+			store.ProjectEntry(
+				ctx, sampleProjection("payment"),
+			),
+		),
+	)
+
+	require.NoError(t, store.RemoveEntry(ctx, "ledger-3"))
+	_, err := store.GetEntry(ctx, "ledger-3")
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	_, err = store.GetEntry(ctx, "payment")
+	require.NoError(t, err)
+
+	events, err := store.PullEvents(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.Equal(t, "payment", events[0].CanonicalID)
+
+	// Startup and periodic reconciliation may both discover the same stale
+	// id, so removal must stay idempotent after the row is gone.
+	require.NoError(t, store.RemoveEntry(ctx, "ledger-3"))
+}
+
 // TestActivityStoreRejectsTerminalRegression verifies a stale pending write
 // cannot overwrite a terminal row or append a backward lifecycle event.
 func TestActivityStoreRejectsTerminalRegression(t *testing.T) {

--- a/db/sqlc/activity_log.sql.go
+++ b/db/sqlc/activity_log.sql.go
@@ -57,6 +57,33 @@ func (q *Queries) CountActivityEntriesByStatus(ctx context.Context, status int64
 	return count, err
 }
 
+const DeleteActivityEntry = `-- name: DeleteActivityEntry :execrows
+DELETE FROM activity_entries WHERE canonical_id = $1
+`
+
+// DeleteActivityEntry removes the current-state projection after its erroneous
+// transition events have been removed in the same transaction.
+func (q *Queries) DeleteActivityEntry(ctx context.Context, canonicalID string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, DeleteActivityEntry, canonicalID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const DeleteActivityEventsByCanonicalID = `-- name: DeleteActivityEventsByCanonicalID :exec
+DELETE FROM activity_events WHERE canonical_id = $1
+`
+
+// DeleteActivityEventsByCanonicalID removes transition events for a projection
+// that was proven to be an internal implementation detail rather than wallet
+// activity. Callers delete these first to satisfy the activity_entries foreign
+// key without weakening it for ordinary lifecycle rows.
+func (q *Queries) DeleteActivityEventsByCanonicalID(ctx context.Context, canonicalID string) error {
+	_, err := q.db.ExecContext(ctx, DeleteActivityEventsByCanonicalID, canonicalID)
+	return err
+}
+
 const GetActivityEntry = `-- name: GetActivityEntry :one
 SELECT canonical_id, kind, status, amount_sat, fee_sat, counterparty, note, phase, phase_label, failure_code, failure_reason, payment_hash, txid, confirmation_height, vtxo_outpoint, swap_session_id, ledger_txid, boarding_addr, request_json, created_at_unix, updated_at_unix FROM activity_entries WHERE canonical_id = $1
 `

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -38,6 +38,14 @@ type Querier interface {
 	// CountVTXOsByStatus returns the count of VTXOs with the specified status.
 	CountVTXOsByStatus(ctx context.Context, status int32) (int64, error)
 	CountWalletUTXOLog(ctx context.Context) (int64, error)
+	// DeleteActivityEntry removes the current-state projection after its erroneous
+	// transition events have been removed in the same transaction.
+	DeleteActivityEntry(ctx context.Context, canonicalID string) (int64, error)
+	// DeleteActivityEventsByCanonicalID removes transition events for a projection
+	// that was proven to be an internal implementation detail rather than wallet
+	// activity. Callers delete these first to satisfy the activity_entries foreign
+	// key without weakening it for ordinary lifecycle rows.
+	DeleteActivityEventsByCanonicalID(ctx context.Context, canonicalID string) error
 	DeleteClientTreeTxids(ctx context.Context, arg DeleteClientTreeTxidsParams) error
 	DeleteOORPackageCheckpoints(ctx context.Context, sessionID []byte) error
 	DeleteOrphanedPendingBoardIntents(ctx context.Context) error

--- a/db/sqlc/queries/activity_log.sql
+++ b/db/sqlc/queries/activity_log.sql
@@ -60,6 +60,18 @@ RETURNING event_seq;
 -- GetActivityEntry returns one entry by its canonical id.
 SELECT * FROM activity_entries WHERE canonical_id = $1;
 
+-- name: DeleteActivityEventsByCanonicalID :exec
+-- DeleteActivityEventsByCanonicalID removes transition events for a projection
+-- that was proven to be an internal implementation detail rather than wallet
+-- activity. Callers delete these first to satisfy the activity_entries foreign
+-- key without weakening it for ordinary lifecycle rows.
+DELETE FROM activity_events WHERE canonical_id = $1;
+
+-- name: DeleteActivityEntry :execrows
+-- DeleteActivityEntry removes the current-state projection after its erroneous
+-- transition events have been removed in the same transaction.
+DELETE FROM activity_entries WHERE canonical_id = $1;
+
 -- name: CountActivityEntriesByStatus :one
 -- CountActivityEntriesByStatus returns the number of current-state rows in the
 -- given status. It backs the wallet status summary's pending count, which must

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -1341,7 +1341,11 @@ func projectOORLedgerActivity(rows []*waverpc.TransactionHistoryEntry,
 		amounts := correlations.payAmountsByFundingSession[session]
 		received := receivedBySession[session]
 		if received == 0 {
-			if consumePayFundingAmount(amounts, row.GetAmountSat()) {
+			if internalSwapOORSend(correlations, session) ||
+				consumePayFundingAmount(
+					amounts, row.GetAmountSat(),
+				) {
+
 				projection.hidden[row.GetEntryId()] = struct{}{}
 			}
 
@@ -1386,14 +1390,24 @@ func consumePayFundingAmount(amounts map[int64]int, amount int64) bool {
 	return true
 }
 
+// internalSwapOORSend reports whether a session-keyed OOR outflow is the
+// claim or refund leg of an existing swap activity row. These sessions remain
+// internal even when the claimed or refunded output has no separate ledger
+// receive row to pair with the send.
+func internalSwapOORSend(correlations swapOORCorrelations,
+	session string) bool {
+
+	return sessionInSet(correlations.claimSessions, session) ||
+		sessionInSet(correlations.refundSessions, session)
+}
+
 // internalZeroDeltaSession reports whether a balanced same-session OOR
 // send+receive pair belongs to a swap-internal claim or refund. Those rows
 // are already represented by the swap entry itself.
 func internalZeroDeltaSession(correlations swapOORCorrelations,
 	claimOutputSessions map[string]struct{}, session string) bool {
 
-	return sessionInSet(correlations.claimSessions, session) ||
-		sessionInSet(correlations.refundSessions, session) ||
+	return internalSwapOORSend(correlations, session) ||
 		sessionInSet(claimOutputSessions, session)
 }
 

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -44,6 +44,12 @@ type history struct {
 	// instead of one per page. Instances are used single-threaded.
 	creditTopupLinks    map[string]creditTopupLink
 	creditTopupLinksSet bool
+
+	// internalOORActivityIDs collects synthetic canonical ids for ledger
+	// rows that structured swap correlation proved are internal. The
+	// projector uses the set after a successful derive pass to remove rows
+	// that an older binary already persisted in the canonical store.
+	internalOORActivityIDs map[string]struct{}
 }
 
 // newHistory constructs the history merger.
@@ -1164,6 +1170,8 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 	)
 	for _, t := range resp.GetTransactions() {
 		if _, ok := oorProjection.hidden[t.GetEntryId()]; ok {
+			h.rememberInternalOORActivity(t)
+
 			continue
 		}
 
@@ -1187,6 +1195,36 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 	// UTXOs paid to the same address show their total rather than
 	// overwriting each other. See sumDepositsByAddress.
 	return sumDepositsByAddress(out), nil
+}
+
+// rememberInternalOORActivity records the synthetic canonical id of a hidden
+// ledger row so reconciliation can remove a copy persisted by an older binary.
+// Stable non-ledger ids are excluded because this repair targets only the
+// `ledger-N` artifact produced when a session-keyed send has no txid.
+func (h *history) rememberInternalOORActivity(
+	row *waverpc.TransactionHistoryEntry) {
+
+	entry, ok := walletEntryFromLedgerRow(row)
+	if !ok || !strings.HasPrefix(entry.GetId(), "ledger-") {
+		return
+	}
+
+	if h.internalOORActivityIDs == nil {
+		h.internalOORActivityIDs = make(map[string]struct{})
+	}
+	h.internalOORActivityIDs[entry.GetId()] = struct{}{}
+}
+
+// sortedInternalOORActivityIDs returns the hidden synthetic ids in stable
+// order so cleanup and tests are deterministic.
+func (h *history) sortedInternalOORActivityIDs() []string {
+	ids := make([]string, 0, len(h.internalOORActivityIDs))
+	for id := range h.internalOORActivityIDs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	return ids
 }
 
 // sumDepositsByAddress collapses boarding-deposit rows that share a canonical

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -1170,7 +1170,9 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 	)
 	for _, t := range resp.GetTransactions() {
 		if _, ok := oorProjection.hidden[t.GetEntryId()]; ok {
-			h.rememberInternalOORActivity(t)
+			if _, repair := oorProjection.repairableInternalSend[t.GetEntryId()]; repair {
+				h.rememberInternalOORActivity(t)
+			}
 
 			continue
 		}
@@ -1325,6 +1327,7 @@ func swapOORCorrelationsFromSwaps(
 type oorLedgerActivityProjection struct {
 	hidden                 map[int64]struct{}
 	displayAmountByEntryID map[int64]int64
+	repairableInternalSend map[int64]struct{}
 }
 
 // internalOORLedgerEntries returns ledger entry IDs for OOR legs that are
@@ -1369,6 +1372,7 @@ func projectOORLedgerActivity(rows []*waverpc.TransactionHistoryEntry,
 	projection := oorLedgerActivityProjection{
 		hidden:                 make(map[int64]struct{}),
 		displayAmountByEntryID: make(map[int64]int64),
+		repairableInternalSend: make(map[int64]struct{}),
 	}
 	for _, row := range rows {
 		session, ok := oorSendSessionID(row)
@@ -1379,10 +1383,16 @@ func projectOORLedgerActivity(rows []*waverpc.TransactionHistoryEntry,
 		amounts := correlations.payAmountsByFundingSession[session]
 		received := receivedBySession[session]
 		if received == 0 {
-			if internalSwapOORSend(correlations, session) ||
-				consumePayFundingAmount(
-					amounts, row.GetAmountSat(),
-				) {
+			if internalSwapOORSend(correlations, session) {
+				projection.hidden[row.GetEntryId()] = struct{}{}
+				projection.repairableInternalSend[row.GetEntryId()] = struct{}{}
+
+				continue
+			}
+
+			if consumePayFundingAmount(
+				amounts, row.GetAmountSat(),
+			) {
 
 				projection.hidden[row.GetEntryId()] = struct{}{}
 			}

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -332,6 +332,11 @@ func TestHistoryHidesReceiveClaimOORSend(t *testing.T) {
 		t, wavewalletrpc.EntryKind_ENTRY_KIND_RECV,
 		entries[0].GetKind(),
 	)
+	require.Empty(
+		t, h.sortedInternalOORActivityIDs(),
+		"paired internal rows were already suppressed before this "+
+			"repair",
+	)
 }
 
 // TestHistoryHidesReceiveClaimOORSendWithoutReceiveLedgerRow confirms a
@@ -385,6 +390,9 @@ func TestHistoryHidesReceiveClaimOORSendWithoutReceiveLedgerRow(t *testing.T) {
 	require.Equal(
 		t, wavewalletrpc.EntryKind_ENTRY_KIND_RECV,
 		entries[0].GetKind(),
+	)
+	require.Equal(
+		t, []string{"ledger-3"}, h.sortedInternalOORActivityIDs(),
 	)
 }
 
@@ -468,6 +476,7 @@ func TestHistoryKeepsUnpairedOORSend(t *testing.T) {
 		entries[0].GetKind(),
 	)
 	require.Equal(t, int64(-1_000), entries[0].GetAmountSat())
+	require.Empty(t, h.sortedInternalOORActivityIDs())
 }
 
 // TestClassifyLedgerRowHidesBoardingFeeLeg confirms the boarding_fee_paid

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -334,6 +334,60 @@ func TestHistoryHidesReceiveClaimOORSend(t *testing.T) {
 	)
 }
 
+// TestHistoryHidesReceiveClaimOORSendWithoutReceiveLedgerRow confirms a
+// receive swap's session-keyed claim input stays internal when the claimed
+// output is represented by the swap activity row rather than a paired ledger
+// receive row. A raw OOR send with no swap correlation remains covered by
+// TestHistoryKeepsUnpairedOORSend.
+func TestHistoryHidesReceiveClaimOORSendWithoutReceiveLedgerRow(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+
+	sessionID := testBytes(32, 0x83)
+	sessionHex := testSessionString(t, sessionID)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{
+		Swaps: []*swapclientrpc.SwapSummary{
+			{
+				PaymentHash: "payment-hash",
+				Direction: swapclientrpc.
+					SwapDirection_SWAP_DIRECTION_RECEIVE,
+				State: swapclientrpc.
+					SwapState_SWAP_STATE_COMPLETED,
+				AmountSat:      1_000,
+				UpdatedAtUnix:  200,
+				ClaimSessionId: sessionHex,
+			},
+		},
+	}
+	rpc.listTxResp = &waverpc.ListTransactionsResponse{
+		Transactions: []*waverpc.TransactionHistoryEntry{
+			{
+				Type:               "oor",
+				Subtype:            ledger.EventVTXOSent,
+				ConfirmationStatus: "recorded",
+				AmountSat:          1_000,
+				DebitAccount:       ledger.AccountTransfersOut,
+				CreditAccount:      ledger.AccountVTXOBalance,
+				SessionId:          sessionID,
+				EntryId:            3,
+				CreatedAtUnixS:     100,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &wavewalletrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "payment-hash", entries[0].GetId())
+	require.Equal(
+		t, wavewalletrpc.EntryKind_ENTRY_KIND_RECV,
+		entries[0].GetKind(),
+	)
+}
+
 // TestHistoryPendingFilterHidesReceiveClaimByOutputTxid confirms --pending
 // hides completed receive-swap OOR rows even when the ledger OOR session id is
 // different from the materialized claim output txid stored in the swap summary.

--- a/swapwallet/projector.go
+++ b/swapwallet/projector.go
@@ -215,6 +215,27 @@ func (r *Runtime) projectDerivedPage(ctx context.Context,
 	}
 }
 
+// removePersistedInternalOORActivity removes synthetic `ledger-N` rows that a
+// prior binary projected before the current structured OOR correlation hid
+// them. The underlying double-entry ledger remains the audit source of truth;
+// only the incorrect wallet activity projection and its replay events are
+// removed. Calls are idempotent, so startup and periodic reconciliation can
+// repeat the repair safely.
+func (r *Runtime) removePersistedInternalOORActivity(ctx context.Context,
+	ids []string) error {
+
+	for _, id := range ids {
+		if err := r.deps.ActivityStore.RemoveEntry(
+			ctx, id,
+		); err != nil {
+			return fmt.Errorf("remove internal OOR activity %s: %w",
+				id, err)
+		}
+	}
+
+	return nil
+}
+
 // reprojectActivity pages the derive-on-read feed and projects every row into
 // the canonical activity store, returning the number of rows projected. Because
 // ProjectEntry is idempotent on canonical_id and suppresses no-op changes,
@@ -275,6 +296,12 @@ func (r *Runtime) reprojectActivity(ctx context.Context,
 		}
 	}
 
+	if err := r.removePersistedInternalOORActivity(
+		ctx, h.sortedInternalOORActivityIDs(),
+	); err != nil {
+		return projected, err
+	}
+
 	return projected, nil
 }
 
@@ -311,6 +338,11 @@ func (r *Runtime) reprojectRecentActivity(ctx context.Context,
 
 	entries := list.GetEntries()
 	r.projectDerivedPage(ctx, entries)
+	if err := r.removePersistedInternalOORActivity(
+		ctx, h.sortedInternalOORActivityIDs(),
+	); err != nil {
+		return len(entries), err
+	}
 
 	return len(entries), nil
 }

--- a/swapwallet/projector.go
+++ b/swapwallet/projector.go
@@ -219,12 +219,23 @@ func (r *Runtime) projectDerivedPage(ctx context.Context,
 // prior binary projected before the current structured OOR correlation hid
 // them. The underlying double-entry ledger remains the audit source of truth;
 // only the incorrect wallet activity projection and its replay events are
-// removed. Calls are idempotent, so startup and periodic reconciliation can
-// repeat the repair safely.
+// removed. Startup runs before activity subscribers connect, so the repair
+// cannot leave a live consumer holding a row without a corresponding removal
+// event. Calls are idempotent across restarts.
 func (r *Runtime) removePersistedInternalOORActivity(ctx context.Context,
 	ids []string) error {
 
 	for _, id := range ids {
+		_, err := r.deps.ActivityStore.GetEntry(ctx, id)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			continue
+
+		case err != nil:
+			return fmt.Errorf("read internal OOR activity %s: %w",
+				id, err)
+		}
+
 		if err := r.deps.ActivityStore.RemoveEntry(
 			ctx, id,
 		); err != nil {
@@ -248,6 +259,8 @@ func (r *Runtime) removePersistedInternalOORActivity(ctx context.Context,
 // to seed every kind, while the reconciler passes only the low-volume
 // DEPOSIT/EXIT producers here and reconciles the high-volume SEND/RECV kinds
 // separately over a bounded window (reprojectRecentActivity).
+// repairInternalOOR is true only during startup, before activity subscribers
+// connect, and removes synthetic rows persisted by an older binary.
 //
 // A wallet-local EXIT's pending record is cleared only from here and
 // reprojectRecentActivity (via projectDerivedPage), and only after its terminal
@@ -255,7 +268,7 @@ func (r *Runtime) removePersistedInternalOORActivity(ctx context.Context,
 // projection or a row that paged out is retried on a later pass instead of
 // being stranded PENDING in the store.
 func (r *Runtime) reprojectActivity(ctx context.Context,
-	kinds []wavewalletrpc.EntryKind) (int, error) {
+	kinds []wavewalletrpc.EntryKind, repairInternalOOR bool) (int, error) {
 
 	if r.deps == nil || r.deps.ActivityStore == nil {
 		return 0, nil
@@ -296,10 +309,12 @@ func (r *Runtime) reprojectActivity(ctx context.Context,
 		}
 	}
 
-	if err := r.removePersistedInternalOORActivity(
-		ctx, h.sortedInternalOORActivityIDs(),
-	); err != nil {
-		return projected, err
+	if repairInternalOOR {
+		if err := r.removePersistedInternalOORActivity(
+			ctx, h.sortedInternalOORActivityIDs(),
+		); err != nil {
+			return projected, err
+		}
 	}
 
 	return projected, nil
@@ -338,11 +353,6 @@ func (r *Runtime) reprojectRecentActivity(ctx context.Context,
 
 	entries := list.GetEntries()
 	r.projectDerivedPage(ctx, entries)
-	if err := r.removePersistedInternalOORActivity(
-		ctx, h.sortedInternalOORActivityIDs(),
-	); err != nil {
-		return len(entries), err
-	}
 
 	return len(entries), nil
 }
@@ -394,7 +404,7 @@ func (r *Runtime) backfillActivity(ctx context.Context) {
 	}
 
 	log := r.deps.resolveLog()
-	projected, err := r.reprojectActivity(ctx, nil)
+	projected, err := r.reprojectActivity(ctx, nil, true)
 	if err != nil {
 		log.WarnS(ctx, "Activity backfill stopped: list failed", err)
 

--- a/swapwallet/projector_test.go
+++ b/swapwallet/projector_test.go
@@ -30,6 +30,8 @@ type fakeActivityProjector struct {
 	onProject func()
 }
 
+// ProjectEntry records one successful projection and returns a monotonic fake
+// event sequence, or returns the configured failure.
 func (f *fakeActivityProjector) ProjectEntry(_ context.Context,
 	p db.ActivityProjection) (int64, error) {
 
@@ -59,6 +61,13 @@ func (f *fakeActivityProjector) GetEntry(context.Context, string) (
 	return sqlc.ActivityEntry{}, sql.ErrNoRows
 }
 
+// RemoveEntry satisfies waved.ActivityStore. The fake has no durable rows, so
+// removing an already-hidden projection is an idempotent no-op.
+func (f *fakeActivityProjector) RemoveEntry(context.Context, string) error {
+	return nil
+}
+
+// count returns the number of projections recorded by the fake.
 func (f *fakeActivityProjector) count() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/swapwallet/reconciler.go
+++ b/swapwallet/reconciler.go
@@ -114,7 +114,10 @@ func (r *Runtime) reconcilerLoop() {
 // backfill.
 func (r *Runtime) reconcileActivity(ctx context.Context) {
 	// Full-history pass over the low-volume DEPOSIT/EXIT kinds.
-	if _, err := r.reprojectActivity(ctx, reconcilerKinds); err != nil {
+	if _, err := r.reprojectActivity(
+		ctx, reconcilerKinds, false,
+	); err != nil {
+
 		r.deps.resolveLog().WarnS(ctx, "Activity reconcile pass failed",
 			err,
 		)

--- a/swapwallet/reconciler_test.go
+++ b/swapwallet/reconciler_test.go
@@ -4,6 +4,7 @@ package swapwallet
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 
@@ -174,6 +175,99 @@ func TestReconcileProjectsRawOORLive(t *testing.T) {
 		t, wavewalletrpc.EntryStatus_ENTRY_STATUS_COMPLETE, recv.Status,
 		"reconciler must land the raw-OOR receive live",
 	)
+}
+
+// TestBackfillRemovesPersistedInternalOORSend simulates an upgrade after an
+// older binary projected a receive swap's internal claim input as `ledger-3`.
+// Startup backfill must remove that durable artifact while keeping the real
+// RECV row and an unrelated raw OOR SEND.
+func TestBackfillRemovesPersistedInternalOORSend(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	runtime, store, rpc := newReconcileFixture(t)
+	swap := runtime.deps.SwapService.(*fakeSwapService)
+
+	_, _, err := runtime.project(ctx, &wavewalletrpc.WalletEntry{
+		Id:            "ledger-3",
+		Kind:          wavewalletrpc.EntryKind_ENTRY_KIND_SEND,
+		Status:        wavewalletrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		AmountSat:     -1_000,
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 100,
+		Progress: &wavewalletrpc.WalletEntryProgress{
+			Phase: wavewalletrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED,
+			PhaseLabel: "confirmed",
+		},
+	})
+	require.NoError(t, err)
+
+	claimSession := testBytes(32, 0x83)
+	claimSessionHex := testSessionString(t, claimSession)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{
+		Swaps: []*swapclientrpc.SwapSummary{
+			{
+				PaymentHash: "payment-hash",
+				Direction: swapclientrpc.
+					SwapDirection_SWAP_DIRECTION_RECEIVE,
+				State: swapclientrpc.
+					SwapState_SWAP_STATE_COMPLETED,
+				AmountSat:      1_000,
+				UpdatedAtUnix:  200,
+				ClaimSessionId: claimSessionHex,
+			},
+		},
+	}
+	rpc.listTxResp = &waverpc.ListTransactionsResponse{
+		Transactions: []*waverpc.TransactionHistoryEntry{
+			{
+				Type:               "oor",
+				Subtype:            ledger.EventVTXOSent,
+				ConfirmationStatus: "recorded",
+				AmountSat:          1_000,
+				DebitAccount:       ledger.AccountTransfersOut,
+				CreditAccount:      ledger.AccountVTXOBalance,
+				SessionId:          claimSession,
+				EntryId:            3,
+				CreatedAtUnixS:     100,
+			},
+			{
+				Type:               "oor",
+				Subtype:            ledger.EventVTXOSent,
+				ConfirmationStatus: "recorded",
+				AmountSat:          2_000,
+				DebitAccount:       ledger.AccountTransfersOut,
+				CreditAccount:      ledger.AccountVTXOBalance,
+				SessionId:          testBytes(32, 0x84),
+				EntryId:            4,
+				CreatedAtUnixS:     101,
+			},
+		},
+	}
+
+	runtime.backfillActivity(ctx)
+
+	_, err = store.GetEntry(ctx, "ledger-3")
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	recv, err := store.GetEntry(ctx, "payment-hash")
+	require.NoError(t, err)
+	require.EqualValues(
+		t, wavewalletrpc.EntryKind_ENTRY_KIND_RECV, recv.Kind,
+	)
+
+	rawSend, err := store.GetEntry(ctx, "ledger-4")
+	require.NoError(t, err)
+	require.EqualValues(
+		t, wavewalletrpc.EntryKind_ENTRY_KIND_SEND, rawSend.Kind,
+	)
+
+	events, err := store.PullEvents(ctx, 0, 10)
+	require.NoError(t, err)
+	for _, event := range events {
+		require.NotEqual(t, "ledger-3", event.CanonicalID)
+	}
 }
 
 // TestReconcileSkipsCreditOnlySwapRows asserts the periodic SEND/RECV
@@ -453,6 +547,7 @@ type failingProjectStore struct {
 	waved.ActivityStore
 }
 
+// ProjectEntry injects a durable projection failure for every call.
 func (failingProjectStore) ProjectEntry(context.Context,
 	db.ActivityProjection) (int64, error) {
 
@@ -650,6 +745,7 @@ type erringRehydrateStore struct {
 	waved.ActivityStore
 }
 
+// ListEntriesByKindStatus injects a rehydration scan failure.
 func (erringRehydrateStore) ListEntriesByKindStatus(context.Context, int64,
 	int64, string, int32) ([]sqlc.ActivityEntry, error) {
 

--- a/waved/config.go
+++ b/waved/config.go
@@ -854,6 +854,11 @@ type ActivityStore interface {
 	GetEntry(ctx context.Context,
 		canonicalID string) (sqlc.ActivityEntry, error)
 
+	// RemoveEntry deletes a projection and its transition events after the
+	// history merger proves that the row is internal accounting rather than
+	// user activity. The underlying accounting ledger is not changed.
+	RemoveEntry(ctx context.Context, canonicalID string) error
+
 	// ListEntries returns up to limit current-state rows newest-first,
 	// starting after the (cursorCreated, cursorID) keyset. A cursorCreated
 	// of 0 starts from the newest row.


### PR DESCRIPTION
## Problem

A completed receive swap can appear twice in wallet activity:

```text
RECV COMPLETE  1000 sat  payment-hash
SEND COMPLETE -1000 sat  ledger-3
```

The `SEND` is not a second user action. It is the receive swap's internal
out-of-round (OOR) claim input leaking from the accounting ledger into the
wallet activity projection.

Fixes #865.

## Cause

The reachable path is:

1. A receive swap claims its vHTLC through an outgoing OOR session.
2. OOR finalization records a `vtxo_sent` accounting row for the custom
   inputs. The row is keyed by the OOR session and has no chain transaction
   id.
3. Activity synthesis looks for OOR send/receive pairs and structured swap
   correlation.
4. When this send has no same-session ledger receive row, the no-receive
   branch checked pay-swap funding correlation but skipped receive-claim and
   refund session correlation.
5. The generic ledger projector then exposed the row as a standalone `SEND`.
   With no transaction id, its canonical id fell back to `ledger-<entry_id>`.

This behavior predates the current activity persistence work. Recent activity
changes made the leaked row durable, so suppressing future derivation alone
would not repair wallets that already stored it.

## Fix

- Check structured claim/refund session ownership before projecting an
  unpaired OOR send.
- Keep uncorrelated raw OOR sends visible. They are legitimate user activity.
- During startup backfill, collect only an unpaired claim/refund send's hidden
  synthetic `ledger-N` id when current structured correlation proves it
  internal.
- Remove those incorrect wallet activity rows and their replay events in one
  database transaction during wallet-ready startup. Skip cleanup when the
  artifact is already absent. Do not modify the underlying double-entry
  accounting ledger.

The invariant is: a structured swap owns its internal OOR claim/refund leg,
while an OOR send with no swap correlation remains a user-visible `SEND`.

## Before and after

Before:

```text
RECV COMPLETE  1000 sat  payment-hash
SEND COMPLETE -1000 sat  ledger-3
```

After:

```text
RECV COMPLETE  1000 sat  payment-hash
```

An unrelated raw OOR send still appears as:

```text
SEND COMPLETE -2000 sat  ledger-4
```

## Regression coverage

- Exact session-keyed receive-claim row with no paired ledger receive row.
- Raw uncorrelated OOR send negative control.
- Zero-delta raw OOR send negative control.
- Upgrade/restart case with a previously persisted `ledger-3` artifact.
- Transactional event and projection deletion, including idempotent retry.

## Verification

- `go test ./... -tags 'wavewalletrpc swapruntime' -count=1`
- Focused regression and negative controls under `-race`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make tidy-module-check`
- `make sqlc-check`
- `make commitmsg-lint range=origin/main..HEAD`
- Changed-file Go documentation audit
- `make doc-check`
- `make schema-check`
- All three commits have valid GPG signatures.

## Compatibility and rollout

No RPC, schema migration, or accounting format changes are required. Existing
ledger rows remain available for accounting inspection. On upgrade, normal
startup backfill removes a proven internal synthetic activity artifact. The
cleanup is idempotent across restarts and does not run during live periodic
reconciliation.

Activity event sequence gaps are already supported by cursor consumers. This
repair is restricted to wallet-ready startup, not live periodic
reconciliation, and deletes only replay events for an activity row that should
never have been user-visible.

Risk is limited to activity presentation and repair. There is no funds or
transaction-state mutation. The cleanup cannot match solely by amount or
session shape: it requires structured claim/refund correlation and a synthetic
`ledger-N` identity, which preserves legitimate raw OOR activity.

## Duplicate and history search

Before implementation, I searched open and closed Wavelength issues and PRs
for activity, ledger activity, `ledger-N`, leaked/internal ledger rows,
synthetic or duplicate SEND/RECV, OOR and `vtxo_sent`, session-keyed inputs,
and outpoint correlation. Issue #865 describes the same reachable bug and
acceptance criteria, so I updated it instead of opening a duplicate.

Related work inspected: #518, #573, #595, #929, #989, and #903. Those changes
establish two relevant constraints: structured swap-owned OOR legs stay
internal, and raw OOR sends without swap correlation stay visible.
