### PR TITLE
build: bump version to v0.1.2-rc2

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -19,7 +19,7 @@ const (
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = "rc1"
+	AppPreRelease = "rc2"
 )
 
 var (


### PR DESCRIPTION
## Summary

Bump the v0.1.x release line from v0.1.2-rc1 to v0.1.2-rc2.

This branch is based on the latest `v0.1.x-branch`, including backport #1167, and changes only `build/version.go`:

- `AppPreRelease`: `"rc1"` to `"rc2"`

## Impact

Release binaries now report `0.1.2-rc2`. There are no runtime or dependency changes.

## Validation

- `make fmt-changed`
- `go test ./build`
- `make build`
- `make lint-changed-local`
- `./bin/waved --version`
- `./bin/wavecli --version`
- `make commitmsg-lint range='origin/v0.1.x-branch..HEAD'`
- `git diff --check`
