### PR TITLE
docs: nightly doc-gardening sweep 2026-08-24

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,7 +28,7 @@ package may import from a higher layer.
 | [`lib/recovery`](lib/recovery/) | Immutable recovery proof graph, session state machine, TLV codec for unilateral exit |
 | [`unrollplan`](unrollplan/) | Pure dependency-resolution planner driving unilateral-exit broadcast/sweep ordering |
 | [`vhtlcrecovery`](vhtlcrecovery/) | Durable control-plane types for vHTLC on-chain recovery jobs (action, state, script parameters, swap linkage) |
-| [`credit`](credit/) | Client-side credit subsystem: supervisor/per-operation-actor pair driving fault-tolerant sub-dust pay, credit-receive, and redeem flows against the authoritative server ledger |
+| [`credit`](credit/) | Client-side credit subsystem: supervisor/per-operation-actor pair driving fault-tolerant sub-floor pay, credit-receive, and redeem flows against the authoritative server ledger |
 | [`coinselect`](coinselect/) | Single coin-type-agnostic coin-selection algorithm shared across wallet backends |
 
 ### Layer 2: Infrastructure (Chain, Storage, Messaging)

--- a/credit/AGENTS.md
+++ b/credit/AGENTS.md
@@ -3,9 +3,10 @@
 ## Purpose
 
 Client-side credit subsystem: a supervisor/per-operation-actor pair that drives
-sub-dust pays (with optional Ark top-up), server-owned Lightning receives, and
+sub-floor pays (with optional Ark top-up), server-owned Lightning receives, and
 credit redemptions against the swap-server credit ledger, as a crash-safe
-`protofsm` state machine per operation.
+`protofsm` state machine per operation. "Sub-floor" means below the effective
+operator VTXO floor, `max(dust_limit, min_vtxo_amount_sat)`.
 
 ## Key Types
 
@@ -22,7 +23,9 @@ credit redemptions against the swap-server credit ledger, as a crash-safe
   `ProcessEvent` dispatch in transitions.go.
 - `CreditServer` / `CreditDaemon` / `Store` — external surfaces: the
   swap-server credit/pay RPCs, the wallet/daemon (OOR send, receive-script
-  allocation, VTXO lookup), and the durable control-plane store.
+  allocation, VTXO lookup, and `VTXOFloor` — the live effective operator
+  minimum, which must be positive or an error), and the durable control-plane
+  store.
 - `StartCreditPayRequest` / `StartCreditReceiveRequest` / `RedeemRequest` —
   admission messages for the three operation kinds (`KindPay`, `KindReceive`,
   `KindRedeem`).
@@ -55,9 +58,13 @@ credit redemptions against the swap-server credit ledger, as a crash-safe
 - Auto-redeem is receive-triggered, not a periodic sweep. Its boot reconcile
   retries transient failures with exponential backoff for at most four
   minutes, stops immediately on permanent mailbox/Ark version errors, and
-  requires a positive live operator VTXO floor. Its bounded context scopes
-  evaluation only; the queued registry signal uses a separately cancelable
-  child of the daemon-lifetime context so shutdown remains prompt.
+  requires a positive live operator VTXO floor. The redeem watermark is
+  `max(AutoRedeemConfig.MinRedeemSat, VTXOFloor())`, refreshed per decision,
+  so a raised operator minimum takes effect immediately and an unavailable
+  operator suppresses the sweep rather than minting below the floor. Its
+  bounded context scopes evaluation only; the queued registry signal uses a
+  separately cancelable child of the daemon-lifetime context so shutdown
+  remains prompt.
   `triggerRedeem` fires only after the settled receive's terminal snapshot
   commits, so a crash before that leaves no half-applied redeem.
 

--- a/credit/CLAUDE.md
+++ b/credit/CLAUDE.md
@@ -3,9 +3,10 @@
 ## Purpose
 
 Client-side credit subsystem: a supervisor/per-operation-actor pair that drives
-sub-dust pays (with optional Ark top-up), server-owned Lightning receives, and
+sub-floor pays (with optional Ark top-up), server-owned Lightning receives, and
 credit redemptions against the swap-server credit ledger, as a crash-safe
-`protofsm` state machine per operation.
+`protofsm` state machine per operation. "Sub-floor" means below the effective
+operator VTXO floor, `max(dust_limit, min_vtxo_amount_sat)`.
 
 ## Key Types
 
@@ -22,7 +23,9 @@ credit redemptions against the swap-server credit ledger, as a crash-safe
   `ProcessEvent` dispatch in transitions.go.
 - `CreditServer` / `CreditDaemon` / `Store` — external surfaces: the
   swap-server credit/pay RPCs, the wallet/daemon (OOR send, receive-script
-  allocation, VTXO lookup), and the durable control-plane store.
+  allocation, VTXO lookup, and `VTXOFloor` — the live effective operator
+  minimum, which must be positive or an error), and the durable control-plane
+  store.
 - `StartCreditPayRequest` / `StartCreditReceiveRequest` / `RedeemRequest` —
   admission messages for the three operation kinds (`KindPay`, `KindReceive`,
   `KindRedeem`).
@@ -55,9 +58,13 @@ credit redemptions against the swap-server credit ledger, as a crash-safe
 - Auto-redeem is receive-triggered, not a periodic sweep. Its boot reconcile
   retries transient failures with exponential backoff for at most four
   minutes, stops immediately on permanent mailbox/Ark version errors, and
-  requires a positive live operator VTXO floor. Its bounded context scopes
-  evaluation only; the queued registry signal uses a separately cancelable
-  child of the daemon-lifetime context so shutdown remains prompt.
+  requires a positive live operator VTXO floor. The redeem watermark is
+  `max(AutoRedeemConfig.MinRedeemSat, VTXOFloor())`, refreshed per decision,
+  so a raised operator minimum takes effect immediately and an unavailable
+  operator suppresses the sweep rather than minting below the floor. Its
+  bounded context scopes evaluation only; the queued registry signal uses a
+  separately cancelable child of the daemon-lifetime context so shutdown
+  remains prompt.
   `triggerRedeem` fires only after the settled receive's terminal snapshot
   commits, so a crash before that leaves no half-applied redeem.
 

--- a/docs/credit_durable_actor_design.md
+++ b/docs/credit_durable_actor_design.md
@@ -3,9 +3,9 @@
 The credit subsystem orchestrates server-custodial sat "credits" through three
 multi-step flows:
 
-- a sub-dust or shortfall **pay** (an optional Ark top-up, then a credit or
+- a sub-floor or shortfall **pay** (an optional Ark top-up, then a credit or
   mixed pay),
-- a sub-dust **credit receive**, and
+- a sub-floor **credit receive**, and
 - a **redeem** that materializes available credits back into an Ark vTXO.
 
 The server ledger is authoritative and guarantees no fund loss. The *client
@@ -109,7 +109,7 @@ Returning an error from a turn means retry until dead-letter, so each transition
 classifies server responses:
 
 - **Deterministic rejections** (insufficient balance, idempotency-key reuse with
-  different params, expired invoice, impossible sub-dust) **terminal-fail** the
+  different params, expired invoice, impossible sub-floor) **terminal-fail** the
   op with a durable reason. They never wedge in redelivery.
 - **Transient errors** (network, `Unavailable`) return the error for the
   framework's free retry and backoff.

--- a/docs/credit_system.md
+++ b/docs/credit_system.md
@@ -92,7 +92,8 @@ effective VTXO floor.
 | `requested_amount_sat < vtxo_floor_sat` and `requested + available >= vtxo_floor_sat` | credit-assisted | Server reserves all available credits and funds a vHTLC for `requested + attached_credit_sat`. |
 
 For credit-assisted receives, the server attaches all currently available
-credits, not only the shortfall needed to reach dust. The quote/prepare surface
+credits, not only the shortfall needed to reach the floor. The quote/prepare
+surface
 returns the full plan:
 
 | Field | Meaning |

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ into specific topics below.
 | [mailbox_durable_actor_layer.md](mailbox_durable_actor_layer.md) | The durable mailbox and durable actor: leases, dedup, transactional outbox, DurableAsk, and the classic vs. Read/Commit (`TxBehavior`/`Exec[S]`) execution paths |
 | [mailbox_transport_serverconn_clientconn.md](mailbox_transport_serverconn_clientconn.md) | The RPC-over-mailbox transport relating this client's `serverconn` to the operator's `clientconn`: envelope, edge API, shared `mailbox/conn` primitives, ack watermark, identity/auth/liveness, and the wire contract |
 | [RPC_MAILBOX_CONTRACT.md](RPC_MAILBOX_CONTRACT.md) | Envelope semantics, at-least-once delivery, ack watermarks |
-| [credit_durable_actor_design.md](credit_durable_actor_design.md) | Credit subsystem durable-actor design: supervisor + per-operation actors driving fault-tolerant sub-dust pay, credit-receive, and redeem flows against the authoritative server ledger |
+| [credit_durable_actor_design.md](credit_durable_actor_design.md) | Credit subsystem durable-actor design: supervisor + per-operation actors driving fault-tolerant sub-floor pay, credit-receive, and redeem flows against the authoritative server ledger |
 | [wavewalletdk_mobile.md](wavewalletdk_mobile.md) | gomobile-safe `sdk/wavewalletdk/mobile` facade: drives an embedded in-process `waved` wallet from Android/iOS over the private bufconn transport (bytes-out API, no daemon binary) |
 
 ## Development

--- a/swapclientserver/AGENTS.md
+++ b/swapclientserver/AGENTS.md
@@ -36,7 +36,9 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
   in-process Ark/daemon facade to the `credit` package's `CreditServer` /
   `CreditDaemon` interfaces, so the credit durable-actor subsystem reuses this
   package's account-key resolution, payment-hash dedup, and worker registry
-  instead of duplicating them.
+  instead of duplicating them. `creditDaemonBridge.VTXOFloor` forwards to
+  `waved.RPCServer.OperatorVTXOFloor` — a live, authenticated operator-terms
+  refresh, not the daemon's bootstrap `GetInfo` snapshot.
 - `Register(ctx, grpcServer, rpcServer, cfg)` — Top-level entry point called
   by a `swapruntime`-tagged `waved` binary. Opens the daemon-owned SQLite
   swap store, dials `swapdk-server`, creates an in-process Ark SDK facade over
@@ -106,6 +108,13 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `CreateCredit`/`RedeemCredit`/`ListCredits` type-assert `s.client` for the
   optional credit methods and return `Unimplemented` if the underlying
   `swapRuntimeClient` does not support credits.
+- `creditDaemonBridge.VTXOFloor` **fails closed**: it returns an error rather
+  than a zero floor when the operator terms cannot be refreshed. The credit
+  actor treats that as "do not materialize", so a stalled or unreachable
+  operator suppresses redemption instead of minting a VTXO below the live
+  minimum. Do not add a zero/dust fallback here — the effective floor is
+  `max(dust_limit, min_vtxo_amount_sat)` and it can be raised by the operator
+  at any time.
 - `newSwapServerClients` wires **two** independent daemon-backed signers into
   every swap-server transport: `RPCServer.SignMailboxAuth` for the mailbox
   edge's `x-mailbox-auth-sig` header, and `RPCServer.SignCreditAccountAuth`

--- a/swapclientserver/CLAUDE.md
+++ b/swapclientserver/CLAUDE.md
@@ -36,7 +36,9 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
   in-process Ark/daemon facade to the `credit` package's `CreditServer` /
   `CreditDaemon` interfaces, so the credit durable-actor subsystem reuses this
   package's account-key resolution, payment-hash dedup, and worker registry
-  instead of duplicating them.
+  instead of duplicating them. `creditDaemonBridge.VTXOFloor` forwards to
+  `waved.RPCServer.OperatorVTXOFloor` — a live, authenticated operator-terms
+  refresh, not the daemon's bootstrap `GetInfo` snapshot.
 - `Register(ctx, grpcServer, rpcServer, cfg)` — Top-level entry point called
   by a `swapruntime`-tagged `waved` binary. Opens the daemon-owned SQLite
   swap store, dials `swapdk-server`, creates an in-process Ark SDK facade over
@@ -106,6 +108,13 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `CreateCredit`/`RedeemCredit`/`ListCredits` type-assert `s.client` for the
   optional credit methods and return `Unimplemented` if the underlying
   `swapRuntimeClient` does not support credits.
+- `creditDaemonBridge.VTXOFloor` **fails closed**: it returns an error rather
+  than a zero floor when the operator terms cannot be refreshed. The credit
+  actor treats that as "do not materialize", so a stalled or unreachable
+  operator suppresses redemption instead of minting a VTXO below the live
+  minimum. Do not add a zero/dust fallback here — the effective floor is
+  `max(dust_limit, min_vtxo_amount_sat)` and it can be raised by the operator
+  at any time.
 - `newSwapServerClients` wires **two** independent daemon-backed signers into
   every swap-server transport: `RPCServer.SignMailboxAuth` for the mailbox
   edge's `x-mailbox-auth-sig` header, and `RPCServer.SignCreditAccountAuth`

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -8,7 +8,8 @@ cooperative-leave RPC, the daemon's wallet/admin surface, the boarding
 ledger, the `credit` durable-actor subsystem, and the unilateral-exit
 registry into one flat user-facing API: the seven wallet verbs (Create,
 Unlock, Send, Recv, List, Balance, Exit) plus the supporting Deposit /
-Status / SubscribeWallet methods. Sends/receives that are sub-dust or
+Status / SubscribeWallet methods. Sends/receives that fall below the
+effective operator VTXO floor (`max(dust_limit, min_vtxo_amount_sat)`) or are
 otherwise credit-eligible are routed through the credit registry
 transparently — the caller only sees wallet vocabulary.
 
@@ -108,6 +109,15 @@ default builds avoid the swap executor's dependency graph.
   per-entry error — the entry stays priced, because a committed VTXO is
   still exitable by the manual path and that exit is the only recovery when
   the operator is unreachable.
+- **Receive routing reads the VTXO floor, not the dust limit.**
+  `receiveVTXOFloor` returns `max(ServerInfo.dust_limit,
+  ServerInfo.min_vtxo_amount_sat)` from the daemon's `GetInfo` snapshot.
+  Unlike the credit boundary (`swapclientserver.creditDaemonBridge.VTXOFloor`,
+  which fails closed on a live-terms refresh), this lookup is **advisory and
+  falls open**: an unavailable snapshot logs a warning and plans with floor
+  `0`, so the receive proceeds down the normal vHTLC path. That is safe
+  because the swap server re-checks its own live floor before funding — a
+  stale local snapshot can misroute a receive, never mint a sub-floor VTXO.
 - Credit-backed routing is nil-safe: `Deps.CreditRegistry == nil` disables
   credit-only sends (falls back with `ErrSwapBackendUnavailable`) and the
   credit projector loop is a no-op, so builds without the credit subsystem

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -8,7 +8,8 @@ cooperative-leave RPC, the daemon's wallet/admin surface, the boarding
 ledger, the `credit` durable-actor subsystem, and the unilateral-exit
 registry into one flat user-facing API: the seven wallet verbs (Create,
 Unlock, Send, Recv, List, Balance, Exit) plus the supporting Deposit /
-Status / SubscribeWallet methods. Sends/receives that are sub-dust or
+Status / SubscribeWallet methods. Sends/receives that fall below the
+effective operator VTXO floor (`max(dust_limit, min_vtxo_amount_sat)`) or are
 otherwise credit-eligible are routed through the credit registry
 transparently — the caller only sees wallet vocabulary.
 
@@ -108,6 +109,15 @@ default builds avoid the swap executor's dependency graph.
   per-entry error — the entry stays priced, because a committed VTXO is
   still exitable by the manual path and that exit is the only recovery when
   the operator is unreachable.
+- **Receive routing reads the VTXO floor, not the dust limit.**
+  `receiveVTXOFloor` returns `max(ServerInfo.dust_limit,
+  ServerInfo.min_vtxo_amount_sat)` from the daemon's `GetInfo` snapshot.
+  Unlike the credit boundary (`swapclientserver.creditDaemonBridge.VTXOFloor`,
+  which fails closed on a live-terms refresh), this lookup is **advisory and
+  falls open**: an unavailable snapshot logs a warning and plans with floor
+  `0`, so the receive proceeds down the normal vHTLC path. That is safe
+  because the swap server re-checks its own live floor before funding — a
+  stale local snapshot can misroute a receive, never mint a sub-floor VTXO.
 - Credit-backed routing is nil-safe: `Deps.CreditRegistry == nil` disables
   credit-only sends (falls back with `ErrSwapBackendUnavailable`) and the
   credit projector loop is a no-op, so builds without the credit subsystem


### PR DESCRIPTION
Automated nightly doc-gardening sweep (`.claude/skills/doc-gardening`, scope
`all`), baselined against the last merged sweep (`5f3c3ec3`).

Workflow run: https://github.com/lightninglabs/wavelength/actions

## What changed

The VTXO-floor work merged since the last sweep (#1168) renamed
`CreditDaemon.DustLimit` → `VTXOFloor` and reworked receive routing, but the
per-package doc graph still described the old dust-limit behaviour. This sweep
realigns it:

- `credit/` — `CreditDaemon.VTXOFloor` documented as the live effective
  operator minimum; auto-redeem watermark stated as
  `max(AutoRedeemConfig.MinRedeemSat, VTXOFloor())`.
- `swapclientserver/` — new invariant recording that
  `creditDaemonBridge.VTXOFloor` **fails closed** (live authenticated terms
  refresh, no zero/dust fallback).
- `swapwallet/` — new invariant recording that `receiveVTXOFloor` is
  **advisory and falls open** on an unavailable `GetInfo` snapshot, and why
  that is safe (the swap server re-checks its own live floor).
- `ARCHITECTURE.md`, `docs/index.md`, `docs/credit_system.md`,
  `docs/credit_durable_actor_design.md` — "sub-dust" → "sub-floor" so the
  whole graph uses the same term for
  `max(dust_limit, min_vtxo_amount_sat)`.

`make doc-check` passes; every touched `CLAUDE.md`/`AGENTS.md` pair is
byte-identical.

## Review notes

Please review the updated `CLAUDE.md`/`AGENTS.md` and `ARCHITECTURE.md` diffs —
in particular the two new fail-closed vs. falls-open invariants, which are
asserted from `swapclientserver/credit_bridge.go` and `swapwallet/recv.go`
respectively.

Docs-only: no Go source is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
