### PR TITLE
multi: Use Lightning Labs mainnet mempool endpoint

### DIFF
--- a/chainfees/mempoolspace.go
+++ b/chainfees/mempoolspace.go
@@ -32,10 +32,10 @@ const (
 	// wall-clock time but not the number of bytes read.
 	maxMempoolSpaceResponseBytes = 64 << 10
 
-	// The test networks default to Lightning Labs-operated mempool
-	// instances, matching the lwwallet Esplora defaults; only mainnet uses
-	// the public mempool.space endpoint.
-	mempoolSpaceMainnetURL = "https://mempool.space/api/v1/fees/recommended"
+	// All networks default to Lightning Labs-operated mempool instances,
+	// matching the lwwallet Esplora defaults.
+	mempoolSpaceMainnetURL = "https://mempool.staging." +
+		"lightningcluster.com/api/v1/fees/recommended"
 	mempoolSpaceTestnetURL = "https://mempool-testnet3.testnet." +
 		"lightningcluster.com/api/v1/fees/recommended"
 	mempoolSpaceTestnet4URL = "https://mempool-testnet4.testnet." +

--- a/chainfees/mempoolspace_test.go
+++ b/chainfees/mempoolspace_test.go
@@ -229,7 +229,7 @@ func TestMempoolSpaceEstimatorRejectsInsecureURL(t *testing.T) {
 	}{
 		{
 			name: "https ok",
-			url:  "https://mempool.space/api/v1/fees/recommended",
+			url:  mempoolSpaceMainnetURL,
 		},
 		{
 			name: "loopback http ok",

--- a/docs/signet.md
+++ b/docs/signet.md
@@ -40,7 +40,7 @@ network defaults when left empty:
 
 | Network config | lwwallet Esplora URL | btcwallet fee URL |
 |----------------|-----------------------|--------------------|
-| `mainnet` | `https://mempool.space/api` | `https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json` |
+| `mainnet` | `https://mempool.staging.lightningcluster.com/api` | `https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json` |
 | `testnet` | `https://mempool-testnet3.testnet.lightningcluster.com/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
 | `testnet4` | `https://mempool-testnet4.testnet.lightningcluster.com/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
 | `signet` | `https://mempool-signet.testnet.lightningcluster.com/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |

--- a/lwwallet/config.go
+++ b/lwwallet/config.go
@@ -33,9 +33,9 @@ type Config struct {
 	// uses it to bound recovery rescans instead of starting from genesis.
 	Birthday time.Time
 
-	// EsploraURL is the base URL of the Esplora/mempool.space REST API
-	// (e.g. "https://mempool.space/api" or "http://localhost:3000"). The
-	// wallet uses this for all chain data: blocks, transactions, UTXOs,
+	// EsploraURL is the base URL of the Esplora/mempool.space REST API.
+	// For example, DefaultEsploraURLMainnet or "http://localhost:3000".
+	// The wallet uses this for all chain data: blocks, transactions, UTXOs,
 	// fee estimates, and broadcasting.
 	EsploraURL string
 

--- a/lwwallet/defaults.go
+++ b/lwwallet/defaults.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	// DefaultEsploraURLMainnet is the public mempool.space
-	// Esplora-compatible REST API for mainnet.
-	DefaultEsploraURLMainnet = "https://mempool.space/api"
+	// DefaultEsploraURLMainnet is the Esplora-compatible REST API for
+	// mainnet, backed by a Lightning Labs-operated mempool instance.
+	DefaultEsploraURLMainnet = "https://mempool.staging." +
+		"lightningcluster.com/api"
 
 	// DefaultEsploraURLTestnet3 is the Esplora-compatible REST API for
 	// testnet3, backed by a Lightning Labs-operated mempool instance.

--- a/lwwallet/defaults_test.go
+++ b/lwwallet/defaults_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 // TestDefaultEsploraURL verifies each supported network resolves to its
-// public mempool.space Esplora endpoint, and unsupported networks error out
-// instead of silently returning an empty URL.
+// Esplora endpoint, and unsupported networks error out instead of silently
+// returning an empty URL.
 func TestDefaultEsploraURL(t *testing.T) {
 	t.Parallel()
 

--- a/lwwallet/esplora.go
+++ b/lwwallet/esplora.go
@@ -36,7 +36,8 @@ import (
 // address UTXOs, tx confirmation status, mempool fee estimates) are
 // never cached.
 type EsploraClient struct {
-	// baseURL is the Esplora API root (e.g. "https://mempool.space/api").
+	// baseURL is the Esplora API root (e.g. the mainnet default in
+	// DefaultEsploraURLMainnet).
 	baseURL string
 
 	// httpClient is the underlying HTTP client with a configured timeout.
@@ -79,8 +80,8 @@ type EsploraClient struct {
 }
 
 // NewEsploraClient creates a new Esplora REST API client. The baseURL should
-// point to the API root without a trailing slash (e.g.
-// "https://mempool.space/api").
+// point to the API root without a trailing slash (e.g. the mainnet default in
+// DefaultEsploraURLMainnet).
 func NewEsploraClient(baseURL string, logger btclog.Logger) *EsploraClient {
 	return &EsploraClient{
 		baseURL: strings.TrimRight(baseURL, "/"),

--- a/sample-waved.conf
+++ b/sample-waved.conf
@@ -224,9 +224,8 @@
 # feeestimation.mempoolspace.enabled=false
 
 # Override the network-default recommended-fee endpoint. Must be an absolute
-# https URL. Empty uses the per-network default: public mempool.space on
-# mainnet, Lightning Labs-operated mempool instances on testnet3, testnet4,
-# and signet.
+# https URL. Empty uses a Lightning Labs-operated mempool instance for the
+# configured network.
 # feeestimation.mempoolspace.url=
 
 # Number of blocks after which unroll attempts a fee-bump rebroadcast. The zero

--- a/waved/config_mempoolspace_fee_test.go
+++ b/waved/config_mempoolspace_fee_test.go
@@ -23,6 +23,9 @@ func lndBaseConfig() *Config {
 func TestMempoolSpaceFeeAccessorsAreNilSafe(t *testing.T) {
 	t.Parallel()
 
+	const mainnetURL = "https://mempool.staging.lightningcluster.com/" +
+		"api/v1/fees/recommended"
+
 	cfg := &Config{}
 	require.False(t, cfg.MempoolSpaceFeeEnabled())
 	require.Empty(t, cfg.MempoolSpaceFeeURL())
@@ -33,13 +36,10 @@ func TestMempoolSpaceFeeAccessorsAreNilSafe(t *testing.T) {
 
 	cfg.FeeEstimation.MempoolSpace = &MempoolSpaceFeeConfig{
 		Enabled: true,
-		URL:     "https://mempool.space/api/v1/fees/recommended",
+		URL:     mainnetURL,
 	}
 	require.True(t, cfg.MempoolSpaceFeeEnabled())
-	require.Equal(
-		t, "https://mempool.space/api/v1/fees/recommended",
-		cfg.MempoolSpaceFeeURL(),
-	)
+	require.Equal(t, mainnetURL, cfg.MempoolSpaceFeeURL())
 }
 
 // TestDefaultConfigDisablesMempoolSpaceFee locks in that the provider is off by


### PR DESCRIPTION
## Summary

- route the lwwallet mainnet Esplora default through `mempool.staging.lightningcluster.com`
- use the same mainnet instance for recommended-fee estimates
- align configuration examples and operator documentation with the new defaults

## Testing

- `make lint-changed-local`
- `make unit pkg=chainfees case=TestDefaultMempoolSpaceURL`
- `make unit pkg=lwwallet case=TestDefaultEsploraURL`
- `make unit pkg=waved case=TestMempoolSpaceFeeAccessorsAreNilSafe`
- `make unit pkg=waved case=TestConfigValidateWalletDefaults`
- live probes of `/api/blocks/tip/height` and `/api/v1/fees/recommended`