### PR TITLE
build: bump version to v0.1.2-rc3

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -19,7 +19,7 @@ const (
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = "rc2"
+	AppPreRelease = "rc3"
 )
 
 var (


### PR DESCRIPTION
## Summary

Bump the v0.1.x release line from v0.1.2-rc2 to v0.1.2-rc3.

This branch is based on the latest `v0.1.x-branch`, including backport #1173, and changes only `build/version.go`:

- `AppPreRelease`: `"rc2"` to `"rc3"`

## Impact

Release binaries now report `0.1.2-rc3`. There are no runtime or dependency changes.

## Validation

- `make fmt-changed`
- `go test ./build`
- `make build`
- `make lint-changed-local`
- `./bin/waved --version`
- `./bin/wavecli --version`
- `make commitmsg-lint range='origin/v0.1.x-branch..HEAD'`
- `git diff --check`
