### PR TITLE
credit: Honor live operator VTXO floor for redemption

### DIFF
--- a/credit/AGENTS.md
+++ b/credit/AGENTS.md
@@ -52,10 +52,14 @@ credit redemptions against the swap-server credit ledger, as a crash-safe
 - Every external call the behavior makes (`CreateCredit`, `SendOOR`,
   `StartPay`, `RedeemCredit`) must stay idempotent by op key or payment hash,
   since a redelivered message or a reload-after-`commitFailed` re-runs it.
-- Auto-redeem is receive-triggered, not a periodic sweep (except a single
-  boot-time reconcile); `triggerRedeem` fires only after the settled receive's
-  terminal snapshot commits, so a crash before that leaves no half-applied
-  redeem.
+- Auto-redeem is receive-triggered, not a periodic sweep. Its boot reconcile
+  retries transient failures with exponential backoff for at most four
+  minutes, stops immediately on permanent mailbox/Ark version errors, and
+  requires a positive live operator VTXO floor. Its bounded context scopes
+  evaluation only; the queued registry signal uses a separately cancelable
+  child of the daemon-lifetime context so shutdown remains prompt.
+  `triggerRedeem` fires only after the settled receive's terminal snapshot
+  commits, so a crash before that leaves no half-applied redeem.
 
 ## Deep Docs
 

--- a/credit/CLAUDE.md
+++ b/credit/CLAUDE.md
@@ -52,10 +52,14 @@ credit redemptions against the swap-server credit ledger, as a crash-safe
 - Every external call the behavior makes (`CreateCredit`, `SendOOR`,
   `StartPay`, `RedeemCredit`) must stay idempotent by op key or payment hash,
   since a redelivered message or a reload-after-`commitFailed` re-runs it.
-- Auto-redeem is receive-triggered, not a periodic sweep (except a single
-  boot-time reconcile); `triggerRedeem` fires only after the settled receive's
-  terminal snapshot commits, so a crash before that leaves no half-applied
-  redeem.
+- Auto-redeem is receive-triggered, not a periodic sweep. Its boot reconcile
+  retries transient failures with exponential backoff for at most four
+  minutes, stops immediately on permanent mailbox/Ark version errors, and
+  requires a positive live operator VTXO floor. Its bounded context scopes
+  evaluation only; the queued registry signal uses a separately cancelable
+  child of the daemon-lifetime context so shutdown remains prompt.
+  `triggerRedeem` fires only after the settled receive's terminal snapshot
+  commits, so a crash before that leaves no half-applied redeem.
 
 ## Deep Docs
 

--- a/credit/config.go
+++ b/credit/config.go
@@ -152,8 +152,9 @@ type CreditServer interface {
 	ListCredits(ctx context.Context,
 		accountPubKey []byte) (*CreditSnapshot, error)
 
-	// RedeemCredit reserves available credits and sends them to the
-	// supplied Ark destination.
+	// RedeemCredit reserves available credits and sends amountSat as the
+	// exact Ark recipient output amount. Transfer fees must be funded
+	// separately and never deducted from this payout.
 	RedeemCredit(ctx context.Context, accountPubKey []byte,
 		idempotencyKey string, amountSat uint64,
 		destinationPubKey []byte) (*RedeemResult, error)
@@ -195,14 +196,15 @@ type Store interface {
 
 // CreditDaemon is the wallet/daemon surface the credit actor uses to fund
 // top-ups, allocate redemption destinations, observe redeemed outputs, and read
-// the operator dust limit.
+// the operator's effective VTXO floor.
 type CreditDaemon interface {
 	// IdentityPubKey returns the compressed wallet identity pubkey that
 	// keys the server credit account.
 	IdentityPubKey(ctx context.Context) ([]byte, error)
 
-	// DustLimit returns the operator dust limit in satoshis.
-	DustLimit(ctx context.Context) (uint64, error)
+	// VTXOFloor returns the positive live effective operator minimum in
+	// satoshis. A zero floor must be returned as an error.
+	VTXOFloor(ctx context.Context) (uint64, error)
 
 	// SendOOR submits an idempotency-keyed OOR transfer of amountSat to the
 	// pubkey-backed destination and returns the OOR session id. The
@@ -273,9 +275,8 @@ type OpActorConfig struct {
 	// without ever considering a redeem.
 	AutoRedeemEnabled bool
 
-	// MinRedeemSat is the available-credit watermark above which a settled
-	// receive triggers an auto-redeem. Zero defaults to the operator dust
-	// limit at runtime, the smallest amount that can legally become a vTXO.
+	// MinRedeemSat is an optional available-credit watermark. The effective
+	// threshold is never lower than the live operator VTXO floor.
 	MinRedeemSat uint64
 
 	// Earmark, when set, reports the credit balance reserved by in-flight
@@ -359,16 +360,16 @@ type EarmarkFunc = func(context.Context) (uint64, error)
 // AutoRedeemConfig configures the wallet-owned auto-redeem policy. Redemption
 // is never exposed to the user: the wallet decides when to materialize
 // available credits back into a vTXO. Auto-redeem is driven by the receive
-// state machine (a settled receive that clears the watermark) plus a single
-// boot-time reconcile; there is no periodic sweep.
+// state machine (a settled receive that clears the watermark) plus a boot-time
+// reconcile that retries until one complete evaluation succeeds; there is no
+// steady-state periodic sweep.
 type AutoRedeemConfig struct {
 	// Enabled turns receive-driven auto-redeem and the boot-time reconcile
 	// on.
 	Enabled bool
 
-	// MinRedeemSat is the available-credit threshold above which a settled
-	// receive triggers a redeem. Zero defaults to the operator dust limit
-	// at runtime, the smallest amount that can legally become a vTXO.
+	// MinRedeemSat is an optional available-credit threshold. The effective
+	// threshold is never lower than the live operator VTXO floor.
 	MinRedeemSat uint64
 
 	// EarmarkedSat, when set, reports the credit balance reserved by

--- a/credit/config.go
+++ b/credit/config.go
@@ -360,9 +360,9 @@ type EarmarkFunc = func(context.Context) (uint64, error)
 // AutoRedeemConfig configures the wallet-owned auto-redeem policy. Redemption
 // is never exposed to the user: the wallet decides when to materialize
 // available credits back into a vTXO. Auto-redeem is driven by the receive
-// state machine (a settled receive that clears the watermark) plus a boot-time
-// reconcile that retries until one complete evaluation succeeds; there is no
-// steady-state periodic sweep.
+// state machine (a settled receive that clears the watermark) plus a bounded
+// boot-time reconcile that retries transient failures with backoff until one
+// complete evaluation succeeds; there is no steady-state periodic sweep.
 type AutoRedeemConfig struct {
 	// Enabled turns receive-driven auto-redeem and the boot-time reconcile
 	// on.

--- a/credit/op_actor_test.go
+++ b/credit/op_actor_test.go
@@ -307,6 +307,8 @@ type fakeDaemon struct {
 	sendOORCalls map[string]int
 	allocCalls   int
 	vtxoFound    bool
+	vtxoFloor    uint64
+	vtxoFloorErr error
 }
 
 func newFakeDaemon() *fakeDaemon {
@@ -317,7 +319,14 @@ func (d *fakeDaemon) IdentityPubKey(context.Context) ([]byte, error) {
 	return []byte("identity-pubkey"), nil
 }
 
-func (d *fakeDaemon) DustLimit(context.Context) (uint64, error) {
+func (d *fakeDaemon) VTXOFloor(context.Context) (uint64, error) {
+	if d.vtxoFloorErr != nil {
+		return 0, d.vtxoFloorErr
+	}
+	if d.vtxoFloor > 0 {
+		return d.vtxoFloor, nil
+	}
+
 	return 354, nil
 }
 

--- a/credit/policy.go
+++ b/credit/policy.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
@@ -21,15 +22,17 @@ import (
 // Steady-state auto-redeem is folded into the receive state machine: a settled
 // receive that clears the watermark signals the registry directly (see
 // awaitingSettlementState). The autoRedeemer therefore no longer runs a
-// periodic sweep; it performs a single boot-time reconcile so a balance that
-// accumulated over the watermark before this start — which no receive trigger
-// will re-evaluate — is still materialized.
+// steady-state periodic sweep; it performs a boot-time reconcile, retrying
+// transient evaluation failures until one succeeds, so a balance accumulated
+// before this start is still materialized even when no receive will re-evaluate
+// it.
 type autoRedeemer struct {
 	cfg      AutoRedeemConfig
 	server   CreditServer
 	daemon   CreditDaemon
 	registry actor.TellOnlyRef[CreditMsg]
 	log      btclog.Logger
+	retry    time.Duration
 
 	// earmark is the shared credit-earmark provider, read on the boot
 	// reconcile. It is the same atomic pointer the per-operation children
@@ -37,7 +40,9 @@ type autoRedeemer struct {
 	// every redeem decision.
 	earmark *atomic.Pointer[EarmarkFunc]
 
-	wg sync.WaitGroup
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
 }
 
 // newAutoRedeemer builds an auto-redeemer from the registry config, sharing the
@@ -46,12 +51,17 @@ type autoRedeemer struct {
 func newAutoRedeemer(cfg RegistryConfig, registry actor.TellOnlyRef[CreditMsg],
 	earmark *atomic.Pointer[EarmarkFunc]) *autoRedeemer {
 
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = DefaultPollInterval
+	}
+
 	return &autoRedeemer{
 		cfg:      cfg.AutoRedeem,
 		server:   cfg.Server,
 		daemon:   cfg.Daemon,
 		registry: registry,
 		log:      cfg.Log.UnwrapOr(btclog.Disabled),
+		retry:    cfg.PollInterval,
 		earmark:  earmark,
 	}
 }
@@ -67,29 +77,68 @@ func (a *autoRedeemer) setEarmark(fn EarmarkFunc) {
 	a.earmark.Store(&fn)
 }
 
-// start runs the single boot-time reconcile when the policy is enabled. There
-// is no periodic loop: the receive state machine drives steady-state
-// auto-redeem. It is anchored to ctx, which must be a daemon-lifetime context.
+// start runs the boot-time reconcile when the policy is enabled. A failed
+// evaluation retries until one complete evaluation succeeds, because no later
+// receive necessarily exists to reconsider an already-available balance.
+// Steady-state auto-redeem remains receive-driven. The retry loop is anchored
+// to ctx, which must be a daemon-lifetime context.
 func (a *autoRedeemer) start(ctx context.Context) {
 	if a == nil || !a.cfg.Enabled {
 		return
 	}
 
+	a.mu.Lock()
+	if a.cancel != nil {
+		a.mu.Unlock()
+
+		return
+	}
+
+	reconcileCtx, cancel := context.WithCancel(ctx)
+	a.cancel = cancel
 	a.wg.Add(1)
+	a.mu.Unlock()
+
 	go func() {
 		defer a.wg.Done()
 
-		if err := a.reconcile(ctx); err != nil {
-			a.logger(ctx).DebugS(ctx, "Boot auto-redeem reconcile "+
-				"failed", slog.String("err", err.Error()))
+		for attempt := 1; ; attempt++ {
+			err := a.reconcile(reconcileCtx)
+			if err == nil || reconcileCtx.Err() != nil {
+				return
+			}
+
+			a.logger(reconcileCtx).WarnS(
+				reconcileCtx,
+				"Boot auto-redeem reconcile failed; retrying",
+				err,
+				slog.Int("attempt", attempt),
+			)
+
+			timer := time.NewTimer(a.retry)
+			select {
+			case <-reconcileCtx.Done():
+				timer.Stop()
+
+				return
+
+			case <-timer.C:
+			}
 		}
 	}()
 }
 
-// stop waits for the boot reconcile goroutine to exit.
+// stop cancels and waits for the boot reconcile goroutine to exit.
 func (a *autoRedeemer) stop() {
 	if a == nil {
 		return
+	}
+
+	a.mu.Lock()
+	cancel := a.cancel
+	a.mu.Unlock()
+	if cancel != nil {
+		cancel()
 	}
 
 	a.wg.Wait()
@@ -137,7 +186,7 @@ func (a *autoRedeemer) reconcile(ctx context.Context) error {
 		}
 	}
 
-	if available <= threshold {
+	if available < threshold {
 		return nil
 	}
 
@@ -151,19 +200,18 @@ func (a *autoRedeemer) reconcile(ctx context.Context) error {
 	})
 }
 
-// threshold returns the configured minimum, defaulting to the operator dust
-// limit (the smallest amount that can legally become a vTXO).
+// threshold returns the greater of the configured minimum and the live
+// effective operator VTXO floor.
 func (a *autoRedeemer) threshold(ctx context.Context) (uint64, error) {
-	if a.cfg.MinRedeemSat > 0 {
-		return a.cfg.MinRedeemSat, nil
-	}
-
-	dust, err := a.daemon.DustLimit(ctx)
+	floor, err := a.daemon.VTXOFloor(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("get dust limit: %w", err)
+		return 0, fmt.Errorf("get operator VTXO floor: %w", err)
+	}
+	if floor == 0 {
+		return 0, fmt.Errorf("operator VTXO floor is unavailable")
 	}
 
-	return dust, nil
+	return max(a.cfg.MinRedeemSat, floor), nil
 }
 
 // logger returns the redeemer logger bound to ctx.

--- a/credit/policy.go
+++ b/credit/policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -13,6 +14,20 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/lightninglabs/wavelength/build"
+	mailboxconn "github.com/lightninglabs/wavelength/mailbox/conn"
+)
+
+const (
+	// defaultBootReconcileTimeout bounds how long startup keeps probing for
+	// a transiently unavailable operator. It matches the durable credit
+	// operation backstop closely enough to absorb a short outage without
+	// creating an unbounded daemon-lifetime retry loop.
+	defaultBootReconcileTimeout = 4 * time.Minute
+
+	// maxBootReconcileBackoff caps exponential retry spacing so a
+	// recovering operator is noticed promptly without being polled every
+	// two seconds throughout a longer outage.
+	maxBootReconcileBackoff = 30 * time.Second
 )
 
 // autoRedeemer runs the wallet-owned auto-redeem policy. Redemption is never
@@ -22,17 +37,19 @@ import (
 // Steady-state auto-redeem is folded into the receive state machine: a settled
 // receive that clears the watermark signals the registry directly (see
 // awaitingSettlementState). The autoRedeemer therefore no longer runs a
-// steady-state periodic sweep; it performs a boot-time reconcile, retrying
-// transient evaluation failures until one succeeds, so a balance accumulated
-// before this start is still materialized even when no receive will re-evaluate
-// it.
+// steady-state periodic sweep; it performs a bounded boot-time reconcile,
+// retrying transient evaluation failures with backoff so a balance accumulated
+// before this start can still be materialized even when no receive will
+// re-evaluate it.
 type autoRedeemer struct {
-	cfg      AutoRedeemConfig
-	server   CreditServer
-	daemon   CreditDaemon
-	registry actor.TellOnlyRef[CreditMsg]
-	log      btclog.Logger
-	retry    time.Duration
+	cfg          AutoRedeemConfig
+	server       CreditServer
+	daemon       CreditDaemon
+	registry     actor.TellOnlyRef[CreditMsg]
+	log          btclog.Logger
+	retry        time.Duration
+	maxRetry     time.Duration
+	retryTimeout time.Duration
 
 	// earmark is the shared credit-earmark provider, read on the boot
 	// reconcile. It is the same atomic pointer the per-operation children
@@ -40,9 +57,10 @@ type autoRedeemer struct {
 	// every redeem decision.
 	earmark *atomic.Pointer[EarmarkFunc]
 
-	mu     sync.Mutex
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	mu           sync.Mutex
+	cancel       context.CancelFunc
+	signalCancel context.CancelFunc
+	wg           sync.WaitGroup
 }
 
 // newAutoRedeemer builds an auto-redeemer from the registry config, sharing the
@@ -56,13 +74,15 @@ func newAutoRedeemer(cfg RegistryConfig, registry actor.TellOnlyRef[CreditMsg],
 	}
 
 	return &autoRedeemer{
-		cfg:      cfg.AutoRedeem,
-		server:   cfg.Server,
-		daemon:   cfg.Daemon,
-		registry: registry,
-		log:      cfg.Log.UnwrapOr(btclog.Disabled),
-		retry:    cfg.PollInterval,
-		earmark:  earmark,
+		cfg:          cfg.AutoRedeem,
+		server:       cfg.Server,
+		daemon:       cfg.Daemon,
+		registry:     registry,
+		log:          cfg.Log.UnwrapOr(btclog.Disabled),
+		retry:        cfg.PollInterval,
+		maxRetry:     maxBootReconcileBackoff,
+		retryTimeout: defaultBootReconcileTimeout,
+		earmark:      earmark,
 	}
 }
 
@@ -77,11 +97,11 @@ func (a *autoRedeemer) setEarmark(fn EarmarkFunc) {
 	a.earmark.Store(&fn)
 }
 
-// start runs the boot-time reconcile when the policy is enabled. A failed
-// evaluation retries until one complete evaluation succeeds, because no later
-// receive necessarily exists to reconsider an already-available balance.
-// Steady-state auto-redeem remains receive-driven. The retry loop is anchored
-// to ctx, which must be a daemon-lifetime context.
+// start runs the boot-time reconcile when the policy is enabled. Transient
+// evaluation failures retry with exponential backoff until one evaluation
+// succeeds or the cumulative retry window expires. Permanent compatibility
+// errors stop immediately. Steady-state auto-redeem remains receive-driven.
+// The retry loop is anchored to ctx, which must be a daemon-lifetime context.
 func (a *autoRedeemer) start(ctx context.Context) {
 	if a == nil || !a.cfg.Enabled {
 		return
@@ -94,18 +114,79 @@ func (a *autoRedeemer) start(ctx context.Context) {
 		return
 	}
 
-	reconcileCtx, cancel := context.WithCancel(ctx)
+	retry := a.retry
+	if retry <= 0 {
+		retry = DefaultPollInterval
+	}
+	maxRetry := a.maxRetry
+	if maxRetry < retry {
+		maxRetry = retry
+	}
+	retryTimeout := a.retryTimeout
+	if retryTimeout <= 0 {
+		retryTimeout = defaultBootReconcileTimeout
+	}
+
+	reconcileCtx, cancel := context.WithTimeout(ctx, retryTimeout)
+	signalCtx, signalCancel := context.WithCancel(ctx)
 	a.cancel = cancel
+	a.signalCancel = signalCancel
 	a.wg.Add(1)
 	a.mu.Unlock()
 
 	go func() {
 		defer a.wg.Done()
+		defer cancel()
 
-		for attempt := 1; ; attempt++ {
-			err := a.reconcile(reconcileCtx)
-			if err == nil || reconcileCtx.Err() != nil {
+		var (
+			attempt int
+			lastErr error
+		)
+		for {
+			if reconcileCtx.Err() != nil {
+				if ctx.Err() == nil && errors.Is(
+					reconcileCtx.Err(),
+					context.DeadlineExceeded,
+				) {
+
+					a.logger(ctx).WarnS(
+						ctx,
+						"Boot auto-redeem reconcile "+
+							"stopped",
+						lastErr,
+						slog.Int("attempt", attempt),
+						slog.String(
+							"reason",
+							"retry window expired",
+						),
+					)
+				}
+
 				return
+			}
+
+			attempt++
+			err := a.reconcile(reconcileCtx, signalCtx)
+			if err == nil || ctx.Err() != nil {
+				return
+			}
+			lastErr = err
+			if mailboxconn.IsPermanentVersionError(err) {
+				a.logger(reconcileCtx).WarnS(
+					reconcileCtx,
+					"Boot auto-redeem reconcile stopped",
+					err,
+					slog.Int("attempt", attempt),
+					slog.String(
+						"reason",
+						"incompatible operator",
+					),
+				)
+
+				return
+			}
+			if reconcileCtx.Err() != nil {
+				continue
 			}
 
 			a.logger(reconcileCtx).WarnS(
@@ -113,16 +194,19 @@ func (a *autoRedeemer) start(ctx context.Context) {
 				"Boot auto-redeem reconcile failed; retrying",
 				err,
 				slog.Int("attempt", attempt),
+				slog.Duration("retry_after", retry),
 			)
 
-			timer := time.NewTimer(a.retry)
+			timer := time.NewTimer(retry)
 			select {
 			case <-reconcileCtx.Done():
 				timer.Stop()
 
-				return
-
 			case <-timer.C:
+			}
+
+			if retry < maxRetry {
+				retry = min(retry*2, maxRetry)
 			}
 		}
 	}()
@@ -136,30 +220,31 @@ func (a *autoRedeemer) stop() {
 
 	a.mu.Lock()
 	cancel := a.cancel
+	signalCancel := a.signalCancel
 	a.mu.Unlock()
 	if cancel != nil {
 		cancel()
+	}
+	if signalCancel != nil {
+		signalCancel()
 	}
 
 	a.wg.Wait()
 }
 
 // reconcile evaluates the auto-redeem watermark once and signals the registry
-// when an over-watermark balance is already sitting available. The registry
-// applies the no-pending-pay/redeem interlock before admitting the redeem, so
-// this only has to clear the threshold against the earmark-adjusted balance.
-func (a *autoRedeemer) reconcile(ctx context.Context) error {
-	threshold, err := a.threshold(ctx)
-	if err != nil {
-		return err
-	}
-
-	acctKey, err := a.daemon.IdentityPubKey(ctx)
+// when an over-watermark balance is already sitting available. evalCtx bounds
+// the external reads, while signalCtx owns the queued actor work and must live
+// until auto-redeemer shutdown. The registry applies the no-pending-pay/redeem
+// interlock before admitting the redeem, so this only has to clear the
+// threshold against the earmark-adjusted balance.
+func (a *autoRedeemer) reconcile(evalCtx, signalCtx context.Context) error {
+	acctKey, err := a.daemon.IdentityPubKey(evalCtx)
 	if err != nil {
 		return fmt.Errorf("get identity pubkey: %w", err)
 	}
 
-	snapshot, err := a.server.ListCredits(ctx, acctKey)
+	snapshot, err := a.server.ListCredits(evalCtx, acctKey)
 	if err != nil {
 		return fmt.Errorf("list credits: %w", err)
 	}
@@ -173,7 +258,7 @@ func (a *autoRedeemer) reconcile(ctx context.Context) error {
 	available := snapshot.AvailableSat
 	if a.earmark != nil {
 		if earmarkFn := a.earmark.Load(); earmarkFn != nil {
-			earmarked, err := (*earmarkFn)(ctx)
+			earmarked, err := (*earmarkFn)(evalCtx)
 			if err != nil {
 				return fmt.Errorf("read earmarked credits: %w",
 					err)
@@ -186,16 +271,24 @@ func (a *autoRedeemer) reconcile(ctx context.Context) error {
 		}
 	}
 
+	if available == 0 || available < a.cfg.MinRedeemSat {
+		return nil
+	}
+
+	threshold, err := a.threshold(evalCtx)
+	if err != nil {
+		return err
+	}
 	if available < threshold {
 		return nil
 	}
 
-	a.logger(ctx).InfoS(ctx, "Boot reconcile signaling auto-redeem",
+	a.logger(evalCtx).InfoS(evalCtx, "Boot reconcile signaling auto-redeem",
 		slog.Uint64("available_sat", available),
 		slog.Uint64("threshold_sat", threshold),
 	)
 
-	return a.registry.Tell(ctx, &ConsiderRedeemRequest{
+	return a.registry.Tell(signalCtx, &ConsiderRedeemRequest{
 		AvailableSat: available,
 	})
 }

--- a/credit/policy_test.go
+++ b/credit/policy_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
+	mailboxconn "github.com/lightninglabs/wavelength/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,6 +21,7 @@ type scriptedFloorDaemon struct {
 	calls     atomic.Int32
 	failCalls int32
 	floor     uint64
+	floorErr  error
 }
 
 // VTXOFloor returns the scripted transient failures and eventual floor.
@@ -27,6 +30,9 @@ func (d *scriptedFloorDaemon) VTXOFloor(context.Context) (uint64, error) {
 	if call <= d.failCalls {
 		return 0, context.DeadlineExceeded
 	}
+	if d.floorErr != nil {
+		return 0, d.floorErr
+	}
 
 	return d.floor, nil
 }
@@ -34,6 +40,7 @@ func (d *scriptedFloorDaemon) VTXOFloor(context.Context) (uint64, error) {
 // recordingCreditRef captures policy messages without starting an actor.
 type recordingCreditRef struct {
 	messages chan CreditMsg
+	contexts chan context.Context
 }
 
 // ID returns the stable test reference id.
@@ -43,6 +50,14 @@ func (r *recordingCreditRef) ID() string {
 
 // Tell captures one policy message or returns caller cancellation.
 func (r *recordingCreditRef) Tell(ctx context.Context, msg CreditMsg) error {
+	if r.contexts != nil {
+		select {
+		case r.contexts <- ctx:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	select {
 	case r.messages <- msg:
 		return nil
@@ -315,11 +330,13 @@ func TestBootAutoRedeemRetriesTransientFloorFailure(t *testing.T) {
 		cfg: AutoRedeemConfig{
 			Enabled: true,
 		},
-		server:   server,
-		daemon:   daemon,
-		registry: registry,
-		log:      btclog.Disabled,
-		retry:    5 * time.Millisecond,
+		server:       server,
+		daemon:       daemon,
+		registry:     registry,
+		log:          btclog.Disabled,
+		retry:        5 * time.Millisecond,
+		maxRetry:     10 * time.Millisecond,
+		retryTimeout: time.Second,
 	}
 
 	redeemer.start(t.Context())
@@ -338,6 +355,259 @@ func TestBootAutoRedeemRetriesTransientFloorFailure(t *testing.T) {
 				"floor error",
 		)
 	}
+}
+
+// TestBootAutoRedeemStopsOnPermanentFloorFailure verifies a compatibility
+// transition is terminal for startup reconciliation rather than a daemon-life
+// retry loop.
+func TestBootAutoRedeemStopsOnPermanentFloorFailure(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeServer()
+	server.available = 1_000
+	permanentErr := mailboxconn.NewStatusError(
+		"GetInfo", &mailboxpb.Status{
+			Code: mailboxconn.StatusUpgradeRequired,
+		},
+	)
+	daemon := &scriptedFloorDaemon{
+		fakeDaemon: newFakeDaemon(),
+		floorErr:   permanentErr,
+	}
+	redeemer := &autoRedeemer{
+		cfg: AutoRedeemConfig{
+			Enabled: true,
+		},
+		server: server,
+		daemon: daemon,
+		registry: &recordingCreditRef{
+			messages: make(chan CreditMsg, 1),
+		},
+		log:          btclog.Disabled,
+		retry:        time.Millisecond,
+		maxRetry:     2 * time.Millisecond,
+		retryTimeout: time.Second,
+	}
+
+	redeemer.start(t.Context())
+	t.Cleanup(redeemer.stop)
+
+	done := make(chan struct{})
+	go func() {
+		redeemer.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("permanent boot reconcile failure kept retrying")
+	}
+	require.Equal(t, int32(1), daemon.calls.Load())
+}
+
+// TestBootAutoRedeemBoundsTransientFailures verifies a persistently
+// unavailable operator exhausts a cumulative retry window with backoff.
+func TestBootAutoRedeemBoundsTransientFailures(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeServer()
+	server.available = 1_000
+	daemon := &scriptedFloorDaemon{
+		fakeDaemon: newFakeDaemon(),
+		failCalls:  1_000,
+	}
+	redeemer := &autoRedeemer{
+		cfg: AutoRedeemConfig{
+			Enabled: true,
+		},
+		server: server,
+		daemon: daemon,
+		registry: &recordingCreditRef{
+			messages: make(chan CreditMsg, 1),
+		},
+		log:          btclog.Disabled,
+		retry:        5 * time.Millisecond,
+		maxRetry:     10 * time.Millisecond,
+		retryTimeout: 30 * time.Millisecond,
+	}
+
+	redeemer.start(t.Context())
+	t.Cleanup(redeemer.stop)
+
+	done := make(chan struct{})
+	go func() {
+		redeemer.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal(
+			"transient boot reconcile failures exceeded retry " +
+				"window",
+		)
+	}
+	require.Greater(t, daemon.calls.Load(), int32(1))
+}
+
+// TestBootAutoRedeemSkipsFloorWithoutAvailableCredit verifies a fresh wallet
+// completes boot reconciliation without waiting for unreachable operator
+// terms it cannot use.
+func TestBootAutoRedeemSkipsFloorWithoutAvailableCredit(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeServer()
+	daemon := &scriptedFloorDaemon{
+		fakeDaemon: newFakeDaemon(),
+		failCalls:  1_000,
+	}
+	registry := &recordingCreditRef{
+		messages: make(chan CreditMsg, 1),
+	}
+	redeemer := &autoRedeemer{
+		cfg: AutoRedeemConfig{
+			Enabled: true,
+		},
+		server:       server,
+		daemon:       daemon,
+		registry:     registry,
+		log:          btclog.Disabled,
+		retry:        time.Millisecond,
+		maxRetry:     2 * time.Millisecond,
+		retryTimeout: time.Second,
+	}
+
+	redeemer.start(t.Context())
+	t.Cleanup(redeemer.stop)
+
+	done := make(chan struct{})
+	go func() {
+		redeemer.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("empty wallet boot reconcile did not finish")
+	}
+	require.Zero(t, daemon.calls.Load())
+	select {
+	case <-registry.messages:
+		t.Fatal("empty wallet signaled auto-redeem")
+
+	default:
+	}
+}
+
+// TestBootAutoRedeemSignalOutlivesReconcile verifies the bounded evaluation
+// context is not attached to queued registry work and canceled on success.
+func TestBootAutoRedeemSignalOutlivesReconcile(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeServer()
+	server.available = 1_000
+	registry := &recordingCreditRef{
+		messages: make(chan CreditMsg, 1),
+		contexts: make(chan context.Context, 1),
+	}
+	redeemer := &autoRedeemer{
+		cfg: AutoRedeemConfig{
+			Enabled: true,
+		},
+		server: server,
+		daemon: &scriptedFloorDaemon{
+			fakeDaemon: newFakeDaemon(),
+			floor:      1_000,
+		},
+		registry:     registry,
+		log:          btclog.Disabled,
+		retry:        time.Millisecond,
+		maxRetry:     2 * time.Millisecond,
+		retryTimeout: time.Second,
+	}
+
+	redeemer.start(t.Context())
+	t.Cleanup(redeemer.stop)
+
+	select {
+	case <-registry.messages:
+	case <-time.After(time.Second):
+		t.Fatal("boot auto-redeem did not signal registry")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		redeemer.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("boot auto-redeem did not finish")
+	}
+
+	signalCtx := <-registry.contexts
+	require.NoError(t, signalCtx.Err())
+}
+
+// TestBootAutoRedeemStopCancelsQueuedSignal verifies shutdown interrupts a
+// registry delivery blocked behind a full mailbox without coupling successful
+// reconciliation to its shorter evaluation context.
+func TestBootAutoRedeemStopCancelsQueuedSignal(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeServer()
+	server.available = 1_000
+	registry := &recordingCreditRef{
+		messages: make(chan CreditMsg),
+		contexts: make(chan context.Context, 1),
+	}
+	redeemer := &autoRedeemer{
+		cfg: AutoRedeemConfig{
+			Enabled: true,
+		},
+		server: server,
+		daemon: &scriptedFloorDaemon{
+			fakeDaemon: newFakeDaemon(),
+			floor:      1_000,
+		},
+		registry:     registry,
+		log:          btclog.Disabled,
+		retry:        time.Millisecond,
+		maxRetry:     2 * time.Millisecond,
+		retryTimeout: time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	redeemer.start(ctx)
+
+	var signalCtx context.Context
+	select {
+	case signalCtx = <-registry.contexts:
+	case <-time.After(time.Second):
+		t.Fatal("boot auto-redeem did not begin registry delivery")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		redeemer.stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal(
+			"boot auto-redeem stop did not cancel registry " +
+				"delivery",
+		)
+	}
+	require.ErrorIs(t, signalCtx.Err(), context.Canceled)
 }
 
 // TestRedeemOpKeyUnique asserts redeem op keys are prefixed and random.

--- a/credit/policy_test.go
+++ b/credit/policy_test.go
@@ -4,14 +4,72 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/stretchr/testify/require"
 )
 
+// scriptedFloorDaemon records floor reads and can fail an initial prefix of
+// calls before returning the configured floor.
+type scriptedFloorDaemon struct {
+	*fakeDaemon
+
+	calls     atomic.Int32
+	failCalls int32
+	floor     uint64
+}
+
+// VTXOFloor returns the scripted transient failures and eventual floor.
+func (d *scriptedFloorDaemon) VTXOFloor(context.Context) (uint64, error) {
+	call := d.calls.Add(1)
+	if call <= d.failCalls {
+		return 0, context.DeadlineExceeded
+	}
+
+	return d.floor, nil
+}
+
+// recordingCreditRef captures policy messages without starting an actor.
+type recordingCreditRef struct {
+	messages chan CreditMsg
+}
+
+// ID returns the stable test reference id.
+func (r *recordingCreditRef) ID() string {
+	return "recording-credit-ref"
+}
+
+// Tell captures one policy message or returns caller cancellation.
+func (r *recordingCreditRef) Tell(ctx context.Context, msg CreditMsg) error {
+	select {
+	case r.messages <- msg:
+		return nil
+
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// TryTell captures without parking when the test channel is full.
+func (r *recordingCreditRef) TryTell(ctx context.Context, msg CreditMsg) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	select {
+	case r.messages <- msg:
+		return nil
+
+	default:
+		return actor.ErrMailboxFull
+	}
+}
+
 // TestRedeemWatermarkCleared asserts the receive-driven auto-redeem watermark
 // check: a settled receive triggers a redeem only when auto-redeem is enabled
-// and the earmark-adjusted available balance strictly clears the threshold. The
+// and the earmark-adjusted available balance reaches the threshold. The
 // no-pending-pay/redeem interlock is applied separately by the registry.
 func TestRedeemWatermarkCleared(t *testing.T) {
 	t.Parallel()
@@ -56,7 +114,8 @@ func TestRedeemWatermarkCleared(t *testing.T) {
 			name:      "at threshold",
 			enabled:   true,
 			available: threshold,
-			wantOK:    false,
+			wantAmt:   threshold,
+			wantOK:    true,
 		},
 		{
 			name:      "below threshold",
@@ -118,6 +177,166 @@ func TestRedeemWatermarkCleared(t *testing.T) {
 			require.Equal(t, tc.wantOK, ok)
 			require.Equal(t, tc.wantAmt, amt)
 		})
+	}
+}
+
+// TestRedeemWatermarkHonorsLiveOperatorFloor verifies a lower configured
+// watermark cannot authorize a redemption below the current VTXO minimum.
+func TestRedeemWatermarkHonorsLiveOperatorFloor(t *testing.T) {
+	t.Parallel()
+
+	b := &opBehavior{
+		cfg: OpActorConfig{
+			OpID:              "op",
+			AutoRedeemEnabled: true,
+			MinRedeemSat:      354,
+			Daemon: &fakeDaemon{
+				vtxoFloor: 1_000,
+			},
+		},
+		log: btclog.Disabled,
+	}
+
+	amount, ok := b.redeemWatermarkCleared(
+		t.Context(), &CreditSnapshot{
+			AvailableSat: 999,
+		},
+	)
+	require.False(t, ok)
+	require.Zero(t, amount)
+
+	amount, ok = b.redeemWatermarkCleared(
+		t.Context(), &CreditSnapshot{
+			AvailableSat: 1_000,
+		},
+	)
+	require.True(t, ok)
+	require.Equal(t, uint64(1_000), amount)
+}
+
+// TestRedeemWatermarkFailsClosedWithoutOperatorFloor verifies configured
+// policy never substitutes for unavailable live operator terms.
+func TestRedeemWatermarkFailsClosedWithoutOperatorFloor(t *testing.T) {
+	t.Parallel()
+
+	b := &opBehavior{
+		cfg: OpActorConfig{
+			OpID:              "op",
+			AutoRedeemEnabled: true,
+			MinRedeemSat:      354,
+			Daemon: &fakeDaemon{
+				vtxoFloorErr: context.DeadlineExceeded,
+			},
+		},
+		log: btclog.Disabled,
+	}
+
+	amount, ok := b.redeemWatermarkCleared(
+		t.Context(), &CreditSnapshot{
+			AvailableSat: 10_000,
+		},
+	)
+	require.False(t, ok)
+	require.Zero(t, amount)
+}
+
+// TestRedeemWatermarkSkipsFloorBelowConfiguredMinimum verifies a cheap local
+// watermark rejection does not put an operator round trip on the receive turn.
+func TestRedeemWatermarkSkipsFloorBelowConfiguredMinimum(t *testing.T) {
+	t.Parallel()
+
+	daemon := &scriptedFloorDaemon{
+		fakeDaemon: newFakeDaemon(),
+		floor:      1_000,
+	}
+	b := &opBehavior{
+		cfg: OpActorConfig{
+			OpID:              "op",
+			AutoRedeemEnabled: true,
+			MinRedeemSat:      2_000,
+			Daemon:            daemon,
+		},
+		log: btclog.Disabled,
+	}
+
+	amount, ok := b.redeemWatermarkCleared(
+		t.Context(), &CreditSnapshot{
+			AvailableSat: 1_999,
+		},
+	)
+	require.False(t, ok)
+	require.Zero(t, amount)
+	require.Zero(t, daemon.calls.Load())
+}
+
+// TestRedeemWatermarkRejectsZeroFloor verifies the policy boundary remains
+// fail-closed even when a future daemon implementation returns zero and nil.
+func TestRedeemWatermarkRejectsZeroFloor(t *testing.T) {
+	t.Parallel()
+
+	daemon := &scriptedFloorDaemon{
+		fakeDaemon: newFakeDaemon(),
+	}
+	b := &opBehavior{
+		cfg: OpActorConfig{
+			OpID:              "op",
+			AutoRedeemEnabled: true,
+			Daemon:            daemon,
+		},
+		log: btclog.Disabled,
+	}
+
+	amount, ok := b.redeemWatermarkCleared(
+		t.Context(), &CreditSnapshot{
+			AvailableSat: 1_000,
+		},
+	)
+	require.False(t, ok)
+	require.Zero(t, amount)
+	require.Equal(t, int32(1), daemon.calls.Load())
+}
+
+// TestBootAutoRedeemRetriesTransientFloorFailure verifies startup keeps the one
+// uncovered balance case live until a complete reconciliation succeeds.
+func TestBootAutoRedeemRetriesTransientFloorFailure(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeServer()
+	server.available = 1_000
+	daemon := &scriptedFloorDaemon{
+		fakeDaemon: newFakeDaemon(),
+		failCalls:  1,
+		floor:      1_000,
+	}
+	registry := &recordingCreditRef{
+		messages: make(chan CreditMsg, 1),
+	}
+	redeemer := &autoRedeemer{
+		cfg: AutoRedeemConfig{
+			Enabled: true,
+		},
+		server:   server,
+		daemon:   daemon,
+		registry: registry,
+		log:      btclog.Disabled,
+		retry:    5 * time.Millisecond,
+	}
+
+	redeemer.start(t.Context())
+	t.Cleanup(redeemer.stop)
+
+	select {
+	case msg := <-registry.messages:
+		request, ok := msg.(*ConsiderRedeemRequest)
+		require.True(t, ok)
+		require.Equal(t, uint64(1_000), request.AvailableSat)
+		require.Equal(t, int32(2), daemon.calls.Load())
+
+	case <-time.After(time.Second):
+		t.Fatal(
+			"boot auto-redeem did not recover from transient " +
+				"floor error",
+		)
 	}
 }
 

--- a/credit/registry.go
+++ b/credit/registry.go
@@ -154,10 +154,11 @@ func NewRegistry(cfg RegistryConfig) (*Registry, error) {
 }
 
 // StartAutoRedeem runs the wallet-owned auto-redeem boot reconcile (a no-op
-// when the policy is disabled). Steady-state auto-redeem is driven by the
-// receive state machine; this only covers a balance already over the watermark
-// at start. It is anchored to ctx, which must be a daemon-lifetime context, not
-// an RPC-call context.
+// when the policy is disabled) and retries transient evaluation failures until
+// one evaluation succeeds. Steady-state auto-redeem is driven by the receive
+// state machine; this only covers a balance already over the watermark at
+// start. It is anchored to ctx, which must be a daemon-lifetime context, not an
+// RPC-call context.
 func (r *Registry) StartAutoRedeem(ctx context.Context) {
 	if r == nil {
 		return

--- a/credit/registry.go
+++ b/credit/registry.go
@@ -154,11 +154,11 @@ func NewRegistry(cfg RegistryConfig) (*Registry, error) {
 }
 
 // StartAutoRedeem runs the wallet-owned auto-redeem boot reconcile (a no-op
-// when the policy is disabled) and retries transient evaluation failures until
-// one evaluation succeeds. Steady-state auto-redeem is driven by the receive
-// state machine; this only covers a balance already over the watermark at
-// start. It is anchored to ctx, which must be a daemon-lifetime context, not an
-// RPC-call context.
+// when the policy is disabled) and retries transient evaluation failures with
+// bounded backoff. Steady-state auto-redeem is driven by the receive state
+// machine; this only covers a balance already over the watermark at start. It
+// is anchored to ctx, which must be a daemon-lifetime context, not an RPC-call
+// context.
 func (r *Registry) StartAutoRedeem(ctx context.Context) {
 	if r == nil {
 		return

--- a/credit/transitions.go
+++ b/credit/transitions.go
@@ -454,30 +454,16 @@ func (s failedState) ProcessEvent(_ context.Context, _ CreditEvent,
 // redeemWatermarkCleared reports whether the wallet-owned auto-redeem watermark
 // is cleared for the supplied account snapshot, and the earmark-adjusted
 // available balance to redeem. It returns false when auto-redeem is disabled,
-// when the available balance does not strictly exceed the threshold, or when
-// the earmark provider errors (fail-safe: never redeem credits an in-flight
-// wallet operation may be about to spend). The registry still applies the
-// no-pending-pay/redeem interlock before admitting the redeem.
+// when the available balance is below the threshold, or when the earmark
+// provider or live-floor lookup errors (fail-safe: never redeem credits an
+// in-flight wallet operation may be about to spend, and never materialize an
+// invalid VTXO). The registry still applies the no-pending-pay/redeem interlock
+// before admitting the redeem.
 func (b *opBehavior) redeemWatermarkCleared(ctx context.Context,
 	snapshot *CreditSnapshot) (uint64, bool) {
 
 	if !b.cfg.AutoRedeemEnabled || snapshot == nil {
 		return 0, false
-	}
-
-	threshold := b.cfg.MinRedeemSat
-	if threshold == 0 {
-		dust, err := b.cfg.Daemon.DustLimit(ctx)
-		if err != nil {
-			b.logger(ctx).DebugS(ctx, "Skipping auto-redeem: dust "+
-				"limit unavailable",
-				slog.String("op_id", b.cfg.OpID),
-				slog.String("err", err.Error()),
-			)
-
-			return 0, false
-		}
-		threshold = dust
 	}
 
 	available := snapshot.AvailableSat
@@ -505,7 +491,30 @@ func (b *opBehavior) redeemWatermarkCleared(ctx context.Context,
 		}
 	}
 
-	if available <= threshold {
+	// A configured watermark can rule the decision out without consulting
+	// the operator. Equality continues because the live floor may allow an
+	// exact-threshold payout.
+	if available < b.cfg.MinRedeemSat {
+		return 0, false
+	}
+
+	floor, err := b.cfg.Daemon.VTXOFloor(ctx)
+	if err != nil || floor == 0 {
+		if err == nil {
+			err = fmt.Errorf("operator returned a zero VTXO floor")
+		}
+
+		b.logger(ctx).DebugS(ctx, "Skipping auto-redeem: VTXO "+
+			"floor unavailable",
+			slog.String("op_id", b.cfg.OpID),
+			slog.String("err", err.Error()),
+		)
+
+		return 0, false
+	}
+	threshold := max(b.cfg.MinRedeemSat, floor)
+
+	if available < threshold {
 		return 0, false
 	}
 

--- a/docs/credit_durable_actor_design.md
+++ b/docs/credit_durable_actor_design.md
@@ -80,17 +80,18 @@ The wallet decides when to redeem, and redemption is **not exposed to the user**
 A settled receive is the only event that grows the available balance, so
 auto-redeem is driven by the receive state machine: when a receive settles and
 the available balance clears the watermark, it signals a redeem (section 6). A
-single boot-time reconcile covers the one case the receive trigger cannot, a
-balance already sitting over the watermark at startup. There is no periodic
-sweep.
+boot-time reconcile covers the one case the receive trigger cannot, a balance
+already sitting over the watermark at startup. It retries transient evaluation
+failures until one complete evaluation succeeds; after that there is no
+periodic sweep.
 
 The policy stays conservative, to avoid churn and to never strand value:
 
-- **Threshold.** Auto-redeem fires once `available_sat` strictly exceeds
-  `MinRedeemSat`, which **defaults to the operator dust limit**. The dust limit
-  is the smallest amount that can legally become a vTXO, so the default recovers
-  stranded value as early as possible and never attempts an impossible sub-dust
-  redemption.
+- **Threshold.** Auto-redeem fires once `available_sat` reaches
+  `max(MinRedeemSat, live_operator_vtxo_floor)`. The live floor is
+  `max(dust_limit, min_vtxo_amount_sat)` and is refreshed for every decision.
+  An unavailable floor skips redemption, so configured policy can delay
+  materialization but can never authorize an invalid smaller vTXO.
 - **Earmark interlock.** A credit-backed `PrepareSend` reserves nothing
   server-side and writes no durable row until `Send`. Before deciding,
   auto-redeem subtracts the credits earmarked by such in-flight sends (an
@@ -362,12 +363,15 @@ intent; the registry owns the decision.
 `redeemWatermarkCleared` decides whether to redeem:
 
 1. Gate on `AutoRedeemEnabled`.
-2. Resolve the threshold: `MinRedeemSat`, or the operator dust limit when zero.
-3. Subtract the earmark. The earmark provider is an `atomic.Pointer[EarmarkFunc]`
+2. Subtract the earmark. The earmark provider is an `atomic.Pointer[EarmarkFunc]`
    shared by the registry and every child, so the daemon can wire it once after
    construction. A nil provider subtracts nothing (safe before any credit-backed
    send has been prepared); an error from the provider redeems nothing.
-4. Redeem only when the earmark-adjusted balance strictly exceeds the threshold.
+3. Return before contacting the operator when the earmark-adjusted balance is
+   below `MinRedeemSat`.
+4. Refresh the operator terms and resolve the threshold as
+   `max(MinRedeemSat, live_operator_vtxo_floor)`.
+5. Redeem when the earmark-adjusted balance reaches the threshold.
    The subtraction floors at zero, so it cannot underflow.
 
 When it clears, the step emits `triggerRedeem{AvailableSat}`. The actor stashes it

--- a/docs/credit_durable_actor_design.md
+++ b/docs/credit_durable_actor_design.md
@@ -82,8 +82,9 @@ auto-redeem is driven by the receive state machine: when a receive settles and
 the available balance clears the watermark, it signals a redeem (section 6). A
 boot-time reconcile covers the one case the receive trigger cannot, a balance
 already sitting over the watermark at startup. It retries transient evaluation
-failures until one complete evaluation succeeds; after that there is no
-periodic sweep.
+failures with exponential backoff inside a bounded window, stops immediately on
+permanent compatibility errors, and has no periodic sweep after a successful
+evaluation.
 
 The policy stays conservative, to avoid churn and to never strand value:
 

--- a/docs/credit_system.md
+++ b/docs/credit_system.md
@@ -87,9 +87,9 @@ effective VTXO floor.
 
 | Condition | Rail | Result |
 |---|---|---|
-| `requested_amount_sat >= dust_limit_sat` | normal | Server funds a vHTLC for the requested amount. |
-| `requested_amount_sat < dust_limit_sat` and `requested + available < dust_limit_sat` | credit | Server creates a credit receive invoice. No vHTLC is created. |
-| `requested_amount_sat < dust_limit_sat` and `requested + available >= dust_limit_sat` | credit-assisted | Server reserves all available credits and funds a vHTLC for `requested + attached_credit_sat`. |
+| `requested_amount_sat >= vtxo_floor_sat` | normal | Server funds a vHTLC for the requested amount. |
+| `requested_amount_sat < vtxo_floor_sat` and `requested + available < vtxo_floor_sat` | credit | Server creates a credit receive invoice. No vHTLC is created. |
+| `requested_amount_sat < vtxo_floor_sat` and `requested + available >= vtxo_floor_sat` | credit-assisted | Server reserves all available credits and funds a vHTLC for `requested + attached_credit_sat`. |
 
 For credit-assisted receives, the server attaches all currently available
 credits, not only the shortfall needed to reach dust. The quote/prepare surface
@@ -101,14 +101,14 @@ returns the full plan:
 | `available_credit_sat` | Server balance considered by the planner. |
 | `attached_credit_sat` | Credits reserved and added to the receive vHTLC. |
 | `vhtlc_amount_sat` | Amount the client must see in the funded vHTLC. |
-| `dust_limit_sat` | Effective operator VTXO floor used for the decision. |
+| `dust_limit_sat` | Legacy wire-field name carrying the effective operator VTXO floor used for the decision. |
 | `settlement_type` | `LIGHTNING`, `CREDIT`, or `MIXED`. |
 
 ```mermaid
 flowchart TD
-    A["Recv(requested_amount_sat)"] --> B{"requested >= dust?"}
+    A["Recv(requested_amount_sat)"] --> B{"requested >= floor?"}
     B -->|"yes"| N["normal receive"]
-    B -->|"no"| C{"requested + available_credit >= dust?"}
+    B -->|"no"| C{"requested + available_credit >= floor?"}
     C -->|"no"| R["credit receive invoice"]
     C -->|"yes"| M["credit-assisted receive"]
     M --> V["reserve all available credits"]
@@ -171,7 +171,7 @@ preview, and call `Send` with the prepared intent id. There is no public
 
 | Field | Meaning |
 |---|---|
-| `must_use_credit` | This payment must use credits, such as a sub-dust invoice. |
+| `must_use_credit` | This payment must use credits, such as a sub-floor invoice. |
 | `credit_applied_sat` | Credits the server expects to reserve. |
 | `credit_shortfall_sat` | More credits needed before the payment can start. |
 | `credit_topup_sat` | Ark top-up amount needed to cover the shortfall. |
@@ -198,7 +198,7 @@ sequenceDiagram
     Swap->>Server: CreateInSwap(max_credit_sat)
 ```
 
-For a sub-dust invoice, the quote sets `must_use_credit=true`. If the account
+For a sub-floor invoice, the quote sets `must_use_credit=true`. If the account
 lacks enough credits, `PrepareSend` shows the required Ark top-up and `Send`
 performs that top-up before starting the credit-backed pay.
 

--- a/docs/credit_system.md
+++ b/docs/credit_system.md
@@ -2,13 +2,14 @@
 
 Credits are a server-held sat balance for one wallet identity. They let a
 wallet handle Lightning amounts that cannot safely become an Ark vTXO yet,
-without changing the operator dust limit.
+without changing the operator VTXO floor.
 
 A credit is not a vTXO. A vTXO is a sat-denominated Ark output that can be
 refreshed, transferred, exited, or used to fund a virtual HTLC. It must clear
-the operator dust limit. A credit is a row in the swap server ledger. The
-server keys that ledger by the wallet identity public key, reserves credits
-before using them, and writes ledger entries when value is credited or debited.
+the effective operator floor, `max(dust_limit, min_vtxo_amount_sat)`. A credit
+is a row in the swap server ledger. The server keys that ledger by the wallet
+identity public key, reserves credits before using them, and writes ledger
+entries when value is credited or debited.
 
 Lightning can carry millisatoshi amounts. The client and server keep those
 msats at the invoice and HTLC validation boundary. When value enters the credit
@@ -62,6 +63,10 @@ Raw callers can use `sdk/swaps` and `swapclientrpc` directly:
   credits into a vTXO once the balance clears a watermark, without exposing
   that decision to the caller.
 
+The watermark is `max(configured_minimum, live_operator_vtxo_floor)`. The
+client refreshes operator terms for each redeem decision, accepts a balance
+exactly at the floor, and skips redemption when terms are unavailable.
+
 ```mermaid
 flowchart TB
     APP["app / CLI"] --> WDK["sdk/wavewalletdk"]
@@ -78,13 +83,13 @@ flowchart TB
 
 The receive planner decides whether a requested Lightning receive can become a
 normal vHTLC, must become credits, or can attach existing credits to clear the
-dust limit.
+effective VTXO floor.
 
 | Condition | Rail | Result |
 |---|---|---|
 | `requested_amount_sat >= dust_limit_sat` | normal | Server funds a vHTLC for the requested amount. |
-| `requested_amount_sat < dust_limit_sat` and `requested + available < dust` | credit | Server creates a credit receive invoice. No vHTLC is created. |
-| `requested_amount_sat < dust_limit_sat` and `requested + available >= dust` | credit-assisted | Server reserves all available credits and funds a vHTLC for `requested + attached_credit_sat`. |
+| `requested_amount_sat < dust_limit_sat` and `requested + available < dust_limit_sat` | credit | Server creates a credit receive invoice. No vHTLC is created. |
+| `requested_amount_sat < dust_limit_sat` and `requested + available >= dust_limit_sat` | credit-assisted | Server reserves all available credits and funds a vHTLC for `requested + attached_credit_sat`. |
 
 For credit-assisted receives, the server attaches all currently available
 credits, not only the shortfall needed to reach dust. The quote/prepare surface
@@ -96,7 +101,7 @@ returns the full plan:
 | `available_credit_sat` | Server balance considered by the planner. |
 | `attached_credit_sat` | Credits reserved and added to the receive vHTLC. |
 | `vhtlc_amount_sat` | Amount the client must see in the funded vHTLC. |
-| `dust_limit_sat` | Operator dust limit used for the decision. |
+| `dust_limit_sat` | Effective operator VTXO floor used for the decision. |
 | `settlement_type` | `LIGHTNING`, `CREDIT`, or `MIXED`. |
 
 ```mermaid

--- a/sample-waved.conf
+++ b/sample-waved.conf
@@ -275,8 +275,9 @@
 # redemption threshold.
 # swap.credit.autoredeemdisabled=false
 
-# Available-credit threshold above which a settled receive triggers an
-# auto-redeem back into a vTXO. Zero uses the operator dust limit.
+# Optional available-credit threshold that can delay an auto-redeem above the
+# live operator VTXO floor. Redemption triggers at or above the greater of this
+# value and the live floor; zero uses the live floor alone.
 # swap.credit.autoredeemminsat=0
 
 # Maximum reconciliation polls a single credit-operation awaiting state (top-up

--- a/swapclientserver/credit_bridge.go
+++ b/swapclientserver/credit_bridge.go
@@ -149,17 +149,15 @@ func (b *creditDaemonBridge) IdentityPubKey(ctx context.Context) ([]byte,
 	return key.SerializeCompressed(), nil
 }
 
-// DustLimit returns the operator dust limit from the daemon GetInfo surface.
-func (b *creditDaemonBridge) DustLimit(ctx context.Context) (uint64, error) {
-	info, err := b.rpc.GetInfo(ctx, &waverpc.GetInfoRequest{})
+// VTXOFloor fetches the operator's live effective VTXO minimum. Credit
+// redemptions fail closed when the operator terms cannot be refreshed.
+func (b *creditDaemonBridge) VTXOFloor(ctx context.Context) (uint64, error) {
+	floor, err := b.rpc.OperatorVTXOFloor(ctx)
 	if err != nil {
-		return 0, err
-	}
-	if info.GetServerInfo() == nil {
-		return 0, fmt.Errorf("server info is required for dust limit")
+		return 0, fmt.Errorf("fetch operator VTXO floor: %w", err)
 	}
 
-	return info.GetServerInfo().GetDustLimit(), nil
+	return floor, nil
 }
 
 // SendOOR submits an idempotency-keyed OOR transfer to a pubkey-backed

--- a/swapwallet/recv.go
+++ b/swapwallet/recv.go
@@ -57,40 +57,40 @@ func (r *receiver) Recv(ctx context.Context, req *wavewalletrpc.RecvRequest) (
 	}
 
 	plannedVHTLCSat := amt
-	dustLimit, err := r.receiveDustLimit(ctx)
+	vtxoFloor, err := r.receiveVTXOFloor(ctx)
 	if err != nil {
-		r.deps.resolveLog().WarnS(ctx, "Skipping receive dust "+
+		r.deps.resolveLog().WarnS(ctx, "Skipping receive VTXO floor "+
 			"planning: operator terms unavailable", err)
-		dustLimit = 0
+		vtxoFloor = 0
 	}
-	if dustLimit > 0 && amt < dustLimit {
+	if vtxoFloor > 0 && amt < vtxoFloor {
 		availableCreditSat, err := r.availableCreditSat(ctx)
 		switch {
 		case err != nil:
 			// Credit balance lookup failed; still route to credit
 			// (a fresh wallet has no credits anyway), but log the
-			// decision so the sub-dust path is not silent.
-			r.deps.resolveLog().InfoS(ctx, "Routing sub-dust "+
+			// decision so the sub-floor path is not silent.
+			r.deps.resolveLog().InfoS(ctx, "Routing sub-floor "+
 				"receive to credit subsystem",
 				slog.Uint64("amt_sat", amt),
-				slog.Uint64("dust_limit_sat", dustLimit),
+				slog.Uint64("vtxo_floor_sat", vtxoFloor),
 				slog.String("credit_balance", "unavailable"))
 
-			return r.recvCredit(ctx, req, amt, dustLimit)
+			return r.recvCredit(ctx, req, amt, vtxoFloor)
 
 		case amt > ^uint64(0)-availableCreditSat ||
-			amt+availableCreditSat < dustLimit:
+			amt+availableCreditSat < vtxoFloor:
 
-			r.deps.resolveLog().InfoS(ctx, "Routing sub-dust "+
+			r.deps.resolveLog().InfoS(ctx, "Routing sub-floor "+
 				"receive to credit subsystem",
 				slog.Uint64("amt_sat", amt),
-				slog.Uint64("dust_limit_sat", dustLimit),
+				slog.Uint64("vtxo_floor_sat", vtxoFloor),
 				slog.Uint64(
 					"available_credit_sat",
 					availableCreditSat,
 				))
 
-			return r.recvCredit(ctx, req, amt, dustLimit)
+			return r.recvCredit(ctx, req, amt, vtxoFloor)
 
 		default:
 			plannedVHTLCSat = amt + availableCreditSat
@@ -147,7 +147,11 @@ func (r *receiver) Recv(ctx context.Context, req *wavewalletrpc.RecvRequest) (
 	}, nil
 }
 
-func (r *receiver) receiveDustLimit(ctx context.Context) (uint64, error) {
+// receiveVTXOFloor returns the effective floor from the daemon's latest
+// operator snapshot. Receive routing is advisory and falls open when the
+// snapshot is unavailable; the swap server enforces its live floor at the
+// credit boundary.
+func (r *receiver) receiveVTXOFloor(ctx context.Context) (uint64, error) {
 	if r.deps.RPCServer == nil {
 		return 0, nil
 	}
@@ -160,7 +164,9 @@ func (r *receiver) receiveDustLimit(ctx context.Context) (uint64, error) {
 		return 0, nil
 	}
 
-	return info.GetServerInfo().GetDustLimit(), nil
+	server := info.GetServerInfo()
+
+	return max(server.GetDustLimit(), server.GetMinVtxoAmountSat()), nil
 }
 
 func (r *receiver) availableCreditSat(ctx context.Context) (uint64, error) {
@@ -176,14 +182,14 @@ func (r *receiver) availableCreditSat(ctx context.Context) (uint64, error) {
 	return credits.GetAvailableSat(), nil
 }
 
-// recvCredit hands a sub-dust receive to the durable credit subsystem. The
+// recvCredit hands a sub-floor receive to the durable credit subsystem. The
 // registry creates the server-owned receive invoice synchronously and returns
 // it, while durably tracking the operation so the pending row survives a
 // restart. Each Recv is a distinct receive, so the op key is freshly random
 // (inbound receives carry no double-spend risk that would need cross-call
 // dedup).
 func (r *receiver) recvCredit(ctx context.Context,
-	req *wavewalletrpc.RecvRequest, amt, dustLimit uint64) (
+	req *wavewalletrpc.RecvRequest, amt, vtxoFloor uint64) (
 	*wavewalletrpc.RecvResponse, error) {
 
 	if r.deps.CreditRegistry == nil {
@@ -218,14 +224,16 @@ func (r *receiver) recvCredit(ctx context.Context,
 			return nil, err
 		}
 
-		// A sub-dust receive that the swap server never completes must
+		// A sub-floor receive that the swap server never completes must
 		// not vanish silently (wavelength#1041): log it, record a
 		// FAILED activity row, and return a typed, actionable error
 		// instead of the opaque underlying deadline/RPC error.
-		r.deps.resolveLog().WarnS(ctx, "Sub-dust credit receive failed",
+		r.deps.resolveLog().WarnS(
+			ctx,
+			"Sub-floor credit receive failed",
 			err,
 			slog.Uint64("amt_sat", amt),
-			slog.Uint64("dust_limit_sat", dustLimit),
+			slog.Uint64("vtxo_floor_sat", vtxoFloor),
 		)
 
 		r.projectFailedCreditReceive(ctx, req, "recv:"+keyID, amt)
@@ -239,8 +247,8 @@ func (r *receiver) recvCredit(ctx context.Context,
 		// cause is logged above.
 		return nil, fmt.Errorf("%w: the operator did not complete the "+
 			"credit request for %d sat and may not support "+
-			"sub-dust receives; receive at least %d sat instead",
-			ErrCreditReceiveUnavailable, amt, dustLimit)
+			"sub-floor receives; receive at least %d sat instead",
+			ErrCreditReceiveUnavailable, amt, vtxoFloor)
 	}
 
 	start, ok := resp.(*credit.StartCreditResponse)
@@ -271,7 +279,7 @@ func (r *receiver) recvCredit(ctx context.Context,
 }
 
 // projectFailedCreditReceive records a terminal FAILED activity row for a
-// sub-dust credit receive whose admission never completed. Without it a failed
+// sub-floor credit receive whose admission never completed. Without it a failed
 // attempt leaves no trace at all (the success path is the only place that
 // projects a row), so the user has no evidence the receive was attempted
 // (wavelength#1041).

--- a/swapwallet/recv_test.go
+++ b/swapwallet/recv_test.go
@@ -119,17 +119,19 @@ func TestRecvProjectsPendingEntry(t *testing.T) {
 	)
 }
 
-// TestRecvBelowDustHandsToCreditRegistry asserts a sub-dust receive is handed
-// to the durable credit registry, which returns the server-owned invoice
-// synchronously, instead of the wallet calling CreateCredit inline.
-func TestRecvBelowDustHandsToCreditRegistry(t *testing.T) {
+// TestRecvBelowVTXOFloorHandsToCreditRegistry asserts receive planning uses the
+// larger operator VTXO minimum rather than routing an above-dust, sub-floor
+// amount to a normal swap.
+func TestRecvBelowVTXOFloorHandsToCreditRegistry(t *testing.T) {
 	t.Parallel()
+	const amountSat = 800
 
 	swap := &fakeSwapService{}
 	rpc := &fakeRPCServer{
 		getInfoResp: &waverpc.GetInfoResponse{
 			ServerInfo: &waverpc.ServerInfo{
-				DustLimit: 1_000,
+				DustLimit:        546,
+				MinVtxoAmountSat: 1_000,
 			},
 		},
 	}
@@ -155,7 +157,7 @@ func TestRecvBelowDustHandsToCreditRegistry(t *testing.T) {
 
 	resp, err := receiver.Recv(
 		t.Context(), &wavewalletrpc.RecvRequest{
-			AmtSat: 500,
+			AmtSat: amountSat,
 			Memo:   "tiny",
 		},
 	)
@@ -166,7 +168,7 @@ func TestRecvBelowDustHandsToCreditRegistry(t *testing.T) {
 	require.Equal(t, 0, swap.createCreditCalls)
 	require.Equal(t, 1, reg.receiveCalls)
 	require.NotNil(t, reg.lastReceive)
-	require.Equal(t, uint64(500), reg.lastReceive.AmountSat)
+	require.Equal(t, uint64(amountSat), reg.lastReceive.AmountSat)
 	require.Equal(t, "tiny", reg.lastReceive.Memo)
 	require.Contains(t, reg.lastReceive.OpKey, "recv:")
 
@@ -174,7 +176,7 @@ func TestRecvBelowDustHandsToCreditRegistry(t *testing.T) {
 	require.Equal(t, "lnbc1credit", resp.GetInvoice())
 	require.Equal(t, "cr_recv", resp.GetCreditReceive().GetOperationId())
 	require.Equal(t, "abcd", resp.GetCreditReceive().GetPaymentHash())
-	require.Equal(t, int64(500), resp.GetEntry().GetAmountSat())
+	require.Equal(t, int64(amountSat), resp.GetEntry().GetAmountSat())
 	require.Equal(
 		t, wavewalletrpc.EntryKind_ENTRY_KIND_RECV,
 		resp.GetEntry().GetKind(),
@@ -188,14 +190,14 @@ func TestRecvBelowDustHandsToCreditRegistry(t *testing.T) {
 	require.Equal(t, 1, store.count())
 	projection := store.lastProjection()
 	require.Equal(t, "cr_recv", projection.CanonicalID)
-	require.Equal(t, int64(500), projection.AmountSat)
+	require.Equal(t, int64(amountSat), projection.AmountSat)
 	require.Equal(t, "tiny", projection.Note)
 	require.NotEmpty(t, projection.RequestJSON)
 	require.Equal(t, []byte{0xab, 0xcd}, projection.PaymentHash)
 }
 
 // TestRecvCreditFailureIsTypedAndRecorded locks the wavelength#1041 fix: when a
-// sub-dust receive is routed to the credit subsystem and the swap server never
+// sub-floor receive is routed to the credit subsystem and the swap server never
 // completes the credit request (here a DeadlineExceeded, the exact symptom seen
 // on signet), the failure must (1) surface as the typed
 // ErrCreditReceiveUnavailable with actionable guidance rather than an opaque
@@ -243,7 +245,7 @@ func TestRecvCreditFailureIsTypedAndRecorded(t *testing.T) {
 	})
 
 	// (1) The failure is the typed sentinel carrying actionable guidance:
-	// the requested amount and the dust floor to retry at or above.
+	// the requested amount and the VTXO floor to retry at or above.
 	require.ErrorIs(t, err, ErrCreditReceiveUnavailable)
 	require.Contains(t, err.Error(), "999")
 	require.Contains(t, err.Error(), "1000")
@@ -336,9 +338,9 @@ func TestRecvCreditCallerContextIsPreserved(t *testing.T) {
 	}
 }
 
-// TestRecvDustLimitLookupFailureFallsBackOpen asserts that advisory dust
-// planning does not block receives when the daemon has not fetched terms.
-func TestRecvDustLimitLookupFailureFallsBackOpen(t *testing.T) {
+// TestRecvVTXOFloorLookupFailureFallsBackOpen asserts advisory floor planning
+// does not block receives when the daemon has not fetched terms.
+func TestRecvVTXOFloorLookupFailureFallsBackOpen(t *testing.T) {
 	t.Parallel()
 
 	swap := &fakeSwapService{

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -246,6 +246,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   so the bound survives restarts.
 - `operatorTermsFromResponse` and daemon `GetInfo` must preserve
   `FreeRefreshWindowBlocks` end to end.
+- `RPCServer.OperatorVTXOFloor` refreshes authenticated operator terms for
+  each credit materialization decision and bounds that refresh with
+  `operatorTermsRefreshTimeout` (30 s). Its callers use daemon/actor lifetime
+  contexts, so removing this local timeout can park boot reconciliation or a
+  settled-receive actor turn forever on a stalled operator.
 - `deriveIdentityKeyEarly` publishes `clientKeyDesc` before mailbox bootstrap.
   `GetInfo` reuses this descriptor instead of deriving the same key for every
   status request because btcwallet-backed derivation opens a wallet database

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -246,6 +246,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   so the bound survives restarts.
 - `operatorTermsFromResponse` and daemon `GetInfo` must preserve
   `FreeRefreshWindowBlocks` end to end.
+- `RPCServer.OperatorVTXOFloor` refreshes authenticated operator terms for
+  each credit materialization decision and bounds that refresh with
+  `operatorTermsRefreshTimeout` (30 s). Its callers use daemon/actor lifetime
+  contexts, so removing this local timeout can park boot reconciliation or a
+  settled-receive actor turn forever on a stalled operator.
 - `deriveIdentityKeyEarly` publishes `clientKeyDesc` before mailbox bootstrap.
   `GetInfo` reuses this descriptor instead of deriving the same key for every
   status request because btcwallet-backed derivation opens a wallet database

--- a/waved/config.go
+++ b/waved/config.go
@@ -750,9 +750,9 @@ type CreditConfig struct {
 	// manually set this to true.
 	AutoRedeemDisabled bool `mapstructure:"autoredeemdisabled"`
 
-	// AutoRedeemMinSat is the available-credit threshold above which a
-	// settled receive triggers a redeem. Zero defaults to the operator dust
-	// limit, the smallest amount that can legally become a vTXO.
+	// AutoRedeemMinSat optionally delays redemption above the live operator
+	// VTXO floor. A settled receive triggers at or above the greater of
+	// this value and the live floor; zero uses the live floor alone.
 	AutoRedeemMinSat uint64 `mapstructure:"autoredeemminsat"`
 
 	// MaxAwaitingPolls caps how many reconciliation polls a single

--- a/waved/operator_negotiation_test.go
+++ b/waved/operator_negotiation_test.go
@@ -264,6 +264,25 @@ func TestOperatorVTXOFloorFailsClosed(t *testing.T) {
 	require.ErrorContains(t, err, "operator unavailable")
 }
 
+// TestOperatorVTXOFloorRejectsZero verifies an otherwise successful terms
+// refresh cannot authorize a zero-satoshi credit materialization threshold.
+func TestOperatorVTXOFloorRejectsZero(t *testing.T) {
+	t.Parallel()
+
+	rpc := &RPCServer{server: &Server{
+		arkClient: &stubArkServiceClient{
+			resp: &arkrpc.GetInfoResponse{
+				Pubkey:             testOperatorPubKeyBytes(t),
+				SelectedArkVersion: 1,
+			},
+		},
+		arkProtocolVersion: 1,
+	}}
+
+	_, err := rpc.OperatorVTXOFloor(t.Context())
+	require.ErrorContains(t, err, "operator VTXO floor is unavailable")
+}
+
 // TestRefreshAuthenticatedOperatorTermsUsesMailbox verifies that the
 // post-bootstrap refresh replaces anonymous policy with the terms resolved for
 // the daemon's authenticated mailbox identity.

--- a/waved/operator_negotiation_test.go
+++ b/waved/operator_negotiation_test.go
@@ -60,14 +60,20 @@ type stubArkServiceClient struct {
 	resp  *arkrpc.GetInfoResponse
 	err   error
 	calls int
+	await func(context.Context) error
 }
 
 // GetInfo returns the canned response.
-func (s *stubArkServiceClient) GetInfo(_ context.Context,
+func (s *stubArkServiceClient) GetInfo(ctx context.Context,
 	_ *arkrpc.GetInfoRequest, _ ...grpc.CallOption) (
 	*arkrpc.GetInfoResponse, error) {
 
 	s.calls++
+	if s.await != nil {
+		if err := s.await(ctx); err != nil {
+			return nil, err
+		}
+	}
 
 	if s.err != nil {
 		return nil, s.err
@@ -281,6 +287,34 @@ func TestOperatorVTXOFloorRejectsZero(t *testing.T) {
 
 	_, err := rpc.OperatorVTXOFloor(t.Context())
 	require.ErrorContains(t, err, "operator VTXO floor is unavailable")
+}
+
+// TestOperatorVTXOFloorBoundsRefresh verifies a daemon-lifetime caller cannot
+// leave the policy turn parked forever on an operator that never responds.
+func TestOperatorVTXOFloorBoundsRefresh(t *testing.T) {
+	t.Parallel()
+
+	var observedDeadline time.Time
+	rpc := &RPCServer{server: &Server{
+		arkClient: &stubArkServiceClient{
+			await: func(ctx context.Context) error {
+				deadline, ok := ctx.Deadline()
+				require.True(t, ok)
+				observedDeadline = deadline
+
+				return context.DeadlineExceeded
+			},
+		},
+		arkProtocolVersion: 1,
+	}}
+
+	started := time.Now()
+	_, err := rpc.OperatorVTXOFloor(t.Context())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.WithinDuration(
+		t, started.Add(operatorTermsRefreshTimeout), observedDeadline,
+		time.Second,
+	)
 }
 
 // TestRefreshAuthenticatedOperatorTermsUsesMailbox verifies that the

--- a/waved/operator_negotiation_test.go
+++ b/waved/operator_negotiation_test.go
@@ -219,6 +219,51 @@ func TestFetchOperatorTermsRefreshPinsVersion(t *testing.T) {
 	require.Equal(t, uint32(1), srv.arkProtocolVersion)
 }
 
+// TestOperatorVTXOFloorRefreshesEffectiveMinimum verifies credit policy reads
+// the current operator terms and uses the VTXO minimum when it exceeds dust.
+func TestOperatorVTXOFloorRefreshesEffectiveMinimum(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 1,
+			DustLimit:          546,
+			MinVtxoAmountSat:   1_000,
+		},
+	}
+	rpc := &RPCServer{server: &Server{
+		arkClient:          stub,
+		arkProtocolVersion: 1,
+	}}
+
+	floor, err := rpc.OperatorVTXOFloor(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1_000), floor)
+
+	stub.resp.MinVtxoAmountSat = 1_200
+	floor, err = rpc.OperatorVTXOFloor(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1_200), floor)
+	require.Equal(t, 2, stub.calls)
+}
+
+// TestOperatorVTXOFloorFailsClosed verifies credit policy cannot fall back to
+// a baked-in threshold while operator terms are unavailable.
+func TestOperatorVTXOFloorFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	rpc := &RPCServer{server: &Server{
+		arkClient: &stubArkServiceClient{
+			err: fmt.Errorf("operator unavailable"),
+		},
+		arkProtocolVersion: 1,
+	}}
+
+	_, err := rpc.OperatorVTXOFloor(t.Context())
+	require.ErrorContains(t, err, "operator unavailable")
+}
+
 // TestRefreshAuthenticatedOperatorTermsUsesMailbox verifies that the
 // post-bootstrap refresh replaces anonymous policy with the terms resolved for
 // the daemon's authenticated mailbox identity.

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -757,7 +757,12 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *waverpc.GetInfoRequest) (
 // refresh also enforces protocol compatibility and can transition the daemon to
 // incompatible when the operator disables the bound Ark version.
 func (r *RPCServer) OperatorVTXOFloor(ctx context.Context) (uint64, error) {
-	terms, err := r.server.fetchOperatorTerms(ctx)
+	refreshCtx, cancel := context.WithTimeout(
+		ctx, operatorTermsRefreshTimeout,
+	)
+	defer cancel()
+
+	terms, err := r.server.fetchOperatorTerms(refreshCtx)
 	if err != nil {
 		return 0, fmt.Errorf("fetch operator terms: %w", err)
 	}

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -753,7 +753,9 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *waverpc.GetInfoRequest) (
 // OperatorVTXOFloor refreshes the operator terms and returns the effective
 // minimum amount for a newly materialized VTXO. Credit policy uses this direct
 // lookup instead of the daemon's bootstrap snapshot so an unavailable operator
-// fails closed and a raised minimum takes effect on the next request.
+// fails closed and a raised minimum takes effect on the next request. The terms
+// refresh also enforces protocol compatibility and can transition the daemon to
+// incompatible when the operator disables the bound Ark version.
 func (r *RPCServer) OperatorVTXOFloor(ctx context.Context) (uint64, error) {
 	terms, err := r.server.fetchOperatorTerms(ctx)
 	if err != nil {

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -750,6 +750,24 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *waverpc.GetInfoRequest) (
 	return resp, nil
 }
 
+// OperatorVTXOFloor refreshes the operator terms and returns the effective
+// minimum amount for a newly materialized VTXO. Credit policy uses this direct
+// lookup instead of the daemon's bootstrap snapshot so an unavailable operator
+// fails closed and a raised minimum takes effect on the next request.
+func (r *RPCServer) OperatorVTXOFloor(ctx context.Context) (uint64, error) {
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("fetch operator terms: %w", err)
+	}
+
+	floor := terms.MinVTXOAmountFloor()
+	if floor <= 0 {
+		return 0, fmt.Errorf("operator VTXO floor is unavailable")
+	}
+
+	return uint64(floor), nil
+}
+
 // requireWalletReady returns a gRPC error if the wallet is not yet
 // ready. Callers use this to gate RPCs that need wallet access.
 func (r *RPCServer) requireWalletReady() error {


### PR DESCRIPTION
## Summary

- refresh operator terms for every credit auto-redeem decision
- use the greater of the configured threshold, dust limit, and minimum VTXO amount
- redeem at the exact floor and fail closed while operator terms are unavailable

## Commit structure

1. `waved`: expose the live effective operator VTXO floor
2. `credit`: apply that floor in redemption policy, the runtime bridge, tests, and docs

## Companion PR

- Server: lightninglabs/swapdk-server#328
- Related to #1160

## Testing

- `make unit pkg=waved tags=swapruntime timeout=5m`
- `make unit pkg=credit timeout=5m`
- `make unit pkg=swapclientserver tags=swapruntime timeout=5m`
- `make lint-changed-local workers=4`
- `make lint workers=4`
- `make build`