### PR TITLE
tapassets: add caller-funded asset batch anchors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/btcsuite/btcd/txscript/v2 v2.0.0
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
 	github.com/lightninglabs/go-wasmsqlite v0.0.0-20260811033710-d14cd0d80aa0
-	github.com/lightninglabs/tap-sdk v0.1.1-0.20260818172001-f657858b0fcc
+	github.com/lightninglabs/tap-sdk v0.1.1-0.20260825101119-cec6f09b69e5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1078,8 +1078,8 @@ github.com/lightninglabs/neutrino/cache v1.1.4 h1:KVtvUmBwYr7eKtjfjHG/q6/cQlcrjH
 github.com/lightninglabs/neutrino/cache v1.1.4/go.mod h1:ZqLzxghPggIRfNXeAZN1VtTKofMyK/ALI6niYsPH6OE=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS/00EiEg0qp0FhehxnQfk3vv8U6Xt3nN+rTY=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260818172001-f657858b0fcc h1:0/t/1pcWhwmivIZdWdsrMbwiisjKd1XM9/eYnv+wVLE=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260818172001-f657858b0fcc/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260825101119-cec6f09b69e5 h1:8092P1VXnziYXuUtFTeAJo6zPMXO4AztdScf1Br7mOw=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260825101119-cec6f09b69e5/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260729123750-e798aabc7f20 h1:UAT9Gyakh2BdelcgATIoC8X8gOL/Kaq0myk+J6MFTIU=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260729123750-e798aabc7f20/go.mod h1:fm0WaNsDpP7jEgR9zMap3hpum7lXVDtjsi783MW9BxY=
 github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260729123750-e798aabc7f20 h1:kf8jqYz9YS9aN25X5H8NSImc+UQzFXVZxDboEzCxfJU=

--- a/lib/tree/batch.go
+++ b/lib/tree/batch.go
@@ -303,6 +303,44 @@ func BuildConnectorTree(batchOutpoint wire.OutPoint, batchOutput *wire.TxOut,
 func BuildBatchOutput(vtxos []VTXODescriptor, operatorMuSigKey *btcec.PublicKey,
 	sweepKey *btcec.PublicKey, sweepDelay uint32) (*wire.TxOut, error) {
 
+	spec, err := BuildBatchOutputSpec(
+		vtxos, operatorMuSigKey, sweepKey, sweepDelay,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return spec.Output, nil
+}
+
+// BatchOutputSpec contains a batch output and its taproot tree.
+type BatchOutputSpec struct {
+	// Output is the batch output.
+	Output *wire.TxOut
+
+	// InternalKey is the untweaked MuSig2 aggregate key.
+	InternalKey *btcec.PublicKey
+
+	// SweepLeaf is the operator's timeout path.
+	SweepLeaf txscript.TapLeaf
+}
+
+// TapTreeBytes returns the BIP-371 PSBT output tap tree.
+func (s *BatchOutputSpec) TapTreeBytes() []byte {
+	var buf bytes.Buffer
+	buf.WriteByte(0) // Depth: the sweep leaf is the whole tree.
+	buf.WriteByte(byte(s.SweepLeaf.LeafVersion))
+	_ = wire.WriteVarInt(&buf, 0, uint64(len(s.SweepLeaf.Script)))
+	buf.Write(s.SweepLeaf.Script)
+
+	return buf.Bytes()
+}
+
+// BuildBatchOutputSpec builds a batch output and its taproot data.
+func BuildBatchOutputSpec(vtxos []VTXODescriptor,
+	operatorMuSigKey *btcec.PublicKey, sweepKey *btcec.PublicKey,
+	sweepDelay uint32) (*BatchOutputSpec, error) {
+
 	if len(vtxos) == 0 {
 		return nil, fmt.Errorf("batch output requires at least one " +
 			"VTXO")
@@ -378,9 +416,13 @@ func BuildBatchOutput(vtxos []VTXODescriptor, operatorMuSigKey *btcec.PublicKey,
 			err)
 	}
 
-	return &wire.TxOut{
-		Value:    int64(totalAmount),
-		PkScript: pkScript,
+	return &BatchOutputSpec{
+		Output: &wire.TxOut{
+			Value:    int64(totalAmount),
+			PkScript: pkScript,
+		},
+		InternalKey: aggKey.PreTweakedKey,
+		SweepLeaf:   sweepTapLeaf,
 	}, nil
 }
 

--- a/tapassets/batch_anchor.go
+++ b/tapassets/batch_anchor.go
@@ -1,0 +1,1334 @@
+package tapassets
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
+)
+
+// BatchAnchorSource describes one confirmed asset input.
+type BatchAnchorSource struct {
+	// ProofFile is the input's confirmed proof file.
+	ProofFile []byte
+
+	// Amount is the input's asset amount.
+	Amount uint64
+
+	// Witness is empty when tapd should sign the asset input.
+	Witness [][]byte
+
+	// Verifier verifies ProofFile.
+	Verifier tapsdk.ConfirmedProofVerifier
+
+	// AnchorOutpoint is the Bitcoin output that holds the asset.
+	AnchorOutpoint wire.OutPoint
+
+	// AnchorInternalKey authorizes the Bitcoin input.
+	AnchorInternalKey *btcec.PublicKey
+}
+
+const (
+	batchAnchorOutputID = "batch-anchor-output"
+	batchAnchorChangeID = "batch-anchor-change"
+)
+
+// ErrReconciliationRequired reports that publication may have succeeded and
+// its outcome must be checked before retrying.
+var ErrReconciliationRequired = errors.New("asset transition reconciliation " +
+	"required")
+
+// BatchAnchorChange returns surplus assets to the tapd wallet.
+type BatchAnchorChange struct {
+	// Amount is the change output's asset amount.
+	Amount uint64
+
+	// OutputIndex is the change anchor output's position in the anchor
+	// transaction.
+	OutputIndex uint32
+
+	// OutputValueSat is the change anchor output's Bitcoin value.
+	OutputValueSat int64
+
+	// ScriptKey is the tapd wallet script key that owns the change.
+	ScriptKey tapsdk.ScriptKey
+
+	// AnchorInternalKey is the tapd wallet internal key of the change
+	// anchor output.
+	AnchorInternalKey tapsdk.InternalKey
+}
+
+// DeriveBatchAnchorChange derives the wallet keys for an asset change output.
+func DeriveBatchAnchorChange(ctx context.Context, wallet *tapsdk.Wallet,
+	amount uint64, outputValueSat int64) (*BatchAnchorChange, error) {
+
+	if wallet == nil {
+		return nil, fmt.Errorf("tap-sdk wallet is required")
+	}
+	if amount == 0 || outputValueSat <= 0 {
+		return nil, fmt.Errorf("change amount and value are required")
+	}
+
+	keys, err := wallet.DeriveKeys(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("derive change keys: %w", err)
+	}
+
+	return &BatchAnchorChange{
+		Amount:            amount,
+		OutputValueSat:    outputValueSat,
+		ScriptKey:         keys.ScriptKey,
+		AnchorInternalKey: keys.InternalKey,
+	}, nil
+}
+
+// internalPubKey parses the change anchor internal key.
+func (c *BatchAnchorChange) internalPubKey() (*btcec.PublicKey, error) {
+	key, err := btcec.ParsePubKey(c.AnchorInternalKey.PubKey[:])
+	if err != nil {
+		return nil, fmt.Errorf("change anchor internal key: %w", err)
+	}
+
+	return key, nil
+}
+
+// BatchAnchorRequest moves confirmed assets into one caller-funded output.
+// Output indexes must be final before deriving a request with change.
+type BatchAnchorRequest struct {
+	// AssetRef identifies the asset carried by the batch output.
+	AssetRef tapsdk.AssetRef
+
+	// Amount is the batch output's total asset amount. The funding
+	// sources must carry exactly this amount plus any change.
+	Amount uint64
+
+	// Change optionally returns the funding surplus to the operator's
+	// tapd wallet on its own anchor output.
+	Change *BatchAnchorChange
+
+	// Sources are the confirmed asset inputs.
+	Sources []BatchAnchorSource
+
+	// Cosigners aggregate into the batch output's internal key.
+	Cosigners []*btcec.PublicKey
+
+	// SweepLeaf is the operator's timeout path.
+	SweepLeaf txscript.TapLeaf
+
+	// Digest scopes the deterministic asset script key.
+	Digest tapsdk.Hash
+
+	// OutputIndex is the batch output's position in the anchor
+	// transaction.
+	OutputIndex uint32
+
+	// OutputValueSat is the batch output's Bitcoin value.
+	OutputValueSat int64
+}
+
+// BatchAnchorScript contains the derived batch output script and its roots.
+type BatchAnchorScript struct {
+	// PkScript is the composed batch output script.
+	PkScript []byte
+
+	// InternalKey is the untweaked cosigner aggregate.
+	InternalKey *btcec.PublicKey
+
+	// SigningTweak commits to the sweep leaf and asset root.
+	SigningTweak []byte
+
+	// AssetRoot is the batch output's Taproot Asset commitment root.
+	AssetRoot tapsdk.Hash
+
+	// ChangePkScript is the composed change anchor output script, set
+	// only when the request carries change.
+	ChangePkScript []byte
+}
+
+// BatchAnchorCommit contains the sealed transition and its tree root input.
+type BatchAnchorCommit struct {
+	// AssetRef identifies the committed asset.
+	AssetRef string
+
+	// OutputIndex is the batch output's position in the anchor
+	// transaction.
+	OutputIndex uint32
+
+	// PackageBytes is the sealed transfer package.
+	PackageBytes []byte
+
+	// AnchorPSBT contains any input signatures produced by tapd.
+	AnchorPSBT []byte
+
+	// Script echoes the validated batch output derivation.
+	Script BatchAnchorScript
+
+	// RootSource provides the asset inputs for tree materialization.
+	RootSource TreeRootAssetSource
+}
+
+// BatchAnchorCommitter creates caller-funded asset batch outputs.
+type BatchAnchorCommitter struct {
+	driver          batchAnchorDriver
+	store           Store
+	encodeProofPath func(*tapsdk.AssetProofPath) ([]byte, error)
+	mu              sync.Mutex
+}
+
+// BatchAnchorCommitterConfig configures a BatchAnchorCommitter.
+type BatchAnchorCommitterConfig struct {
+	Wallet *tapsdk.Wallet
+	Store  Store
+}
+
+// NewBatchAnchorCommitter creates a durable batch anchor committer.
+func NewBatchAnchorCommitter(cfg BatchAnchorCommitterConfig) (
+	*BatchAnchorCommitter, error) {
+
+	if cfg.Wallet == nil {
+		return nil, fmt.Errorf("tap-sdk wallet is required")
+	}
+	if cfg.Store == nil {
+		return nil, fmt.Errorf("asset transition store is required")
+	}
+
+	return &BatchAnchorCommitter{
+		driver: &sdkDriver{
+			wallet: cfg.Wallet,
+		},
+		store: cfg.Store,
+	}, nil
+}
+
+// DeriveScript computes the batch output script before Bitcoin funding.
+func (c *BatchAnchorCommitter) DeriveScript(ctx context.Context,
+	req *BatchAnchorRequest, template *psbt.Packet) (*BatchAnchorScript,
+	error) {
+
+	if c == nil || c.driver == nil {
+		return nil, fmt.Errorf("batch anchor committer is required")
+	}
+
+	balanced, err := balanceTemplate(template)
+	if err != nil {
+		return nil, err
+	}
+
+	request, internalKey, err := c.buildRequest(req, balanced)
+	if err != nil {
+		return nil, err
+	}
+
+	previews, err := c.driver.Preview(
+		ctx, request, sourcesVerifier(req.Sources),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("preview batch anchor: %w", err)
+	}
+
+	preview, err := previewedOutput(
+		previews, batchAnchorOutputID, req.OutputIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	pkScript, err := composedScript(internalKey, preview.merkleRoot)
+	if err != nil {
+		return nil, err
+	}
+	derived := &BatchAnchorScript{
+		PkScript:     pkScript,
+		InternalKey:  internalKey,
+		SigningTweak: append([]byte(nil), preview.merkleRoot[:]...),
+		AssetRoot:    preview.assetRoot,
+	}
+	if req.Change == nil {
+		return derived, nil
+	}
+
+	changeScript, err := changePreviewScript(req.Change, previews)
+	if err != nil {
+		return nil, err
+	}
+	derived.ChangePkScript = changeScript
+
+	return derived, nil
+}
+
+// changePreviewScript composes the change anchor output script from its
+// previewed roots.
+func changePreviewScript(change *BatchAnchorChange,
+	previews []outputCommitmentPreview) ([]byte, error) {
+
+	changeKey, err := change.internalPubKey()
+	if err != nil {
+		return nil, err
+	}
+
+	preview, err := previewedOutput(
+		previews, batchAnchorChangeID, change.OutputIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return composedScript(changeKey, preview.merkleRoot)
+}
+
+// previewedOutput verifies that every issuance assigned to a Bitcoin output
+// produces the same commitment roots.
+func previewedOutput(previews []outputCommitmentPreview, logicalID string,
+	outputIndex uint32) (outputCommitmentPreview, error) {
+
+	var result *outputCommitmentPreview
+	for idx := range previews {
+		preview := &previews[idx]
+		if preview.logicalOutputID != logicalID {
+			continue
+		}
+		if preview.anchorOutputIndex != outputIndex {
+			return outputCommitmentPreview{}, fmt.Errorf("preview "+
+				"%q uses output %d, want %d", logicalID,
+				preview.anchorOutputIndex, outputIndex)
+		}
+		if result == nil {
+			outputPreview := *preview
+			result = &outputPreview
+
+			continue
+		}
+		if preview.assetRoot != result.assetRoot ||
+			preview.merkleRoot != result.merkleRoot {
+			return outputCommitmentPreview{}, fmt.Errorf("preview "+
+				"%q has inconsistent commitment roots",
+				logicalID)
+		}
+	}
+	if result == nil {
+		return outputCommitmentPreview{}, fmt.Errorf("preview misses "+
+			"output %q", logicalID)
+	}
+
+	return *result, nil
+}
+
+// Commit seals and validates the transition for a funded anchor transaction.
+func (c *BatchAnchorCommitter) Commit(ctx context.Context,
+	req *BatchAnchorRequest, funded *psbt.Packet,
+	derived *BatchAnchorScript) (*BatchAnchorCommit, error) {
+
+	if c == nil || c.driver == nil {
+		return nil, fmt.Errorf("batch anchor committer is required")
+	}
+	if c.store == nil {
+		return nil, fmt.Errorf("asset transition store is required")
+	}
+	if req == nil {
+		return nil, fmt.Errorf("batch anchor request is required")
+	}
+	if funded == nil || funded.UnsignedTx == nil {
+		return nil, fmt.Errorf("funded anchor PSBT is required")
+	}
+
+	// Keep the journal check and tapd mutation in one critical section.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if derived == nil || len(derived.PkScript) == 0 {
+		return nil, fmt.Errorf("derived batch anchor script is " +
+			"required")
+	}
+	finalTx := funded.UnsignedTx
+	if int(req.OutputIndex) >= len(finalTx.TxOut) {
+		return nil, fmt.Errorf("batch output %d exceeds anchor outputs",
+			req.OutputIndex)
+	}
+	if !bytes.Equal(
+		finalTx.TxOut[req.OutputIndex].PkScript, derived.PkScript,
+	) {
+		return nil, fmt.Errorf("funded anchor output %d does not "+
+			"carry the derived batch script", req.OutputIndex)
+	}
+	if err := checkFundedChange(req.Change, derived, finalTx); err != nil {
+		return nil, err
+	}
+
+	request, internalKey, err := c.buildRequest(req, funded)
+	if err != nil {
+		return nil, err
+	}
+
+	journal := customAnchorCommitJournal{
+		store:        c.store,
+		driver:       c.driver,
+		operation:    "batch anchor",
+		digestDomain: "wavelength/asset-batch-request/v0",
+	}
+	journalKey := fmt.Sprintf("asset-batch/%s/%s/%d", req.Digest,
+		req.AssetRef, req.OutputIndex)
+	committed, err := journal.commitDurably(
+		ctx, journalKey, request, sourcesVerifier(req.Sources),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("commit batch anchor: %w", err)
+	}
+	if len(committed.packageBytes) == 0 {
+		return nil, fmt.Errorf("batch anchor commit misses sealed " +
+			"package")
+	}
+	if committed.fundingMode !=
+		tapsdk.CustomAnchorFundingCallerFundedExact {
+		return nil, fmt.Errorf("unexpected funding mode %d",
+			committed.fundingMode)
+	}
+	if err := validateBatchInputs(req, committed); err != nil {
+		return nil, err
+	}
+
+	if err := validateCommittedOutputIDs(
+		committed, req.Change != nil,
+	); err != nil {
+		return nil, err
+	}
+	batchOutputs, err := committedOutputs(
+		committed, batchAnchorOutputID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkCommittedChange(
+		req.Change, req.AssetRef, finalTx, derived, committed,
+	); err != nil {
+		return nil, err
+	}
+	out := batchOutputs.outputs[0]
+	if out.anchorOutputIndex != req.OutputIndex {
+		return nil, fmt.Errorf("batch anchor committed output index "+
+			"%d, want %d", out.anchorOutputIndex, req.OutputIndex)
+	}
+	if batchOutputs.amount != req.Amount {
+		return nil, fmt.Errorf("batch anchor committed amount "+
+			"%d, want %d", batchOutputs.amount, req.Amount)
+	}
+	if out.anchorValueSat != req.OutputValueSat {
+		return nil, fmt.Errorf("batch anchor committed value "+
+			"%d, want %d", out.anchorValueSat, req.OutputValueSat)
+	}
+	for idx := range batchOutputs.outputs {
+		output := &batchOutputs.outputs[idx]
+		if !output.assetRef.Equivalent(req.AssetRef) {
+			return nil, fmt.Errorf("batch anchor output %d asset "+
+				"ref mismatch", idx)
+		}
+		if output.scriptMode != tapsdk.CustomAssetScriptOPTrue {
+			return nil, fmt.Errorf("batch anchor output %d script "+
+				"mode %d is not OP_TRUE", idx,
+				output.scriptMode)
+		}
+		if len(output.opTrueWitness) == 0 ||
+			len(output.proofBlob) == 0 {
+			return nil, fmt.Errorf("batch anchor output %d misses "+
+				"witness or proof material", idx)
+		}
+	}
+	if out.taprootMerkleRoot == (tapsdk.Hash{}) ||
+		out.taprootAssetRoot == (tapsdk.Hash{}) {
+		return nil, fmt.Errorf("batch anchor commit misses taproot " +
+			"roots")
+	}
+	if !bytes.Equal(out.taprootMerkleRoot[:], derived.SigningTweak) {
+		return nil, fmt.Errorf("batch anchor merkle root diverged " +
+			"from the pre-funding derivation")
+	}
+	if out.taprootAssetRoot != derived.AssetRoot {
+		return nil, fmt.Errorf("batch anchor asset root diverged " +
+			"from the pre-funding derivation")
+	}
+
+	pkScript, err := composedScript(internalKey, out.taprootMerkleRoot)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(pkScript, derived.PkScript) {
+		return nil, fmt.Errorf("committed batch output script does " +
+			"not reproduce the derived script")
+	}
+
+	committedPacket, err := psbtutil.Parse(committed.anchorPSBT)
+	if err != nil {
+		return nil, fmt.Errorf("parse committed anchor PSBT: %w", err)
+	}
+	if committedPacket.UnsignedTx.TxHash() != finalTx.TxHash() {
+		return nil, fmt.Errorf("committed anchor transaction " +
+			"diverged from the funded transaction")
+	}
+	expectedOutpoint := sdkOutpoint(wire.OutPoint{
+		Hash:  finalTx.TxHash(),
+		Index: req.OutputIndex,
+	})
+	if out.anchorOutpoint != expectedOutpoint {
+		return nil, fmt.Errorf("batch anchor committed outpoint " +
+			"mismatch")
+	}
+
+	rootSource, err := batchRootSource(
+		req, batchOutputs.outputs, committed.inputs, finalTx, derived,
+		c.encodeProofPath,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BatchAnchorCommit{
+		AssetRef:     req.AssetRef.String(),
+		OutputIndex:  req.OutputIndex,
+		PackageBytes: append([]byte(nil), committed.packageBytes...),
+		AnchorPSBT:   append([]byte(nil), committed.anchorPSBT...),
+		Script:       *derived,
+		RootSource:   rootSource,
+	}, nil
+}
+
+// Publish verifies a finalized anchor PSBT and records it in tapd.
+func (c *BatchAnchorCommitter) Publish(ctx context.Context, packageBytes,
+	finalPSBT []byte) error {
+
+	if c == nil || c.driver == nil {
+		return fmt.Errorf("batch anchor committer is required")
+	}
+	if len(packageBytes) == 0 || len(finalPSBT) == 0 {
+		return fmt.Errorf("sealed package and final anchor PSBT are " +
+			"required")
+	}
+
+	err := c.driver.Publish(ctx, packageBytes, finalPSBT)
+	if err != nil {
+		var attemptErr *tapsdk.CustomAnchorPublishAttemptError
+		if errors.As(err, &attemptErr) && attemptErr.OutcomeUnknown {
+			return errors.Join(
+				ErrReconciliationRequired,
+				fmt.Errorf("publish batch anchor transfer: %w",
+					err),
+			)
+		}
+
+		return fmt.Errorf("publish batch anchor transfer: %w", err)
+	}
+
+	return nil
+}
+
+// validateBatchInputs matches committed inputs to their requested sources.
+func validateBatchInputs(req *BatchAnchorRequest,
+	committed *commitResult) error {
+
+	if len(committed.inputs) != len(req.Sources) {
+		return fmt.Errorf("batch anchor committed %d inputs, want %d",
+			len(committed.inputs), len(req.Sources))
+	}
+
+	byID := make(map[string]*commitInput, len(committed.inputs))
+	for idx := range committed.inputs {
+		input := &committed.inputs[idx]
+		if _, ok := byID[input.logicalInputID]; ok {
+			return fmt.Errorf("batch anchor repeats committed "+
+				"input %q", input.logicalInputID)
+		}
+		byID[input.logicalInputID] = input
+	}
+
+	for idx := range req.Sources {
+		source := &req.Sources[idx]
+		id := fmt.Sprintf("batch-anchor-input-%d", idx)
+		input, ok := byID[id]
+		if !ok {
+			return fmt.Errorf("batch anchor commit misses input %q",
+				id)
+		}
+		if input.anchorOutpoint != sdkOutpoint(source.AnchorOutpoint) {
+			return fmt.Errorf("batch anchor input %d outpoint "+
+				"mismatch", idx)
+		}
+		if !input.assetRef.Equivalent(req.AssetRef) {
+			return fmt.Errorf("batch anchor input %d asset ref "+
+				"mismatch", idx)
+		}
+		if input.amount != source.Amount {
+			return fmt.Errorf("batch anchor input %d amount "+
+				"%d, want %d", idx, input.amount, source.Amount)
+		}
+		if input.proofSource.kind !=
+			tapsdk.CustomAnchorProofSourceConfirmedFile ||
+			!bytes.Equal(input.proofSource.blob, source.ProofFile) {
+			return fmt.Errorf("batch anchor input %d proof source "+
+				"mismatch", idx)
+		}
+	}
+
+	return nil
+}
+
+type committedOutputSet struct {
+	outputs []commitOutput
+	amount  uint64
+}
+
+// validateCommittedOutputIDs rejects unexpected logical outputs.
+func validateCommittedOutputIDs(committed *commitResult, hasChange bool) error {
+	for idx := range committed.outputs {
+		logicalID := committed.outputs[idx].logicalOutputID
+		if logicalID == batchAnchorOutputID ||
+			(hasChange && logicalID == batchAnchorChangeID) {
+
+			continue
+		}
+
+		return fmt.Errorf("batch anchor committed unexpected output %q",
+			logicalID)
+	}
+
+	return nil
+}
+
+// committedOutputs groups issuance outputs that share a Bitcoin output.
+func committedOutputs(committed *commitResult,
+	logicalID string) (*committedOutputSet, error) {
+
+	result := &committedOutputSet{}
+	seenIssuances := make(map[tapsdk.AssetID]struct{})
+	for idx := range committed.outputs {
+		output := committed.outputs[idx]
+		if output.logicalOutputID != logicalID {
+			continue
+		}
+		if _, ok := seenIssuances[output.issuanceID]; ok {
+			return nil, fmt.Errorf("output %q repeats issuance %x",
+				logicalID, output.issuanceID)
+		}
+		seenIssuances[output.issuanceID] = struct{}{}
+		if output.amount > math.MaxUint64-result.amount {
+			return nil, fmt.Errorf("output %q amount overflow",
+				logicalID)
+		}
+		result.amount += output.amount
+
+		if len(result.outputs) != 0 {
+			first := result.outputs[0]
+			if !sameCommittedAnchor(output, first) {
+				return nil, fmt.Errorf("output %q has "+
+					"inconsistent anchor data", logicalID)
+			}
+		}
+
+		result.outputs = append(result.outputs, output)
+	}
+	if len(result.outputs) == 0 {
+		return nil, fmt.Errorf("batch anchor commit misses output %q",
+			logicalID)
+	}
+
+	return result, nil
+}
+
+// sameCommittedAnchor compares the shared fields of issuance outputs.
+func sameCommittedAnchor(first, second commitOutput) bool {
+	return first.anchorOutputIndex == second.anchorOutputIndex &&
+		first.anchorOutpoint == second.anchorOutpoint &&
+		first.anchorValueSat == second.anchorValueSat &&
+		first.taprootAssetRoot == second.taprootAssetRoot &&
+		first.taprootMerkleRoot == second.taprootMerkleRoot
+}
+
+// checkFundedChange verifies the optional change script.
+func checkFundedChange(change *BatchAnchorChange, derived *BatchAnchorScript,
+	finalTx *wire.MsgTx) error {
+
+	if change == nil {
+		return nil
+	}
+	if len(derived.ChangePkScript) == 0 {
+		return fmt.Errorf("derived change script is required")
+	}
+	if int(change.OutputIndex) >= len(finalTx.TxOut) {
+		return fmt.Errorf("change output %d exceeds anchor outputs",
+			change.OutputIndex)
+	}
+	if !bytes.Equal(
+		finalTx.TxOut[change.OutputIndex].PkScript,
+		derived.ChangePkScript,
+	) {
+		return fmt.Errorf("funded anchor output %d does not carry the "+
+			"derived change script", change.OutputIndex)
+	}
+
+	return nil
+}
+
+// checkCommittedChange verifies the committed change allocation and script.
+func checkCommittedChange(change *BatchAnchorChange, assetRef tapsdk.AssetRef,
+	finalTx *wire.MsgTx, derived *BatchAnchorScript,
+	committed *commitResult) error {
+
+	if change == nil {
+		return nil
+	}
+
+	changeOutputs, err := committedOutputs(committed, batchAnchorChangeID)
+	if err != nil {
+		return err
+	}
+	out := changeOutputs.outputs[0]
+	if out.anchorOutputIndex != change.OutputIndex {
+		return fmt.Errorf("committed change output index %d, want %d",
+			out.anchorOutputIndex, change.OutputIndex)
+	}
+	if changeOutputs.amount != change.Amount {
+		return fmt.Errorf("committed change amount %d, want %d",
+			changeOutputs.amount, change.Amount)
+	}
+	if out.anchorValueSat != change.OutputValueSat {
+		return fmt.Errorf("committed change value %d, want %d",
+			out.anchorValueSat, change.OutputValueSat)
+	}
+	for idx := range changeOutputs.outputs {
+		output := &changeOutputs.outputs[idx]
+		if !output.assetRef.Equivalent(assetRef) {
+			return fmt.Errorf("committed change output %d asset "+
+				"ref mismatch", idx)
+		}
+		if output.scriptMode != scriptExternal {
+			return fmt.Errorf("committed change output %d script "+
+				"mode %d is not external", idx,
+				output.scriptMode)
+		}
+		if len(output.proofBlob) == 0 {
+			return fmt.Errorf("committed change output %d "+
+				"misses proof", idx)
+		}
+	}
+	if out.taprootMerkleRoot == (tapsdk.Hash{}) ||
+		out.taprootAssetRoot == (tapsdk.Hash{}) {
+		return fmt.Errorf("committed change misses taproot roots")
+	}
+	expectedOutpoint := sdkOutpoint(wire.OutPoint{
+		Hash:  finalTx.TxHash(),
+		Index: change.OutputIndex,
+	})
+	if out.anchorOutpoint != expectedOutpoint {
+		return fmt.Errorf("committed change outpoint mismatch")
+	}
+
+	changeKey, err := change.internalPubKey()
+	if err != nil {
+		return err
+	}
+	pkScript, err := composedScript(changeKey, out.taprootMerkleRoot)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(pkScript, derived.ChangePkScript) {
+		return fmt.Errorf("committed change output script does not " +
+			"reproduce the derived script")
+	}
+
+	return nil
+}
+
+// buildRequest creates the SDK request used by derivation and commit.
+func (c *BatchAnchorCommitter) buildRequest(req *BatchAnchorRequest,
+	anchor *psbt.Packet) (*tapsdk.CustomAnchorRequest, *btcec.PublicKey,
+	error) {
+
+	if err := validateBatchAnchorRequest(req, anchor); err != nil {
+		return nil, nil, err
+	}
+	anchorTx := anchor.UnsignedTx
+
+	cosigners := tree.UniqueCosigners(req.Cosigners)
+	internalKey, err := tree.ComputeInternalKey(cosigners)
+	if err != nil {
+		return nil, nil, fmt.Errorf("aggregate batch cosigners: %w",
+			err)
+	}
+
+	// tapd replaces the placeholder metadata for inputs it signs.
+	sanitized, err := psbt.NewFromUnsignedTx(anchor.UnsignedTx.Copy())
+	if err != nil {
+		return nil, nil, fmt.Errorf("clone anchor PSBT: %w", err)
+	}
+	copy(sanitized.Inputs, anchor.Inputs)
+	copy(sanitized.Outputs, anchor.Outputs)
+	for idx, txIn := range sanitized.UnsignedTx.TxIn {
+		for i := range req.Sources {
+			outpoint := req.Sources[i].AnchorOutpoint
+			if txIn.PreviousOutPoint == outpoint {
+				sanitized.Inputs[idx] = psbt.PInput{}
+				break
+			}
+		}
+	}
+
+	anchorBytes, err := psbtutil.Serialize(sanitized)
+	if err != nil {
+		return nil, nil, fmt.Errorf("serialize anchor PSBT: %w", err)
+	}
+
+	inputs := make([]tapsdk.CustomAssetInput, 0, len(req.Sources))
+	for i := range req.Sources {
+		source := &req.Sources[i]
+		witnessPlan := tapsdk.CustomAssetWitnessPlan{
+			Mode: witnessBackendSigner,
+		}
+		if len(source.Witness) != 0 {
+			witnessPlan = tapsdk.CustomAssetWitnessPlan{
+				Mode:  witnessCallerProvided,
+				Stack: cloneByteSlices(source.Witness),
+			}
+		}
+		inputs = append(inputs, tapsdk.CustomAssetInput{
+			ID:       fmt.Sprintf("batch-anchor-input-%d", i),
+			AssetRef: req.AssetRef,
+			Amount:   source.Amount,
+			ProofFile: append(
+				[]byte(nil), source.ProofFile...,
+			),
+			Witness: witnessPlan,
+		})
+	}
+
+	plans, err := batchSigningPlans(anchorTx, req.Sources)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	outputs := []tapsdk.CustomAssetOutput{{
+		ID:                batchAnchorOutputID,
+		AssetRef:          req.AssetRef,
+		Amount:            req.Amount,
+		AnchorOutputIndex: req.OutputIndex,
+		AnchorValueSat:    uint64(req.OutputValueSat),
+		Script: tapsdk.CustomAssetScriptPlan{
+			Mode: tapsdk.CustomAssetScriptOPTrue,
+			OPTrue: &tapsdk.CustomAssetOPTrueScriptPlan{
+				InternalKey: tapsdk.KeyDescriptor{
+					RawKeyBytes: deterministicKey(
+						req.Digest, "batch-anchor",
+					),
+				},
+			},
+		},
+		Anchor: anchorPlan(
+			internalKey, []txscript.TapLeaf{req.SweepLeaf},
+		),
+	}}
+	if req.Change != nil {
+		outputs = append(outputs, tapsdk.CustomAssetOutput{
+			ID:                batchAnchorChangeID,
+			AssetRef:          req.AssetRef,
+			Amount:            req.Change.Amount,
+			AnchorOutputIndex: req.Change.OutputIndex,
+			AnchorValueSat: uint64(
+				req.Change.OutputValueSat,
+			),
+			// Reuse the key derived before the anchor was funded.
+			Script: tapsdk.CustomAssetScriptPlan{
+				Mode: scriptExternal,
+				External: &tapsdk.
+					CustomAssetExternalScriptPlan{
+					ScriptKey: req.Change.ScriptKey,
+				},
+			},
+			Anchor: tapsdk.CustomAnchorOutputPlan{
+				InternalKey: req.Change.AnchorInternalKey,
+			},
+		})
+	}
+
+	request := &tapsdk.CustomAnchorRequest{
+		Inputs:     inputs,
+		Outputs:    outputs,
+		AnchorPSBT: anchorBytes,
+		Funding: tapsdk.CustomAnchorFundingPlan{
+			Mode: tapsdk.CustomAnchorFundingCallerFundedExact,
+			CallerFundedExact: &tapsdk.
+				CustomAnchorCallerFundedExact{},
+		},
+		PassiveAssets: tapsdk.CustomAnchorPassiveAssets{
+			Policy: tapsdk.CustomAnchorPassiveReject,
+		},
+		LossPolicy: tapsdk.CustomAnchorLossPolicy{
+			Mode: tapsdk.CustomAnchorLossReject,
+		},
+		SigningPlans: plans,
+	}
+
+	return request, internalKey, nil
+}
+
+func validateBatchAnchorRequest(req *BatchAnchorRequest,
+	anchor *psbt.Packet) error {
+
+	if req == nil {
+		return fmt.Errorf("batch anchor request is required")
+	}
+	if anchor == nil || anchor.UnsignedTx == nil {
+		return fmt.Errorf("anchor PSBT is required")
+	}
+	if err := req.AssetRef.Validate(); err != nil {
+		return fmt.Errorf("asset ref: %w", err)
+	}
+	if req.Amount == 0 {
+		return fmt.Errorf("batch asset amount is required")
+	}
+	if len(req.Sources) == 0 {
+		return fmt.Errorf("at least one funding source is required")
+	}
+	for idx, cosigner := range req.Cosigners {
+		if cosigner == nil {
+			return fmt.Errorf("batch cosigner %d is required", idx)
+		}
+	}
+
+	sourceTotal, err := validateBatchSources(req.Sources, anchor.UnsignedTx)
+	if err != nil {
+		return err
+	}
+	wantTotal := req.Amount
+	if req.Change != nil {
+		change := req.Change
+		if change.Amount == 0 || change.OutputValueSat <= 0 {
+			return fmt.Errorf("change amount and value are " +
+				"required")
+		}
+		if change.OutputIndex == req.OutputIndex {
+			return fmt.Errorf("change and batch outputs share "+
+				"anchor index %d", change.OutputIndex)
+		}
+		if change.Amount > math.MaxUint64-wantTotal {
+			return fmt.Errorf("batch and change amount overflow")
+		}
+		wantTotal += change.Amount
+	}
+	if sourceTotal != wantTotal {
+		return fmt.Errorf("funding sources carry %d units, the batch "+
+			"and change carry %d", sourceTotal, wantTotal)
+	}
+	if len(req.SweepLeaf.Script) == 0 {
+		return fmt.Errorf("sweep leaf is required")
+	}
+	if req.OutputValueSat <= 0 {
+		return fmt.Errorf("batch output value is required")
+	}
+	if int(req.OutputIndex) >= len(anchor.UnsignedTx.TxOut) {
+		return fmt.Errorf("batch output %d exceeds anchor outputs",
+			req.OutputIndex)
+	}
+	if req.Digest == (tapsdk.Hash{}) {
+		return fmt.Errorf("batch script key digest is required")
+	}
+
+	return nil
+}
+
+func validateBatchSources(sources []BatchAnchorSource,
+	anchorTx *wire.MsgTx) (uint64, error) {
+
+	var sourceTotal uint64
+	seenProofs := make(map[string]struct{}, len(sources))
+	sourcesByOutpoint := make(
+		map[wire.OutPoint]*BatchAnchorSource, len(sources),
+	)
+	for i := range sources {
+		source := &sources[i]
+		if len(source.ProofFile) == 0 {
+			return 0, fmt.Errorf("funding proof file %d is "+
+				"required", i)
+		}
+		if source.AnchorInternalKey == nil {
+			return 0, fmt.Errorf("funding anchor internal key %d "+
+				"is required", i)
+		}
+		if source.Amount == 0 {
+			return 0, fmt.Errorf("funding amount %d is required", i)
+		}
+		if source.Verifier == nil {
+			return 0, fmt.Errorf("funding proof verifier %d is "+
+				"required", i)
+		}
+		proofKey := string(source.ProofFile)
+		if _, ok := seenProofs[proofKey]; ok {
+			return 0, fmt.Errorf("funding proof file %d is "+
+				"repeated", i)
+		}
+		seenProofs[proofKey] = struct{}{}
+		previous := sourcesByOutpoint[source.AnchorOutpoint]
+		if previous != nil {
+			sameKey := previous.AnchorInternalKey.IsEqual(
+				source.AnchorInternalKey,
+			)
+			sameSigner := (len(previous.Witness) == 0) ==
+				(len(source.Witness) == 0)
+			if !sameKey || !sameSigner {
+				return 0, fmt.Errorf("funding sources at %s "+
+					"use different anchor signing plans",
+					source.AnchorOutpoint)
+			}
+		} else {
+			sourcesByOutpoint[source.AnchorOutpoint] = source
+		}
+		if source.Amount > math.MaxUint64-sourceTotal {
+			return 0, fmt.Errorf("funding source amount overflow")
+		}
+		sourceTotal += source.Amount
+
+	}
+
+	for outpoint := range sourcesByOutpoint {
+		fundingSpends := 0
+		for _, txIn := range anchorTx.TxIn {
+			if txIn.PreviousOutPoint == outpoint {
+				fundingSpends++
+			}
+		}
+		if fundingSpends == 0 {
+			return 0, fmt.Errorf("anchor transaction does not "+
+				"spend the funding anchor %s", outpoint)
+		}
+		if fundingSpends != 1 {
+			return 0, fmt.Errorf("anchor transaction spends the "+
+				"funding anchor %s %d times", outpoint,
+				fundingSpends)
+		}
+	}
+
+	return sourceTotal, nil
+}
+
+// batchSigningPlans assigns tapd-owned inputs and caller-owned inputs.
+func batchSigningPlans(tx *wire.MsgTx,
+	sources []BatchAnchorSource) ([]tapsdk.CustomAnchorInputSigningPlan,
+	error) {
+
+	type fundingPlan struct {
+		callerSigned bool
+		signer       tapsdk.XOnlyPubKey
+	}
+	funding := make(map[wire.OutPoint]fundingPlan, len(sources))
+	for i := range sources {
+		source := &sources[i]
+		signer, err := tapsdk.ParseXOnlyPubKey(
+			schnorr.SerializePubKey(source.AnchorInternalKey),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("funding anchor signer %d: %w",
+				i, err)
+		}
+		funding[source.AnchorOutpoint] = fundingPlan{
+			callerSigned: len(source.Witness) != 0,
+			signer:       signer,
+		}
+	}
+
+	plans := make(
+		[]tapsdk.CustomAnchorInputSigningPlan, 0, len(tx.TxIn),
+	)
+	for idx, txIn := range tx.TxIn {
+		plan, ok := funding[txIn.PreviousOutPoint]
+		if ok && !plan.callerSigned {
+			plans = append(
+				plans, tapsdk.CustomAnchorInputSigningPlan{
+					InputIndex: uint32(idx),
+					KeyPath: &tapsdk.
+						CustomAnchorKeyPathSigningPlan{
+						Signer: plan.signer,
+					},
+				},
+			)
+
+			continue
+		}
+
+		plans = append(plans, tapsdk.CustomAnchorInputSigningPlan{
+			InputIndex: uint32(idx),
+			CallerSigned: &tapsdk.
+				CustomAnchorCallerSignedPlan{},
+		})
+	}
+
+	return plans, nil
+}
+
+// sourcesVerifier combines the verifiers for all requested sources.
+func sourcesVerifier(
+	sources []BatchAnchorSource) tapsdk.ConfirmedProofVerifier {
+
+	verifiers := make([]tapsdk.ConfirmedProofVerifier, 0, len(sources))
+	for i := range sources {
+		if sources[i].Verifier != nil {
+			verifiers = append(verifiers, sources[i].Verifier)
+		}
+	}
+
+	return &multiSourceVerifier{verifiers: verifiers}
+}
+
+// multiSourceVerifier fans a proof out to the per-source verifiers.
+type multiSourceVerifier struct {
+	verifiers []tapsdk.ConfirmedProofVerifier
+}
+
+// VerifyConfirmedProof accepts a proof any per-source verifier accepts.
+func (v *multiSourceVerifier) VerifyConfirmedProof(ctx context.Context,
+	proofFile []byte) (*tapsdk.ConfirmedProofVerification, error) {
+
+	if len(v.verifiers) == 0 {
+		return nil, fmt.Errorf("no funding source verifiers")
+	}
+
+	var errs []error
+	for _, verifier := range v.verifiers {
+		verification, err := verifier.VerifyConfirmedProof(
+			ctx, proofFile,
+		)
+		if err == nil {
+			return verification, nil
+		}
+		errs = append(errs, err)
+	}
+
+	return nil, fmt.Errorf("no funding source accepts the proof: %w",
+		errors.Join(errs...))
+}
+
+// batchRootSource builds one proof path for each issuance held by the batch
+// output.
+func batchRootSource(req *BatchAnchorRequest, outputs []commitOutput,
+	inputs []commitInput, finalTx *wire.MsgTx, derived *BatchAnchorScript,
+	encodeProofPath func(*tapsdk.AssetProofPath) ([]byte, error)) (
+	TreeRootAssetSource, error) {
+
+	root := TreeRootAssetSource{
+		Inputs:        make([]TreeRootAssetInput, 0, len(outputs)),
+		SigningTweak:  append([]byte(nil), derived.SigningTweak...),
+		BatchPkScript: append([]byte(nil), derived.PkScript...),
+	}
+	anchorOutpoint := wire.OutPoint{
+		Hash:  finalTx.TxHash(),
+		Index: req.OutputIndex,
+	}
+	anchorTx := serializeTx(finalTx)
+	for idx := range outputs {
+		output := outputs[idx]
+		rootInput, err := batchRootInput(
+			req, output, inputs, anchorOutpoint, anchorTx,
+			encodeProofPath,
+		)
+		if err != nil {
+			return TreeRootAssetSource{}, fmt.Errorf("batch "+
+				"output issuance %x: %w", output.issuanceID,
+				err)
+		}
+		root.Inputs = append(root.Inputs, rootInput)
+	}
+
+	return root, nil
+}
+
+// batchRootInput joins one issuance's confirmed inputs to its batch
+// transition.
+func batchRootInput(req *BatchAnchorRequest, output commitOutput,
+	inputs []commitInput, anchorOutpoint wire.OutPoint, anchorTx []byte,
+	encodeProofPath func(*tapsdk.AssetProofPath) ([]byte, error)) (
+	TreeRootAssetInput, error) {
+
+	step := tapsdk.AssetProofPathStep{
+		TransitionProof: append([]byte(nil), output.proofBlob...),
+	}
+
+	packetInputs := make([]commitInput, 0, len(inputs))
+	for idx := range inputs {
+		input := inputs[idx]
+		if input.packetRole == output.packetRole &&
+			input.packetIndex == output.packetIndex {
+
+			packetInputs = append(packetInputs, input)
+		}
+	}
+	if len(packetInputs) == 0 {
+		return TreeRootAssetInput{}, fmt.Errorf("transition has no " +
+			"inputs")
+	}
+	sort.Slice(packetInputs, func(i, j int) bool {
+		return packetInputs[i].virtualInputIndex <
+			packetInputs[j].virtualInputIndex
+	})
+
+	for idx := range packetInputs {
+		input := packetInputs[idx]
+		if input.virtualInputIndex != uint32(idx) {
+			return TreeRootAssetInput{}, fmt.Errorf("packet " +
+				"input indexes are not contiguous")
+		}
+		if input.issuanceID != output.issuanceID {
+			return TreeRootAssetInput{}, fmt.Errorf("packet input "+
+				"%d has a different issuance", idx)
+		}
+	}
+	base := packetInputs[0]
+	previousOutpoint := base.anchorOutpoint
+	if len(packetInputs) > 1 {
+		summary, err := step.Summary()
+		if err != nil {
+			return TreeRootAssetInput{}, fmt.Errorf("summarize "+
+				"transition: %w", err)
+		}
+		if summary.IssuanceID != output.issuanceID ||
+			!summary.AssetRef.Equivalent(output.assetRef) ||
+			summary.Amount != output.amount ||
+			summary.AnchorOutpoint != output.anchorOutpoint ||
+			summary.AnchorValueSat != output.anchorValueSat {
+			return TreeRootAssetInput{}, fmt.Errorf("transition " +
+				"summary does not match committed output")
+		}
+		previousOutpoint = summary.PreviousAnchorOutpoint
+		if base.anchorOutpoint != previousOutpoint {
+			return TreeRootAssetInput{}, fmt.Errorf("transition " +
+				"base does not match packet input zero")
+		}
+	}
+
+	path := &tapsdk.AssetProofPath{
+		ConfirmedBaseProof: append(
+			[]byte(nil), base.proofSource.blob...,
+		),
+		Steps: []tapsdk.AssetProofPathStep{
+			step,
+		},
+	}
+	previousOutpoints := []tapsdk.Outpoint{base.anchorOutpoint}
+	if len(packetInputs) > 1 {
+		for idx := 1; idx < len(packetInputs); idx++ {
+			input := packetInputs[idx]
+			coPath := &tapsdk.AssetProofPath{
+				ConfirmedBaseProof: append(
+					[]byte(nil), input.proofSource.blob...,
+				),
+			}
+			path.Steps[0].CoInputPaths = append(
+				path.Steps[0].CoInputPaths, coPath,
+			)
+			previousOutpoints = append(
+				previousOutpoints, input.anchorOutpoint,
+			)
+		}
+	}
+	if encodeProofPath == nil {
+		encodeProofPath = func(path *tapsdk.AssetProofPath) ([]byte,
+			error) {
+
+			return path.MarshalBinary()
+		}
+	}
+	encodedPath, err := encodeProofPath(path)
+	if err != nil {
+		return TreeRootAssetInput{}, fmt.Errorf("encode proof path: %w",
+			err)
+	}
+
+	expected := &expectedUnconfirmedAnchor{
+		previousOutpoint:  previousOutpoint,
+		previousOutpoints: previousOutpoints,
+		anchorOutpoint:    output.anchorOutpoint,
+		transaction:       append([]byte(nil), anchorTx...),
+	}
+
+	return TreeRootAssetInput{
+		ProofPath:      encodedPath,
+		Amount:         output.amount,
+		AnchorOutpoint: anchorOutpoint,
+		Witness:        cloneByteSlices(output.opTrueWitness),
+		Verifier: &treePathVerifier{
+			base:      sourcesVerifier(req.Sources),
+			baseDepth: 0,
+			steps: []*expectedUnconfirmedAnchor{
+				expected,
+			},
+		},
+	}, nil
+}
+
+// composedScript derives the P2TR script of the internal key tweaked with
+// the combined taproot root.
+func composedScript(internalKey *btcec.PublicKey,
+	merkleRoot tapsdk.Hash) ([]byte, error) {
+
+	outputKey := txscript.ComputeTaprootOutputKey(
+		internalKey, merkleRoot[:],
+	)
+
+	script, err := txscript.PayToTaprootScript(outputKey)
+	if err != nil {
+		return nil, fmt.Errorf("compose batch output script: %w", err)
+	}
+
+	return script, nil
+}
+
+// balanceTemplate funds a copy of the pre-funding template for SDK preview.
+func balanceTemplate(template *psbt.Packet) (*psbt.Packet, error) {
+	if template == nil || template.UnsignedTx == nil {
+		return nil, fmt.Errorf("anchor template PSBT is required")
+	}
+
+	stubValue := int64(0)
+	for _, out := range template.UnsignedTx.TxOut {
+		if out.Value < 0 || out.Value > math.MaxInt64-stubValue {
+			return nil, fmt.Errorf("anchor template output value " +
+				"overflow")
+		}
+		stubValue += out.Value
+	}
+
+	tx := template.UnsignedTx.Copy()
+	tx.AddTxIn(wire.NewTxIn(&fundingStubOutpoint, nil, nil))
+
+	balanced, err := psbt.NewFromUnsignedTx(tx)
+	if err != nil {
+		return nil, fmt.Errorf("balance anchor template: %w", err)
+	}
+	copy(balanced.Inputs, template.Inputs)
+	copy(balanced.Outputs, template.Outputs)
+
+	stubScript, err := txscript.PayToTaprootScript(
+		txscript.ComputeTaprootKeyNoScript(&arkscript.ARKNUMSKey),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("funding stub script: %w", err)
+	}
+	balanced.Inputs[len(balanced.Inputs)-1].WitnessUtxo = &wire.TxOut{
+		Value:    stubValue,
+		PkScript: stubScript,
+	}
+
+	return balanced, nil
+}
+
+// fundingStubOutpoint is the synthetic outpoint of the derivation-time
+// funding stub. It never appears in a committed transaction.
+var fundingStubOutpoint = wire.OutPoint{
+	Hash: chainhash.HashH([]byte("wavelength/batch-anchor/funding-stub")),
+}

--- a/tapassets/batch_anchor_test.go
+++ b/tapassets/batch_anchor_test.go
@@ -1,0 +1,1066 @@
+package tapassets
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeBatchDriver struct {
+	mutateCommit func(*commitResult)
+	commitErr    error
+	afterCommit  func()
+	commits      int
+	packages     map[string]*commitResult
+	paths        []*tapsdk.AssetProofPath
+	publishErr   error
+	published    int
+}
+
+func (f *fakeBatchDriver) Publish(_ context.Context, _, _ []byte) error {
+	f.published++
+
+	return f.publishErr
+}
+
+// batchMerkleRoot returns a stable root for a test output.
+func batchMerkleRoot(input wire.OutPoint, index uint32) tapsdk.Hash {
+	seed := sha256.Sum256([]byte(fmt.Sprintf("batch/%s/%d", input, index)))
+
+	return tapsdk.Hash(seed)
+}
+
+// batchAssetRoot returns a stable asset root for a test output.
+func batchAssetRoot(input wire.OutPoint, index uint32) tapsdk.Hash {
+	seed := sha256.Sum256([]byte(fmt.Sprintf("asset/%s/%d", input, index)))
+
+	return tapsdk.Hash(seed)
+}
+
+func (f *fakeBatchDriver) Preview(_ context.Context,
+	request *tapsdk.CustomAnchorRequest, _ tapsdk.ConfirmedProofVerifier) (
+	[]outputCommitmentPreview, error) {
+
+	template, err := parseAnchorTx(request.AnchorPSBT)
+	if err != nil {
+		return nil, err
+	}
+	input := template.TxIn[0].PreviousOutPoint
+
+	previews := make(
+		[]outputCommitmentPreview, 0,
+		len(request.Outputs)*len(request.Inputs),
+	)
+	for _, out := range request.Outputs {
+		for range request.Inputs {
+			previews = append(previews, outputCommitmentPreview{
+				logicalOutputID:   out.ID,
+				anchorOutputIndex: out.AnchorOutputIndex,
+				assetRoot: batchAssetRoot(
+					input, out.AnchorOutputIndex,
+				),
+				merkleRoot: batchMerkleRoot(
+					input, out.AnchorOutputIndex,
+				),
+			})
+		}
+	}
+
+	return previews, nil
+}
+
+func (f *fakeBatchDriver) Commit(_ context.Context,
+	request *tapsdk.CustomAnchorRequest, _ tapsdk.ConfirmedProofVerifier) (
+	*commitResult, error) {
+
+	template, err := parseAnchorTx(request.AnchorPSBT)
+	if err != nil {
+		return nil, err
+	}
+	input := template.TxIn[0].PreviousOutPoint
+
+	result := &commitResult{
+		fundingMode: tapsdk.CustomAnchorFundingCallerFundedExact,
+		anchorPSBT:  request.AnchorPSBT,
+	}
+	remaining := make([]uint64, len(request.Inputs))
+	issuances := make([]tapsdk.AssetID, len(request.Inputs))
+	for idx, input := range request.Inputs {
+		anchorIndex := idx
+		if anchorIndex >= len(template.TxIn) {
+			return nil, fmt.Errorf("fake request input exceeds " +
+				"anchor inputs")
+		}
+		issuance := tapsdk.AssetID(sha256.Sum256([]byte(input.ID)))
+		issuances[idx] = issuance
+		remaining[idx] = input.Amount
+		result.inputs = append(result.inputs, commitInput{
+			logicalInputID:    input.ID,
+			packetIndex:       uint32(idx),
+			packetRole:        tapsdk.CustomAnchorPacketRoleActive,
+			virtualInputIndex: 0,
+			anchorOutpoint: sdkOutpoint(
+				template.TxIn[anchorIndex].PreviousOutPoint,
+			),
+			assetRef:   input.AssetRef,
+			issuanceID: issuance,
+			amount:     input.Amount,
+			proofSource: commitProofSource{
+				kind: tapsdk.
+					CustomAnchorProofSourceConfirmedFile,
+				blob: append([]byte(nil), input.ProofFile...),
+			},
+		})
+	}
+	for _, out := range request.Outputs {
+		scriptMode := tapsdk.CustomAssetScriptOPTrue
+		if out.ID == batchAnchorChangeID {
+			scriptMode = scriptExternal
+		}
+		amount := out.Amount
+		for inputIdx := range remaining {
+			if amount == 0 {
+				break
+			}
+			allocated := min(amount, remaining[inputIdx])
+			if allocated == 0 {
+				continue
+			}
+			amount -= allocated
+			remaining[inputIdx] -= allocated
+			result.outputs = append(result.outputs, commitOutput{
+				logicalOutputID: out.ID,
+				packetIndex:     uint32(inputIdx),
+				packetRole: tapsdk.
+					CustomAnchorPacketRoleActive,
+				anchorOutputIndex: out.AnchorOutputIndex,
+				anchorOutpoint: sdkOutpoint(wire.OutPoint{
+					Hash:  template.TxHash(),
+					Index: out.AnchorOutputIndex,
+				}),
+				anchorValueSat: int64(out.AnchorValueSat),
+				assetRef:       out.AssetRef,
+				issuanceID:     issuances[inputIdx],
+				amount:         allocated,
+				taprootMerkleRoot: batchMerkleRoot(
+					input, out.AnchorOutputIndex,
+				),
+				taprootAssetRoot: batchAssetRoot(
+					input, out.AnchorOutputIndex,
+				),
+				scriptMode: scriptMode,
+				opTrueWitness: [][]byte{
+					{0x51},
+				},
+				proofBlob: []byte(
+					fmt.Sprintf("batch-proof/%s/%d", input,
+						inputIdx),
+				),
+			})
+		}
+		if amount != 0 {
+			return nil, fmt.Errorf("fake output exceeds input " +
+				"amount")
+		}
+	}
+	result.packageBytes = []byte(fmt.Sprintf("batch-package/%s", input))
+
+	if f.mutateCommit != nil {
+		f.mutateCommit(result)
+	}
+	f.commits++
+	if f.afterCommit != nil {
+		f.afterCommit()
+	}
+	if f.commitErr != nil {
+		return nil, f.commitErr
+	}
+	if f.packages == nil {
+		f.packages = make(map[string]*commitResult)
+	}
+	f.packages[string(result.packageBytes)] = result
+
+	return result, nil
+}
+
+// DecodePackage restores a prior fake commit for journal replay.
+func (f *fakeBatchDriver) DecodePackage(encoded []byte) (*commitResult, error) {
+	result := f.packages[string(encoded)]
+	if result == nil {
+		return nil, fmt.Errorf("fake package not found")
+	}
+
+	return result, nil
+}
+
+// parseAnchorTx extracts the unsigned transaction from a serialized PSBT.
+func parseAnchorTx(anchorPSBT []byte) (*wire.MsgTx, error) {
+	packet, err := psbtutil.Parse(anchorPSBT)
+	if err != nil {
+		return nil, err
+	}
+
+	return packet.UnsignedTx, nil
+}
+
+// newBatchAnchorFixture creates a single-source batch request.
+func newBatchAnchorFixture(t *testing.T) (*BatchAnchorCommitter,
+	*BatchAnchorRequest, *psbt.Packet) {
+
+	t.Helper()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	userKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	anchorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		operatorKey.PubKey(), 1008,
+	)
+	require.NoError(t, err)
+
+	fundingOutpoint := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("funding-utxo")),
+		Index: 1,
+	}
+	assetRef := tapsdk.AssetRefFromAssetID(
+		tapsdk.AssetID(
+			chainhash.HashH(
+				[]byte("asset"),
+			),
+		),
+	)
+
+	req := &BatchAnchorRequest{
+		AssetRef: assetRef,
+		Amount:   1_500,
+		Sources: []BatchAnchorSource{{
+			ProofFile:         []byte("funding-proof"),
+			Amount:            1_500,
+			Verifier:          staticProofVerifier{},
+			AnchorOutpoint:    fundingOutpoint,
+			AnchorInternalKey: anchorKey.PubKey(),
+		}},
+		Cosigners: []*btcec.PublicKey{
+			operatorKey.PubKey(), userKey.PubKey(),
+		},
+		SweepLeaf:      sweepLeaf,
+		Digest:         tapsdk.Hash(chainhash.HashH([]byte("round"))),
+		OutputIndex:    0,
+		OutputValueSat: 30_000,
+	}
+
+	template := wire.NewMsgTx(2)
+	template.AddTxIn(wire.NewTxIn(&fundingOutpoint, nil, nil))
+	template.AddTxOut(&wire.TxOut{
+		Value:    30_000,
+		PkScript: []byte{0x51},
+	})
+
+	packet, err := psbt.NewFromUnsignedTx(template)
+	require.NoError(t, err)
+
+	fake := &fakeBatchDriver{}
+	committer := &BatchAnchorCommitter{
+		driver: fake,
+		store:  newMemoryStore(),
+		encodeProofPath: func(path *tapsdk.AssetProofPath) ([]byte,
+			error) {
+
+			fake.paths = append(fake.paths, path.Clone())
+
+			encoded := fmt.Sprintf("proof-path-%d", len(fake.paths))
+
+			return []byte(encoded), nil
+		},
+	}
+
+	return committer, req, packet
+}
+
+// fundedFromTemplate adds Bitcoin funding and change.
+func fundedFromTemplate(t *testing.T, template *psbt.Packet,
+	derived *BatchAnchorScript) *psbt.Packet {
+
+	t.Helper()
+
+	fundedTx := template.UnsignedTx.Copy()
+	fundedTx.TxOut[0].PkScript = append(
+		[]byte(nil), derived.PkScript...,
+	)
+	fundedTx.AddTxIn(
+		wire.NewTxIn(
+			&wire.OutPoint{
+				Hash:  chainhash.HashH([]byte("fee-input")),
+				Index: 0,
+			},
+			nil,
+			nil,
+		),
+	)
+	fundedTx.AddTxOut(&wire.TxOut{
+		Value:    5_000,
+		PkScript: []byte{0x52},
+	})
+
+	funded, err := psbt.NewFromUnsignedTx(fundedTx)
+	require.NoError(t, err)
+
+	return funded
+}
+
+// TestBatchAnchorDeriveAndCommit checks the complete batch-anchor flow.
+func TestBatchAnchorDeriveAndCommit(t *testing.T) {
+	t.Parallel()
+
+	committer, req, template := newBatchAnchorFixture(t)
+	ctx := context.Background()
+
+	derived, err := committer.DeriveScript(ctx, req, template)
+	require.NoError(t, err)
+
+	wantInternal, err := tree.ComputeInternalKey(req.Cosigners)
+	require.NoError(t, err)
+	wantKey := txscript.ComputeTaprootOutputKey(
+		wantInternal, derived.SigningTweak,
+	)
+	wantScript, err := txscript.PayToTaprootScript(wantKey)
+	require.NoError(t, err)
+	require.Equal(t, wantScript, derived.PkScript)
+
+	funded := fundedFromTemplate(t, template, derived)
+
+	commit, err := committer.Commit(ctx, req, funded, derived)
+	require.NoError(t, err)
+	require.NotEmpty(t, commit.PackageBytes)
+	require.Equal(t, derived.PkScript, commit.Script.PkScript)
+	require.Equal(
+		t, derived.SigningTweak, commit.RootSource.SigningTweak,
+	)
+	require.Equal(t, derived.PkScript, commit.RootSource.BatchPkScript)
+
+	require.Len(t, commit.RootSource.Inputs, 1)
+	rootInput := commit.RootSource.Inputs[0]
+	fake, ok := committer.driver.(*fakeBatchDriver)
+	require.True(t, ok)
+	require.Len(t, fake.paths, 1)
+	path := fake.paths[0]
+	require.Equal(t, req.Sources[0].ProofFile, path.ConfirmedBaseProof)
+	require.Len(t, path.Steps, 1)
+
+	verifier, ok := rootInput.Verifier.(*treePathVerifier)
+	require.True(t, ok)
+	require.Len(t, verifier.steps, 1)
+	step := verifier.steps[0]
+	require.Equal(
+		t, sdkOutpoint(req.Sources[0].AnchorOutpoint),
+		step.previousOutpoint,
+	)
+	require.Equal(
+		t, serializeTx(funded.UnsignedTx), step.transaction,
+	)
+}
+
+func TestBatchAnchorCosigners(t *testing.T) {
+	t.Parallel()
+
+	committer, req, template := newBatchAnchorFixture(t)
+	req.Cosigners = append(req.Cosigners, req.Cosigners[1])
+
+	derived, err := committer.DeriveScript(t.Context(), req, template)
+	require.NoError(t, err)
+
+	want, err := tree.ComputeInternalKey(req.Cosigners[:2])
+	require.NoError(t, err)
+	require.True(t, derived.InternalKey.IsEqual(want))
+
+	req.Cosigners[1] = nil
+	_, err = committer.DeriveScript(t.Context(), req, template)
+	require.ErrorContains(t, err, "batch cosigner 1 is required")
+}
+
+// TestBatchAnchorCommitValidation checks mismatched commit data.
+func TestBatchAnchorCommitValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		corrupt func(req *BatchAnchorRequest, funded *psbt.Packet,
+			derived *BatchAnchorScript, fake *fakeBatchDriver)
+		wantErr string
+	}{
+		{
+			name: "committed funding mode diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.fundingMode = tapsdk.
+						CustomAnchorFundingWalletFunded
+				}
+			},
+			wantErr: "unexpected funding mode",
+		},
+		{
+			name: "committed input outpoint diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.inputs[0].anchorOutpoint.Index++
+				}
+			},
+			wantErr: "input 0 outpoint mismatch",
+		},
+		{
+			name: "committed input asset diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.inputs[0].assetRef =
+						tapsdk.AssetRefFromAssetID(
+							tapsdk.AssetID{0xff},
+						)
+				}
+			},
+			wantErr: "input 0 asset ref mismatch",
+		},
+		{
+			name: "committed input amount diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.inputs[0].amount--
+				}
+			},
+			wantErr: "input 0 amount",
+		},
+		{
+			name: "funded output misses derived script",
+			corrupt: func(_ *BatchAnchorRequest,
+				funded *psbt.Packet, _ *BatchAnchorScript,
+				_ *fakeBatchDriver) {
+
+				funded.UnsignedTx.TxOut[0].PkScript = []byte{
+					0x53,
+				}
+			},
+			wantErr: "does not carry the derived batch script",
+		},
+		{
+			name: "committed merkle root diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].taprootMerkleRoot[0] ^= 1
+				}
+			},
+			wantErr: "merkle root diverged",
+		},
+		{
+			name: "committed asset root diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].taprootAssetRoot[0] ^= 1
+				}
+			},
+			wantErr: "asset root diverged",
+		},
+		{
+			name: "committed amount diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].amount--
+				}
+			},
+			wantErr: "committed amount",
+		},
+		{
+			name: "committed value diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].anchorValueSat++
+				}
+			},
+			wantErr: "committed value",
+		},
+		{
+			name: "committed asset ref diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].assetRef =
+						tapsdk.AssetRefFromAssetID(
+							tapsdk.AssetID{0xff},
+						)
+				}
+			},
+			wantErr: "asset ref mismatch",
+		},
+		{
+			name: "committed script mode diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].scriptMode = scriptExternal
+				}
+			},
+			wantErr: "not OP_TRUE",
+		},
+		{
+			name: "committed outpoint diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].anchorOutpoint.Index++
+				}
+			},
+			wantErr: "committed outpoint mismatch",
+		},
+		{
+			name: "committed transaction diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					packet, err := psbtutil.Parse(
+						r.anchorPSBT,
+					)
+					if err != nil {
+						panic(err)
+					}
+					packet.UnsignedTx.LockTime++
+					mutated, err := psbtutil.Serialize(
+						packet,
+					)
+					if err != nil {
+						panic(err)
+					}
+					r.anchorPSBT = mutated
+				}
+			},
+			wantErr: "diverged from the funded transaction",
+		},
+		{
+			name: "extra committed output",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs = append(
+						r.outputs, r.outputs[0],
+					)
+				}
+			},
+			wantErr: "repeats issuance",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			committer, req, template := newBatchAnchorFixture(t)
+			fake, ok := committer.driver.(*fakeBatchDriver)
+			require.True(t, ok)
+			ctx := context.Background()
+
+			derived, err := committer.DeriveScript(
+				ctx, req, template,
+			)
+			require.NoError(t, err)
+
+			funded := fundedFromTemplate(t, template, derived)
+			test.corrupt(req, funded, derived, fake)
+
+			_, err = committer.Commit(ctx, req, funded, derived)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+// addBatchAnchorChange adds a 600-unit asset change output.
+func addBatchAnchorChange(t *testing.T, req *BatchAnchorRequest,
+	template *psbt.Packet) *psbt.Packet {
+
+	t.Helper()
+
+	scriptPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	scriptPub, err := tapsdk.ParsePubKey(
+		scriptPriv.PubKey().SerializeCompressed(),
+	)
+	require.NoError(t, err)
+	internalPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	internalPub, err := tapsdk.ParsePubKey(
+		internalPriv.PubKey().SerializeCompressed(),
+	)
+	require.NoError(t, err)
+
+	req.Amount = 900
+	req.Change = &BatchAnchorChange{
+		Amount:         600,
+		OutputIndex:    1,
+		OutputValueSat: 1_000,
+		ScriptKey: tapsdk.ScriptKey{
+			PubKey: scriptPub,
+		},
+		AnchorInternalKey: tapsdk.InternalKey{
+			PubKey: internalPub,
+		},
+	}
+
+	tx := template.UnsignedTx.Copy()
+	tx.AddTxOut(&wire.TxOut{
+		Value:    req.Change.OutputValueSat,
+		PkScript: []byte{0x51},
+	})
+	rebuilt, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	return rebuilt
+}
+
+// TestBatchAnchorChangeDeriveAndCommit checks asset change handling.
+func TestBatchAnchorChangeDeriveAndCommit(t *testing.T) {
+	t.Parallel()
+
+	committer, req, template := newBatchAnchorFixture(t)
+	template = addBatchAnchorChange(t, req, template)
+	ctx := context.Background()
+
+	derived, err := committer.DeriveScript(ctx, req, template)
+	require.NoError(t, err)
+	require.NotEmpty(t, derived.ChangePkScript)
+
+	input := template.UnsignedTx.TxIn[0].PreviousOutPoint
+	changeInternal, err := btcec.ParsePubKey(
+		req.Change.AnchorInternalKey.PubKey[:],
+	)
+	require.NoError(t, err)
+	wantScript, err := composedScript(
+		changeInternal, batchMerkleRoot(input, req.Change.OutputIndex),
+	)
+	require.NoError(t, err)
+	require.Equal(t, wantScript, derived.ChangePkScript)
+
+	funded := fundedFromTemplate(t, template, derived)
+	funded.UnsignedTx.TxOut[1].PkScript = append(
+		[]byte(nil), derived.ChangePkScript...,
+	)
+
+	commit, err := committer.Commit(ctx, req, funded, derived)
+	require.NoError(t, err)
+	require.Equal(t, derived.ChangePkScript, commit.Script.ChangePkScript)
+}
+
+// TestBatchAnchorChangeValidation checks mismatched change data.
+func TestBatchAnchorChangeValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		corrupt func(req *BatchAnchorRequest, funded *psbt.Packet,
+			fake *fakeBatchDriver)
+		wantErr string
+	}{
+		{
+			name: "sources do not cover batch and change",
+			corrupt: func(req *BatchAnchorRequest, _ *psbt.Packet,
+				_ *fakeBatchDriver) {
+
+				req.Change.Amount--
+			},
+			wantErr: "funding sources carry",
+		},
+		{
+			name: "funded output misses change script",
+			corrupt: func(_ *BatchAnchorRequest,
+				funded *psbt.Packet, _ *fakeBatchDriver) {
+
+				funded.UnsignedTx.TxOut[1].PkScript = []byte{
+					0x53,
+				}
+			},
+			wantErr: "does not carry the derived change script",
+		},
+		{
+			name: "committed change amount diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[1].amount--
+				}
+			},
+			wantErr: "committed change amount",
+		},
+		{
+			name: "committed change root diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[1].taprootMerkleRoot[0] ^= 1
+				}
+			},
+			wantErr: "does not reproduce the derived script",
+		},
+		{
+			name: "committed change asset diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[1].assetRef =
+						tapsdk.AssetRefFromAssetID(
+							tapsdk.AssetID{0xff},
+						)
+				}
+			},
+			wantErr: "change output 0 asset ref mismatch",
+		},
+		{
+			name: "committed change script mode diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[1].scriptMode =
+						tapsdk.CustomAssetScriptOPTrue
+				}
+			},
+			wantErr: "is not external",
+		},
+		{
+			name: "committed change outpoint diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[1].anchorOutpoint.Index++
+				}
+			},
+			wantErr: "change outpoint mismatch",
+		},
+		{
+			name: "committed change output missing",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs = r.outputs[:1]
+				}
+			},
+			wantErr: "misses output",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			committer, req, template := newBatchAnchorFixture(t)
+			template = addBatchAnchorChange(t, req, template)
+			fake, ok := committer.driver.(*fakeBatchDriver)
+			require.True(t, ok)
+			ctx := context.Background()
+
+			derived, err := committer.DeriveScript(
+				ctx, req, template,
+			)
+			require.NoError(t, err)
+
+			funded := fundedFromTemplate(t, template, derived)
+			funded.UnsignedTx.TxOut[1].PkScript = append(
+				[]byte(nil), derived.ChangePkScript...,
+			)
+			test.corrupt(req, funded, fake)
+
+			_, err = committer.Commit(ctx, req, funded, derived)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+// TestBatchAnchorRequestGuards checks invalid requests.
+func TestBatchAnchorRequestGuards(t *testing.T) {
+	t.Parallel()
+
+	committer, req, template := newBatchAnchorFixture(t)
+	ctx := context.Background()
+
+	foreignTx := template.UnsignedTx.Copy()
+	foreignTx.TxIn[0].PreviousOutPoint.Index++
+	foreign, err := psbt.NewFromUnsignedTx(foreignTx)
+	require.NoError(t, err)
+	_, err = committer.DeriveScript(ctx, req, foreign)
+	require.ErrorContains(t, err, "does not spend the funding anchor")
+
+	broken := *req
+	brokenSource := req.Sources[0]
+	brokenSource.ProofFile = nil
+	broken.Sources = []BatchAnchorSource{brokenSource}
+	_, err = committer.DeriveScript(ctx, &broken, template)
+	require.ErrorContains(t, err, "proof file 0 is required")
+
+	broken = *req
+	broken.Amount = 0
+	_, err = committer.DeriveScript(ctx, &broken, template)
+	require.ErrorContains(t, err, "asset amount is required")
+
+	broken = *req
+	brokenSource = req.Sources[0]
+	brokenSource.Verifier = nil
+	broken.Sources = []BatchAnchorSource{brokenSource}
+	_, err = committer.DeriveScript(ctx, &broken, template)
+	require.ErrorContains(t, err, "proof verifier 0 is required")
+
+	broken = *req
+	broken.Sources = append(
+		[]BatchAnchorSource(nil), req.Sources[0], req.Sources[0],
+	)
+	broken.Sources[0].Amount = 750
+	broken.Sources[1].Amount = 750
+	_, err = committer.DeriveScript(ctx, &broken, template)
+	require.ErrorContains(t, err, "proof file 1 is repeated")
+
+	broken = *req
+	broken.Sources = append([]BatchAnchorSource(nil), req.Sources...)
+	second := req.Sources[0]
+	second.ProofFile = []byte("second-proof")
+	second.AnchorOutpoint.Index++
+	second.Amount = 1
+	broken.Sources[0].Amount = math.MaxUint64
+	broken.Sources = append(broken.Sources, second)
+	brokenTx := template.UnsignedTx.Copy()
+	brokenTx.AddTxIn(wire.NewTxIn(&second.AnchorOutpoint, nil, nil))
+	brokenPacket, err := psbt.NewFromUnsignedTx(brokenTx)
+	require.NoError(t, err)
+	_, err = committer.DeriveScript(ctx, &broken, brokenPacket)
+	require.ErrorContains(t, err, "amount overflow")
+}
+
+// TestBalanceTemplatePreservesOutputMetadata checks BIP-371 output fields.
+func TestBalanceTemplatePreservesOutputMetadata(t *testing.T) {
+	t.Parallel()
+
+	_, _, template := newBatchAnchorFixture(t)
+	template.Outputs[0].TaprootInternalKey = make([]byte, 32)
+	template.Outputs[0].TaprootTapTree = []byte{0x03, 0x04}
+
+	balanced, err := balanceTemplate(template)
+	require.NoError(t, err)
+	require.Equal(
+		t, template.Outputs[0].TaprootInternalKey,
+		balanced.Outputs[0].TaprootInternalKey,
+	)
+	require.Equal(
+		t, template.Outputs[0].TaprootTapTree,
+		balanced.Outputs[0].TaprootTapTree,
+	)
+}
+
+// TestBatchAnchorMultiSourceRequest checks a batch with two issuances.
+func TestBatchAnchorMultiSourceRequest(t *testing.T) {
+	t.Parallel()
+
+	committer, req, template := newBatchAnchorFixture(t)
+	groupKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	parsedGroupKey, err := tapsdk.ParsePubKey(
+		groupKey.PubKey().SerializeCompressed(),
+	)
+	require.NoError(t, err)
+	req.AssetRef = tapsdk.AssetRefFromGroupKey(parsedGroupKey)
+	req.Sources[0].Amount = 750
+
+	anchorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	secondOutpoint := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("second-tranche")),
+		Index: 2,
+	}
+	req.Sources = append(req.Sources, BatchAnchorSource{
+		ProofFile:         []byte("second-tranche-proof"),
+		Amount:            750,
+		Verifier:          staticProofVerifier{},
+		AnchorOutpoint:    secondOutpoint,
+		AnchorInternalKey: anchorKey.PubKey(),
+	})
+	tx := template.UnsignedTx.Copy()
+	tx.AddTxIn(wire.NewTxIn(&secondOutpoint, nil, nil))
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	request, _, err := committer.buildRequest(req, packet)
+	require.NoError(t, err)
+	require.Len(t, request.Inputs, 2)
+	require.True(t, request.Inputs[0].AssetRef.Equivalent(req.AssetRef))
+	require.True(t, request.Inputs[1].AssetRef.Equivalent(req.AssetRef))
+
+	derived, err := committer.DeriveScript(t.Context(), req, packet)
+	require.NoError(t, err)
+	funded := fundedFromTemplate(t, packet, derived)
+	commit, err := committer.Commit(t.Context(), req, funded, derived)
+	require.NoError(t, err)
+	require.Len(t, commit.RootSource.Inputs, 2)
+	require.Equal(t, uint64(750), commit.RootSource.Inputs[0].Amount)
+	require.Equal(t, uint64(750), commit.RootSource.Inputs[1].Amount)
+
+	fake, ok := committer.driver.(*fakeBatchDriver)
+	require.True(t, ok)
+	require.Len(t, fake.paths, 2)
+	for _, path := range fake.paths {
+		require.Empty(t, path.Steps[0].CoInputPaths)
+	}
+}
+
+// TestBatchSourcesSharedAnchor allows distinct assets in one Bitcoin output.
+func TestBatchSourcesSharedAnchor(t *testing.T) {
+	t.Parallel()
+
+	_, req, template := newBatchAnchorFixture(t)
+	req.Sources[0].Amount = 750
+	second := req.Sources[0]
+	second.ProofFile = []byte("second-proof")
+	second.Amount = 750
+	req.Sources = append(req.Sources, second)
+
+	total, err := validateBatchSources(req.Sources, template.UnsignedTx)
+	require.NoError(t, err)
+	require.Equal(t, req.Amount, total)
+}
+
+// TestBatchAnchorPublish checks publish errors and unknown outcomes.
+func TestBatchAnchorPublish(t *testing.T) {
+	t.Parallel()
+
+	committer, _, _ := newBatchAnchorFixture(t)
+	fake, ok := committer.driver.(*fakeBatchDriver)
+	require.True(t, ok)
+
+	err := committer.Publish(t.Context(), nil, []byte("psbt"))
+	require.ErrorContains(t, err, "required")
+
+	err = committer.Publish(
+		t.Context(), []byte("package"), []byte("psbt"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, fake.published)
+
+	fake.publishErr = &tapsdk.CustomAnchorPublishAttemptError{
+		Err:            fmt.Errorf("transport failed"),
+		OutcomeUnknown: true,
+	}
+	err = committer.Publish(
+		t.Context(), []byte("package"), []byte("psbt"),
+	)
+	require.ErrorIs(t, err, ErrReconciliationRequired)
+}
+
+// TestBatchAnchorJournal checks completed replay and preparation retries.
+func TestBatchAnchorJournal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("completed replay", func(t *testing.T) {
+		committer, req, template := newBatchAnchorFixture(t)
+		fake, ok := committer.driver.(*fakeBatchDriver)
+		require.True(t, ok)
+		derived, err := committer.DeriveScript(
+			t.Context(), req, template,
+		)
+		require.NoError(t, err)
+		funded := fundedFromTemplate(t, template, derived)
+
+		_, err = committer.Commit(t.Context(), req, funded, derived)
+		require.NoError(t, err)
+		commits := fake.commits
+		_, err = committer.Commit(t.Context(), req, funded, derived)
+		require.NoError(t, err)
+		require.Equal(t, commits, fake.commits)
+
+		changed := *req
+		changed.Sources = append(
+			[]BatchAnchorSource(nil), req.Sources...,
+		)
+		changed.Sources[0].Witness = [][]byte{{0x51}}
+		_, err = committer.Commit(
+			t.Context(), &changed, funded, derived,
+		)
+		require.ErrorContains(t, err, "different request")
+		require.Equal(t, commits, fake.commits)
+	})
+
+	t.Run("failed preparation retry", func(t *testing.T) {
+		committer, req, template := newBatchAnchorFixture(t)
+		fake, ok := committer.driver.(*fakeBatchDriver)
+		require.True(t, ok)
+		derived, err := committer.DeriveScript(
+			t.Context(), req, template,
+		)
+		require.NoError(t, err)
+		funded := fundedFromTemplate(t, template, derived)
+		fake.commitErr = &tapsdk.CustomAnchorCommitAttemptError{
+			Err:            fmt.Errorf("transport failed"),
+			OutcomeUnknown: true,
+		}
+
+		_, err = committer.Commit(t.Context(), req, funded, derived)
+		require.ErrorContains(t, err, "transport failed")
+		commits := fake.commits
+		fake.commitErr = nil
+		_, err = committer.Commit(t.Context(), req, funded, derived)
+		require.NoError(t, err)
+		require.Equal(t, commits+1, fake.commits)
+	})
+
+	t.Run("request cancellation after commit", func(t *testing.T) {
+		committer, req, template := newBatchAnchorFixture(t)
+		fake, ok := committer.driver.(*fakeBatchDriver)
+		require.True(t, ok)
+		derived, err := committer.DeriveScript(
+			t.Context(), req, template,
+		)
+		require.NoError(t, err)
+		funded := fundedFromTemplate(t, template, derived)
+		ctx, cancel := context.WithCancel(t.Context())
+		fake.afterCommit = cancel
+
+		_, err = committer.Commit(ctx, req, funded, derived)
+		require.NoError(t, err)
+		commits := fake.commits
+		fake.afterCommit = nil
+		_, err = committer.Commit(t.Context(), req, funded, derived)
+		require.NoError(t, err)
+		require.Equal(t, commits, fake.commits)
+	})
+}

--- a/tapassets/driver.go
+++ b/tapassets/driver.go
@@ -9,6 +9,9 @@ import (
 )
 
 type commitOutput struct {
+	logicalOutputID   string
+	packetIndex       uint32
+	packetRole        tapsdk.CustomAnchorPacketRole
 	anchorOutputIndex uint32
 	anchorOutpoint    tapsdk.Outpoint
 	anchorValueSat    int64
@@ -23,11 +26,20 @@ type commitOutput struct {
 }
 
 type commitInput struct {
-	logicalInputID string
-	anchorOutpoint tapsdk.Outpoint
-	assetRef       tapsdk.AssetRef
-	issuanceID     tapsdk.AssetID
-	amount         uint64
+	logicalInputID    string
+	packetIndex       uint32
+	packetRole        tapsdk.CustomAnchorPacketRole
+	virtualInputIndex uint32
+	anchorOutpoint    tapsdk.Outpoint
+	assetRef          tapsdk.AssetRef
+	issuanceID        tapsdk.AssetID
+	amount            uint64
+	proofSource       commitProofSource
+}
+
+type commitProofSource struct {
+	kind tapsdk.CustomAnchorProofSourceKind
+	blob []byte
 }
 
 type commitResult struct {
@@ -46,8 +58,87 @@ type assetTreeDriver interface {
 	DecodePackage([]byte) (*commitResult, error)
 }
 
+type outputCommitmentPreview struct {
+	logicalOutputID   string
+	anchorOutputIndex uint32
+	assetRoot         tapsdk.Hash
+	merkleRoot        tapsdk.Hash
+}
+
+type batchAnchorDriver interface {
+	assetTreeDriver
+
+	Preview(context.Context, *tapsdk.CustomAnchorRequest,
+		tapsdk.ConfirmedProofVerifier) (
+		[]outputCommitmentPreview,
+		error,
+	)
+
+	Publish(context.Context, []byte, []byte) error
+}
+
 type sdkDriver struct {
 	wallet *tapsdk.Wallet
+}
+
+// Preview returns the commitment roots produced by a custom-anchor request.
+func (d *sdkDriver) Preview(ctx context.Context,
+	request *tapsdk.CustomAnchorRequest,
+	verifier tapsdk.ConfirmedProofVerifier) ([]outputCommitmentPreview,
+	error) {
+
+	if d == nil || d.wallet == nil {
+		return nil, fmt.Errorf("tap-sdk wallet is required")
+	}
+
+	builder := d.wallet.NewCustomAnchorTxBuilder()
+	if verifier != nil {
+		builder.SetConfirmedProofVerifier(verifier)
+	}
+	plan, err := builder.Build(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	previews, err := plan.PreviewOutputCommitments()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]outputCommitmentPreview, len(previews))
+	for idx := range previews {
+		preview := previews[idx]
+		result[idx] = outputCommitmentPreview{
+			logicalOutputID:   preview.LogicalOutputID,
+			anchorOutputIndex: preview.AnchorOutputIndex,
+			assetRoot:         preview.TaprootAssetRoot,
+			merkleRoot:        preview.TaprootMerkleRoot,
+		}
+	}
+
+	return result, nil
+}
+
+// Publish verifies and records a finalized custom-anchor transaction.
+func (d *sdkDriver) Publish(ctx context.Context, packageBytes,
+	finalPSBT []byte) error {
+
+	if d == nil || d.wallet == nil {
+		return fmt.Errorf("tap-sdk wallet is required")
+	}
+
+	var transfer tapsdk.CustomAnchorTransferPackage
+	if err := transfer.UnmarshalBinary(packageBytes); err != nil {
+		return fmt.Errorf("decode sealed transfer package: %w", err)
+	}
+	if err := transfer.VerifyFinalAnchorPSBT(finalPSBT); err != nil {
+		return fmt.Errorf("verify final anchor PSBT: %w", err)
+	}
+
+	_, err := d.wallet.PublishCustomAnchorTransfer(
+		ctx, &transfer, finalPSBT,
+	)
+
+	return err
 }
 
 // Commit builds, commits, verifies, and seals one SDK custom-anchor request.
@@ -133,11 +224,20 @@ func commitResultFromValidatedPackage(
 	for idx := range transfer.Inputs {
 		input := transfer.Inputs[idx]
 		result.inputs[idx] = commitInput{
-			logicalInputID: input.LogicalInputID,
-			anchorOutpoint: input.AnchorOutpoint,
-			assetRef:       input.AssetRef,
-			issuanceID:     input.IssuanceID,
-			amount:         input.Amount,
+			logicalInputID:    input.LogicalInputID,
+			packetIndex:       input.PacketIndex,
+			packetRole:        input.PacketRole,
+			virtualInputIndex: input.VirtualInputIndex,
+			anchorOutpoint:    input.AnchorOutpoint,
+			assetRef:          input.AssetRef,
+			issuanceID:        input.IssuanceID,
+			amount:            input.Amount,
+			proofSource: commitProofSource{
+				kind: input.ProofSource.Kind,
+				blob: append(
+					[]byte(nil), input.ProofSource.Blob...,
+				),
+			},
 		}
 	}
 
@@ -170,6 +270,9 @@ func commitResultFromValidatedPackage(
 		}
 
 		result.outputs[idx] = commitOutput{
+			logicalOutputID:   output.LogicalOutputID,
+			packetIndex:       output.PacketIndex,
+			packetRole:        output.PacketRole,
 			anchorOutputIndex: output.AnchorOutputIndex,
 			anchorOutpoint:    output.AnchorOutpoint,
 			anchorValueSat:    output.AnchorValueSat,

--- a/tapassets/driver_test.go
+++ b/tapassets/driver_test.go
@@ -24,16 +24,27 @@ func TestCommitResultProjection(t *testing.T) {
 			ActualFeeSat: 5,
 		},
 		Inputs: []tapsdk.CustomAnchorAssetInputSummary{{
-			LogicalInputID: "input-0",
-			AnchorOutpoint: firstOutpoint,
-			AssetRef:       assetRef,
+			LogicalInputID:    "input-0",
+			PacketIndex:       3,
+			PacketRole:        tapsdk.CustomAnchorPacketRoleActive,
+			VirtualInputIndex: 4,
+			AnchorOutpoint:    firstOutpoint,
+			AssetRef:          assetRef,
 			IssuanceID: tapsdk.AssetID{
 				0x05,
 			},
 			Amount: 10,
+			ProofSource: tapsdk.CustomAnchorProofSourceSummary{
+				Kind: tapsdk.
+					CustomAnchorProofSourceConfirmedFile,
+				Blob: []byte{
+					0x0D,
+				},
+			},
 		}},
 		Outputs: []tapsdk.CustomAnchorAssetOutputSummary{
 			{
+				LogicalOutputID: "output-0",
 				PacketRole: tapsdk.
 					CustomAnchorPacketRoleActive,
 				PacketIndex:        0,
@@ -63,6 +74,7 @@ func TestCommitResultProjection(t *testing.T) {
 				},
 			},
 			{
+				LogicalOutputID: "output-1",
 				PacketRole: tapsdk.
 					CustomAnchorPacketRoleActive,
 				PacketIndex:        1,
@@ -109,8 +121,20 @@ func TestCommitResultProjection(t *testing.T) {
 	require.Equal(t, transfer.Funding.ActualFeeSat, result.actualFeeSat)
 	require.Len(t, result.inputs, 1)
 	require.Equal(t, "input-0", result.inputs[0].logicalInputID)
+	require.Equal(t, uint32(3), result.inputs[0].packetIndex)
+	require.Equal(
+		t, tapsdk.CustomAnchorPacketRoleActive,
+		result.inputs[0].packetRole,
+	)
+	require.Equal(t, uint32(4), result.inputs[0].virtualInputIndex)
 	require.Equal(t, tapsdk.AssetID{0x05}, result.inputs[0].issuanceID)
+	require.Equal(
+		t, tapsdk.CustomAnchorProofSourceConfirmedFile,
+		result.inputs[0].proofSource.kind,
+	)
+	require.Equal(t, []byte{0x0D}, result.inputs[0].proofSource.blob)
 	require.Len(t, result.outputs, 2)
+	require.Equal(t, "output-0", result.outputs[0].logicalOutputID)
 	require.Equal(t, []byte{0x0B}, result.outputs[0].proofBlob)
 	require.Equal(t, []byte{0x0A}, result.outputs[1].proofBlob)
 	require.Equal(
@@ -119,9 +143,11 @@ func TestCommitResultProjection(t *testing.T) {
 
 	packageBytes[0]++
 	transfer.AnchorPsbt[0]++
+	transfer.Inputs[0].ProofSource.Blob[0]++
 	transfer.ProofUpdates[1].ProofBlob[0]++
 	require.Equal(t, []byte{0x0C}, result.packageBytes)
 	require.Equal(t, []byte{0x04}, result.anchorPSBT)
+	require.Equal(t, []byte{0x0D}, result.inputs[0].proofSource.blob)
 	require.Equal(t, []byte{0x0B}, result.outputs[0].proofBlob)
 }
 

--- a/tapassets/transition_helpers.go
+++ b/tapassets/transition_helpers.go
@@ -127,7 +127,6 @@ func (s *assetSpendSource) appendTransition(output commitOutput,
 		path = s.proofPath.Clone()
 	} else {
 		path = &tapsdk.AssetProofPath{
-			Version: tapsdk.AssetProofPathVersionV0,
 			ConfirmedBaseProof: append(
 				[]byte(nil), s.proofFile...,
 			),

--- a/tapassets/transition_helpers.go
+++ b/tapassets/transition_helpers.go
@@ -17,6 +17,7 @@ const (
 	opTrueKeyDomain       = "wavelength/assets/optrue/v0/"
 	witnessBackendSigner  = tapsdk.CustomAssetWitnessBackendSigner
 	witnessCallerProvided = tapsdk.CustomAssetWitnessCallerProvided
+	scriptExternal        = tapsdk.CustomAssetScriptExternal
 )
 
 type expectedUnconfirmedAnchor struct {

--- a/tapassets/tree_journal.go
+++ b/tapassets/tree_journal.go
@@ -13,136 +13,174 @@ import (
 )
 
 const (
-	treeCommitStateVersion  = uint16(0)
-	maxTreeCommitStateSize  = 128 * 1024 * 1024
-	treeJournalWriteTimeout = 5 * time.Second
+	customAnchorCommitStateVersion = uint16(0)
+	maxCustomAnchorCommitStateSize = 128 * 1024 * 1024
+	commitJournalWriteTimeout      = 5 * time.Second
+	treeCommitDigestDomain         = "wavelength/asset-tree-request/v0"
 )
 
-type treeCommitState struct {
+type customAnchorCommitState struct {
 	Version       uint16      `json:"version"`
 	RequestDigest tapsdk.Hash `json:"request_digest"`
 	Package       []byte      `json:"package,omitempty"`
+}
+
+type customAnchorCommitJournal struct {
+	store        Store
+	driver       assetTreeDriver
+	operation    string
+	digestDomain string
 }
 
 func (m *treeMaterializer) commitDurably(ctx context.Context,
 	input wire.OutPoint, request *tapsdk.CustomAnchorRequest,
 	verifier tapsdk.ConfirmedProofVerifier) (*commitResult, error) {
 
-	if request == nil {
-		return nil, fmt.Errorf("asset tree request is required")
+	key := fmt.Sprintf("asset-tree/%s/%s", m.cfg.Digest, input)
+	journal := customAnchorCommitJournal{
+		store:        m.cfg.Store,
+		driver:       m.driver,
+		operation:    "asset tree",
+		digestDomain: treeCommitDigestDomain,
 	}
 
-	digest, err := treeCommitRequestDigest(request)
+	return journal.commitDurably(ctx, key, request, verifier)
+}
+
+func (j *customAnchorCommitJournal) commitDurably(ctx context.Context,
+	key string, request *tapsdk.CustomAnchorRequest,
+	verifier tapsdk.ConfirmedProofVerifier) (*commitResult, error) {
+
+	if request == nil {
+		return nil, fmt.Errorf("%s request is required", j.operation)
+	}
+	if j.store == nil {
+		return nil, fmt.Errorf("%s store is required", j.operation)
+	}
+	if j.driver == nil {
+		return nil, fmt.Errorf("%s driver is required", j.operation)
+	}
+	if key == "" || j.digestDomain == "" || j.operation == "" {
+		return nil, fmt.Errorf("commit journal configuration is " +
+			"invalid")
+	}
+
+	digest, err := customAnchorCommitRequestDigest(
+		request, j.digestDomain,
+	)
 	if err != nil {
 		return nil, err
 	}
-	key := fmt.Sprintf("asset-tree/%s/%s", m.cfg.Digest, input)
 
-	state, err := m.loadTreeCommitState(ctx, key, digest)
+	state, err := j.load(ctx, key, digest)
 	if err != nil {
 		return nil, err
 	}
 	if len(state.Package) != 0 {
-		committed, err := m.driver.DecodePackage(state.Package)
+		committed, err := j.driver.DecodePackage(state.Package)
 		if err != nil {
-			return nil, fmt.Errorf("decode journaled asset tree "+
-				"package: %w", err)
+			return nil, fmt.Errorf("decode journaled %s "+
+				"package: %w", j.operation, err)
 		}
 
 		return committed, nil
 	}
-	committed, err := m.driver.Commit(ctx, request, verifier)
+
+	committed, err := j.driver.Commit(ctx, request, verifier)
 	if err != nil {
 		return nil, err
 	}
 	if committed == nil || len(committed.packageBytes) == 0 {
-		return nil, fmt.Errorf("committed asset tree has no sealed " +
-			"package")
+		return nil, fmt.Errorf("committed %s has no sealed package",
+			j.operation)
 	}
 
 	state.Package = append([]byte(nil), committed.packageBytes...)
-	if err := m.storeTreeCommitStateAfterCommit(
+	if err := j.storeStateAfterCommit(
 		ctx, key, state,
 	); err != nil {
-		return nil, fmt.Errorf("record committed asset tree "+
-			"package: %w", err)
+		return nil, fmt.Errorf("record committed %s package: %w",
+			j.operation, err)
 	}
 
 	return committed, nil
 }
 
-func (m *treeMaterializer) storeTreeCommitStateAfterCommit(
-	requestCtx context.Context, key string, state *treeCommitState) error {
+func (j *customAnchorCommitJournal) storeStateAfterCommit(
+	requestCtx context.Context, key string,
+	state *customAnchorCommitState) error {
 
 	journalCtx, cancel := context.WithTimeout(
-		context.WithoutCancel(requestCtx), treeJournalWriteTimeout,
+		context.WithoutCancel(requestCtx), commitJournalWriteTimeout,
 	)
 	defer cancel()
 
-	return m.storeTreeCommitState(journalCtx, key, state)
+	return j.storeState(journalCtx, key, state)
 }
 
-func (m *treeMaterializer) loadTreeCommitState(ctx context.Context, key string,
-	digest tapsdk.Hash) (*treeCommitState, error) {
+func (j *customAnchorCommitJournal) load(ctx context.Context, key string,
+	digest tapsdk.Hash) (*customAnchorCommitState, error) {
 
-	encoded, err := m.cfg.Store.Load(ctx, key)
+	encoded, err := j.store.Load(ctx, key)
 	if errors.Is(err, ErrStoreNotFound) {
-		return &treeCommitState{
-			Version:       treeCommitStateVersion,
+		return &customAnchorCommitState{
+			Version:       customAnchorCommitStateVersion,
 			RequestDigest: digest,
 		}, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("load asset tree commit state: %w", err)
-	}
-	if len(encoded) == 0 || len(encoded) > maxTreeCommitStateSize {
-		return nil, fmt.Errorf("asset tree commit state size %d "+
-			"is invalid", len(encoded))
-	}
-
-	var state treeCommitState
-	if err := json.Unmarshal(encoded, &state); err != nil {
-		return nil, fmt.Errorf("decode asset tree commit state: %w",
+		return nil, fmt.Errorf("load %s commit state: %w", j.operation,
 			err)
 	}
-	if state.Version != treeCommitStateVersion {
-		return nil, fmt.Errorf("asset tree commit state version %d is "+
-			"unsupported", state.Version)
+	if len(encoded) == 0 || len(encoded) > maxCustomAnchorCommitStateSize {
+		return nil, fmt.Errorf("%s commit state size %d is invalid",
+			j.operation, len(encoded))
+	}
+
+	var state customAnchorCommitState
+	if err := json.Unmarshal(encoded, &state); err != nil {
+		return nil, fmt.Errorf("decode %s commit state: %w",
+			j.operation, err)
+	}
+	if state.Version != customAnchorCommitStateVersion {
+		return nil, fmt.Errorf("%s commit state version %d is "+
+			"unsupported", j.operation, state.Version)
 	}
 	if state.RequestDigest != digest {
-		return nil, fmt.Errorf("asset tree journal key reused with a " +
-			"different request")
+		return nil, fmt.Errorf("%s journal key reused with a "+
+			"different request", j.operation)
 	}
 
 	return &state, nil
 }
 
-func (m *treeMaterializer) storeTreeCommitState(ctx context.Context, key string,
-	state *treeCommitState) error {
+func (j *customAnchorCommitJournal) storeState(ctx context.Context, key string,
+	state *customAnchorCommitState) error {
 
 	encoded, err := json.Marshal(state)
 	if err != nil {
-		return fmt.Errorf("encode asset tree commit state: %w", err)
+		return fmt.Errorf("encode %s commit state: %w", j.operation,
+			err)
 	}
-	if len(encoded) > maxTreeCommitStateSize {
-		return fmt.Errorf("asset tree commit state exceeds %d bytes",
-			maxTreeCommitStateSize)
+	if len(encoded) > maxCustomAnchorCommitStateSize {
+		return fmt.Errorf("%s commit state exceeds %d bytes",
+			j.operation, maxCustomAnchorCommitStateSize)
 	}
 
-	return m.cfg.Store.Store(ctx, key, encoded)
+	return j.store.Store(ctx, key, encoded)
 }
 
-func treeCommitRequestDigest(request *tapsdk.CustomAnchorRequest) (tapsdk.Hash,
-	error) {
+func customAnchorCommitRequestDigest(request *tapsdk.CustomAnchorRequest,
+	domain string) (tapsdk.Hash, error) {
 
 	encoded, err := json.Marshal(request)
 	if err != nil {
-		return tapsdk.Hash{}, fmt.Errorf("encode asset tree "+
+		return tapsdk.Hash{}, fmt.Errorf("encode custom anchor "+
 			"request: %w", err)
 	}
 
 	digest := sha256.New()
-	_, _ = digest.Write([]byte("wavelength/asset-tree-request/v0"))
+	_, _ = digest.Write([]byte(domain))
 	_, _ = digest.Write(encoded)
 
 	var result tapsdk.Hash


### PR DESCRIPTION
## Summary

- expose the batch output aggregate key and sweep leaf for BIP-371 output metadata
- derive and commit caller-funded asset batch outputs from one or more confirmed sources, with optional wallet-owned asset change
- validate concrete issuance outputs against their shared Bitcoin anchor and preserve one tree root input per issuance
- bind merged inputs of one issuance through ordered recursive co-input paths
- persist commit attempts and sealed packages, and publish the finalized anchor through tapd

Grouped asset references can combine several proven issuances in one batch output, providing the batch-anchor primitive for multi-tranche onboarding.