### PR TITLE
docs: nightly doc-gardening sweep 2026-08-21

### DIFF
--- a/chainfees/AGENTS.md
+++ b/chainfees/AGENTS.md
@@ -10,8 +10,11 @@ on-chain transactions from wallet and daemon chain backends.
 - `WalletKitEstimator` — proxies fee estimates to an `lndclient.WalletKitClient`;
   fail-fast by default, optional `FallbackOnError` to serve the last
   successful rate instead of propagating errors.
-- `MempoolSpaceEstimator` — fetches recommended fees from the mempool.space
-  HTTP API, with a TTL cache and network-default endpoint selection.
+- `MempoolSpaceEstimator` — fetches recommended fees from a mempool.space-style
+  `/api/v1/fees/recommended` endpoint, with a TTL cache and network-default
+  endpoint selection. Every network's default is a Lightning Labs-operated
+  mempool instance, mirroring the `lwwallet` Esplora defaults; set
+  `MempoolSpaceConfig.URL` to point at another instance.
 - `MinEstimator` — composes multiple `NamedEstimator` children and returns the
   lowest successful estimate, logging when providers diverge.
 - `NamedEstimator` — pairs a `chainfee.Estimator` with a stable name for logs.

--- a/chainfees/CLAUDE.md
+++ b/chainfees/CLAUDE.md
@@ -10,8 +10,11 @@ on-chain transactions from wallet and daemon chain backends.
 - `WalletKitEstimator` — proxies fee estimates to an `lndclient.WalletKitClient`;
   fail-fast by default, optional `FallbackOnError` to serve the last
   successful rate instead of propagating errors.
-- `MempoolSpaceEstimator` — fetches recommended fees from the mempool.space
-  HTTP API, with a TTL cache and network-default endpoint selection.
+- `MempoolSpaceEstimator` — fetches recommended fees from a mempool.space-style
+  `/api/v1/fees/recommended` endpoint, with a TTL cache and network-default
+  endpoint selection. Every network's default is a Lightning Labs-operated
+  mempool instance, mirroring the `lwwallet` Esplora defaults; set
+  `MempoolSpaceConfig.URL` to point at another instance.
 - `MinEstimator` — composes multiple `NamedEstimator` children and returns the
   lowest successful estimate, logging when providers diverge.
 - `NamedEstimator` — pairs a `chainfee.Estimator` with a stable name for logs.

--- a/lwwallet/AGENTS.md
+++ b/lwwallet/AGENTS.md
@@ -42,6 +42,12 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
   cumulative serialized byte size (see `esplora_cache.go`). Mutable live data
   (tip height, UTXOs, fee estimates) is never cached. Cache integrity: every
   response is verified to hash to the requested key before insertion.
+- `DefaultEsploraURL(params)` (`defaults.go`) — resolves the network's default
+  Esplora REST endpoint from the `DefaultEsploraURL{Mainnet,Testnet3,Testnet4,
+  Signet}` constants, all of which point at Lightning Labs-operated mempool
+  instances (the `chainfees` mempool.space fee defaults mirror the same hosts).
+  Networks without a default error out rather than returning an empty URL, so a
+  regtest/simnet setup must supply `Config.EsploraURL` explicitly.
 - `EsploraChainService` — `chain.Interface` adapter over `EsploraClient`,
   driven by a shared `TipPoller`. Feeds btcwallet's internal address-credit
   pipeline. Constructor: `NewEsploraChainService(esplora, tipPoller, logger)`.

--- a/lwwallet/CLAUDE.md
+++ b/lwwallet/CLAUDE.md
@@ -42,6 +42,12 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
   cumulative serialized byte size (see `esplora_cache.go`). Mutable live data
   (tip height, UTXOs, fee estimates) is never cached. Cache integrity: every
   response is verified to hash to the requested key before insertion.
+- `DefaultEsploraURL(params)` (`defaults.go`) — resolves the network's default
+  Esplora REST endpoint from the `DefaultEsploraURL{Mainnet,Testnet3,Testnet4,
+  Signet}` constants, all of which point at Lightning Labs-operated mempool
+  instances (the `chainfees` mempool.space fee defaults mirror the same hosts).
+  Networks without a default error out rather than returning an empty URL, so a
+  regtest/simnet setup must supply `Config.EsploraURL` explicitly.
 - `EsploraChainService` — `chain.Interface` adapter over `EsploraClient`,
   driven by a shared `TipPoller`. Feeds btcwallet's internal address-credit
   pipeline. Constructor: `NewEsploraChainService(esplora, tipPoller, logger)`.


### PR DESCRIPTION
Automated nightly doc-gardening sweep: refreshes the `chainfees` and `lwwallet` package docs after the mainnet mempool endpoint move.

Workflow: https://github.com/lightninglabs/wavelength/actions/workflows/doc-gardening-nightly.yml

Please review the updated CLAUDE.md/AGENTS.md diffs (ARCHITECTURE.md and docs/index.md needed no changes this run). `make doc-check` passes.