### PR TITLE
arkscript/oor: Prepare channel-backed OOR funding

### DIFF
--- a/db/oor_session_registry_store.go
+++ b/db/oor_session_registry_store.go
@@ -311,6 +311,49 @@ func (s *OORSessionRegistryStoreDB) GetSession(ctx context.Context,
 	return record, nil
 }
 
+// GetUnfailedSessionByIdempotencyKey loads a durable outgoing identity before
+// an immutable dispatch attempt exists. Failed rows deliberately release the
+// key; pending and completed rows retain it.
+func (s *OORSessionRegistryStoreDB) GetUnfailedSessionByIdempotencyKey(
+	ctx context.Context, key string) (*OORSessionRegistryRecord, error) {
+
+	if key == "" {
+		return nil, ErrOORSessionNotFound
+	}
+
+	var record *OORSessionRegistryRecord
+	readFn := func(q *sqlc.Queries) error {
+		row, err := q.GetUnfailedOORSessionRegistryByIdempotencyKey(
+			ctx, sql.NullString{
+				String: key,
+				Valid:  true,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		converted, err := oorSessionRecordFromRow(row)
+		if err != nil {
+			return err
+		}
+
+		record = &converted
+
+		return nil
+	}
+
+	err := s.ExecTx(ctx, ReadTxOption(), readFn)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrOORSessionNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return record, nil
+}
+
 // GetDispatchAttemptByIdempotencyKey loads the immutable outgoing dispatch
 // bound to key. Unlike the mutable session lookup, it remains valid across
 // terminal and incoming lifecycle updates.

--- a/db/oor_session_registry_store_test.go
+++ b/db/oor_session_registry_store_test.go
@@ -97,6 +97,51 @@ func TestOORSessionRegistryGetNotFound(t *testing.T) {
 	require.ErrorIs(t, err, ErrOORSessionNotFound)
 }
 
+// TestOORSessionRegistryLookupPreparedIdentity verifies that the caller key is
+// queryable before the first dispatch attempt is persisted. This is the
+// durable identity boundary for prepare-only OOR sessions across restarts.
+func TestOORSessionRegistryLookupPreparedIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newOORSessionRegistryStoreForTest(t)
+	sid := sessionHash(0x03)
+	record := OORSessionRegistryRecord{
+		SessionID:      sid,
+		ActorID:        "actor-" + sid.String(),
+		Direction:      OORSessionDirectionOutgoing,
+		Phase:          "prepared",
+		IdempotencyKey: "prepared-key",
+		Status:         OORSessionStatusPending,
+		SnapshotData: []byte{
+			0x01,
+		},
+		SnapshotVersion: 1,
+	}
+	require.NoError(t, store.UpsertSession(ctx, record))
+
+	got, err := store.GetUnfailedSessionByIdempotencyKey(
+		ctx, record.IdempotencyKey,
+	)
+	require.NoError(t, err)
+	require.Equal(t, sid, got.SessionID)
+	require.Equal(t, "prepared", got.Phase)
+
+	_, err = store.GetDispatchAttemptByIdempotencyKey(
+		ctx, record.IdempotencyKey,
+	)
+	require.ErrorIs(t, err, ErrOORDispatchAttemptNotFound)
+
+	record.Status = OORSessionStatusFailed
+	record.Phase = "failed"
+	require.NoError(t, store.UpsertSession(ctx, record))
+
+	_, err = store.GetUnfailedSessionByIdempotencyKey(
+		ctx, record.IdempotencyKey,
+	)
+	require.ErrorIs(t, err, ErrOORSessionNotFound)
+}
+
 // TestOORSessionRegistryUpsertUpdates verifies a second upsert advances the
 // mutable fields while preserving the original created_at.
 func TestOORSessionRegistryUpsertUpdates(t *testing.T) {

--- a/db/oor_unroll_resolver.go
+++ b/db/oor_unroll_resolver.go
@@ -56,15 +56,72 @@ type unrollPackageNode struct {
 func (s *OORArtifactPersistenceStore) ResolveUnrollPackages(ctx context.Context,
 	outpoint wire.OutPoint) (*OORUnrollPackages, error) {
 
+	return s.resolveUnrollPackages(
+		ctx, outpoint,
+		func(ctx context.Context, q OORArtifactStore) (
+			*OORPackageBundle, error) {
+
+			return loadPackageBundleByOutpoint(ctx, q, outpoint)
+		},
+	)
+}
+
+// ResolveUnrollPackagesBySessionID resolves a package chain before the local
+// endpoint has installed an outpoint binding. OOR senders use this while
+// promoting a recipient output into shared channel recovery state.
+func (s *OORArtifactPersistenceStore) ResolveUnrollPackagesBySessionID(
+	ctx context.Context, outpoint wire.OutPoint, sessionID chainhash.Hash) (
+	*OORUnrollPackages, error) {
+
+	if sessionID != outpoint.Hash {
+		return nil, fmt.Errorf("target outpoint %s does not match OOR "+
+			"session %s", outpoint, sessionID)
+	}
+
+	return s.resolveUnrollPackages(
+		ctx, outpoint,
+		func(ctx context.Context, q OORArtifactStore) (
+			*OORPackageBundle, error) {
+
+			pkg, err := loadPackageBundleBySessionID(
+				ctx, q, sessionID,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if !packageProducesAncestorOutput(
+				pkg, outpoint.Hash, outpoint.Index,
+			) {
+				return nil, fmt.Errorf("OOR session %s does "+
+					"not create target outpoint %s",
+					sessionID, outpoint)
+			}
+
+			return pkg, nil
+		},
+	)
+}
+
+// resolveUnrollPackages traverses one package chain from a caller-selected
+// target loader. The target outpoint remains part of the result even when the
+// first package is known only by session ID.
+func (s *OORArtifactPersistenceStore) resolveUnrollPackages(ctx context.Context,
+	outpoint wire.OutPoint,
+	loadTarget func(context.Context, OORArtifactStore) (*OORPackageBundle,
+		error)) (*OORUnrollPackages, error) {
+
 	if s == nil || s.db == nil {
 		return nil, fmt.Errorf("store must be provided")
+	}
+	if loadTarget == nil {
+		return nil, fmt.Errorf("target package loader must be provided")
 	}
 
 	readTx := ReadTxOption()
 	var result *OORUnrollPackages
 
 	err := s.db.ExecTx(ctx, readTx, func(q OORArtifactStore) error {
-		targetPkg, err := loadPackageBundleByOutpoint(ctx, q, outpoint)
+		targetPkg, err := loadTarget(ctx, q)
 		if err != nil {
 			return err
 		}

--- a/db/oor_unroll_resolver_test.go
+++ b/db/oor_unroll_resolver_test.go
@@ -33,6 +33,43 @@ func TestResolveUnrollPackagesUnknownOutpoint(t *testing.T) {
 	require.True(t, errors.Is(err, sql.ErrNoRows))
 }
 
+// TestResolveUnrollPackagesBySessionID verifies an OOR sender can resolve the
+// recipient output before shared channel recovery state creates a local VTXO
+// row and output binding.
+func TestResolveUnrollPackagesBySessionID(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newOORArtifactStoreForTest(t)
+	sessionID, arkPSBT, checkpoints, outpoint, _, _, unresolvedInput :=
+		buildTestOORPackage(t, 0x31)
+
+	err := store.UpsertPackage(
+		ctx, OORPackageDirectionOutgoing, sessionID, arkPSBT,
+		checkpoints,
+	)
+	require.NoError(t, err)
+
+	resolved, err := store.ResolveUnrollPackagesBySessionID(
+		ctx, outpoint, sessionID,
+	)
+	require.NoError(t, err)
+	require.Equal(t, outpoint, resolved.TargetOutpoint)
+	require.Len(t, resolved.Packages, 1)
+	require.Equal(t, sessionID, resolved.Packages[0].SessionID)
+	require.Equal(
+		t, []wire.OutPoint{unresolvedInput},
+		resolved.UnresolvedCheckpointInputs,
+	)
+
+	wrongSession := sessionID
+	wrongSession[0] ^= 1
+	_, err = store.ResolveUnrollPackagesBySessionID(
+		ctx, outpoint, wrongSession,
+	)
+	require.ErrorContains(t, err, "does not match OOR session")
+}
+
 // TestResolveUnrollPackagesWithKnownAncestor verifies that resolver traversal
 // returns a deterministic ancestor-first package chain and surfaces unresolved
 // outermost checkpoint inputs.

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -150,6 +150,9 @@ type RoundStore interface {
 		ctx context.Context, arg sqlc.UpdateVTXOStatusParams,
 	) error
 
+	SetRecoveryOnlyVTXORelativeExpiry(ctx context.Context,
+		arg sqlc.SetRecoveryOnlyVTXORelativeExpiryParams) (int64, error)
+
 	// DeleteSpendingReservation removes a spending-reservation row so the
 	// VTXO store can atomically update a VTXO's status and drop its
 	// reservation in the same transaction when it leaves SpendingState.

--- a/db/sqlc/migrations/000004_vtxos.up.sql
+++ b/db/sqlc/migrations/000004_vtxos.up.sql
@@ -76,6 +76,8 @@ CREATE TABLE IF NOT EXISTS vtxos (
     --   5 = UnilateralExit
     --   6 = Failed
     --   7 = Spending
+	--   8 = Expired
+	--   9 = RecoveryOnly
     status INTEGER NOT NULL DEFAULT 0,
 
     -- forfeit_round_id is the round in which this VTXO is being forfeited.

--- a/db/sqlc/oor_session_registry.sql.go
+++ b/db/sqlc/oor_session_registry.sql.go
@@ -69,6 +69,33 @@ func (q *Queries) GetOORSessionRegistry(ctx context.Context, sessionID []byte) (
 	return i, err
 }
 
+const GetUnfailedOORSessionRegistryByIdempotencyKey = `-- name: GetUnfailedOORSessionRegistryByIdempotencyKey :one
+SELECT session_id, actor_id, direction, phase, idempotency_key, status, last_error, snapshot_data, snapshot_version, flow_version, created_at, updated_at FROM oor_session_registry
+WHERE idempotency_key = $1 AND status != 2
+ORDER BY created_at ASC
+LIMIT 1
+`
+
+func (q *Queries) GetUnfailedOORSessionRegistryByIdempotencyKey(ctx context.Context, idempotencyKey sql.NullString) (OorSessionRegistry, error) {
+	row := q.db.QueryRowContext(ctx, GetUnfailedOORSessionRegistryByIdempotencyKey, idempotencyKey)
+	var i OorSessionRegistry
+	err := row.Scan(
+		&i.SessionID,
+		&i.ActorID,
+		&i.Direction,
+		&i.Phase,
+		&i.IdempotencyKey,
+		&i.Status,
+		&i.LastError,
+		&i.SnapshotData,
+		&i.SnapshotVersion,
+		&i.FlowVersion,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const InsertOORDispatchAttempt = `-- name: InsertOORDispatchAttempt :exec
 INSERT INTO oor_dispatch_attempts (
     idempotency_key, session_id, request_data, created_at

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -414,6 +414,9 @@ type Querier interface {
 	// round actually adopted, so a round can never release a deposit another round
 	// has since taken.
 	RevertRoundAdoptedBoardingIntents(ctx context.Context, arg RevertRoundAdoptedBoardingIntentsParams) error
+	// Selects the exact final-spend delay for an application-owned recovery row.
+	// Ordinary wallet VTXOs can never be modified through this query.
+	SetRecoveryOnlyVTXORelativeExpiry(ctx context.Context, arg SetRecoveryOnlyVTXORelativeExpiryParams) (int64, error)
 	SumBoardingIntentAmountsByStatus(ctx context.Context, status string) (interface{}, error)
 	SumUnspentVTXOAmounts(ctx context.Context) (interface{}, error)
 	UpdateBoardingIntentStatus(ctx context.Context, arg UpdateBoardingIntentStatusParams) error

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -142,6 +142,7 @@ type Querier interface {
 	// Returns cumulative Ark protocol fees paid to the operator (fees_paid
 	// account only). Does not include L1 chain/miner fees (onchain_fees).
 	GetTotalOperatorFeesPaid(ctx context.Context) (int64, error)
+	GetUnfailedOORSessionRegistryByIdempotencyKey(ctx context.Context, idempotencyKey sql.NullString) (OorSessionRegistry, error)
 	GetUnilateralExitJob(ctx context.Context, arg GetUnilateralExitJobParams) (UnilateralExitJob, error)
 	GetVHTLCRecoveryJob(ctx context.Context, id string) (VhtlcRecoveryJob, error)
 	GetVHTLCRecoveryJobByRequestID(ctx context.Context, requestID string) (VhtlcRecoveryJob, error)

--- a/db/sqlc/queries/oor_session_registry.sql
+++ b/db/sqlc/queries/oor_session_registry.sql
@@ -25,6 +25,13 @@ SELECT * FROM oor_session_registry
 WHERE session_id = $1
 ;
 
+-- name: GetUnfailedOORSessionRegistryByIdempotencyKey :one
+SELECT * FROM oor_session_registry
+WHERE idempotency_key = $1 AND status != 2
+ORDER BY created_at ASC
+LIMIT 1
+;
+
 -- name: ListNonTerminalOORSessionRegistry :many
 -- Status 1 = Completed, 2 = Failed (anchored to Go iota in
 -- db/oor_session_registry_store.go OORSessionStatus).

--- a/db/sqlc/queries/vtxo.sql
+++ b/db/sqlc/queries/vtxo.sql
@@ -85,6 +85,14 @@ SET status = $3,
     last_update_time = $4
 WHERE outpoint_hash = $1 AND outpoint_index = $2;
 
+-- name: SetRecoveryOnlyVTXORelativeExpiry :execrows
+-- Selects the exact final-spend delay for an application-owned recovery row.
+-- Ordinary wallet VTXOs can never be modified through this query.
+UPDATE vtxos
+SET expiry = $3,
+    last_update_time = $4
+WHERE outpoint_hash = $1 AND outpoint_index = $2 AND status = 9;
+
 -- name: MarkVTXOForfeiting :exec
 -- MarkVTXOForfeiting transitions a VTXO to Forfeiting status and persists
 -- the forfeit round ID and transaction for crash recovery. Called when

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -1695,6 +1695,8 @@ CREATE TABLE vtxos (
     --   5 = UnilateralExit
     --   6 = Failed
     --   7 = Spending
+	--   8 = Expired
+	--   9 = RecoveryOnly
     status INTEGER NOT NULL DEFAULT 0,
 
     -- forfeit_round_id is the round in which this VTXO is being forfeited.

--- a/db/sqlc/vtxo.sql.go
+++ b/db/sqlc/vtxo.sql.go
@@ -459,6 +459,35 @@ func (q *Queries) MarkVTXOForfeiting(ctx context.Context, arg MarkVTXOForfeiting
 	return err
 }
 
+const SetRecoveryOnlyVTXORelativeExpiry = `-- name: SetRecoveryOnlyVTXORelativeExpiry :execrows
+UPDATE vtxos
+SET expiry = $3,
+    last_update_time = $4
+WHERE outpoint_hash = $1 AND outpoint_index = $2 AND status = 9
+`
+
+type SetRecoveryOnlyVTXORelativeExpiryParams struct {
+	OutpointHash   []byte
+	OutpointIndex  int32
+	Expiry         int32
+	LastUpdateTime int64
+}
+
+// Selects the exact final-spend delay for an application-owned recovery row.
+// Ordinary wallet VTXOs can never be modified through this query.
+func (q *Queries) SetRecoveryOnlyVTXORelativeExpiry(ctx context.Context, arg SetRecoveryOnlyVTXORelativeExpiryParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, SetRecoveryOnlyVTXORelativeExpiry,
+		arg.OutpointHash,
+		arg.OutpointIndex,
+		arg.Expiry,
+		arg.LastUpdateTime,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const UpdateVTXOStatus = `-- name: UpdateVTXOStatus :exec
 UPDATE vtxos
 SET status = $3,

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"slices"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -119,6 +120,125 @@ func (s *VTXOPersistenceStore) SaveVTXO(
 			int32(desc.Outpoint.Index), desc.Ancestry,
 		)
 	})
+}
+
+// SaveRecoveryOnlyVTXO atomically persists an application-owned descriptor in
+// the recovery-only state. Unlike SaveVTXO, this method never exposes the row
+// as live between insertion and the status transition, so concurrent wallet
+// selection cannot mistake a channel or contract output for wallet liquidity.
+// Replays are accepted only when the existing immutable descriptor matches.
+func (s *VTXOPersistenceStore) SaveRecoveryOnlyVTXO(ctx context.Context,
+	desc *vtxo.Descriptor) error {
+
+	if desc == nil {
+		return fmt.Errorf("descriptor must be provided")
+	}
+	if desc.Status != vtxo.VTXOStatusRecoveryOnly {
+		return fmt.Errorf("recovery-only descriptor has status %s",
+			desc.Status)
+	}
+
+	return s.db.ExecTx(ctx, WriteTxOption(), func(q RoundStore) error {
+		key := sqlc.GetVTXOParams{
+			OutpointHash:  desc.Outpoint.Hash[:],
+			OutpointIndex: int32(desc.Outpoint.Index),
+		}
+		existing, err := q.GetVTXO(ctx, key)
+		switch {
+		case err == nil:
+			if err := validateRecoveryOnlyVTXORow(
+				existing, desc,
+			); err != nil {
+				return err
+			}
+
+			return upsertAncestryPaths(
+				ctx, q, desc.Outpoint.Hash[:],
+				int32(desc.Outpoint.Index), desc.Ancestry,
+			)
+
+		case !errors.Is(err, sql.ErrNoRows):
+			return fmt.Errorf("load recovery-only VTXO: %w", err)
+		}
+
+		if err := s.ensureRoundExists(ctx, q, desc); err != nil {
+			return fmt.Errorf("ensure round: %w", err)
+		}
+		params, err := s.descriptorToInsertParams(ctx, q, desc)
+		if err != nil {
+			return fmt.Errorf("convert descriptor: %w", err)
+		}
+		if err := q.InsertVTXO(ctx, params); err != nil {
+			return fmt.Errorf("insert recovery-only VTXO: %w", err)
+		}
+		if err := q.UpdateVTXOStatus(ctx, sqlc.UpdateVTXOStatusParams{
+			OutpointHash:   desc.Outpoint.Hash[:],
+			OutpointIndex:  int32(desc.Outpoint.Index),
+			Status:         int32(desc.Status),
+			LastUpdateTime: s.clock.Now().Unix(),
+		}); err != nil {
+			return fmt.Errorf("mark VTXO recovery-only: %w", err)
+		}
+
+		return upsertAncestryPaths(
+			ctx, q, desc.Outpoint.Hash[:],
+			int32(desc.Outpoint.Index), desc.Ancestry,
+		)
+	})
+}
+
+// SetRecoveryOnlyVTXORelativeExpiry selects the delay used by the exact Ark
+// channel final-spend policy without making the descriptor wallet-owned.
+func (s *VTXOPersistenceStore) SetRecoveryOnlyVTXORelativeExpiry(
+	ctx context.Context, outpoint wire.OutPoint, delay uint32) error {
+
+	if delay > math.MaxInt32 {
+		return fmt.Errorf("recovery-only VTXO delay %d exceeds "+
+			"storage range", delay)
+	}
+
+	return s.db.ExecTx(ctx, WriteTxOption(), func(q RoundStore) error {
+		rows, err := q.SetRecoveryOnlyVTXORelativeExpiry(
+			ctx, sqlc.SetRecoveryOnlyVTXORelativeExpiryParams{
+				OutpointHash:   outpoint.Hash[:],
+				OutpointIndex:  int32(outpoint.Index),
+				Expiry:         int32(delay),
+				LastUpdateTime: s.clock.Now().Unix(),
+			},
+		)
+		if err != nil {
+			return err
+		}
+		if rows != 1 {
+			return fmt.Errorf("recovery-only VTXO %s not found",
+				outpoint)
+		}
+
+		return nil
+	})
+}
+
+// validateRecoveryOnlyVTXORow rejects an outpoint collision or a replay after
+// another subsystem has taken ownership of the same VTXO.
+func validateRecoveryOnlyVTXORow(row VTXORow, desc *vtxo.Descriptor) error {
+	status := vtxo.VTXOStatus(row.Status)
+	if status != vtxo.VTXOStatusRecoveryOnly &&
+		status != vtxo.VTXOStatusSpent {
+		return fmt.Errorf("recovery-only VTXO already has status %s",
+			status)
+	}
+	if row.RoundID != desc.RoundID || row.Amount != int64(desc.Amount) ||
+		!bytes.Equal(row.PkScript, desc.PkScript) ||
+		!bytes.Equal(row.PolicyTemplate, desc.PolicyTemplate) ||
+		row.Expiry != int32(desc.RelativeExpiry) ||
+		row.BatchExpiry != desc.BatchExpiry ||
+		row.ChainDepth != int32(desc.ChainDepth) ||
+		row.CreatedHeight != desc.CreatedHeight ||
+		!bytes.Equal(row.CommitmentTxid, desc.CommitmentTxID[:]) {
+		return fmt.Errorf("recovery-only VTXO descriptor mismatch")
+	}
+
+	return nil
 }
 
 // ensureRoundExists inserts a minimal confirmed round row when a VTXO refers

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -219,7 +219,8 @@ func (s *VTXOPersistenceStore) SetRecoveryOnlyVTXORelativeExpiry(
 }
 
 // validateRecoveryOnlyVTXORow rejects an outpoint collision or a replay after
-// another subsystem has taken ownership of the same VTXO.
+// another subsystem has taken ownership of the same VTXO. Relative expiry is
+// excluded because channel recovery selects it after registration.
 func validateRecoveryOnlyVTXORow(row VTXORow, desc *vtxo.Descriptor) error {
 	status := vtxo.VTXOStatus(row.Status)
 	if status != vtxo.VTXOStatusRecoveryOnly &&
@@ -230,7 +231,6 @@ func validateRecoveryOnlyVTXORow(row VTXORow, desc *vtxo.Descriptor) error {
 	if row.RoundID != desc.RoundID || row.Amount != int64(desc.Amount) ||
 		!bytes.Equal(row.PkScript, desc.PkScript) ||
 		!bytes.Equal(row.PolicyTemplate, desc.PolicyTemplate) ||
-		row.Expiry != int32(desc.RelativeExpiry) ||
 		row.BatchExpiry != desc.BatchExpiry ||
 		row.ChainDepth != int32(desc.ChainDepth) ||
 		row.CreatedHeight != desc.CreatedHeight ||

--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -2484,3 +2484,62 @@ func TestVTXOPersistenceStoreListVTXOsByStatusesLight(t *testing.T) {
 		outpoints(live),
 	)
 }
+
+// TestVTXOStoreRecoveryOnlyExcludedFromWalletSets verifies that a descriptor
+// prepared for channel materialization remains available to the unroller but
+// cannot become wallet liquidity or spawn an ordinary VTXO actor.
+func TestVTXOStoreRecoveryOnlyExcludedFromWalletSets(t *testing.T) {
+	t.Parallel()
+
+	vtxoStore, _, _ := newVTXOStoreForTest(t)
+	ctx := t.Context()
+	desc := createTestVTXODescriptor(
+		t, testRoundIDDB("test-round-recovery-only"), 21,
+	)
+	desc.Status = vtxo.VTXOStatusRecoveryOnly
+
+	require.NoError(t, vtxoStore.SaveRecoveryOnlyVTXO(ctx, desc))
+
+	stored, err := vtxoStore.GetVTXO(ctx, desc.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, vtxo.VTXOStatusRecoveryOnly, stored.Status)
+	require.Len(t, stored.Ancestry, len(desc.Ancestry))
+	require.Equal(
+		t, desc.Ancestry[0].CommitmentTxID,
+		stored.Ancestry[0].CommitmentTxID,
+	)
+	require.Equal(
+		t, desc.Ancestry[0].TreeDepth, stored.Ancestry[0].TreeDepth,
+	)
+
+	live, err := vtxoStore.ListLiveVTXOs(ctx)
+	require.NoError(t, err)
+	require.Empty(t, live)
+
+	recoverable, err := vtxoStore.ListRecoverableVTXOs(ctx)
+	require.NoError(t, err)
+	require.Empty(t, recoverable)
+	require.ErrorContains(
+		t, vtxoStore.SetRecoveryOnlyVTXORelativeExpiry(
+			ctx, desc.Outpoint, ^uint32(0),
+		),
+		"exceeds storage range",
+	)
+
+	candidates, err := vtxoStore.ListSelectionCandidatesByStatus(
+		ctx, vtxo.VTXOStatusLive,
+	)
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+
+	// Durable close actions may replay source preparation after the row has
+	// already been committed. Identical terms are idempotent, while an
+	// outpoint collision with different immutable terms must fail.
+	require.NoError(t, vtxoStore.SaveRecoveryOnlyVTXO(ctx, desc))
+	mismatch := *desc
+	mismatch.Amount++
+	require.ErrorContains(
+		t, vtxoStore.SaveRecoveryOnlyVTXO(ctx, &mismatch),
+		"descriptor mismatch",
+	)
+}

--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -2526,6 +2526,23 @@ func TestVTXOStoreRecoveryOnlyExcludedFromWalletSets(t *testing.T) {
 		"exceeds storage range",
 	)
 
+	// Channel registration sets the materialization delay after the row is
+	// first saved. Replaying source preparation must preserve that selected
+	// value instead of mistaking it for an outpoint collision.
+	selectedExpiry := desc.RelativeExpiry + 10
+	require.NoError(
+		t, vtxoStore.SetRecoveryOnlyVTXORelativeExpiry(
+			ctx, desc.Outpoint, selectedExpiry,
+		),
+	)
+	require.NoError(t, vtxoStore.SaveRecoveryOnlyVTXO(ctx, desc))
+	storedRow, err := vtxoStore.db.GetVTXO(ctx, sqlc.GetVTXOParams{
+		OutpointHash:  desc.Outpoint.Hash[:],
+		OutpointIndex: int32(desc.Outpoint.Index),
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(selectedExpiry), storedRow.Expiry)
+
 	candidates, err := vtxoStore.ListSelectionCandidatesByStatus(
 		ctx, vtxo.VTXOStatusLive,
 	)
@@ -2541,5 +2558,24 @@ func TestVTXOStoreRecoveryOnlyExcludedFromWalletSets(t *testing.T) {
 	require.ErrorContains(
 		t, vtxoStore.SaveRecoveryOnlyVTXO(ctx, &mismatch),
 		"descriptor mismatch",
+	)
+
+	// The setter must not repurpose an ordinary wallet VTXO as channel
+	// recovery state.
+	liveDescriptor := createTestVTXODescriptor(
+		t, testRoundIDDB("test-round-live-expiry-guard"), 22,
+	)
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, liveDescriptor))
+	require.ErrorContains(
+		t, vtxoStore.SetRecoveryOnlyVTXORelativeExpiry(
+			ctx, liveDescriptor.Outpoint,
+			liveDescriptor.RelativeExpiry+10,
+		),
+		"not found",
+	)
+	storedLive, err := vtxoStore.GetVTXO(ctx, liveDescriptor.Outpoint)
+	require.NoError(t, err)
+	require.Equal(
+		t, liveDescriptor.RelativeExpiry, storedLive.RelativeExpiry,
 	)
 }

--- a/lib/actormsg/vtxo_admission.go
+++ b/lib/actormsg/vtxo_admission.go
@@ -408,13 +408,18 @@ const (
 	// vhtlcrecovery.ExitPolicyKindRefundWithoutReceiver.
 	ExitPolicyVHTLCRefundWithoutReceiver ExitPolicyKind = "vhtlc_" +
 		"refund_without_receiver"
+
+	// ExitPolicyArkChannelBacking identifies a pre-signed channel
+	// materialization spend from a recovery-only channel-policy VTXO.
+	ExitPolicyArkChannelBacking ExitPolicyKind = "ark_channel_backing"
 )
 
 // Valid reports whether the exit policy kind is one of the known non-standard
 // policies that can ride the ForceUnroll path.
 func (k ExitPolicyKind) Valid() bool {
 	switch k {
-	case ExitPolicyVHTLCClaim, ExitPolicyVHTLCRefundWithoutReceiver:
+	case ExitPolicyVHTLCClaim, ExitPolicyVHTLCRefundWithoutReceiver,
+		ExitPolicyArkChannelBacking:
 		return true
 
 	default:

--- a/lib/actormsg/vtxo_admission_test.go
+++ b/lib/actormsg/vtxo_admission_test.go
@@ -1,0 +1,24 @@
+package actormsg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExitPolicyKindValid verifies every durable non-standard exit policy can
+// pass the VTXO manager's recovery-only admission guard.
+func TestExitPolicyKindValid(t *testing.T) {
+	t.Parallel()
+
+	valid := []ExitPolicyKind{
+		ExitPolicyVHTLCClaim,
+		ExitPolicyVHTLCRefundWithoutReceiver,
+		ExitPolicyArkChannelBacking,
+	}
+	for _, kind := range valid {
+		require.True(t, kind.Valid(), kind)
+	}
+
+	require.False(t, ExitPolicyKind("unknown").Valid())
+}

--- a/lib/arkscript/channel_vtxo.go
+++ b/lib/arkscript/channel_vtxo.go
@@ -1,0 +1,291 @@
+package arkscript
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+const (
+	// DefaultChannelReactionWindow gives either channel endpoint roughly
+	// three days to materialize before the original funder can refund.
+	DefaultChannelReactionWindow uint32 = 432
+)
+
+// ChannelVTXOParams defines the key roles and relative delays of a VTXO that
+// backs an unpublished Lightning channel point.
+type ChannelVTXOParams struct {
+	ClientArkKey   *btcec.PublicKey
+	HubArkKey      *btcec.PublicKey
+	ArkOperatorKey *btcec.PublicKey
+
+	ClientChannelKey *btcec.PublicKey
+	HubChannelKey    *btcec.PublicKey
+	FunderKey        *btcec.PublicKey
+
+	ChannelDelay   uint32
+	FunderDelay    uint32
+	MinExitDelay   uint32
+	ReactionWindow uint32
+}
+
+// ChannelVTXOPolicy is the compiled three-path policy for an Ark-backed
+// Lightning channel.
+type ChannelVTXOPolicy struct {
+	Template *PolicyTemplate
+	*CompiledPolicy
+
+	CooperativeClosure Node
+	ChannelClosure     Node
+	FunderClosure      Node
+
+	ChannelDelay uint32
+	FunderDelay  uint32
+}
+
+// NewChannelVTXOPolicy constructs the cooperative, materialization, and
+// funder-refund paths while enforcing their relative timing.
+func NewChannelVTXOPolicy(params ChannelVTXOParams) (*ChannelVTXOPolicy,
+	error) {
+
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	cooperativeClosure := &Multisig{
+		Keys: []*btcec.PublicKey{
+			params.ClientArkKey,
+			params.HubArkKey,
+			params.ArkOperatorKey,
+		},
+	}
+	channelClosure := &CSV{
+		Lock: blockchain.LockTimeToSequence(
+			false, params.ChannelDelay,
+		),
+		Inner: &Multisig{
+			Keys: []*btcec.PublicKey{
+				params.ClientChannelKey,
+				params.HubChannelKey,
+			},
+		},
+	}
+	funderClosure := &CSV{
+		Lock: blockchain.LockTimeToSequence(
+			false, params.FunderDelay,
+		),
+		Inner: &Multisig{
+			Keys: []*btcec.PublicKey{
+				params.FunderKey,
+			},
+		},
+	}
+
+	template := &PolicyTemplate{
+		Leaves: []LeafTemplate{
+			{
+				Node: cooperativeClosure,
+			},
+			{
+				Node: channelClosure,
+			},
+			{
+				Node: funderClosure,
+			},
+		},
+	}
+	if err := template.ValidateArkPolicy(PolicyValidationOpts{
+		OperatorKey:  params.ArkOperatorKey,
+		MinExitDelay: params.MinExitDelay,
+	}); err != nil {
+		return nil, fmt.Errorf("validate channel VTXO policy: %w", err)
+	}
+
+	compiled, err := template.Compile()
+	if err != nil {
+		return nil, fmt.Errorf("compile channel VTXO policy: %w", err)
+	}
+
+	return &ChannelVTXOPolicy{
+		Template:           template,
+		CompiledPolicy:     compiled,
+		CooperativeClosure: cooperativeClosure,
+		ChannelClosure:     channelClosure,
+		FunderClosure:      funderClosure,
+		ChannelDelay:       params.ChannelDelay,
+		FunderDelay:        params.FunderDelay,
+	}, nil
+}
+
+// CooperativeSpendPath returns the immediate client-hub-Ark-operator path.
+func (p *ChannelVTXOPolicy) CooperativeSpendPath() (*SpendPath, error) {
+	return p.SpendPathForNode(p.CooperativeClosure, nil)
+}
+
+// ChannelSpendPath returns the delayed two-party materialization path.
+func (p *ChannelVTXOPolicy) ChannelSpendPath() (*SpendPath, error) {
+	return p.SpendPathForNode(p.ChannelClosure, nil)
+}
+
+// FunderSpendPath returns the later unilateral refund path.
+func (p *ChannelVTXOPolicy) FunderSpendPath() (*SpendPath, error) {
+	return p.SpendPathForNode(p.FunderClosure, nil)
+}
+
+// EncodeChannelVTXOArtifacts returns the semantic policy and its canonical
+// P2TR output script.
+func EncodeChannelVTXOArtifacts(params ChannelVTXOParams) ([]byte, []byte,
+	error) {
+
+	policy, err := NewChannelVTXOPolicy(params)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template, err := policy.Template.Encode()
+	if err != nil {
+		return nil, nil, err
+	}
+	pkScript, err := policy.Template.PkScript()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return template, pkScript, nil
+}
+
+// ValidateChannelVTXOTemplate verifies that an untrusted template has the
+// exact key roles and delays expected by a channel intent.
+func ValidateChannelVTXOTemplate(template *PolicyTemplate,
+	params ChannelVTXOParams) error {
+
+	if template == nil {
+		return fmt.Errorf("channel VTXO template is required")
+	}
+
+	expected, err := NewChannelVTXOPolicy(params)
+	if err != nil {
+		return err
+	}
+	if len(template.Leaves) != len(expected.Template.Leaves) {
+		return fmt.Errorf("channel VTXO policy must contain exactly " +
+			"3 leaves")
+	}
+
+	actualScripts := make(map[string]struct{}, len(template.Leaves))
+	for i := range template.Leaves {
+		script, err := template.Leaves[i].Script()
+		if err != nil {
+			return fmt.Errorf("compile channel VTXO leaf %d: %w", i,
+				err)
+		}
+
+		actualScripts[string(script)] = struct{}{}
+	}
+
+	for i := range expected.Template.Leaves {
+		script, err := expected.Template.Leaves[i].Script()
+		if err != nil {
+			return err
+		}
+		if _, ok := actualScripts[string(script)]; !ok {
+			return fmt.Errorf("channel VTXO policy does not " +
+				"match expected key roles and delays")
+		}
+	}
+
+	return nil
+}
+
+// validate enforces key separation and the funder reaction window.
+func (p ChannelVTXOParams) validate() error {
+	keys := []struct {
+		name string
+		key  *btcec.PublicKey
+	}{
+		{
+			name: "client Ark",
+			key:  p.ClientArkKey,
+		},
+		{
+			name: "hub Ark",
+			key:  p.HubArkKey,
+		},
+		{
+			name: "Ark operator",
+			key:  p.ArkOperatorKey,
+		},
+		{
+			name: "client channel",
+			key:  p.ClientChannelKey,
+		},
+		{
+			name: "hub channel",
+			key:  p.HubChannelKey,
+		},
+		{
+			name: "funder",
+			key:  p.FunderKey,
+		},
+	}
+	for _, key := range keys {
+		if key.key == nil {
+			return fmt.Errorf("channel VTXO %s key is nil",
+				key.name)
+		}
+	}
+
+	if channelKeysEqual(p.ClientArkKey, p.HubArkKey) ||
+		channelKeysEqual(p.ClientArkKey, p.ArkOperatorKey) ||
+		channelKeysEqual(p.HubArkKey, p.ArkOperatorKey) {
+		return fmt.Errorf("channel VTXO cooperative keys must be " +
+			"controlled by three distinct parties")
+	}
+	if channelKeysEqual(p.ClientChannelKey, p.HubChannelKey) {
+		return fmt.Errorf("channel VTXO materialization keys must be " +
+			"distinct")
+	}
+
+	if p.MinExitDelay == 0 {
+		return fmt.Errorf("channel VTXO minimum exit delay must be " +
+			"non-zero")
+	}
+	if p.ChannelDelay < p.MinExitDelay {
+		return fmt.Errorf("channel delay %d is below Ark minimum %d",
+			p.ChannelDelay, p.MinExitDelay)
+	}
+	if p.ChannelDelay > wire.SequenceLockTimeMask ||
+		p.FunderDelay > wire.SequenceLockTimeMask {
+		return fmt.Errorf("channel VTXO delays must fit BIP-68 block " +
+			"mode")
+	}
+
+	reactionWindow := p.ReactionWindow
+	if reactionWindow == 0 {
+		reactionWindow = DefaultChannelReactionWindow
+	}
+	if reactionWindow > wire.SequenceLockTimeMask ||
+		p.ChannelDelay > math.MaxUint32-reactionWindow {
+		return fmt.Errorf("channel VTXO reaction window overflows")
+	}
+	minimumFunderDelay := p.ChannelDelay + reactionWindow
+	if p.FunderDelay < minimumFunderDelay {
+		return fmt.Errorf("funder delay %d must be at least %d to "+
+			"preserve the reaction window", p.FunderDelay,
+			minimumFunderDelay)
+	}
+
+	return nil
+}
+
+// channelKeysEqual compares public keys by their x-only tapscript encoding.
+func channelKeysEqual(a, b *btcec.PublicKey) bool {
+	return bytes.Equal(
+		schnorr.SerializePubKey(a), schnorr.SerializePubKey(b),
+	)
+}

--- a/lib/arkscript/channel_vtxo.go
+++ b/lib/arkscript/channel_vtxo.go
@@ -159,6 +159,110 @@ func EncodeChannelVTXOArtifacts(params ChannelVTXOParams) ([]byte, []byte,
 	return template, pkScript, nil
 }
 
+// ValidateChannelVTXOPolicy recognizes the canonical three-leaf channel VTXO
+// policy using the admitting operator's key and minimum exit delay. It does
+// not assign client and hub labels to the two symmetric endpoint key pairs.
+func ValidateChannelVTXOPolicy(template *PolicyTemplate,
+	operatorKey *btcec.PublicKey, minExitDelay uint32) error {
+
+	if template == nil {
+		return fmt.Errorf("channel VTXO template is required")
+	}
+	if operatorKey == nil {
+		return fmt.Errorf("channel VTXO operator key is required")
+	}
+	if minExitDelay == 0 {
+		return fmt.Errorf("channel VTXO minimum exit delay is required")
+	}
+	if len(template.Leaves) != 3 {
+		return fmt.Errorf("channel VTXO policy must contain exactly " +
+			"3 leaves")
+	}
+
+	var (
+		cooperativeKeys []*btcec.PublicKey
+		channelKeys     []*btcec.PublicKey
+		funderKey       *btcec.PublicKey
+		channelDelay    uint32
+		funderDelay     uint32
+	)
+	for i := range template.Leaves {
+		switch node := template.Leaves[i].Node.(type) {
+		case *Multisig:
+			if len(node.Keys) != 3 || cooperativeKeys != nil {
+				return fmt.Errorf("channel VTXO leaf %d is "+
+					"not the unique 3-of-3 "+
+					"cooperative path", i)
+			}
+
+			cooperativeKeys = node.Keys
+
+		case *CSV:
+			if err := validateCSVLock(node.Lock); err != nil {
+				return fmt.Errorf("channel VTXO leaf %d has "+
+					"invalid CSV: %w", i, err)
+			}
+
+			multisig, ok := node.Inner.(*Multisig)
+			if !ok {
+				return fmt.Errorf("channel VTXO leaf %d is "+
+					"not CSV-gated multisig", i)
+			}
+
+			delay := node.Lock & uint32(wire.SequenceLockTimeMask)
+			switch len(multisig.Keys) {
+			case 2:
+				if channelKeys != nil {
+					return fmt.Errorf("channel VTXO has " +
+						"multiple 2-of-2 " +
+						"materialization paths")
+				}
+
+				channelKeys = multisig.Keys
+				channelDelay = delay
+
+			case 1:
+				if funderKey != nil {
+					return fmt.Errorf("channel VTXO has " +
+						"multiple funder refund paths")
+				}
+
+				funderKey = multisig.Keys[0]
+				funderDelay = delay
+
+			default:
+				return fmt.Errorf("channel VTXO leaf %d has "+
+					"%d signing keys", i, len(
+					multisig.Keys,
+				))
+			}
+
+		default:
+			return fmt.Errorf("channel VTXO leaf %d has an "+
+				"unsupported shape", i)
+		}
+	}
+
+	if cooperativeKeys == nil || channelKeys == nil || funderKey == nil {
+		return fmt.Errorf("channel VTXO policy is missing a required " +
+			"path")
+	}
+
+	params := ChannelVTXOParams{
+		ClientArkKey:     cooperativeKeys[0],
+		HubArkKey:        cooperativeKeys[1],
+		ArkOperatorKey:   operatorKey,
+		ClientChannelKey: channelKeys[0],
+		HubChannelKey:    channelKeys[1],
+		FunderKey:        funderKey,
+		ChannelDelay:     channelDelay,
+		FunderDelay:      funderDelay,
+		MinExitDelay:     minExitDelay,
+	}
+
+	return ValidateChannelVTXOTemplate(template, params)
+}
+
 // ValidateChannelVTXOTemplate verifies that an untrusted template has the
 // exact key roles and delays expected by a channel intent.
 func ValidateChannelVTXOTemplate(template *PolicyTemplate,

--- a/lib/arkscript/channel_vtxo.go
+++ b/lib/arkscript/channel_vtxo.go
@@ -199,6 +199,20 @@ func ValidateChannelVTXOTemplate(template *PolicyTemplate,
 		}
 	}
 
+	actualPkScript, err := template.PkScript()
+	if err != nil {
+		return fmt.Errorf("compile channel VTXO output: %w", err)
+	}
+	expectedPkScript, err := expected.Template.PkScript()
+	if err != nil {
+		return fmt.Errorf("compile expected channel VTXO output: %w",
+			err)
+	}
+	if !bytes.Equal(actualPkScript, expectedPkScript) {
+		return fmt.Errorf("channel VTXO output does not match " +
+			"expected key roles and delays")
+	}
+
 	return nil
 }
 

--- a/lib/arkscript/channel_vtxo_test.go
+++ b/lib/arkscript/channel_vtxo_test.go
@@ -1,0 +1,111 @@
+package arkscript
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestChannelVTXOPolicyPaths verifies each spend path has the intended signer
+// set and relative delay.
+func TestChannelVTXOPolicyPaths(t *testing.T) {
+	t.Parallel()
+
+	params := testChannelVTXOParams(t)
+	policy, err := NewChannelVTXOPolicy(params)
+	require.NoError(t, err)
+
+	cooperative, err := policy.CooperativeSpendPath()
+	require.NoError(t, err)
+	require.Equal(t, ^uint32(0), cooperative.RequiredSequence)
+	cooperativeNode, ok := policy.CooperativeClosure.(*Multisig)
+	require.True(t, ok)
+	require.Len(t, cooperativeNode.Keys, 3)
+
+	channel, err := policy.ChannelSpendPath()
+	require.NoError(t, err)
+	require.Equal(
+		t, blockchain.LockTimeToSequence(
+			false, params.ChannelDelay,
+		),
+		channel.RequiredSequence,
+	)
+	channelCSV, ok := policy.ChannelClosure.(*CSV)
+	require.True(t, ok)
+	channelNode, ok := channelCSV.Inner.(*Multisig)
+	require.True(t, ok)
+	require.Len(t, channelNode.Keys, 2)
+
+	funder, err := policy.FunderSpendPath()
+	require.NoError(t, err)
+	require.Equal(
+		t, blockchain.LockTimeToSequence(
+			false, params.FunderDelay,
+		),
+		funder.RequiredSequence,
+	)
+	funderCSV, ok := policy.FunderClosure.(*CSV)
+	require.True(t, ok)
+	funderNode, ok := funderCSV.Inner.(*Multisig)
+	require.True(t, ok)
+	require.Len(t, funderNode.Keys, 1)
+}
+
+// TestChannelVTXOPolicyReactionWindow rejects a refund path that can overtake
+// the channel endpoints before they have time to materialize.
+func TestChannelVTXOPolicyReactionWindow(t *testing.T) {
+	t.Parallel()
+
+	params := testChannelVTXOParams(t)
+	params.FunderDelay = params.ChannelDelay +
+		DefaultChannelReactionWindow - 1
+
+	_, err := NewChannelVTXOPolicy(params)
+	require.ErrorContains(t, err, "preserve the reaction window")
+}
+
+// TestValidateChannelVTXOTemplate detects any change to the persisted channel
+// contract while accepting a canonical encode/decode round trip.
+func TestValidateChannelVTXOTemplate(t *testing.T) {
+	t.Parallel()
+
+	params := testChannelVTXOParams(t)
+	raw, pkScript, err := EncodeChannelVTXOArtifacts(params)
+	require.NoError(t, err)
+	require.NotEmpty(t, pkScript)
+
+	template, err := DecodePolicyTemplate(raw)
+	require.NoError(t, err)
+	require.NoError(t, ValidateChannelVTXOTemplate(template, params))
+
+	otherKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	params.HubChannelKey = otherKey.PubKey()
+	require.Error(t, ValidateChannelVTXOTemplate(template, params))
+}
+
+// testChannelVTXOParams returns independent keys and valid channel delays.
+func testChannelVTXOParams(t *testing.T) ChannelVTXOParams {
+	t.Helper()
+
+	keys := make([]*btcec.PrivateKey, 6)
+	for i := range keys {
+		key, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		keys[i] = key
+	}
+
+	return ChannelVTXOParams{
+		ClientArkKey:     keys[0].PubKey(),
+		HubArkKey:        keys[1].PubKey(),
+		ArkOperatorKey:   keys[2].PubKey(),
+		ClientChannelKey: keys[3].PubKey(),
+		HubChannelKey:    keys[4].PubKey(),
+		FunderKey:        keys[5].PubKey(),
+		ChannelDelay:     144,
+		FunderDelay:      144 + DefaultChannelReactionWindow,
+		MinExitDelay:     144,
+	}
+}

--- a/lib/arkscript/channel_vtxo_test.go
+++ b/lib/arkscript/channel_vtxo_test.go
@@ -78,6 +78,9 @@ func TestValidateChannelVTXOTemplate(t *testing.T) {
 
 	template, err := DecodePolicyTemplate(raw)
 	require.NoError(t, err)
+	derivedPkScript, err := template.PkScript()
+	require.NoError(t, err)
+	require.Equal(t, pkScript, derivedPkScript)
 	require.NoError(t, ValidateChannelVTXOTemplate(template, params))
 
 	otherKey, err := btcec.NewPrivateKey()

--- a/lib/arkscript/channel_vtxo_test.go
+++ b/lib/arkscript/channel_vtxo_test.go
@@ -89,6 +89,33 @@ func TestValidateChannelVTXOTemplate(t *testing.T) {
 	require.Error(t, ValidateChannelVTXOTemplate(template, params))
 }
 
+// TestValidateChannelVTXOPolicy verifies admission can recognize the
+// canonical policy without trusting caller-supplied channel terms.
+func TestValidateChannelVTXOPolicy(t *testing.T) {
+	t.Parallel()
+
+	params := testChannelVTXOParams(t)
+	raw, _, err := EncodeChannelVTXOArtifacts(params)
+	require.NoError(t, err)
+	template, err := DecodePolicyTemplate(raw)
+	require.NoError(t, err)
+
+	// Leaf order does not affect the Taproot policy or its classification.
+	template.Leaves[0], template.Leaves[2] =
+		template.Leaves[2], template.Leaves[0]
+	err = ValidateChannelVTXOPolicy(
+		template, params.ArkOperatorKey, params.MinExitDelay,
+	)
+	require.NoError(t, err)
+
+	otherOperator, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	err = ValidateChannelVTXOPolicy(
+		template, otherOperator.PubKey(), params.MinExitDelay,
+	)
+	require.ErrorContains(t, err, "does not match expected key roles")
+}
+
 // testChannelVTXOParams returns independent keys and valid channel delays.
 func testChannelVTXOParams(t *testing.T) ChannelVTXOParams {
 	t.Helper()

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -75,10 +75,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
   actor's DB transaction; both phase-1 hint resolution and phase-2
   authoritative metadata lookup go through durable `serverconn` query
   messages and return as fresh events.
-- Snapshots are versioned per direction (`OutgoingSnapshot.Version = 5`,
-  `IncomingSnapshot.Version = 1`); restore rejects a zero version. Outgoing
-  v5 adds the `FirstRejectUnixNanos` record (bounded transient submit-reject
-  retry window); a pre-v5 snapshot decodes it to 0 (a fresh window).
+- Snapshots are versioned per direction (`OutgoingSnapshot.Version = 7`,
+  `IncomingSnapshot.Version = 1`); restore rejects zero and unknown future
+  versions. Outgoing v5 adds `FirstRejectUnixNanos`; v7 adds the pre-PONR
+  terminal-failure marker. Older snapshots decode absent optional records to
+  their conservative zero values.
 - `StartTransferRequest.IdempotencyKey` dedup reads
   `oor_dispatch_attempts`, not the mutable session row. The table has one row
   per caller key and one caller key per deterministic session id. Once the

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -75,10 +75,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
   actor's DB transaction; both phase-1 hint resolution and phase-2
   authoritative metadata lookup go through durable `serverconn` query
   messages and return as fresh events.
-- Snapshots are versioned per direction (`OutgoingSnapshot.Version = 5`,
-  `IncomingSnapshot.Version = 1`); restore rejects a zero version. Outgoing
-  v5 adds the `FirstRejectUnixNanos` record (bounded transient submit-reject
-  retry window); a pre-v5 snapshot decodes it to 0 (a fresh window).
+- Snapshots are versioned per direction (`OutgoingSnapshot.Version = 7`,
+  `IncomingSnapshot.Version = 1`); restore rejects zero and unknown future
+  versions. Outgoing v5 adds `FirstRejectUnixNanos`; v7 adds the pre-PONR
+  terminal-failure marker. Older snapshots decode absent optional records to
+  their conservative zero values.
 - `StartTransferRequest.IdempotencyKey` dedup reads
   `oor_dispatch_attempts`, not the mutable session row. The table has one row
   per caller key and one caller key per deterministic session id. Once the

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -303,6 +303,10 @@ func decodeStartTransferPayloadWithLimits(raw []byte,
 	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return startTransferPayload{}, err
 	}
+	if prepareOnly > 1 {
+		return startTransferPayload{}, fmt.Errorf("prepare-only flag " +
+			"must be 0 or 1")
+	}
 
 	inputs, err := decodeTransferInputSnapshotsWithLimits(
 		inputsRaw, limits,

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -41,6 +41,10 @@ const (
 	// startPayloadDispatchRequestDataType stores the normalized caller
 	// recipient proof for a keyed dispatch.
 	startPayloadDispatchRequestDataType tlv.Type = 9
+
+	// startPayloadPrepareOnlyType stores whether admission must stop before
+	// signing. It is optional so pre-feature messages decode as false.
+	startPayloadPrepareOnlyType tlv.Type = 11
 )
 
 const (
@@ -113,6 +117,8 @@ const (
 	eventKindIncomingMetadata  uint64 = 10
 	eventKindOutboxError       uint64 = 11
 	eventKindArkSigned         uint64 = 12
+	eventKindCommitPrepared    uint64 = 13
+	eventKindAbortPrepared     uint64 = 14
 )
 
 const (
@@ -162,6 +168,7 @@ type startTransferPayload struct {
 	IdempotencyKey             string
 	DispatchRequestData        []byte
 	AdmissionDeadlineUnixNanos int64
+	PrepareOnly                bool
 }
 
 type recipientPayload struct {
@@ -193,6 +200,10 @@ func encodeStartTransferPayload(payload startTransferPayload) ([]byte, error) {
 	idempotencyKey := []byte(payload.IdempotencyKey)
 	dispatchRequestData := payload.DispatchRequestData
 	admissionDeadline := uint64(payload.AdmissionDeadlineUnixNanos)
+	var prepareOnly uint8
+	if payload.PrepareOnly {
+		prepareOnly = 1
+	}
 
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(
@@ -216,6 +227,9 @@ func encodeStartTransferPayload(payload startTransferPayload) ([]byte, error) {
 		tlv.MakePrimitiveRecord(
 			startPayloadDispatchRequestDataType,
 			&dispatchRequestData,
+		),
+		tlv.MakePrimitiveRecord(
+			startPayloadPrepareOnlyType, &prepareOnly,
 		),
 	}
 
@@ -251,6 +265,7 @@ func decodeStartTransferPayloadWithLimits(raw []byte,
 		idKey               []byte
 		dispatchRequestData []byte
 		deadline            uint64
+		prepareOnly         uint8
 	)
 
 	records := []tlv.Record{
@@ -273,6 +288,9 @@ func decodeStartTransferPayloadWithLimits(raw []byte,
 		tlv.MakePrimitiveRecord(
 			startPayloadDispatchRequestDataType,
 			&dispatchRequestData,
+		),
+		tlv.MakePrimitiveRecord(
+			startPayloadPrepareOnlyType, &prepareOnly,
 		),
 	}
 
@@ -308,6 +326,7 @@ func decodeStartTransferPayloadWithLimits(raw []byte,
 		IdempotencyKey:             string(idKey),
 		DispatchRequestData:        dispatchRequestData,
 		AdmissionDeadlineUnixNanos: int64(deadline),
+		PrepareOnly:                prepareOnly != 0,
 	}, nil
 }
 
@@ -2124,6 +2143,13 @@ func encodeEventPayload(event Event) ([]byte, error) {
 	)
 
 	switch evt := event.(type) {
+	case *CommitPreparedEvent:
+		eventKind = eventKindCommitPrepared
+
+	case *AbortPreparedEvent:
+		eventKind = eventKindAbortPrepared
+		reason = []byte(evt.Reason)
+
 	case *ArkSignedEvent:
 		eventKind = eventKindArkSigned
 		if evt.ArkPSBT == nil {
@@ -2388,6 +2414,12 @@ func decodeEventPayloadWithLimits(raw []byte,
 	}
 
 	switch eventKind {
+	case eventKindCommitPrepared:
+		return &CommitPreparedEvent{}, nil
+
+	case eventKindAbortPrepared:
+		return &AbortPreparedEvent{Reason: string(reason)}, nil
+
 	case eventKindArkSigned:
 		ark, err := psbtutil.Parse(arkPSBT)
 		if err != nil {
@@ -2448,43 +2480,10 @@ func decodeEventPayloadWithLimits(raw []byte,
 		return &FailEvent{Reason: string(reason)}, nil
 
 	case eventKindIncomingTransfer:
-		if len(arkPSBT) == 0 {
-			return nil, fmt.Errorf("incoming transfer event ark " +
-				"psbt must be provided")
-		}
-
-		ark, err := psbtutil.Parse(arkPSBT)
-		if err != nil {
-			return nil, err
-		}
-
-		checkpoints, err := decodeCheckpointPSBTsWithLimits(
-			checkpointPSBT, limits,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		ancestors, err := decodePackageArtifactsWithLimits(
-			ancestorPayload, limits,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		recipients, err := decodeIncomingRecipientsWithLimits(
+		return decodeIncomingTransferEvent(
+			arkPSBT, checkpointPSBT, ancestorPayload,
 			recipientPayload, limits,
 		)
-		if err != nil {
-			return nil, err
-		}
-
-		return &IncomingTransferEvent{
-			ArkPSBT:              ark,
-			FinalCheckpointPSBTs: checkpoints,
-			AncestorPackages:     ancestors,
-			Recipients:           recipients,
-		}, nil
 
 	case eventKindIncomingHandled:
 		outpoints, err := decodeOutPointListWithLimits(
@@ -2524,6 +2523,47 @@ func decodeEventPayloadWithLimits(raw []byte,
 	default:
 		return nil, fmt.Errorf("unknown event kind: %d", eventKind)
 	}
+}
+
+// decodeIncomingTransferEvent decodes the list-shaped fields carried by an
+// incoming transfer event under the configured receive limits.
+func decodeIncomingTransferEvent(arkPSBT, checkpointPSBT, ancestorPayload,
+	recipientPayload []byte, limits ReceiveLimits) (Event, error) {
+
+	if len(arkPSBT) == 0 {
+		return nil, fmt.Errorf("incoming transfer event ark psbt " +
+			"must be provided")
+	}
+
+	ark, err := psbtutil.Parse(arkPSBT)
+	if err != nil {
+		return nil, err
+	}
+	checkpoints, err := decodeCheckpointPSBTsWithLimits(
+		checkpointPSBT, limits,
+	)
+	if err != nil {
+		return nil, err
+	}
+	ancestors, err := decodePackageArtifactsWithLimits(
+		ancestorPayload, limits,
+	)
+	if err != nil {
+		return nil, err
+	}
+	recipients, err := decodeIncomingRecipientsWithLimits(
+		recipientPayload, limits,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IncomingTransferEvent{
+		ArkPSBT:              ark,
+		FinalCheckpointPSBTs: checkpoints,
+		AncestorPackages:     ancestors,
+		Recipients:           recipients,
+	}, nil
 }
 
 // decodeCheckpointPSBTsWithLimits decodes checkpoint PSBT lists using receive

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -71,6 +71,7 @@ func TestStartTransferPayloadTLVRoundTrip(t *testing.T) {
 			3,
 		},
 		AdmissionDeadlineUnixNanos: 1_700_000_000_123_456_789,
+		PrepareOnly:                true,
 	}
 
 	raw, err := encodeStartTransferPayload(payload)
@@ -92,8 +93,54 @@ func TestStartTransferPayloadTLVRoundTrip(t *testing.T) {
 		t, payload.AdmissionDeadlineUnixNanos,
 		decoded.AdmissionDeadlineUnixNanos,
 	)
+	require.Equal(t, payload.PrepareOnly, decoded.PrepareOnly)
 	require.Len(t, decoded.Inputs, 1)
 	require.Equal(t, payload.Inputs[0], decoded.Inputs[0])
+}
+
+// TestDriveEventRequestRoundTripPreparedEvents verifies the two-phase OOR
+// control events survive the durable mailbox codec.
+func TestDriveEventRequestRoundTripPreparedEvents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		event Event
+	}{
+		{
+			name:  "commit",
+			event: &CommitPreparedEvent{},
+		},
+		{
+			name: "abort",
+			event: &AbortPreparedEvent{
+				Reason: "channel negotiation failed",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg := &DriveEventRequest{
+				SessionID: SessionID{
+					1,
+					2,
+					3,
+				},
+				Event: test.event,
+			}
+			var buf bytes.Buffer
+			require.NoError(t, msg.Encode(&buf))
+
+			var decoded DriveEventRequest
+			require.NoError(t, decoded.Decode(&buf))
+			require.Equal(t, msg.SessionID, decoded.SessionID)
+			require.Equal(t, test.event, decoded.Event)
+		})
+	}
 }
 
 // TestLookupTransferRequestRoundTrip verifies a read-only keyed reconciliation

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -98,6 +98,23 @@ func TestStartTransferPayloadTLVRoundTrip(t *testing.T) {
 	require.Equal(t, payload.Inputs[0], decoded.Inputs[0])
 }
 
+// TestStartTransferPayloadRejectsNonCanonicalBool verifies durable messages do
+// not silently reinterpret malformed boolean values across implementations.
+func TestStartTransferPayloadRejectsNonCanonicalBool(t *testing.T) {
+	t.Parallel()
+
+	raw, err := encodeStartTransferPayload(startTransferPayload{
+		PrepareOnly: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	// PrepareOnly is the final, one-byte TLV record in this payload.
+	raw[len(raw)-1] = 2
+	_, err = decodeStartTransferPayload(raw)
+	require.ErrorContains(t, err, "prepare-only flag must be 0 or 1")
+}
+
 // TestDriveEventRequestRoundTripPreparedEvents verifies the two-phase OOR
 // control events survive the durable mailbox codec.
 func TestDriveEventRequestRoundTripPreparedEvents(t *testing.T) {

--- a/oor/actor_messages.go
+++ b/oor/actor_messages.go
@@ -120,6 +120,11 @@ type StartTransferRequest struct {
 	// new transfer may be admitted. Existing keyed winners remain readable
 	// after this deadline. Zero leaves admission unbounded.
 	AdmissionDeadlineUnixNanos int64
+
+	// PrepareOnly persists the deterministic package and input reservations
+	// without signing or submitting it. A later CommitPreparedEvent
+	// releases the ordinary OOR flow.
+	PrepareOnly bool
 }
 
 // MessageType returns the type of this message.
@@ -142,6 +147,7 @@ func (m *StartTransferRequest) Encode(w io.Writer) error {
 		IdempotencyKey:             m.IdempotencyKey,
 		DispatchRequestData:        m.DispatchRequestData,
 		AdmissionDeadlineUnixNanos: m.AdmissionDeadlineUnixNanos,
+		PrepareOnly:                m.PrepareOnly,
 		Recipients: make(
 			[]recipientPayload, 0, len(m.Recipients),
 		),
@@ -211,6 +217,7 @@ func (m *StartTransferRequest) Decode(r io.Reader) error {
 	m.IdempotencyKey = payload.IdempotencyKey
 	m.DispatchRequestData = payload.DispatchRequestData
 	m.AdmissionDeadlineUnixNanos = payload.AdmissionDeadlineUnixNanos
+	m.PrepareOnly = payload.PrepareOnly
 
 	m.Inputs = make([]TransferInput, 0, len(payload.Inputs))
 	for i := range payload.Inputs {

--- a/oor/events.go
+++ b/oor/events.go
@@ -44,10 +44,31 @@ type StartTransferEvent struct {
 	// DispatchRequestData is the normalized caller-recipient proof that
 	// must become durable before submit transport is enqueued.
 	DispatchRequestData []byte
+
+	// PrepareOnly stops after deterministically constructing and persisting
+	// the unsigned package. No signature or operator message is released
+	// until CommitPreparedEvent arrives.
+	PrepareOnly bool
 }
 
 // eventSealed marks this as implementing the sealed Event interface.
 func (e *StartTransferEvent) eventSealed() {}
+
+// CommitPreparedEvent releases a previously prepared transfer into the
+// ordinary OOR signing and submission flow.
+type CommitPreparedEvent struct{}
+
+// eventSealed marks this as implementing the sealed Event interface.
+func (*CommitPreparedEvent) eventSealed() {}
+
+// AbortPreparedEvent abandons a prepared transfer before any signature was
+// released and returns its reserved inputs to the wallet.
+type AbortPreparedEvent struct {
+	Reason string
+}
+
+// eventSealed marks this as implementing the sealed Event interface.
+func (*AbortPreparedEvent) eventSealed() {}
 
 // ArkSignedEvent is emitted after the client signs the Ark PSBT.
 type ArkSignedEvent struct {

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -12,6 +12,8 @@ import (
 	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
 )
 
+const outgoingSnapshotVersion uint8 = 7
+
 // OutgoingPhase identifies the coarse stage of an outgoing client transfer.
 //
 // This is intentionally more stable than Go state type names to keep snapshot
@@ -180,7 +182,7 @@ func NewOutgoingSnapshot(sessionID SessionID,
 		// Version 7 adds the pre-PONR terminal-failure marker. Older
 		// snapshots decode it as false and are never treated as safe
 		// abort evidence.
-		Version:   7,
+		Version:   outgoingSnapshotVersion,
 		SessionID: sessionID,
 	}
 
@@ -365,6 +367,10 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 
 	if snapshot.Version == 0 {
 		return nil, fmt.Errorf("snapshot version must be provided")
+	}
+	if snapshot.Version > outgoingSnapshotVersion {
+		return nil, fmt.Errorf("unknown outgoing snapshot version %d",
+			snapshot.Version)
 	}
 
 	switch snapshot.Phase {

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -1,12 +1,14 @@
 package oor
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
 
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/lightninglabs/wavelength/baselib/protofsm"
+	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
 	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
 )
 
@@ -17,6 +19,10 @@ import (
 type OutgoingPhase string
 
 const (
+	// OutgoingPhasePrepared indicates the deterministic package and input
+	// reservations are durable, but no signature has been released.
+	OutgoingPhasePrepared OutgoingPhase = "prepared"
+
 	// OutgoingPhaseArkSignRequested indicates the submit package has been
 	// built and the client must attach Ark signatures before submit can be
 	// sent.
@@ -105,6 +111,57 @@ type OutgoingSnapshot struct {
 	// (which lacks the record) restores to, preserving a fresh retry
 	// window.
 	FirstRejectUnixNanos int64
+
+	// RecipientOutputs preserves semantic policy metadata needed when a
+	// prepared or pre-submit transfer resumes after restart.
+	RecipientOutputs []oortx.RecipientOutput
+
+	// PrePONRFailure records that a terminal failure happened before the
+	// operator co-signed checkpoints, so the source reservation is safe to
+	// release.
+	PrePONRFailure bool
+}
+
+// OutgoingSnapshotRecipients extracts the canonical Ark recipients from one
+// durable outgoing snapshot. Callers use this to recover response metadata for
+// an idempotent replay without rebuilding the transfer or selecting new wallet
+// inputs.
+func OutgoingSnapshotRecipients(raw []byte) ([]ArkRecipientOutput, error) {
+	snapshot, err := decodeOutgoingSnapshot(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode outgoing snapshot: %w", err)
+	}
+
+	ark, err := psbtutil.Parse(snapshot.ArkPSBT)
+	if err != nil {
+		return nil, fmt.Errorf("parse outgoing Ark PSBT: %w", err)
+	}
+
+	recipients, err := ExtractArkRecipients(ark)
+	if err != nil {
+		return nil, fmt.Errorf("extract outgoing recipients: %w", err)
+	}
+
+	for i := range recipients {
+		for j := range snapshot.RecipientOutputs {
+			output := snapshot.RecipientOutputs[j]
+			if output.Value != recipients[i].Value ||
+				!bytes.Equal(
+					output.PkScript, recipients[i].PkScript,
+				) {
+
+				continue
+			}
+
+			recipients[i].VTXOPolicyTemplate = append(
+				[]byte(nil), output.VTXOPolicyTemplate...,
+			)
+
+			break
+		}
+	}
+
+	return recipients, nil
 }
 
 // NewOutgoingSnapshot exports an outgoing transfer FSM state into a snapshot.
@@ -120,15 +177,30 @@ func NewOutgoingSnapshot(sessionID SessionID,
 	}
 
 	snap := &OutgoingSnapshot{
-		// Version 5 adds the FirstRejectUnixNanos record (bounded
-		// transient submit-reject retry window). Restore stays
-		// backward-compatible: a pre-v5 snapshot lacks the record and
-		// decodes FirstRejectUnixNanos to 0 (a fresh window).
-		Version:   5,
+		// Version 7 adds the pre-PONR terminal-failure marker. Older
+		// snapshots decode it as false and are never treated as safe
+		// abort evidence.
+		Version:   7,
 		SessionID: sessionID,
 	}
 
 	switch s := state.(type) {
+	case *Prepared:
+		snap.Phase = OutgoingPhasePrepared
+		snap.IdempotencyKey = s.IdempotencyKey
+		snap.RecipientOutputs = cloneRecipientOutputs(
+			s.RecipientOutputs,
+		)
+		snap.DispatchRequestData = append(
+			[]byte(nil), s.DispatchRequestData...,
+		)
+
+		if err := assignPSBTArtifacts(
+			snap, s.ArkPSBT, s.CheckpointPSBTs, s.TransferInputs,
+		); err != nil {
+			return nil, err
+		}
+
 	case *AwaitingArkSignatures:
 		// Snapshot deterministic submit artifacts before submit.
 		// This lets resume re-drive Ark signing without rebuilding.
@@ -136,6 +208,9 @@ func NewOutgoingSnapshot(sessionID SessionID,
 		snap.IdempotencyKey = s.IdempotencyKey
 		snap.DispatchRequestData = append(
 			[]byte(nil), s.DispatchRequestData...,
+		)
+		snap.RecipientOutputs = cloneRecipientOutputs(
+			s.RecipientOutputs,
 		)
 
 		ark, err := psbtutil.Serialize(s.ArkPSBT)
@@ -172,6 +247,9 @@ func NewOutgoingSnapshot(sessionID SessionID,
 		snap.RetryAfter = s.RetryAfter
 		snap.FailReason = s.RetryReason
 		snap.FirstRejectUnixNanos = s.FirstRejectUnixNanos
+		snap.RecipientOutputs = cloneRecipientOutputs(
+			s.RecipientOutputs,
+		)
 
 		if err := assignPSBTArtifacts(
 			snap, s.ArkPSBT, s.CheckpointPSBTs, s.TransferInputs,
@@ -229,6 +307,7 @@ func NewOutgoingSnapshot(sessionID SessionID,
 		// Failed is terminal. Retrying is not attempted automatically.
 		snap.Phase = OutgoingPhaseFailed
 		snap.FailReason = s.Reason
+		snap.PrePONRFailure = s.PrePONR
 		snap.IdempotencyKey = s.IdempotencyKey
 
 	default:
@@ -289,6 +368,36 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 	}
 
 	switch snapshot.Phase {
+	case OutgoingPhasePrepared:
+		ark, cps, err := parseOutgoingPSBTs(
+			snapshot.ArkPSBT, snapshot.CheckpointPSBTs,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := requireSessionIDMatchesArk(
+			snapshot.SessionID, ark,
+		); err != nil {
+			return nil, err
+		}
+		inputs, err := restoreTransferInputs(snapshot)
+		if err != nil {
+			return nil, err
+		}
+
+		return &Prepared{
+			ArkPSBT:         ark,
+			CheckpointPSBTs: cps,
+			TransferInputs:  inputs,
+			RecipientOutputs: cloneRecipientOutputs(
+				snapshot.RecipientOutputs,
+			),
+			IdempotencyKey: snapshot.IdempotencyKey,
+			DispatchRequestData: append(
+				[]byte(nil), snapshot.DispatchRequestData...,
+			),
+		}, nil
+
 	case OutgoingPhaseArkSignRequested:
 		ark, cps, err := parseOutgoingPSBTs(
 			snapshot.ArkPSBT, snapshot.CheckpointPSBTs,
@@ -314,6 +423,9 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 			IdempotencyKey:  snapshot.IdempotencyKey,
 			DispatchRequestData: append(
 				[]byte(nil), snapshot.DispatchRequestData...,
+			),
+			RecipientOutputs: cloneRecipientOutputs(
+				snapshot.RecipientOutputs,
 			),
 		}, nil
 
@@ -343,8 +455,11 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 			DispatchRequestData: append(
 				[]byte(nil), snapshot.DispatchRequestData...,
 			),
-			RetryAfter:           snapshot.RetryAfter,
-			RetryReason:          snapshot.FailReason,
+			RetryAfter:  snapshot.RetryAfter,
+			RetryReason: snapshot.FailReason,
+			RecipientOutputs: cloneRecipientOutputs(
+				snapshot.RecipientOutputs,
+			),
 			FirstRejectUnixNanos: snapshot.FirstRejectUnixNanos,
 		}, nil
 
@@ -420,6 +535,7 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 	case OutgoingPhaseFailed:
 		return &Failed{
 			Reason:         snapshot.FailReason,
+			PrePONR:        snapshot.PrePONRFailure,
 			IdempotencyKey: snapshot.IdempotencyKey,
 		}, nil
 
@@ -427,6 +543,28 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 		return nil, fmt.Errorf("unknown outgoing phase: %s",
 			snapshot.Phase)
 	}
+}
+
+// cloneRecipientOutputs returns an isolated copy of OOR recipient metadata.
+func cloneRecipientOutputs(
+	outputs []oortx.RecipientOutput) []oortx.RecipientOutput {
+
+	if len(outputs) == 0 {
+		return nil
+	}
+
+	cloned := make([]oortx.RecipientOutput, len(outputs))
+	for i := range outputs {
+		cloned[i] = oortx.RecipientOutput{
+			PkScript: append([]byte(nil), outputs[i].PkScript...),
+			Value:    outputs[i].Value,
+			VTXOPolicyTemplate: append(
+				[]byte(nil), outputs[i].VTXOPolicyTemplate...,
+			),
+		}
+	}
+
+	return cloned
 }
 
 // snapshotTransferInputs converts transfer inputs into portable snapshots.

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -6,7 +6,9 @@ import (
 	"math"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -33,6 +35,14 @@ const (
 	// snapshotDispatchRequestDataRecordType retains the normalized caller
 	// proof until the first submit-capable checkpoint.
 	snapshotDispatchRequestDataRecordType tlv.Type = 25
+
+	// snapshotRecipientsRecordType stores semantic recipient metadata for
+	// prepared and pre-submit sessions.
+	snapshotRecipientsRecordType tlv.Type = 27
+
+	// snapshotPrePONRFailureRecordType stores whether a terminal failure is
+	// definitive evidence that the source reservation was released.
+	snapshotPrePONRFailureRecordType tlv.Type = 29
 )
 
 func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
@@ -49,7 +59,6 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	inputSnapshots, err := encodeTransferInputSnapshots(
 		snapshot.TransferInputSnapshots,
 	)
@@ -62,8 +71,27 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 	idempotencyKey := []byte(snapshot.IdempotencyKey)
 	firstRejectNanos := uint64(snapshot.FirstRejectUnixNanos)
 	dispatchRequestData := snapshot.DispatchRequestData
+	recipientPayloads := make(
+		[]recipientPayload, 0, len(snapshot.RecipientOutputs),
+	)
+	for i := range snapshot.RecipientOutputs {
+		output := snapshot.RecipientOutputs[i]
+		recipientPayloads = append(recipientPayloads, recipientPayload{
+			PkScript:           output.PkScript,
+			ValueSat:           int64(output.Value),
+			VTXOPolicyTemplate: output.VTXOPolicyTemplate,
+		})
+	}
+	recipients, err := encodeRecipientPayloads(recipientPayloads)
+	if err != nil {
+		return nil, err
+	}
 
 	version := uint64(snapshot.Version)
+	var prePONRFailure uint8
+	if snapshot.PrePONRFailure {
+		prePONRFailure = 1
+	}
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(snapshotVersionRecordType, &version),
 		tlv.MakePrimitiveRecord(
@@ -92,6 +120,12 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 		tlv.MakePrimitiveRecord(
 			snapshotDispatchRequestDataRecordType,
 			&dispatchRequestData,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotRecipientsRecordType, &recipients,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotPrePONRFailureRecordType, &prePONRFailure,
 		),
 	}
 
@@ -129,6 +163,8 @@ func decodeOutgoingSnapshotWithLimits(raw []byte,
 		idempotencyKeyRaw   []byte
 		firstRejectNanos    uint64
 		dispatchRequestData []byte
+		recipientsRaw       []byte
+		prePONRFailure      uint8
 	)
 
 	records := []tlv.Record{
@@ -159,6 +195,12 @@ func decodeOutgoingSnapshotWithLimits(raw []byte,
 		tlv.MakePrimitiveRecord(
 			snapshotDispatchRequestDataRecordType,
 			&dispatchRequestData,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotRecipientsRecordType, &recipientsRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotPrePONRFailureRecordType, &prePONRFailure,
 		),
 	}
 
@@ -222,6 +264,40 @@ func decodeOutgoingSnapshotWithLimits(raw []byte,
 	if err != nil {
 		return nil, err
 	}
+	if prePONRFailure > 1 {
+		return nil, fmt.Errorf("snapshot pre-PONR failure must be 0 " +
+			"or 1")
+	}
+
+	var recipientOutputs []oortx.RecipientOutput
+	if len(recipientsRaw) > 0 {
+		recipientPayloads, err := decodeRecipientPayloadsWithLimits(
+			recipientsRaw, limits,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(recipientPayloads) > 0 {
+			recipientOutputs = make(
+				[]oortx.RecipientOutput, 0,
+				len(recipientPayloads),
+			)
+			for i := range recipientPayloads {
+				payload := recipientPayloads[i]
+				recipientOutputs = append(
+					recipientOutputs,
+					oortx.RecipientOutput{
+						PkScript: payload.PkScript,
+						Value: btcutil.Amount(
+							payload.ValueSat,
+						),
+						VTXOPolicyTemplate: payload.
+							VTXOPolicyTemplate,
+					},
+				)
+			}
+		}
+	}
 
 	return &OutgoingSnapshot{
 		Version:                decodedVersion,
@@ -235,6 +311,8 @@ func decodeOutgoingSnapshotWithLimits(raw []byte,
 		IdempotencyKey:         string(idempotencyKeyRaw),
 		FirstRejectUnixNanos:   decodedFirstReject,
 		DispatchRequestData:    dispatchRequestData,
+		RecipientOutputs:       recipientOutputs,
+		PrePONRFailure:         prePONRFailure == 1,
 	}, nil
 }
 

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -250,6 +250,10 @@ func decodeOutgoingSnapshotWithLimits(raw []byte,
 	if err != nil {
 		return nil, err
 	}
+	if decodedVersion > outgoingSnapshotVersion {
+		return nil, fmt.Errorf("unknown outgoing snapshot version %d",
+			decodedVersion)
+	}
 
 	decodedRetryAfter, err := decodeUint64ToDuration(
 		retryAfterNanos, "snapshot retry_after nanos",

--- a/oor/outgoing_snapshot_codec_test.go
+++ b/oor/outgoing_snapshot_codec_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
 )
@@ -69,6 +70,17 @@ func TestOutgoingSnapshotTLVRoundTrip(t *testing.T) {
 		DispatchRequestData: []byte{
 			1, 2, 3,
 		},
+		RecipientOutputs: []oortx.RecipientOutput{{
+			PkScript: []byte{
+				0x51,
+				0x20,
+			},
+			Value: 321,
+			VTXOPolicyTemplate: []byte{
+				0x01, 0x02,
+			},
+		}},
+		PrePONRFailure: true,
 	}
 
 	raw, err := encodeOutgoingSnapshot(snapshot)

--- a/oor/outgoing_snapshot_codec_test.go
+++ b/oor/outgoing_snapshot_codec_test.go
@@ -167,6 +167,20 @@ func TestDecodeOutgoingSnapshotRejectsVersionOverflow(t *testing.T) {
 	require.ErrorContains(t, err, "snapshot version overflows uint8")
 }
 
+// TestDecodeOutgoingSnapshotRejectsFutureVersion verifies this binary fails
+// closed instead of interpreting fields from an unknown snapshot schema.
+func TestDecodeOutgoingSnapshotRejectsFutureVersion(t *testing.T) {
+	t.Parallel()
+
+	raw, err := encodeSnapshotRawForDecodeTest(
+		uint64(outgoingSnapshotVersion)+1, 0,
+	)
+	require.NoError(t, err)
+
+	_, err = decodeOutgoingSnapshot(raw)
+	require.ErrorContains(t, err, "unknown outgoing snapshot version")
+}
+
 func TestDecodeOutgoingSnapshotRejectsRetryAfterOverflow(t *testing.T) {
 	t.Parallel()
 

--- a/oor/registry.go
+++ b/oor/registry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lightninglabs/wavelength/build"
 	clientdb "github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/ledger"
+	"github.com/lightninglabs/wavelength/rpc/oorpb"
 	"github.com/lightninglabs/wavelength/serverconn"
 	"github.com/lightninglabs/wavelength/timeout"
 	"github.com/lightninglabs/wavelength/vtxo"
@@ -759,7 +760,7 @@ func (r *oorRegistryBehavior) handleStartTransfer(ctx context.Context,
 	// daemon's lifetime (one leak per outgoing admission otherwise).
 	session, _, err := newSessionWithDispatchRequest(
 		ctx, req.Policy, req.Inputs, req.Recipients, req.IdempotencyKey,
-		req.DispatchRequestData, r.envConfig(),
+		req.DispatchRequestData, req.PrepareOnly, r.envConfig(),
 	)
 	if err != nil {
 		return fn.Err[ActorResp](err)
@@ -1659,6 +1660,18 @@ func (r *oorRegistryBehavior) routeAsk(ctx context.Context, sessionID SessionID,
 		return fn.Err[ActorResp](err)
 	}
 	if child == nil {
+		if _, ok := msg.(*GetStateRequest); ok {
+			state, found, err := r.persistedState(ctx, sessionID)
+			if err != nil {
+				return fn.Err[ActorResp](err)
+			}
+			if found {
+				return fn.Ok[ActorResp](&GetStateResponse{
+					State: state,
+				})
+			}
+		}
+
 		return fn.Err[ActorResp](
 			fmt.Errorf("unknown session: %s", sessionID),
 		)
@@ -1691,6 +1704,60 @@ func (r *oorRegistryBehavior) routeAsk(ctx context.Context, sessionID SessionID,
 	)
 
 	return fn.Ok[ActorResp](&DriveEventResponse{})
+}
+
+// persistedState reconstructs a reaped session's state from its durable
+// snapshot. Terminal actors are deliberately short-lived, but status readers
+// must remain race-free after the child exits.
+func (r *oorRegistryBehavior) persistedState(ctx context.Context,
+	sessionID SessionID) (SessionState, bool, error) {
+
+	record, err := r.cfg.RegistryStore.GetSession(
+		ctx, chainHashOf(sessionID),
+	)
+	switch {
+	case errors.Is(err, clientdb.ErrOORSessionNotFound):
+		return nil, false, nil
+
+	case err != nil:
+		return nil, false, err
+	}
+
+	if err := oorpb.ValidateFlowVersion(record.FlowVersion); err != nil {
+		return nil, false, err
+	}
+	if len(record.SnapshotData) == 0 {
+		return nil, false, fmt.Errorf("session %s has no snapshot",
+			sessionID)
+	}
+
+	switch record.Direction {
+	case clientdb.OORSessionDirectionOutgoing:
+		snapshot, err := decodeOutgoingSnapshot(record.SnapshotData)
+		if err != nil {
+			return nil, false, err
+		}
+
+		state, err := OutgoingStateFromSnapshot(snapshot)
+
+		return state, true, err
+
+	case clientdb.OORSessionDirectionIncoming:
+		snapshot, err := decodeIncomingSnapshotWithLimits(
+			record.SnapshotData, r.cfg.Limits,
+		)
+		if err != nil {
+			return nil, false, err
+		}
+
+		state, err := IncomingStateFromSnapshot(snapshot)
+
+		return state, true, err
+
+	default:
+		return nil, false, fmt.Errorf("unknown session direction: %d",
+			record.Direction)
+	}
 }
 
 // sessionIsTerminal reports whether the durable row for a session exists and

--- a/oor/registry.go
+++ b/oor/registry.go
@@ -730,6 +730,32 @@ func (r *oorRegistryBehavior) handleStartTransfer(ctx context.Context,
 			return fn.Err[ActorResp](err)
 		}
 
+		prepared, err := store.GetUnfailedSessionByIdempotencyKey(
+			ctx, req.IdempotencyKey,
+		)
+		switch {
+		case err == nil:
+			if prepared.Direction !=
+				clientdb.OORSessionDirectionOutgoing {
+				return fn.Err[ActorResp](
+					fmt.Errorf("%w: key %q belongs to a "+
+						"non-outgoing session",
+						ErrIdempotencyKeyConflict,
+						req.IdempotencyKey),
+				)
+			}
+
+			delete(r.pendingOutgoingKeys, req.IdempotencyKey)
+
+			return fn.Ok[ActorResp](&StartTransferResponse{
+				SessionID: SessionID(prepared.SessionID),
+				Existing:  true,
+			})
+
+		case !errors.Is(err, clientdb.ErrOORSessionNotFound):
+			return fn.Err[ActorResp](err)
+		}
+
 		pendingID, pending := r.pendingOutgoingKeys[req.IdempotencyKey]
 		if pending {
 			if _, active := r.active[pendingID]; active {
@@ -905,9 +931,15 @@ func (r *oorRegistryBehavior) validateOutgoingDispatchIdentity(
 	switch {
 	case err == nil && record.Direction ==
 		clientdb.OORSessionDirectionOutgoing &&
-		record.Status == clientdb.OORSessionStatusFailed:
+		record.Status == clientdb.OORSessionStatusFailed &&
+		(record.IdempotencyKey == "" || record.IdempotencyKey == key):
 
 		replaceFailed = true
+
+	case err == nil && record.Direction ==
+		clientdb.OORSessionDirectionOutgoing &&
+		record.IdempotencyKey == key:
+		return false, nil
 
 	case err == nil:
 		return false, fmt.Errorf("%w: session %s",
@@ -960,6 +992,32 @@ func (r *oorRegistryBehavior) handleLookupTransfer(ctx context.Context,
 		})
 
 	case !errors.Is(err, clientdb.ErrOORDispatchAttemptNotFound):
+		return fn.Err[ActorResp](err)
+	}
+
+	prepared, err := r.cfg.RegistryStore.
+		GetUnfailedSessionByIdempotencyKey(
+			ctx, req.IdempotencyKey,
+		)
+	switch {
+	case err == nil:
+		if prepared.Direction != clientdb.OORSessionDirectionOutgoing {
+			return fn.Err[ActorResp](
+				fmt.Errorf("%w: key %q belongs to a "+
+					"non-outgoing session",
+					ErrIdempotencyKeyConflict,
+					req.IdempotencyKey),
+			)
+		}
+
+		delete(r.pendingOutgoingKeys, req.IdempotencyKey)
+
+		return fn.Ok[ActorResp](&LookupTransferResponse{
+			SessionID: SessionID(prepared.SessionID),
+			Found:     true,
+		})
+
+	case !errors.Is(err, clientdb.ErrOORSessionNotFound):
 		return fn.Err[ActorResp](err)
 	}
 

--- a/oor/registry_test.go
+++ b/oor/registry_test.go
@@ -229,6 +229,34 @@ func upsertRegistryRowContext(ctx context.Context, t *testing.T,
 	require.NoError(t, store.UpsertSession(ctx, rec))
 }
 
+// TestOORRegistryGetStateReadsReapedSnapshot verifies status probes remain
+// valid after a terminal child has been removed from the active set.
+func TestOORRegistryGetStateReadsReapedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newFakeRegistryStore()
+	id := oorSessionID(0x7a)
+	record, err := outgoingRegistryRecord(id, &Completed{
+		IdempotencyKey: "ark-channel:test",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.UpsertSession(ctx, record))
+
+	registry, recorder := newTestRegistryBehavior(store)
+	result := registry.routeAsk(ctx, id, &GetStateRequest{
+		SessionID: id,
+	})
+	require.True(t, result.IsOk(), result.Err())
+	require.Zero(t, recorder.spawns)
+
+	response, ok := result.UnwrapOr(nil).(*GetStateResponse)
+	require.True(t, ok)
+	completed, ok := response.State.(*Completed)
+	require.True(t, ok)
+	require.Equal(t, "ark-channel:test", completed.IdempotencyKey)
+}
+
 // TestOORRegistryRestoreNonTerminal verifies restore spawns one child per
 // non-terminal row and skips terminal ones.
 func TestOORRegistryRestoreNonTerminal(t *testing.T) {

--- a/oor/registry_test.go
+++ b/oor/registry_test.go
@@ -333,6 +333,52 @@ func TestOORRegistryStartTransferDedup(t *testing.T) {
 	require.Equal(t, 0, rec.spawns)
 }
 
+// TestOORRegistryPreparedTransferDedupAfterRestart verifies that a prepared
+// session remains the keyed winner even though it has not emitted transport
+// work and therefore has no immutable dispatch-attempt row yet.
+func TestOORRegistryPreparedTransferDedupAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newFakeRegistryStore()
+	existing := oorSessionID(0x11)
+	record := clientdb.OORSessionRegistryRecord{
+		SessionID:      chainHashOf(existing),
+		ActorID:        ActorIDForSession(existing),
+		Direction:      clientdb.OORSessionDirectionOutgoing,
+		Phase:          "prepared",
+		IdempotencyKey: "prepared-key",
+		Status:         clientdb.OORSessionStatusPending,
+		SnapshotData: []byte{
+			0x01,
+		},
+	}
+	require.NoError(t, store.UpsertSession(ctx, record))
+
+	// A fresh behavior has no process-local pending key map. Both the retry
+	// and explicit lookup must still find the durable prepared winner.
+	b, rec := newTestRegistryBehavior(store)
+	started := b.handleStartTransfer(ctx, &StartTransferRequest{
+		IdempotencyKey: record.IdempotencyKey,
+	})
+	require.True(t, started.IsOk(), started.Err())
+	startResp, ok := started.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+	require.True(t, startResp.Existing)
+	require.Equal(t, existing, startResp.SessionID)
+	require.Zero(t, rec.spawns)
+
+	lookedUp := b.handleLookupTransfer(ctx, &LookupTransferRequest{
+		IdempotencyKey: record.IdempotencyKey,
+	})
+	require.True(t, lookedUp.IsOk(), lookedUp.Err())
+	lookupResp, ok := lookedUp.UnwrapOr(nil).(*LookupTransferResponse)
+	require.True(t, ok)
+	require.True(t, lookupResp.Found)
+	require.False(t, lookupResp.Pending)
+	require.Equal(t, existing, lookupResp.SessionID)
+}
+
 // TestOORRegistryAdmissionDeadline verifies a new transfer cannot cross its
 // caller-owned admission deadline, while an existing key winner remains
 // readable after the same cutoff.

--- a/oor/resume.go
+++ b/oor/resume.go
@@ -132,6 +132,11 @@ func OutboxForState(state State) ([]OutboxEvent, error) {
 	}
 
 	switch s := state.(type) {
+	case *Prepared:
+		// Preparation deliberately has no implied side effect. Only an
+		// explicit CommitPreparedEvent may release signatures.
+		return nil, nil
+
 	case *AwaitingArkSignatures:
 		return []OutboxEvent{
 			&RequestArkSignatures{

--- a/oor/session.go
+++ b/oor/session.go
@@ -50,6 +50,31 @@ func NewSessionWithIdempotencyKey(ctx context.Context,
 	outputs []oortx.RecipientOutput, idempotencyKey string,
 	envCfg EnvConfig) (*Session, []OutboxEvent, error) {
 
+	return newSessionWithIdempotencyKey(
+		ctx, policy, inputs, outputs, idempotencyKey, false, envCfg,
+	)
+}
+
+// NewPreparedSessionWithIdempotencyKey creates a durable OOR session whose
+// deterministic package is built but whose signatures and transport remain
+// gated on CommitPreparedEvent.
+func NewPreparedSessionWithIdempotencyKey(ctx context.Context,
+	policy arkscript.CheckpointPolicy, inputs []TransferInput,
+	outputs []oortx.RecipientOutput, idempotencyKey string,
+	envCfg EnvConfig) (*Session, []OutboxEvent, error) {
+
+	return newSessionWithIdempotencyKey(
+		ctx, policy, inputs, outputs, idempotencyKey, true, envCfg,
+	)
+}
+
+// newSessionWithIdempotencyKey constructs either an immediately committed or
+// explicitly prepared outgoing OOR session.
+func newSessionWithIdempotencyKey(ctx context.Context,
+	policy arkscript.CheckpointPolicy, inputs []TransferInput,
+	outputs []oortx.RecipientOutput, idempotencyKey string,
+	prepareOnly bool, envCfg EnvConfig) (*Session, []OutboxEvent, error) {
+
 	var dispatchRequestData []byte
 	if idempotencyKey != "" {
 		var err error
@@ -61,15 +86,15 @@ func NewSessionWithIdempotencyKey(ctx context.Context,
 
 	return newSessionWithDispatchRequest(
 		ctx, policy, inputs, outputs, idempotencyKey,
-		dispatchRequestData, envCfg,
+		dispatchRequestData, prepareOnly, envCfg,
 	)
 }
 
 func newSessionWithDispatchRequest(ctx context.Context,
 	policy arkscript.CheckpointPolicy, inputs []TransferInput,
 	outputs []oortx.RecipientOutput, idempotencyKey string,
-	dispatchRequestData []byte, envCfg EnvConfig) (*Session, []OutboxEvent,
-	error) {
+	dispatchRequestData []byte, prepareOnly bool, envCfg EnvConfig) (
+	*Session, []OutboxEvent, error) {
 
 	logger(ctx).DebugS(ctx, "Creating new OOR session",
 		slog.Int("num_inputs", len(inputs)),
@@ -101,6 +126,7 @@ func newSessionWithDispatchRequest(ctx context.Context,
 		DispatchRequestData: append(
 			[]byte(nil), dispatchRequestData...,
 		),
+		PrepareOnly: prepareOnly,
 	})
 	result := fut.Await(ctx)
 	if result.IsErr() {
@@ -114,6 +140,9 @@ func newSessionWithDispatchRequest(ctx context.Context,
 
 	var arkPSBT *psbt.Packet
 	switch s := currentState.(type) {
+	case *Prepared:
+		arkPSBT = s.ArkPSBT
+
 	case *AwaitingArkSignatures:
 		arkPSBT = s.ArkPSBT
 

--- a/oor/session_actor_handlers.go
+++ b/oor/session_actor_handlers.go
@@ -90,7 +90,7 @@ func (b *sessionBehavior) handleStartTransfer(ctx context.Context,
 
 	session, outbox, err := newSessionWithDispatchRequest(
 		ctx, req.Policy, req.Inputs, req.Recipients, req.IdempotencyKey,
-		req.DispatchRequestData, b.envConfig(),
+		req.DispatchRequestData, req.PrepareOnly, b.envConfig(),
 	)
 	if err != nil {
 		return fn.Err[ActorResp](err)

--- a/oor/session_actor_test.go
+++ b/oor/session_actor_test.go
@@ -105,6 +105,26 @@ func (s *fakeRegistryStore) GetSession(_ context.Context,
 	return &record, nil
 }
 
+func (s *fakeRegistryStore) GetUnfailedSessionByIdempotencyKey(
+	_ context.Context, key string) (*clientdb.OORSessionRegistryRecord,
+	error) {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, record := range s.rows {
+		if record.IdempotencyKey == key &&
+			record.Status != clientdb.OORSessionStatusFailed {
+
+			recordCopy := record
+
+			return &recordCopy, nil
+		}
+	}
+
+	return nil, clientdb.ErrOORSessionNotFound
+}
+
 func (s *fakeRegistryStore) GetDispatchAttemptByIdempotencyKey(
 	_ context.Context, key string) (*clientdb.OORDispatchAttemptRecord,
 	error) {

--- a/oor/session_registry_bridge.go
+++ b/oor/session_registry_bridge.go
@@ -29,6 +29,11 @@ type SessionRegistryStore interface {
 		error,
 	)
 
+	// GetUnfailedSessionByIdempotencyKey loads an outgoing session before
+	// its immutable dispatch-attempt row exists. Failed rows release keys.
+	GetUnfailedSessionByIdempotencyKey(ctx context.Context,
+		key string) (*clientdb.OORSessionRegistryRecord, error)
+
 	// GetDispatchAttemptByIdempotencyKey loads the immutable outgoing
 	// dispatch carrying the given caller key.
 	GetDispatchAttemptByIdempotencyKey(ctx context.Context,

--- a/oor/session_test.go
+++ b/oor/session_test.go
@@ -166,6 +166,84 @@ func TestSessionHappyPath(t *testing.T) {
 	require.True(t, ok)
 }
 
+// TestPreparedSessionCommitAndAbort verifies a prepared transfer has no
+// signing side effects until commit and releases its inputs when aborted.
+func TestPreparedSessionCommitAndAbort(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+	input := newTestTransferInput(
+		t, clientKey, operatorKey.PubKey(), wire.OutPoint{
+			Hash:  [32]byte{0x02},
+			Index: 1,
+		}, btcutil.Amount(10_000),
+	)
+	outputs := []oortx.RecipientOutput{{
+		PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+		Value:    btcutil.Amount(10_000),
+	}}
+
+	prepared, outbox, err := NewPreparedSessionWithIdempotencyKey(
+		t.Context(), policy, []TransferInput{input}, outputs,
+		"channel-intent", EnvConfig{},
+	)
+	require.NoError(t, err)
+	require.Empty(t, outbox)
+	require.NotEqual(t, SessionID{}, prepared.ID)
+
+	state, err := prepared.FSM.CurrentState()
+	require.NoError(t, err)
+	require.IsType(t, &Prepared{}, state)
+	outgoingState, ok := state.(State)
+	require.True(t, ok)
+	resumeOutbox, err := OutboxForState(outgoingState)
+	require.NoError(t, err)
+	require.Empty(t, resumeOutbox)
+
+	result := prepared.FSM.AskEvent(
+		t.Context(), &CommitPreparedEvent{},
+	).Await(t.Context())
+	require.False(t, result.IsErr())
+	require.Len(t, result.UnwrapOr(nil), 1)
+	require.IsType(t, &RequestArkSignatures{}, result.UnwrapOr(nil)[0])
+
+	committedState, err := prepared.FSM.CurrentState()
+	require.NoError(t, err)
+	require.IsType(t, &AwaitingArkSignatures{}, committedState)
+
+	aborted, _, err := NewPreparedSessionWithIdempotencyKey(
+		t.Context(), policy, []TransferInput{input}, outputs,
+		"aborted-channel-intent", EnvConfig{},
+	)
+	require.NoError(t, err)
+
+	result = aborted.FSM.AskEvent(t.Context(), &AbortPreparedEvent{
+		Reason: "channel negotiation failed",
+	}).Await(t.Context())
+	require.False(t, result.IsErr())
+	require.Len(t, result.UnwrapOr(nil), 1)
+	release, ok := result.UnwrapOr(nil)[0].(*ReleaseInputsRequest)
+	require.True(t, ok)
+	require.Equal(
+		t, []wire.OutPoint{input.VTXO.Outpoint}, release.Outpoints,
+	)
+
+	abortedState, err := aborted.FSM.CurrentState()
+	require.NoError(t, err)
+	failure, ok := abortedState.(*Failed)
+	require.True(t, ok)
+	require.Equal(t, "channel negotiation failed", failure.Reason)
+	require.True(t, failure.PrePONR)
+}
+
 // TestSessionMultiInputHappyPath verifies the outgoing transfer FSM with
 // multiple VTXO inputs. This exercises the multi-input Ark signing path
 // where BIP-341 sighash commits to ALL prevouts, requiring a

--- a/oor/session_test.go
+++ b/oor/session_test.go
@@ -244,6 +244,22 @@ func TestPreparedSessionCommitAndAbort(t *testing.T) {
 	require.True(t, failure.PrePONR)
 }
 
+// TestFailedStateDerivesPrePONRFromPhase verifies malformed input metadata
+// cannot turn a pre-signature failure into post-PONR evidence.
+func TestFailedStateDerivesPrePONRFromPhase(t *testing.T) {
+	t.Parallel()
+
+	failure := failedState("missing input", &Prepared{
+		TransferInputs: []TransferInput{{}},
+	})
+	require.True(t, failure.PrePONR)
+
+	failure = failedState(
+		"operator co-signed", &AwaitingCheckpointSignatures{},
+	)
+	require.False(t, failure.PrePONR)
+}
+
 // TestSessionMultiInputHappyPath verifies the outgoing transfer FSM with
 // multiple VTXO inputs. This exercises the multi-input Ark signing path
 // where BIP-341 sighash commits to ALL prevouts, requiring a

--- a/oor/states.go
+++ b/oor/states.go
@@ -36,6 +36,47 @@ func (s *Idle) IsTerminal() bool {
 // stateSealed marks Idle as implementing the sealed State interface.
 func (s *Idle) stateSealed() {}
 
+// Prepared holds a deterministic OOR package without releasing signatures or
+// transport. A channel coordinator can safely use its output outpoint while
+// negotiating the lnd channel, then explicitly commit or abort the transfer.
+type Prepared struct {
+	// ArkPSBT is the unsigned canonical Ark transaction whose txid is the
+	// stable session identifier.
+	ArkPSBT *psbt.Packet
+
+	// CheckpointPSBTs are the unsigned checkpoint transactions for the
+	// selected source VTXOs.
+	CheckpointPSBTs []*psbt.Packet
+
+	// TransferInputs carry the signing context retained until commit or
+	// abort.
+	TransferInputs []TransferInput
+
+	// RecipientOutputs preserve semantic output metadata for submit.
+	RecipientOutputs []oortx.RecipientOutput
+
+	// IdempotencyKey identifies the caller intent that prepared the
+	// transfer.
+	IdempotencyKey string
+
+	// DispatchRequestData is the normalized caller-recipient proof retained
+	// until the prepared transfer is committed.
+	DispatchRequestData []byte
+}
+
+// String returns the state name.
+func (*Prepared) String() string {
+	return "Prepared"
+}
+
+// IsTerminal reports that a prepared transfer remains resumable.
+func (*Prepared) IsTerminal() bool {
+	return false
+}
+
+// stateSealed marks Prepared as implementing State.
+func (*Prepared) stateSealed() {}
+
 // AwaitingArkSignatures indicates the submit package has been built and the
 // client must attach Ark signatures before submit can be sent.
 type AwaitingArkSignatures struct {
@@ -282,6 +323,10 @@ type Failed struct {
 	// Reason is a human-readable failure reason intended for logs and
 	// tests.
 	Reason string
+
+	// PrePONR is true when failure occurred before the operator co-signed
+	// the checkpoints, so the source VTXO reservation was safe to release.
+	PrePONR bool
 
 	// IdempotencyKey identifies the caller intent that created this
 	// outgoing session, when provided.

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -66,12 +66,16 @@ func unexpectedEvent(state State) *StateTransition {
 func failedState(reason string, current State) *Failed {
 	return &Failed{
 		Reason:         reason,
+		PrePONR:        len(prePONRInputOutpoints(current)) > 0,
 		IdempotencyKey: stateIdempotencyKey(current),
 	}
 }
 
 func stateIdempotencyKey(state State) string {
 	switch s := state.(type) {
+	case *Prepared:
+		return s.IdempotencyKey
+
 	case *AwaitingArkSignatures:
 		return s.IdempotencyKey
 
@@ -179,10 +183,21 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 			}
 		}
 
-		signReq := &RequestArkSignatures{
-			ArkPSBT:         ark,
-			CheckpointPSBTs: checkpoints,
-			TransferInputs:  evt.VTXOInputs,
+		if evt.PrepareOnly {
+			return &StateTransition{
+				NextState: &Prepared{
+					ArkPSBT:          ark,
+					CheckpointPSBTs:  checkpoints,
+					TransferInputs:   evt.VTXOInputs,
+					RecipientOutputs: canonicalRecipients,
+					IdempotencyKey:   evt.IdempotencyKey,
+					DispatchRequestData: append(
+						[]byte(nil),
+						dispatchRequestData...,
+					),
+				},
+				NewEvents: fn.None[EmittedEvent](),
+			}, nil
 		}
 
 		return &StateTransition{
@@ -198,7 +213,11 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 			},
 			NewEvents: fn.Some(EmittedEvent{
 				Outbox: []OutboxEvent{
-					signReq,
+					&RequestArkSignatures{
+						ArkPSBT:         ark,
+						CheckpointPSBTs: checkpoints,
+						TransferInputs:  evt.VTXOInputs,
+					},
 				},
 			}),
 		}, nil
@@ -211,6 +230,66 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 
 	default:
 		return unexpectedEvent(s), nil
+	}
+}
+
+// ProcessEvent handles events for Prepared.
+func (s *Prepared) ProcessEvent(_ context.Context, event Event,
+	_ *Environment) (*StateTransition, error) {
+
+	switch event := event.(type) {
+	case *CommitPreparedEvent:
+		request := &RequestArkSignatures{
+			ArkPSBT:         s.ArkPSBT,
+			CheckpointPSBTs: s.CheckpointPSBTs,
+			TransferInputs:  s.TransferInputs,
+		}
+
+		return &StateTransition{
+			NextState: &AwaitingArkSignatures{
+				ArkPSBT:          s.ArkPSBT,
+				CheckpointPSBTs:  s.CheckpointPSBTs,
+				TransferInputs:   s.TransferInputs,
+				RecipientOutputs: s.RecipientOutputs,
+				IdempotencyKey:   s.IdempotencyKey,
+				DispatchRequestData: append(
+					[]byte(nil), s.DispatchRequestData...,
+				),
+			},
+			NewEvents: fn.Some(EmittedEvent{
+				Outbox: []OutboxEvent{request},
+			}),
+		}, nil
+
+	case *AbortPreparedEvent:
+		return abortPreparedTransition(s, event.Reason), nil
+
+	case *FailEvent:
+		return abortPreparedTransition(s, event.Reason), nil
+
+	default:
+		return unexpectedEvent(s), nil
+	}
+}
+
+// abortPreparedTransition releases every input because preparation has not
+// exposed signatures or crossed the operator co-sign boundary.
+func abortPreparedTransition(state *Prepared, reason string) *StateTransition {
+	if reason == "" {
+		reason = "prepared transfer aborted"
+	}
+
+	return &StateTransition{
+		NextState: failedState(reason, state),
+		NewEvents: fn.Some(EmittedEvent{
+			Outbox: []OutboxEvent{
+				&ReleaseInputsRequest{
+					Outpoints: InputOutpoints(
+						state.TransferInputs,
+					),
+				},
+			},
+		}),
 	}
 }
 
@@ -529,6 +608,9 @@ func (s *Failed) ProcessEvent(ctx context.Context, event Event,
 func prePONRInputOutpoints(state State) []wire.OutPoint {
 	var inputs []TransferInput
 	switch s := state.(type) {
+	case *Prepared:
+		inputs = s.TransferInputs
+
 	case *AwaitingArkSignatures:
 		inputs = s.TransferInputs
 

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -66,8 +66,21 @@ func unexpectedEvent(state State) *StateTransition {
 func failedState(reason string, current State) *Failed {
 	return &Failed{
 		Reason:         reason,
-		PrePONR:        len(prePONRInputOutpoints(current)) > 0,
+		PrePONR:        isPrePONRState(current),
 		IdempotencyKey: stateIdempotencyKey(current),
+	}
+}
+
+// isPrePONRState reports whether the operator has not yet co-signed the
+// checkpoints. This is a protocol-phase property and must not depend on
+// whether a corrupt or partially restored state retained its input pointers.
+func isPrePONRState(state State) bool {
+	switch state.(type) {
+	case *Prepared, *AwaitingArkSignatures, *AwaitingSubmitAccepted:
+		return true
+
+	default:
+		return false
 	}
 }
 

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -1958,9 +1958,21 @@ func (b *behavior) ackPreSignedExitSpend(ctx context.Context,
 		job.PlannerState.ConfirmedTxids, b.cfg.TargetOutpoint.Hash,
 	) {
 
+		// A CSV-delayed spend confirmed at H proves its parent
+		// confirmed no later than H-CSV. Record that conservative upper
+		// bound instead of H, which would make the already-confirmed
+		// spend appear immature.
+		parentHeight := int64(msg.SpendingHeight) -
+			int64(policy.CSVDelay())
+		if parentHeight < 0 {
+			return false, fmt.Errorf("pre-signed exit spend "+
+				"height %d cannot satisfy CSV delay %d",
+				msg.SpendingHeight, policy.CSVDelay())
+		}
+
 		err := b.driveEvent(ctx, ax, &TxConfirmedEvent{
 			Txid:   b.cfg.TargetOutpoint.Hash,
-			Height: msg.SpendingHeight,
+			Height: int32(parentHeight),
 		})
 		if err != nil {
 			return false, err

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -1808,7 +1808,7 @@ func (b *behavior) proofSpendCallerID(outpoint wire.OutPoint) string {
 // when a proof output is consumed on chain, and we have to classify what we
 // are looking at before deciding whether the unroll job is dead.
 //
-// Four cases:
+// Five cases:
 //
 //  1. The spent output belongs to a known node in our recovery proof.
 //     That proves the parent transaction confirmed, even if txconfirm's
@@ -1821,7 +1821,11 @@ func (b *behavior) proofSpendCallerID(outpoint wire.OutPoint) string {
 //     recorded in planner state). Again benign — our sweep confirming is
 //     the goal — so just propagate the height.
 //
-//  4. Anything else: the watched output was spent by someone else. This can
+//  4. The exit policy has an immutable pre-signed final spend and that exact
+//     transaction spent the target. This is success even when the peer won
+//     the publication race.
+//
+//  5. Anything else: the watched output was spent by someone else. This can
 //     happen if the operator cooperatively claims it, if a fraud party
 //     beats us to a signed spend, or if a reorg replays a different
 //     history. In all cases the unroll job cannot finish; drive FailEvent
@@ -1875,7 +1879,21 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 		}
 	}
 
-	// Case 4: neither of the above. Someone else spent the watched output.
+	// Case 4: some policies, such as Ark channel materialization, bind the
+	// final transaction before the unroll starts. Either authorized party
+	// may publish it after CSV maturity. Recognize the exact pre-signed
+	// txid and record both its broadcast and confirmation so the durable
+	// actor converges regardless of which participant reached the chain
+	// first.
+	matched, err := b.ackPreSignedExitSpend(ctx, ax, msg)
+	if err != nil {
+		return fn.Err[Resp](err)
+	}
+	if matched {
+		return fn.Ok[Resp](&AckResp{})
+	}
+
+	// Case 5: neither of the above. Someone else spent the watched output.
 	// This happens if the operator cooperatively claimed the VTXO,
 	// if a reorg replaced history, or in fraud scenarios. There is
 	// no way for this unroll to proceed, so terminate with a
@@ -1890,6 +1908,118 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 		msg.SpendingHeight)
 
 	return b.handleEvent(ctx, ax, &FailEvent{Reason: reason})
+}
+
+// ackPreSignedExitSpend completes an unroll when another authorized party
+// publishes the exact immutable final spend supplied by the exit policy.
+func (b *behavior) ackPreSignedExitSpend(ctx context.Context,
+	ax actor.Exec[unrollTx], msg *SpendObservedMsg) (bool, error) {
+
+	spentOutpoint := msg.Outpoint
+	if spentOutpoint == (wire.OutPoint{}) {
+		spentOutpoint = b.cfg.TargetOutpoint
+	}
+	if spentOutpoint != b.cfg.TargetOutpoint {
+		return false, nil
+	}
+
+	policy, err := b.resolveExitSpendPolicy(ctx)
+	if err != nil {
+		return false, err
+	}
+	preSigned, ok := policy.(PreSignedExitSpendPolicy)
+	if !ok {
+		return false, nil
+	}
+
+	tx, err := preSigned.PreSignedSpendTx()
+	if err != nil {
+		return false, fmt.Errorf("load pre-signed exit spend: %w", err)
+	}
+	if tx == nil || tx.TxHash() != msg.SpendingTxid {
+		return false, nil
+	}
+	if !transactionSpendsOutpoint(tx, b.cfg.TargetOutpoint) {
+		return false, fmt.Errorf("pre-signed exit spend %s does not "+
+			"spend target %s", msg.SpendingTxid,
+			b.cfg.TargetOutpoint)
+	}
+
+	// Preserve the transaction itself, not only its txid. Checkpoint replay
+	// and exit-cost accounting both require the exact final transaction.
+	b.sweepTx = tx
+
+	state, err := b.currentState()
+	if err != nil {
+		return false, err
+	}
+	job := stateJob(state)
+	if !containsHash(
+		job.PlannerState.ConfirmedTxids, b.cfg.TargetOutpoint.Hash,
+	) {
+
+		err := b.driveEvent(ctx, ax, &TxConfirmedEvent{
+			Txid:   b.cfg.TargetOutpoint.Hash,
+			Height: msg.SpendingHeight,
+		})
+		if err != nil {
+			return false, err
+		}
+	}
+
+	state, err = b.currentState()
+	if err != nil {
+		return false, err
+	}
+	job = stateJob(state)
+	if job.PlannerState.Sweep.Txid.IsSome() {
+		if job.PlannerState.Sweep.Txid.UnsafeFromSome() !=
+			msg.SpendingTxid {
+			return false, fmt.Errorf("pre-signed exit spend %s "+
+				"conflicts with recorded sweep %s",
+				msg.SpendingTxid,
+				job.PlannerState.Sweep.Txid.UnsafeFromSome())
+		}
+	} else {
+		if err := b.driveEvent(ctx, ax, &SweepBroadcastedEvent{
+			Txid: msg.SpendingTxid,
+		}); err != nil {
+			return false, err
+		}
+	}
+
+	state, err = b.currentState()
+	if err != nil {
+		return false, err
+	}
+	job = stateJob(state)
+	if job.PlannerState.Sweep.Status !=
+		unrollplan.SweepStatusConfirmed {
+
+		if err := b.driveEvent(ctx, ax, &TxConfirmedEvent{
+			Txid:   msg.SpendingTxid,
+			Height: msg.SpendingHeight,
+		}); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+// transactionSpendsOutpoint reports whether tx consumes the exact outpoint.
+func transactionSpendsOutpoint(tx *wire.MsgTx, outpoint wire.OutPoint) bool {
+	if tx == nil {
+		return false
+	}
+
+	for _, txIn := range tx.TxIn {
+		if txIn != nil && txIn.PreviousOutPoint == outpoint {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ackProofOutputSpend records proof-output spend evidence and reports whether

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -4531,17 +4531,6 @@ func TestPreSignedExitSpendPublishedByPeerCompletesActor(t *testing.T) {
 			proof.TargetOutpoint().Hash,
 		) == 1
 	}, testTimeout, 10*time.Millisecond)
-	txconfirmRef.emitConfirmed(
-		t, 1, proof.TargetOutpoint().Hash, 102,
-	)
-	require.Eventually(t, func() bool {
-		state, ok := mustAsk(
-			t, unrollActor.Ref(), &GetStateRequest{},
-		).(*GetStateResp)
-		require.True(t, ok)
-
-		return state.Phase == PhaseCSVPending
-	}, testTimeout, 10*time.Millisecond)
 
 	chainSource.emitSpendForOutpoint(
 		t, proof.TargetOutpoint(), exitTx.TxHash(), 110,
@@ -4562,6 +4551,10 @@ func TestPreSignedExitSpendPublishedByPeerCompletesActor(t *testing.T) {
 	require.Equal(
 		t, exitTx.TxHash(),
 		checkpoint.State.Sweep.Txid.UnsafeFromSome(),
+	)
+	require.Equal(
+		t, int32(110)-int32(policy.CSVDelay()),
+		checkpoint.State.TargetConfirmHeight.UnwrapOrFail(t),
 	)
 }
 

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -40,6 +40,76 @@ import (
 
 const testTimeout = time.Second
 
+const testPreSignedExitPolicyKind ExitPolicyKind = "test_pre_signed"
+
+// testPreSignedExitPolicy exposes one immutable final spend for actor tests.
+type testPreSignedExitPolicy struct {
+	tx       *wire.MsgTx
+	csvDelay uint32
+}
+
+// Kind returns the test policy identity.
+func (p *testPreSignedExitPolicy) Kind() ExitPolicyKind {
+	return testPreSignedExitPolicyKind
+}
+
+// CSVDelay returns the configured relative delay.
+func (p *testPreSignedExitPolicy) CSVDelay() uint32 {
+	return p.csvDelay
+}
+
+// RequiredLockTime reports no absolute timelock.
+func (*testPreSignedExitPolicy) RequiredLockTime() uint32 {
+	return 0
+}
+
+// FeeEstimateFallbackSatPerVByte disables the emergency fee fallback.
+func (*testPreSignedExitPolicy) FeeEstimateFallbackSatPerVByte() int64 {
+	return 0
+}
+
+// ValidateTarget accepts the actor fixture's proof output.
+func (*testPreSignedExitPolicy) ValidateTarget(target *wire.TxOut) error {
+	if target == nil {
+		return fmt.Errorf("target output is required")
+	}
+
+	return nil
+}
+
+// BuildSpendTx returns the same transaction as the pre-signed fast path.
+func (p *testPreSignedExitPolicy) BuildSpendTx(context.Context,
+	ExitSpendRequest) (*wire.MsgTx, error) {
+
+	return p.PreSignedSpendTx()
+}
+
+// PreSignedSpendTx returns an isolated copy of the fixed spend.
+func (p *testPreSignedExitPolicy) PreSignedSpendTx() (*wire.MsgTx, error) {
+	if p == nil || p.tx == nil {
+		return nil, fmt.Errorf("pre-signed transaction is required")
+	}
+
+	return p.tx.Copy(), nil
+}
+
+// testExitPolicyResolver serves one custom policy to the unroll actor.
+type testExitPolicyResolver struct {
+	policy ExitSpendPolicy
+}
+
+// ResolveExitSpendPolicy returns the configured policy for its exact kind.
+func (r *testExitPolicyResolver) ResolveExitSpendPolicy(_ context.Context,
+	req ExitSpendPolicyRequest) (ExitSpendPolicy, error) {
+
+	if r == nil || r.policy == nil || req.Kind != r.policy.Kind() {
+		return nil, fmt.Errorf("unsupported test exit policy %q",
+			req.Kind)
+	}
+
+	return r.policy, nil
+}
+
 // mockProofAssembler is a programmable proof assembler test double.
 type mockProofAssembler struct {
 	proof *recovery.Proof
@@ -1239,6 +1309,15 @@ func newActorHarnessExec(t *testing.T, proof *recovery.Proof,
 	desc *vtxo.Descriptor) (*actor.Actor[Msg, Resp], *behavior,
 	*fakeTxConfirmRef, *memCheckpointStore, *memExec) {
 
+	return newActorHarnessExecWithConfig(t, proof, desc, nil)
+}
+
+// newActorHarnessExecWithConfig allows focused tests to install optional
+// production seams while preserving the common actor fixture.
+func newActorHarnessExecWithConfig(t *testing.T, proof *recovery.Proof,
+	desc *vtxo.Descriptor, mutate func(*Config)) (*actor.Actor[Msg, Resp],
+	*behavior, *fakeTxConfirmRef, *memCheckpointStore, *memExec) {
+
 	t.Helper()
 
 	txconfirmRef := &fakeTxConfirmRef{}
@@ -1257,6 +1336,9 @@ func newActorHarnessExec(t *testing.T, proof *recovery.Proof,
 		ChainSource:  &fakeChainSourceRef{},
 		Wallet:       &fakeSweepWallet{},
 		Log:          fn.Some(btclog.Disabled),
+	}
+	if mutate != nil {
+		mutate(&cfg)
 	}
 	behavior := &behavior{
 		cfg: cfg,
@@ -4403,6 +4485,86 @@ func TestExternalSpendTerminatesActor(t *testing.T) {
 	require.Contains(t, stateResp.FailReason, "spent externally")
 }
 
+// TestPreSignedExitSpendPublishedByPeerCompletesActor verifies a peer can win
+// the publication race for an immutable final spend without making the local
+// unroller classify the exact expected transaction as an external conflict.
+func TestPreSignedExitSpendPublishedByPeerCompletesActor(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	targetOutput, err := proof.TargetOutput()
+	require.NoError(t, err)
+
+	exitTx := wire.NewMsgTx(2)
+	exitTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: proof.TargetOutpoint(),
+		Sequence:         proof.CSVDelay(),
+	})
+	exitTx.AddTxOut(&wire.TxOut{
+		Value:    targetOutput.Value - 1,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	policy := &testPreSignedExitPolicy{
+		tx:       exitTx,
+		csvDelay: proof.CSVDelay(),
+	}
+	unrollActor, behavior, txconfirmRef, store, _ :=
+		newActorHarnessExecWithConfig(
+			t, proof, desc, func(cfg *Config) {
+				cfg.ExitSpendPolicyResolver =
+					&testExitPolicyResolver{policy: policy}
+			},
+		)
+
+	chainSource, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:         100,
+		Trigger:        TriggerManual,
+		ExitPolicyKind: testPreSignedExitPolicyKind,
+		ExitPolicyRef:  "fixed",
+	})
+
+	rootTxid := proof.RootTxids()[0]
+	txconfirmRef.emitConfirmed(t, 0, rootTxid, 101)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(
+			proof.TargetOutpoint().Hash,
+		) == 1
+	}, testTimeout, 10*time.Millisecond)
+	txconfirmRef.emitConfirmed(
+		t, 1, proof.TargetOutpoint().Hash, 102,
+	)
+	require.Eventually(t, func() bool {
+		state, ok := mustAsk(
+			t, unrollActor.Ref(), &GetStateRequest{},
+		).(*GetStateResp)
+		require.True(t, ok)
+
+		return state.Phase == PhaseCSVPending
+	}, testTimeout, 10*time.Millisecond)
+
+	chainSource.emitSpendForOutpoint(
+		t, proof.TargetOutpoint(), exitTx.TxHash(), 110,
+	)
+	require.Eventually(t, func() bool {
+		state, ok := mustAsk(
+			t, unrollActor.Ref(), &GetStateRequest{},
+		).(*GetStateResp)
+		require.True(t, ok)
+
+		return state.Phase == PhaseCompleted
+	}, testTimeout, 10*time.Millisecond)
+
+	checkpoint := mustDecodeCheckpoint(t, store, "unroll-test")
+	require.NotNil(t, checkpoint.SweepTx)
+	require.Equal(t, exitTx.TxHash(), checkpoint.SweepTx.TxHash())
+	require.True(t, checkpoint.State.Sweep.Txid.IsSome())
+	require.Equal(
+		t, exitTx.TxHash(),
+		checkpoint.State.Sweep.Txid.UnsafeFromSome(),
+	)
+}
+
 // TestStartUnrollIsIdempotent verifies that reissuing start does not duplicate
 // already-in-flight proof requests.
 func TestStartUnrollIsIdempotent(t *testing.T) {
@@ -4431,6 +4593,8 @@ func TestStartUnrollIsIdempotent(t *testing.T) {
 
 var _ input.Signature = testSignature{}
 var _ SweepWallet = (*fakeSweepWallet)(nil)
+var _ PreSignedExitSpendPolicy = (*testPreSignedExitPolicy)(nil)
+var _ ExitSpendPolicyResolver = (*testExitPolicyResolver)(nil)
 var _ vtxo.VTXOStore = (*mockVTXOStore)(nil)
 var _ actor.DeliveryStore = (*memCheckpointStore)(nil)
 var _ actor.ActorRef[txconfirm.Msg, txconfirm.Resp] = (*fakeTxConfirmRef)(nil)

--- a/unroll/interfaces.go
+++ b/unroll/interfaces.go
@@ -134,6 +134,19 @@ type ExitSpendPolicy interface {
 		req ExitSpendRequest) (*wire.MsgTx, error)
 }
 
+// PreSignedExitSpendPolicy is implemented by policies whose final spend is
+// fixed before the unroll actor reaches CSV maturity. Another authorized
+// participant may publish that exact transaction first, so the target spend
+// watcher must recognize it as successful completion instead of an external
+// conflict.
+type PreSignedExitSpendPolicy interface {
+	ExitSpendPolicy
+
+	// PreSignedSpendTx returns an isolated copy of the immutable, fully
+	// signed final spend.
+	PreSignedSpendTx() (*wire.MsgTx, error)
+}
+
 // ExitSpendPolicyResolver reconstructs a policy from the durable identity
 // stored with an unroll job. Custom actor factories can inject resolvers for
 // their policy families; the built-in actor default handles standard VTXO

--- a/unroll/policy_resolvers.go
+++ b/unroll/policy_resolvers.go
@@ -1,0 +1,48 @@
+package unroll
+
+import (
+	"context"
+	"fmt"
+)
+
+// PolicyResolvers dispatches durable non-standard exit policies by kind.
+// Each child resolver remains responsible for validating its own reference.
+type PolicyResolvers []ExitSpendPolicyResolver
+
+// SupportsKind reports whether one child resolver advertises the policy kind.
+func (r PolicyResolvers) SupportsKind(kind ExitPolicyKind) bool {
+	for _, resolver := range r {
+		if resolver == nil {
+			continue
+		}
+		support, ok := resolver.(ResolverKindSupport)
+		if ok && support.SupportsKind(kind) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ResolveExitSpendPolicy delegates to the one resolver advertising the kind.
+func (r PolicyResolvers) ResolveExitSpendPolicy(ctx context.Context,
+	req ExitSpendPolicyRequest) (ExitSpendPolicy, error) {
+
+	for _, resolver := range r {
+		if resolver == nil {
+			continue
+		}
+		support, ok := resolver.(ResolverKindSupport)
+		if !ok || !support.SupportsKind(req.Kind) {
+			continue
+		}
+
+		return resolver.ResolveExitSpendPolicy(ctx, req)
+	}
+
+	return nil, fmt.Errorf("no exit spend policy resolver for kind %q",
+		req.Kind)
+}
+
+var _ ExitSpendPolicyResolver = PolicyResolvers{}
+var _ ResolverKindSupport = PolicyResolvers{}

--- a/unroll/policy_resolvers.go
+++ b/unroll/policy_resolvers.go
@@ -11,17 +11,25 @@ type PolicyResolvers []ExitSpendPolicyResolver
 
 // SupportsKind reports whether one child resolver advertises the policy kind.
 func (r PolicyResolvers) SupportsKind(kind ExitPolicyKind) bool {
+	hasLegacyResolver := false
 	for _, resolver := range r {
 		if resolver == nil {
 			continue
 		}
 		support, ok := resolver.(ResolverKindSupport)
-		if ok && support.SupportsKind(kind) {
+		if !ok {
+			hasLegacyResolver = true
+
+			continue
+		}
+		if support.SupportsKind(kind) {
 			return true
 		}
 	}
 
-	return false
+	// A legacy resolver cannot advertise its coverage. Preserve its former
+	// behavior by admitting the kind and consulting it at resolution time.
+	return hasLegacyResolver
 }
 
 // ResolveExitSpendPolicy delegates to the one resolver advertising the kind.
@@ -34,6 +42,20 @@ func (r PolicyResolvers) ResolveExitSpendPolicy(ctx context.Context,
 		}
 		support, ok := resolver.(ResolverKindSupport)
 		if !ok || !support.SupportsKind(req.Kind) {
+			continue
+		}
+
+		return resolver.ResolveExitSpendPolicy(ctx, req)
+	}
+
+	// Prefer explicit kind routing above, then fall back to the first
+	// legacy resolver exactly as a standalone pre-advertisement resolver
+	// behaved.
+	for _, resolver := range r {
+		if resolver == nil {
+			continue
+		}
+		if _, ok := resolver.(ResolverKindSupport); ok {
 			continue
 		}
 

--- a/unroll/registry_test.go
+++ b/unroll/registry_test.go
@@ -2225,6 +2225,25 @@ func TestRegistryRestoreSkipsCheckWhenResolverHasNoKindSupport(t *testing.T) {
 	require.NoError(t, r.validateResolverCoversRecords(records))
 }
 
+// TestPolicyResolversPreservesLegacyResolver verifies wrapping an older
+// resolver in the composite neither hides its advertised coverage nor skips
+// it when the policy is reconstructed.
+func TestPolicyResolversPreservesLegacyResolver(t *testing.T) {
+	legacy := &recordingExitSpendPolicyResolver{}
+	resolvers := PolicyResolvers{legacy}
+	kind := ExitPolicyKind("legacy-kind")
+
+	require.True(t, resolvers.SupportsKind(kind))
+	_, err := resolvers.ResolveExitSpendPolicy(
+		t.Context(), ExitSpendPolicyRequest{
+			Kind: kind,
+		},
+	)
+	require.ErrorContains(t, err, "recording resolver")
+	require.Len(t, legacy.requests, 1)
+	require.Equal(t, kind, legacy.requests[0].Kind)
+}
+
 var _ RegistryStore = (*memRegistryStore)(nil)
 var _ RegistryStore = (*flakyRegistryStore)(nil)
 var _ RegistryStore = (*terminalFlakyRegistryStore)(nil)

--- a/vtxo/filter.go
+++ b/vtxo/filter.go
@@ -87,7 +87,7 @@ func SumPendingBalance(descs []*Descriptor) btcutil.Amount {
 		// Spendable, terminal, or separately accounted.
 		case VTXOStatusLive, VTXOStatusForfeited, VTXOStatusSpent,
 			VTXOStatusUnilateralExit, VTXOStatusFailed,
-			VTXOStatusExpired:
+			VTXOStatusExpired, VTXOStatusRecoveryOnly:
 		}
 	}
 

--- a/vtxo/filter_test.go
+++ b/vtxo/filter_test.go
@@ -81,7 +81,8 @@ func TestSumSpendableBalanceEmpty(t *testing.T) {
 }
 
 // TestSumPendingBalance checks that only PendingForfeit, Forfeiting, and
-// Spending are summed, excluding Live, Expired, and the terminal states.
+// Spending are summed, excluding Live, Expired, RecoveryOnly, and the terminal
+// states.
 func TestSumPendingBalance(t *testing.T) {
 	t.Parallel()
 
@@ -121,6 +122,10 @@ func TestSumPendingBalance(t *testing.T) {
 		{
 			Amount: 23_000,
 			Status: VTXOStatusExpired,
+		},
+		{
+			Amount: 29_000,
+			Status: VTXOStatusRecoveryOnly,
 		},
 	}
 

--- a/vtxo/interfaces.go
+++ b/vtxo/interfaces.go
@@ -313,6 +313,16 @@ const (
 	// NOTE: Appended last so the numeric values of existing statuses used
 	// in SQL queries are unchanged.
 	VTXOStatusExpired
+
+	// VTXOStatusRecoveryOnly identifies an application-owned output whose
+	// descriptor exists only so the common unroller can recover its
+	// on-chain ancestry. It is deliberately excluded from wallet balance,
+	// coin selection, refresh, and VTXO actor recovery. The application FSM
+	// owns its lifecycle and admits the exact final-spend policy to unroll.
+	//
+	// NOTE: Appended last so the numeric values of existing statuses used
+	// in SQL queries are unchanged.
+	VTXOStatusRecoveryOnly
 )
 
 // String returns a human-readable representation of the VTXO status.
@@ -344,6 +354,9 @@ func (s VTXOStatus) String() string {
 
 	case VTXOStatusExpired:
 		return "expired"
+
+	case VTXOStatusRecoveryOnly:
+		return "recovery_only"
 
 	default:
 		return "unknown"

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -1413,16 +1413,24 @@ func (m *Manager) confirmExitedVTXO(ctx context.Context,
 	}
 
 	// No live actor: persist the terminal spent status directly so a
-	// restarted daemon still records the on-chain spend. Only act on a VTXO
-	// still in the exit state so a re-delivered confirmation cannot stomp a
-	// VTXO that has since been reissued or recovered to live.
+	// restarted daemon still records the on-chain spend. Recovery-only
+	// descriptors are also eligible when a non-standard policy completed;
+	// they deliberately have no VTXO actor because their owning application
+	// FSM controls admission. The policy check prevents an ordinary timeout
+	// job from retiring an application-owned row.
 	descriptor, err := m.cfg.Store.GetVTXO(ctx, req.Outpoint)
 	if err != nil {
 		return fn.Err[ManagerResp](
 			fmt.Errorf("load vtxo for confirm: %w", err),
 		)
 	}
-	if descriptor == nil || descriptor.Status != VTXOStatusUnilateralExit {
+	if descriptor == nil {
+		return fn.Ok[ManagerResp](&ExitOutcomeResp{})
+	}
+	isOrdinaryExit := descriptor.Status == VTXOStatusUnilateralExit
+	isRecoveryOnly := descriptor.Status == VTXOStatusRecoveryOnly &&
+		req.ExitPolicyKind.Valid()
+	if !isOrdinaryExit && !isRecoveryOnly {
 		return fn.Ok[ManagerResp](&ExitOutcomeResp{})
 	}
 
@@ -2274,7 +2282,7 @@ func (m *Manager) exactSpendUnavailableError(ctx context.Context,
 
 	case VTXOStatusForfeited, VTXOStatusSpent,
 		VTXOStatusUnilateralExit, VTXOStatusFailed,
-		VTXOStatusExpired:
+		VTXOStatusExpired, VTXOStatusRecoveryOnly:
 		return fmt.Errorf("%w: exact spend outpoint %s has status %s",
 			ErrInsufficientSpendableFunds, op, desc.Status)
 	}
@@ -2816,11 +2824,13 @@ func (m *Manager) handleCompleteSpend(ctx context.Context,
 	for _, op := range outpoints {
 		ref, ok := m.actors[op]
 		if !ok {
-			spent, err := m.isPersistedSpent(ctx, op)
+			completedWithoutActor, err := m.completePersistedSpend(
+				ctx, op,
+			)
 			if err != nil {
 				return fn.Err[ManagerResp](err)
 			}
-			if spent {
+			if completedWithoutActor {
 				m.dropReserved(op)
 				completed++
 
@@ -2857,15 +2867,17 @@ func (m *Manager) handleCompleteSpend(ctx context.Context,
 	})
 }
 
-// isPersistedSpent returns true when an actor was already cleaned up after
-// the spend status reached durable storage. It returns false with no error
-// when the VTXO is absent, and returns an error when the store cannot give a
-// definitive answer.
+// completePersistedSpend completes the two valid actorless spend cases. A
+// terminal Spent row means a previous attempt already completed. A
+// RecoveryOnly row deliberately has no VTXO actor because its application FSM
+// owns spend admission, so an accepted OOR spend retires it directly while
+// atomically releasing the durable spend reservation. Every other state still
+// requires its normal VTXO actor.
 //
 // This makes CompleteSpend idempotent across crashes that happen after the
 // VTXO status commit but before the OOR session checkpoints Completed.
-func (m *Manager) isPersistedSpent(ctx context.Context, op wire.OutPoint) (bool,
-	error) {
+func (m *Manager) completePersistedSpend(ctx context.Context,
+	op wire.OutPoint) (bool, error) {
 
 	if m.cfg.Store == nil {
 		return false, nil
@@ -2877,7 +2889,7 @@ func (m *Manager) isPersistedSpent(ctx context.Context, op wire.OutPoint) (bool,
 			return false, nil
 		}
 
-		return false, fmt.Errorf("load vtxo for spent check %s: %w", op,
+		return false, fmt.Errorf("load vtxo for completion %s: %w", op,
 			err)
 	}
 
@@ -2885,7 +2897,24 @@ func (m *Manager) isPersistedSpent(ctx context.Context, op wire.OutPoint) (bool,
 		return false, nil
 	}
 
-	return desc.Status == VTXOStatusSpent, nil
+	switch desc.Status {
+	case VTXOStatusSpent:
+		return true, nil
+
+	case VTXOStatusRecoveryOnly:
+		err := m.cfg.Store.UpdateVTXOStatusReleasingReservation(
+			ctx, op, VTXOStatusSpent,
+		)
+		if err != nil {
+			return false, fmt.Errorf("complete recovery-only vtxo "+
+				"%s: %w", op, err)
+		}
+
+		return true, nil
+
+	default:
+		return false, nil
+	}
 }
 
 // =============================================================================

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -1383,6 +1383,62 @@ func TestCompleteSpendAlreadyPersistedSpentIsIdempotent(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// TestCompleteSpendRecoveryOnlyWithoutActor verifies that an application-owned
+// VTXO can complete an admitted OOR spend even though it deliberately has no
+// ordinary VTXO actor. The status transition and reservation release use the
+// store's atomic operation.
+func TestCompleteSpendRecoveryOnlyWithoutActor(t *testing.T) {
+	t.Parallel()
+
+	vtxo := makeDescriptor(t, 50000, 0)
+	vtxo.Status = VTXOStatusRecoveryOnly
+
+	mgr, store := newTestManager(t, nil)
+	store.On(
+		"GetVTXO", t.Context(), vtxo.Outpoint,
+	).Return(vtxo, nil).Once()
+	store.On(
+		"UpdateVTXOStatusReleasingReservation", t.Context(),
+		vtxo.Outpoint, VTXOStatusSpent,
+	).Return(nil).Once()
+
+	result := mgr.Receive(t.Context(), &CompleteSpendRequest{
+		Outpoints: []wire.OutPoint{vtxo.Outpoint},
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	completeResp, ok := resp.(*CompleteSpendResponse)
+	require.True(t, ok, "expected *CompleteSpendResponse")
+	require.Equal(t, 1, completeResp.CompletedCount)
+
+	store.AssertExpectations(t)
+}
+
+// TestCompleteSpendActorlessLiveVTXOReturnsNoActor verifies that the
+// recovery-only exception cannot retire a normal VTXO whose actor is missing.
+func TestCompleteSpendActorlessLiveVTXOReturnsNoActor(t *testing.T) {
+	t.Parallel()
+
+	vtxo := makeDescriptor(t, 50000, 0)
+	vtxo.Status = VTXOStatusLive
+
+	mgr, store := newTestManager(t, nil)
+	store.On(
+		"GetVTXO", t.Context(), vtxo.Outpoint,
+	).Return(vtxo, nil).Once()
+
+	result := mgr.Receive(t.Context(), &CompleteSpendRequest{
+		Outpoints: []wire.OutPoint{vtxo.Outpoint},
+	})
+	_, err := result.Unpack()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no actor for outpoint")
+
+	store.AssertNotCalled(t, "UpdateVTXOStatusReleasingReservation")
+	store.AssertExpectations(t)
+}
+
 // TestCompleteSpendMissingPersistedVTXOReturnsNoActor verifies that a missing
 // persisted VTXO remains a normal unknown-outpoint error.
 func TestCompleteSpendMissingPersistedVTXOReturnsNoActor(t *testing.T) {
@@ -1423,7 +1479,7 @@ func TestCompleteSpendPersistedSpentCheckError(t *testing.T) {
 	})
 	_, err := result.Unpack()
 	require.ErrorIs(t, err, storeErr)
-	require.Contains(t, err.Error(), "load vtxo for spent check")
+	require.Contains(t, err.Error(), "load vtxo for completion")
 
 	store.AssertExpectations(t)
 }

--- a/vtxo/manager_exit_test.go
+++ b/vtxo/manager_exit_test.go
@@ -181,6 +181,40 @@ func TestHandleExitOutcomeConfirmedNoActorPersistsSpent(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// TestHandleExitOutcomeConfirmedNoActorPersistsChannelRecoverySpent verifies
+// that a confirmed channel-backing spend retires its recovery-only source even
+// though the source deliberately has no live wallet actor.
+func TestHandleExitOutcomeConfirmedNoActorPersistsChannelRecoverySpent(
+	t *testing.T) {
+
+	t.Parallel()
+
+	vtxo := makeDescriptor(t, 50_000, 8)
+	vtxo.Status = VTXOStatusRecoveryOnly
+	store := &MockVTXOStore{}
+	mgr := &Manager{
+		cfg: &ManagerConfig{
+			Store: store,
+		},
+		actors: make(map[wire.OutPoint]VTXOActorRef),
+	}
+
+	store.On("GetVTXO", t.Context(), vtxo.Outpoint).Return(vtxo, nil)
+	store.On(
+		"UpdateVTXOStatus", t.Context(), vtxo.Outpoint, VTXOStatusSpent,
+	).Return(nil)
+
+	resp := mgr.Receive(t.Context(), &ExitOutcomeNotification{
+		Outpoint:       vtxo.Outpoint,
+		Outcome:        ExitOutcomeConfirmed,
+		ExitPolicyKind: actormsg.ExitPolicyArkChannelBacking,
+	})
+	_, err := resp.Unpack()
+	require.NoError(t, err)
+
+	store.AssertExpectations(t)
+}
+
 // TestHandleExitOutcomeConfirmedNoActorAlreadySpentIsNoop verifies that a
 // re-delivered confirmation for a VTXO that is no longer in the exit state
 // (e.g. already spent) does not rewrite its status.


### PR DESCRIPTION
## Summary

- define the channel VTXO policy with an immediate 3-of-3 cooperative path, a CSV-delayed 2-of-2 channel-funding path, and a longer funder-refund path
- prepare and validate an OOR transfer before either party commits it
- persist the source lineage needed to materialize the unpublished channel point during recovery

This is layer 1 of 5 in the Ark channels stack. The next layer is #1190.

## Testing

- `go test ./lib/arkscript ./oor ./unroll ./vtxo ./db`
- `make build`
- `make lint-changed-local`