### PR TITLE
docs: nightly doc-gardening sweep 2026-08-20

### DIFF
--- a/cmd/waved/AGENTS.md
+++ b/cmd/waved/AGENTS.md
@@ -42,6 +42,11 @@ hands off to `waved.Main` to run the daemon.
   wallet registrar reads `cfg.Swap.Backend`, which the swap subserver
   registrar publishes, and sets `cfg.Swap.SuppressResume = true` so the
   wallet layer (not the swap subserver) drives the unified startup resume.
+- `lnd.account` is registered here but enforced in `waved`
+  (`validateLndAccount`, which refuses to start on a configured account lnd
+  does not have). Leaving it empty means lnd's `default` account, so a daemon
+  sharing an lnd node with another daemon must set it or the two can drain
+  each other's funds.
 - `EagerRoundJoin`'s flag default comes from `waved.DefaultConfig()`,
   which is itself build-tag aware (true under `wavewalletrpc`, false
   otherwise); `--eagerroundjoin` still overrides it either way.

--- a/cmd/waved/CLAUDE.md
+++ b/cmd/waved/CLAUDE.md
@@ -42,6 +42,11 @@ hands off to `waved.Main` to run the daemon.
   wallet registrar reads `cfg.Swap.Backend`, which the swap subserver
   registrar publishes, and sets `cfg.Swap.SuppressResume = true` so the
   wallet layer (not the swap subserver) drives the unified startup resume.
+- `lnd.account` is registered here but enforced in `waved`
+  (`validateLndAccount`, which refuses to start on a configured account lnd
+  does not have). Leaving it empty means lnd's `default` account, so a daemon
+  sharing an lnd node with another daemon must set it or the two can drain
+  each other's funds.
 - `EagerRoundJoin`'s flag default comes from `waved.DefaultConfig()`,
   which is itself build-tag aware (true under `wavewalletrpc`, false
   otherwise); `--eagerroundjoin` still overrides it either way.

--- a/lib/arkscript/AGENTS.md
+++ b/lib/arkscript/AGENTS.md
@@ -47,7 +47,10 @@ validated invariants.
 - `ValidatePolicy(nodes, opts)` — Structural admission check for any Ark policy
   shape (custom vHTLC, etc.). Enforces: collab leaf with operator key, exit
   leaf without operator key, no operator-unilateral leaf, CSV gating on exit
-  paths. `opts.MinExitDelay = 0` skips the CSV minimum check.
+  paths. `opts.MinExitDelay = 0` skips the CSV minimum check. Every leaf is
+  compiled via `Node.Script()` *before* any structural reasoning, so a nil or
+  uncompilable leaf is rejected up front rather than being read as a shape the
+  structural rules then bless.
 - Decode budget constants: `MaxPolicyTemplateBytes` (64 KiB),
   `MaxLeafTemplateBytes` (16 KiB), `MaxPolicyLeaves` (32),
   `MaxPolicyDepth` (16), `MaxPolicyNodes` (256), `MaxMultisigKeys` (64) —
@@ -77,6 +80,14 @@ validated invariants.
 - CSV values are canonical non-zero block-mode encodings in `1..65535`.
   Time-mode, disable, and reserved high bits are rejected so structural delay
   comparisons cannot diverge from the value enforced by consensus.
+- A `Condition` node's raw `Predicate` may not change how the typed inner clause
+  is parsed or skip it entirely. `Condition.Script()` tokenizes the predicate
+  and rejects it unless it is a complete script fragment (an incomplete data
+  push would swallow the inner script as pushed bytes) and contains no
+  `OP_SUCCESS` (which would make the whole tapscript succeed before the inner
+  clause ever runs). Raw predicate bytes are the one untyped escape hatch in an
+  otherwise sealed AST, so they are validated at compile time, not at review
+  time.
 - Canonical leaf ordering: sorted by version then lexicographic script bytes.
 - All taproot outputs use the unspendable ARK NUMS key for key path (no
   key-path spend possible).

--- a/lib/arkscript/CLAUDE.md
+++ b/lib/arkscript/CLAUDE.md
@@ -47,7 +47,10 @@ validated invariants.
 - `ValidatePolicy(nodes, opts)` — Structural admission check for any Ark policy
   shape (custom vHTLC, etc.). Enforces: collab leaf with operator key, exit
   leaf without operator key, no operator-unilateral leaf, CSV gating on exit
-  paths. `opts.MinExitDelay = 0` skips the CSV minimum check.
+  paths. `opts.MinExitDelay = 0` skips the CSV minimum check. Every leaf is
+  compiled via `Node.Script()` *before* any structural reasoning, so a nil or
+  uncompilable leaf is rejected up front rather than being read as a shape the
+  structural rules then bless.
 - Decode budget constants: `MaxPolicyTemplateBytes` (64 KiB),
   `MaxLeafTemplateBytes` (16 KiB), `MaxPolicyLeaves` (32),
   `MaxPolicyDepth` (16), `MaxPolicyNodes` (256), `MaxMultisigKeys` (64) —
@@ -77,6 +80,14 @@ validated invariants.
 - CSV values are canonical non-zero block-mode encodings in `1..65535`.
   Time-mode, disable, and reserved high bits are rejected so structural delay
   comparisons cannot diverge from the value enforced by consensus.
+- A `Condition` node's raw `Predicate` may not change how the typed inner clause
+  is parsed or skip it entirely. `Condition.Script()` tokenizes the predicate
+  and rejects it unless it is a complete script fragment (an incomplete data
+  push would swallow the inner script as pushed bytes) and contains no
+  `OP_SUCCESS` (which would make the whole tapscript succeed before the inner
+  clause ever runs). Raw predicate bytes are the one untyped escape hatch in an
+  otherwise sealed AST, so they are validated at compile time, not at review
+  time.
 - Canonical leaf ordering: sorted by version then lexicographic script bytes.
 - All taproot outputs use the unspendable ARK NUMS key for key path (no
   key-path spend possible).

--- a/waverpc/AGENTS.md
+++ b/waverpc/AGENTS.md
@@ -3,9 +3,12 @@
 ## Purpose
 
 Daemon gRPC API definitions for wallet, boarding, round, OOR, unroll, and
-VHTLC-recovery operations. Proto source: `waverpc/daemon.proto`. Generated
-gRPC, REST-gateway, and mailbox-RPC stubs plus one hand-written helper file
-(`errors.go`) for structured wallet-lifecycle errors.
+VHTLC-recovery operations, plus the `Sign*` family through which other
+subsystems borrow the daemon identity key (`SignReceiveAuthMessage[Compact]`,
+`SignOORCustomInput`, `SignVTXOForfeit`, `SignOutSwapHtlcAck`,
+`SignCreditAccountAuthorization`). Proto source: `waverpc/daemon.proto`.
+Generated gRPC, REST-gateway, and mailbox-RPC stubs plus one hand-written
+helper file (`errors.go`) for structured wallet-lifecycle errors.
 
 ## Key Types
 
@@ -39,3 +42,9 @@ gRPC, REST-gateway, and mailbox-RPC stubs plus one hand-written helper file
 - `errors.go` is hand-written and not regenerated; callers must match wallet
   lifecycle errors via `IsWalletNotReadyError`/`WalletNotReadyState`, never by
   parsing the error message string.
+- `NewReceiveScriptRequest.idempotency_key` is an API-level contract, not just
+  an implementation detail: the key namespace is **global to one daemon**, so
+  callers sharing a daemon must prefix keys with an application or tenant
+  identity or they will be handed each other's receive scripts. An empty key
+  keeps the legacy allocate-a-fresh-script behavior; repeating a non-empty key
+  with a *different* label is rejected rather than silently reallocated.

--- a/waverpc/CLAUDE.md
+++ b/waverpc/CLAUDE.md
@@ -3,9 +3,12 @@
 ## Purpose
 
 Daemon gRPC API definitions for wallet, boarding, round, OOR, unroll, and
-VHTLC-recovery operations. Proto source: `waverpc/daemon.proto`. Generated
-gRPC, REST-gateway, and mailbox-RPC stubs plus one hand-written helper file
-(`errors.go`) for structured wallet-lifecycle errors.
+VHTLC-recovery operations, plus the `Sign*` family through which other
+subsystems borrow the daemon identity key (`SignReceiveAuthMessage[Compact]`,
+`SignOORCustomInput`, `SignVTXOForfeit`, `SignOutSwapHtlcAck`,
+`SignCreditAccountAuthorization`). Proto source: `waverpc/daemon.proto`.
+Generated gRPC, REST-gateway, and mailbox-RPC stubs plus one hand-written
+helper file (`errors.go`) for structured wallet-lifecycle errors.
 
 ## Key Types
 
@@ -39,3 +42,9 @@ gRPC, REST-gateway, and mailbox-RPC stubs plus one hand-written helper file
 - `errors.go` is hand-written and not regenerated; callers must match wallet
   lifecycle errors via `IsWalletNotReadyError`/`WalletNotReadyState`, never by
   parsing the error message string.
+- `NewReceiveScriptRequest.idempotency_key` is an API-level contract, not just
+  an implementation detail: the key namespace is **global to one daemon**, so
+  callers sharing a daemon must prefix keys with an application or tenant
+  identity or they will be handed each other's receive scripts. An empty key
+  keeps the legacy allocate-a-fresh-script behavior; repeating a non-empty key
+  with a *different* label is rejected rather than silently reallocated.


### PR DESCRIPTION
Nightly documentation-graph sweep via `.claude/skills/doc-gardening` (scope: `all`).

Baseline was `7a88cb4e`, the last merged nightly sweep, covering 60 commits. No
packages were missing a `CLAUDE.md`, so this sweep is entirely staleness repair.
An intermediate sweep (`d2265a6f`, 2026-08-17) plus the feature PRs themselves
had already documented most of the window; these three packages were the
remaining gaps:

- **`waverpc`** — documents the `Sign*` RPC family through which other
  subsystems borrow the daemon identity key, including the newly added
  `SignCreditAccountAuthorization`, and records the API-level contract that
  `NewReceiveScriptRequest.idempotency_key` is namespaced **per daemon** (so
  callers sharing a daemon must prefix keys or be handed each other's receive
  scripts).
- **`lib/arkscript`** — documents the `Condition` predicate hardening
  (complete-script-fragment tokenization and the `OP_SUCCESS` rejection) and
  that `ValidatePolicy` now compiles every leaf before applying any structural
  rule, so a nil or uncompilable leaf is rejected up front.
- **`cmd/waved`** — documents the new `lnd.account` flag, that it is enforced
  in `waved` by `validateLndAccount`, and the fund-safety reason to set it when
  sharing an lnd node.

`ARCHITECTURE.md` and `docs/index.md` were already current for this window
(`internal/wasmhost` and the idempotent-receive-scripts execplan were both
added in-window); no changes were needed there.

**Validation:** `make doc-check` passes. All edited `CLAUDE.md` files are
byte-identical to their `AGENTS.md` siblings, the root pair included. Markdown
was scanned for leaked tool/formatting artifacts — none found. The commit is
docs-only (`git add -- '*.md'`); nothing was compiled, so no stray binaries.

**Note:** the workflow-run URL is omitted from the commit message and this body
because the run metadata environment variables (`RUN_ID`, `RUN_NUMBER`,
`SERVER_URL`, `REPO_NAME`) were not readable from this job's sandbox. A
fabricated link seemed worse than none. The branch is therefore suffixed `-1`
rather than with the real run number.

Please review the updated `CLAUDE.md`/`AGENTS.md` diffs for accuracy against
the source they describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
