### PR TITLE
multi: Validate vHTLC timing windows

### DIFF
--- a/db/postgres_fixture.go
+++ b/db/postgres_fixture.go
@@ -36,6 +36,7 @@ type TestPgFixture struct {
 	resource *dockertest.Resource
 	host     string
 	port     int
+	expiry   *time.Timer
 
 	releaseSlot func()
 }
@@ -96,8 +97,16 @@ func NewTestPgFixture(t testing.TB, expiry time.Duration,
 	databaseURL := fixture.GetDSN()
 	t.Logf("Connecting to Postgres fixture: %v\n", databaseURL)
 
-	// Tell docker to hard kill the container in "expiry" seconds.
-	require.NoError(t, resource.Expire(uint(expiry.Seconds())))
+	// Kill the container if the test outlives the fixture lifetime. The
+	// dockertest Expire method calls Docker's stop endpoint immediately and
+	// uses the duration as the graceful-stop timeout. On Docker daemons
+	// that serialize stop requests, that can block every fixture slot until
+	// the timeout elapses.
+	fixture.expiry = time.AfterFunc(expiry, func() {
+		_ = pool.Client.KillContainer(docker.KillContainerOptions{
+			ID: resource.Container.ID,
+		})
+	})
 
 	// Exponential backoff-retry, because the application in the container
 	// might not be ready to accept connections yet.
@@ -159,6 +168,10 @@ func (f *TestPgFixture) GetConfig() *PostgresConfig {
 
 // TearDown stops the underlying docker container.
 func (f *TestPgFixture) TearDown(t testing.TB) {
+	if f.expiry != nil {
+		f.expiry.Stop()
+	}
+
 	err := f.pool.Purge(f.resource)
 	if f.releaseSlot != nil {
 		f.releaseSlot()

--- a/lib/arkscript/vhtlc.go
+++ b/lib/arkscript/vhtlc.go
@@ -68,6 +68,11 @@ type VHTLCPolicy struct {
 }
 
 // NewVHTLCPolicy constructs a vHTLC policy using the AST closure system.
+// Timing suitability depends on the lifecycle boundary and current chain
+// height, so callers admitting a new policy must separately use
+// VHTLCTiming.ValidateOrder or VHTLCTiming.ValidateClaimWindow. Keeping policy
+// reconstruction separate lets already-funded policies retain their available
+// spend paths even when their remaining timing window is no longer admissible.
 //
 // The vHTLC has 6 leaves:
 //  1. Claim (collab): HashLock(preimage) + Multisig([receiver, server])
@@ -371,9 +376,6 @@ func (opts *VHTLCOpts) validate() error {
 			return fmt.Errorf("vhtlc: invalid %s: %w", delay.name,
 				err)
 		}
-	}
-	if err := opts.Timing().ValidateOrder(); err != nil {
-		return err
 	}
 
 	return nil

--- a/lib/arkscript/vhtlc.go
+++ b/lib/arkscript/vhtlc.go
@@ -372,6 +372,9 @@ func (opts *VHTLCOpts) validate() error {
 				err)
 		}
 	}
+	if err := opts.Timing().ValidateOrder(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/lib/arkscript/vhtlc_timing.go
+++ b/lib/arkscript/vhtlc_timing.go
@@ -103,7 +103,10 @@ func (t VHTLCTiming) ValidateClaimWindow(window VHTLCClaimWindow) error {
 
 // DecodeVHTLCTiming recognizes the canonical six-leaf vHTLC semantic shape
 // and returns its four timing constraints. Other custom policies return an
-// error so callers cannot accidentally apply vHTLC assumptions to them.
+// error so callers cannot accidentally apply vHTLC assumptions to them. The
+// decoded tuple reflects the committed script exactly; admission callers must
+// apply ValidateOrder or ValidateClaimWindow, while recovery code can still
+// reconstruct an already-funded legacy policy.
 func DecodeVHTLCTiming(template *PolicyTemplate) (*VHTLCTiming, error) {
 	if template == nil {
 		return nil, fmt.Errorf("vhtlc: policy template is required")

--- a/lib/arkscript/vhtlc_timing.go
+++ b/lib/arkscript/vhtlc_timing.go
@@ -1,0 +1,318 @@
+package arkscript
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// VHTLCTiming contains the four block-based constraints in a vHTLC policy.
+type VHTLCTiming struct {
+	// RefundLocktime is the absolute height at which the sender and
+	// operator can refund without the receiver.
+	RefundLocktime uint32
+
+	// UnilateralClaimDelay is the receiver-only claim CSV delay.
+	UnilateralClaimDelay uint32
+
+	// UnilateralRefundDelay is the sender-and-receiver refund CSV delay.
+	UnilateralRefundDelay uint32
+
+	// UnilateralRefundWithoutReceiverDelay is the sender-only refund CSV
+	// delay.
+	UnilateralRefundWithoutReceiverDelay uint32
+}
+
+// VHTLCClaimWindow describes the chain budget a receiver needs before the
+// sender-and-operator refund branch becomes available.
+type VHTLCClaimWindow struct {
+	// CurrentHeight is the best chain height at the admission boundary.
+	CurrentHeight uint32
+
+	// ExitAncestryDelay is the conservative number of blocks needed to
+	// confirm the transactions preceding the vHTLC output.
+	ExitAncestryDelay uint32
+
+	// RecoveryMargin is the additional block margin retained after the
+	// unilateral claim path first becomes spendable.
+	RecoveryMargin uint32
+}
+
+// Timing returns the block constraints carried by opts.
+func (opts *VHTLCOpts) Timing() VHTLCTiming {
+	return VHTLCTiming{
+		RefundLocktime: opts.RefundLocktime,
+		UnilateralClaimDelay: opts.
+			UnilateralClaimDelay,
+		UnilateralRefundDelay: opts.
+			UnilateralRefundDelay,
+		UnilateralRefundWithoutReceiverDelay: opts.
+			UnilateralRefundWithoutReceiverDelay,
+	}
+}
+
+// ValidateOrder rejects vHTLC branches whose cooperation requirements become
+// weaker before the more cooperative branch is available.
+func (t VHTLCTiming) ValidateOrder() error {
+	if t.UnilateralClaimDelay > t.UnilateralRefundDelay {
+		return fmt.Errorf("vhtlc: unilateral claim delay %d exceeds "+
+			"unilateral refund delay %d", t.UnilateralClaimDelay,
+			t.UnilateralRefundDelay)
+	}
+
+	if t.UnilateralRefundDelay >
+		t.UnilateralRefundWithoutReceiverDelay {
+		return fmt.Errorf("vhtlc: unilateral refund delay %d exceeds "+
+			"unilateral refund without receiver delay %d",
+			t.UnilateralRefundDelay,
+			t.UnilateralRefundWithoutReceiverDelay)
+	}
+
+	return nil
+}
+
+// ValidateClaimWindow requires enough remaining absolute-locktime budget to
+// publish the exit ancestry, wait out the receiver's claim CSV, and retain the
+// caller-selected recovery margin.
+func (t VHTLCTiming) ValidateClaimWindow(window VHTLCClaimWindow) error {
+	if err := t.ValidateOrder(); err != nil {
+		return err
+	}
+
+	if t.RefundLocktime <= window.CurrentHeight {
+		return fmt.Errorf("vhtlc: refund locktime %d is not after "+
+			"current height %d", t.RefundLocktime,
+			window.CurrentHeight)
+	}
+
+	required := uint64(window.ExitAncestryDelay) +
+		uint64(t.UnilateralClaimDelay) +
+		uint64(window.RecoveryMargin)
+	remaining := uint64(t.RefundLocktime - window.CurrentHeight)
+	if remaining <= required {
+		return fmt.Errorf("vhtlc: refund window %d blocks does not "+
+			"exceed required claim window %d blocks (exit "+
+			"ancestry %d, claim delay %d, recovery margin %d)",
+			remaining, required, window.ExitAncestryDelay,
+			t.UnilateralClaimDelay, window.RecoveryMargin)
+	}
+
+	return nil
+}
+
+// DecodeVHTLCTiming recognizes the canonical six-leaf vHTLC semantic shape
+// and returns its four timing constraints. Other custom policies return an
+// error so callers cannot accidentally apply vHTLC assumptions to them.
+func DecodeVHTLCTiming(template *PolicyTemplate) (*VHTLCTiming, error) {
+	if template == nil {
+		return nil, fmt.Errorf("vhtlc: policy template is required")
+	}
+	if len(template.Leaves) != 6 {
+		return nil, fmt.Errorf("vhtlc: expected 6 leaves, got %d",
+			len(template.Leaves))
+	}
+
+	var shapes vhtlcShapes
+	for i := range template.Leaves {
+		shape, err := decodeVHTLCNode(template.Leaves[i].Node)
+		if err != nil {
+			return nil, fmt.Errorf("vhtlc: leaf %d: %w", i, err)
+		}
+		if err := shapes.add(shape); err != nil {
+			return nil, fmt.Errorf("vhtlc: leaf %d: %w", i, err)
+		}
+	}
+
+	if err := shapes.validate(); err != nil {
+		return nil, err
+	}
+
+	return &VHTLCTiming{
+		RefundLocktime: shapes.refundWithoutReceiver.locktime,
+		UnilateralClaimDelay: shapes.unilateralClaim.
+			csvDelay,
+		UnilateralRefundDelay: shapes.unilateralRefund.
+			csvDelay,
+		UnilateralRefundWithoutReceiverDelay: shapes.
+			unilateralRefundWithoutReceiver.csvDelay,
+	}, nil
+}
+
+type vhtlcNodeShape struct {
+	csvDelay  uint32
+	locktime  uint32
+	predicate []byte
+	keys      [][]byte
+}
+
+type vhtlcShapes struct {
+	claim                           *vhtlcNodeShape
+	refund                          *vhtlcNodeShape
+	refundWithoutReceiver           *vhtlcNodeShape
+	unilateralClaim                 *vhtlcNodeShape
+	unilateralRefund                *vhtlcNodeShape
+	unilateralRefundWithoutReceiver *vhtlcNodeShape
+}
+
+// decodeVHTLCNode accepts only the wrapper shapes emitted by NewVHTLCPolicy.
+func decodeVHTLCNode(node Node) (*vhtlcNodeShape, error) {
+	shape := &vhtlcNodeShape{}
+
+	if csv, ok := node.(*CSV); ok {
+		shape.csvDelay = csv.Lock
+		node = csv.Inner
+	}
+	if condition, ok := node.(*Condition); ok {
+		shape.predicate = bytes.Clone(condition.Predicate)
+		shape.locktime = ExtractAbsoluteLockTime(condition)
+		node = condition.Inner
+	}
+
+	multisig, ok := node.(*Multisig)
+	if !ok {
+		return nil, fmt.Errorf("unsupported closure shape %T", node)
+	}
+	shape.keys = make([][]byte, len(multisig.Keys))
+	for i, key := range multisig.Keys {
+		if key == nil {
+			return nil, fmt.Errorf("multisig key %d is nil", i)
+		}
+
+		shape.keys[i] = key.SerializeCompressed()
+	}
+
+	return shape, nil
+}
+
+// add assigns one structurally unique vHTLC branch.
+func (s *vhtlcShapes) add(shape *vhtlcNodeShape) error {
+	var target **vhtlcNodeShape
+	switch {
+	case shape.csvDelay == 0 && shape.locktime == 0 &&
+		len(shape.predicate) > 0 && len(shape.keys) == 2:
+
+		target = &s.claim
+
+	case shape.csvDelay == 0 && shape.locktime == 0 &&
+		len(shape.predicate) == 0 && len(shape.keys) == 3:
+
+		target = &s.refund
+
+	case shape.csvDelay == 0 && shape.locktime > 0 &&
+		len(shape.keys) == 2:
+
+		target = &s.refundWithoutReceiver
+
+	case shape.csvDelay > 0 && shape.locktime == 0 &&
+		len(shape.predicate) > 0 && len(shape.keys) == 1:
+
+		target = &s.unilateralClaim
+
+	case shape.csvDelay > 0 && shape.locktime == 0 &&
+		len(shape.predicate) == 0 && len(shape.keys) == 2:
+
+		target = &s.unilateralRefund
+
+	case shape.csvDelay > 0 && shape.locktime > 0 &&
+		len(shape.keys) == 1:
+
+		target = &s.unilateralRefundWithoutReceiver
+
+	default:
+		return fmt.Errorf("unrecognized branch shape")
+	}
+
+	if *target != nil {
+		return fmt.Errorf("duplicate branch shape")
+	}
+	*target = shape
+
+	return nil
+}
+
+// validate binds the six structural branches to one sender, receiver,
+// operator, payment hash, and refund locktime.
+func (s *vhtlcShapes) validate() error {
+	branches := []*vhtlcNodeShape{
+		s.claim, s.refund, s.refundWithoutReceiver,
+		s.unilateralClaim, s.unilateralRefund,
+		s.unilateralRefundWithoutReceiver,
+	}
+	for _, branch := range branches {
+		if branch == nil {
+			return fmt.Errorf("vhtlc: missing branch")
+		}
+	}
+
+	sender := s.unilateralRefundWithoutReceiver.keys[0]
+	receiver := s.unilateralClaim.keys[0]
+	server := s.claim.keys[1]
+
+	checks := []struct {
+		name string
+		got  [][]byte
+		want [][]byte
+	}{
+		{
+			"claim",
+			s.claim.keys,
+			[][]byte{
+				receiver,
+				server,
+			},
+		},
+		{
+			"refund",
+			s.refund.keys,
+			[][]byte{
+				sender,
+				receiver,
+				server,
+			},
+		},
+		{"refund without receiver", s.refundWithoutReceiver.keys,
+			[][]byte{
+				sender,
+				server,
+			}},
+		{"unilateral refund", s.unilateralRefund.keys,
+			[][]byte{
+				sender,
+				receiver,
+			}},
+	}
+	for _, check := range checks {
+		if !equalVHTLCKeys(check.got, check.want) {
+			return fmt.Errorf("vhtlc: %s keys do not match",
+				check.name)
+		}
+	}
+
+	if !bytes.Equal(s.claim.predicate,
+		s.unilateralClaim.predicate) {
+		return fmt.Errorf("vhtlc: claim predicates do not match")
+	}
+	if !bytes.Equal(
+		s.refundWithoutReceiver.predicate,
+		s.unilateralRefundWithoutReceiver.predicate,
+	) ||
+		s.refundWithoutReceiver.locktime !=
+			s.unilateralRefundWithoutReceiver.locktime {
+		return fmt.Errorf("vhtlc: refund locktimes do not match")
+	}
+
+	return nil
+}
+
+// equalVHTLCKeys compares ordered compressed public-key encodings.
+func equalVHTLCKeys(left, right [][]byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if !bytes.Equal(left[i], right[i]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/lib/arkscript/vhtlc_timing.go
+++ b/lib/arkscript/vhtlc_timing.go
@@ -3,6 +3,8 @@ package arkscript
 import (
 	"bytes"
 	"fmt"
+
+	"github.com/btcsuite/btcd/wire/v2"
 )
 
 // VHTLCTiming contains the four block-based constraints in a vHTLC policy.
@@ -158,7 +160,14 @@ func decodeVHTLCNode(node Node) (*vhtlcNodeShape, error) {
 	shape := &vhtlcNodeShape{}
 
 	if csv, ok := node.(*CSV); ok {
-		shape.csvDelay = csv.Lock
+		if err := validateCSVLock(csv.Lock); err != nil {
+			return nil, fmt.Errorf("invalid CSV delay: %w", err)
+		}
+
+		// CSV.Lock stores a BIP-68 sequence. Decode the relative block
+		// count explicitly after rejecting disable, time-mode and
+		// reserved flag bits above.
+		shape.csvDelay = csv.Lock & uint32(wire.SequenceLockTimeMask)
 		node = csv.Inner
 	}
 	if condition, ok := node.(*Condition); ok {

--- a/lib/arkscript/vhtlc_timing_test.go
+++ b/lib/arkscript/vhtlc_timing_test.go
@@ -1,0 +1,140 @@
+package arkscript
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestVHTLCTimingValidateOrder verifies that less cooperative refund paths
+// cannot mature before the receiver's claim path.
+func TestVHTLCTimingValidateOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		timing  VHTLCTiming
+		wantErr string
+	}{
+		{
+			name: "ordered",
+			timing: VHTLCTiming{
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+		},
+		{
+			name: "equal delays",
+			timing: VHTLCTiming{
+				UnilateralClaimDelay:                 144,
+				UnilateralRefundDelay:                144,
+				UnilateralRefundWithoutReceiverDelay: 144,
+			},
+		},
+		{
+			name: "claim after cooperative refund",
+			timing: VHTLCTiming{
+				UnilateralClaimDelay:                 25,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			wantErr: "claim delay 25 exceeds",
+		},
+		{
+			name: "cooperative refund after sender refund",
+			timing: VHTLCTiming{
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                37,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			wantErr: "refund delay 37 exceeds",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.timing.ValidateOrder()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+// TestVHTLCTimingValidateClaimWindow verifies strict refund-window arithmetic
+// at its exact boundary.
+func TestVHTLCTimingValidateClaimWindow(t *testing.T) {
+	t.Parallel()
+
+	timing := VHTLCTiming{
+		RefundLocktime:                       329,
+		UnilateralClaimDelay:                 144,
+		UnilateralRefundDelay:                144,
+		UnilateralRefundWithoutReceiverDelay: 256,
+	}
+	window := VHTLCClaimWindow{
+		CurrentHeight:     100,
+		ExitAncestryDelay: 72,
+		RecoveryMargin:    12,
+	}
+
+	require.NoError(t, timing.ValidateClaimWindow(window))
+	timing.RefundLocktime = 328
+	err := timing.ValidateClaimWindow(window)
+	require.ErrorContains(
+		t, err, "refund window 228 blocks does not exceed required "+
+			"claim window 228",
+	)
+
+	timing.RefundLocktime = 100
+	err = timing.ValidateClaimWindow(window)
+	require.ErrorContains(t, err, "is not after current height")
+}
+
+// TestDecodeVHTLCTiming verifies that encoded semantic policies retain the
+// timing tuple and that lookalike policies with mismatched participants fail.
+func TestDecodeVHTLCTiming(t *testing.T) {
+	t.Parallel()
+
+	opts := testVHTLCOpts(t)
+	policy, err := NewVHTLCPolicy(opts)
+	require.NoError(t, err)
+
+	encoded, err := policy.Template.Encode()
+	require.NoError(t, err)
+	decoded, err := DecodePolicyTemplate(encoded)
+	require.NoError(t, err)
+
+	timing, err := DecodeVHTLCTiming(decoded)
+	require.NoError(t, err)
+	require.Equal(t, opts.Timing(), *timing)
+
+	bad := *decoded
+	bad.Leaves = append([]LeafTemplate(nil), decoded.Leaves...)
+	for i := range bad.Leaves {
+		shape, shapeErr := decodeVHTLCNode(bad.Leaves[i].Node)
+		require.NoError(t, shapeErr)
+		if shape.csvDelay > 0 && shape.locktime == 0 &&
+			len(shape.predicate) == 0 && len(shape.keys) == 2 {
+
+			csv, ok := bad.Leaves[i].Node.(*CSV)
+			require.True(t, ok)
+			multisig, ok := csv.Inner.(*Multisig)
+			require.True(t, ok)
+			multisig.Keys[0] = opts.Server
+
+			break
+		}
+	}
+
+	_, err = DecodeVHTLCTiming(&bad)
+	require.ErrorContains(t, err, "unilateral refund keys do not match")
+}

--- a/lib/arkscript/vhtlc_timing_test.go
+++ b/lib/arkscript/vhtlc_timing_test.go
@@ -154,4 +154,18 @@ func TestDecodeVHTLCTiming(t *testing.T) {
 
 	_, err = DecodeVHTLCTiming(badCSV)
 	require.ErrorContains(t, err, "canonical block delay")
+
+	unorderedOpts := opts
+	unorderedOpts.UnilateralClaimDelay =
+		unorderedOpts.UnilateralRefundDelay + 1
+	unorderedPolicy, err := NewVHTLCPolicy(unorderedOpts)
+	require.NoError(t, err)
+	unorderedEncoded, err := unorderedPolicy.Template.Encode()
+	require.NoError(t, err)
+	unordered, err := DecodePolicyTemplate(unorderedEncoded)
+	require.NoError(t, err)
+
+	unorderedTiming, err := DecodeVHTLCTiming(unordered)
+	require.NoError(t, err)
+	require.Equal(t, unorderedOpts.Timing(), *unorderedTiming)
 }

--- a/lib/arkscript/vhtlc_timing_test.go
+++ b/lib/arkscript/vhtlc_timing_test.go
@@ -3,6 +3,7 @@ package arkscript
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -117,8 +118,8 @@ func TestDecodeVHTLCTiming(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, opts.Timing(), *timing)
 
-	bad := *decoded
-	bad.Leaves = append([]LeafTemplate(nil), decoded.Leaves...)
+	bad, err := DecodePolicyTemplate(encoded)
+	require.NoError(t, err)
 	for i := range bad.Leaves {
 		shape, shapeErr := decodeVHTLCNode(bad.Leaves[i].Node)
 		require.NoError(t, shapeErr)
@@ -135,6 +136,22 @@ func TestDecodeVHTLCTiming(t *testing.T) {
 		}
 	}
 
-	_, err = DecodeVHTLCTiming(&bad)
+	_, err = DecodeVHTLCTiming(bad)
 	require.ErrorContains(t, err, "unilateral refund keys do not match")
+
+	badCSV, err := DecodePolicyTemplate(encoded)
+	require.NoError(t, err)
+	for i := range badCSV.Leaves {
+		csv, ok := badCSV.Leaves[i].Node.(*CSV)
+		if !ok {
+			continue
+		}
+
+		csv.Lock |= wire.SequenceLockTimeIsSeconds
+
+		break
+	}
+
+	_, err = DecodeVHTLCTiming(badCSV)
+	require.ErrorContains(t, err, "canonical block delay")
 }

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -628,6 +628,10 @@ func (s *paySession) createSwap(ctx context.Context) error {
 		})
 	}
 
+	if err := vhtlcTiming(cfg.VHTLCConfig).ValidateOrder(); err != nil {
+		return fmt.Errorf("validate in-swap vHTLC timing: %w", err)
+	}
+
 	operatorKey, err := s.client.daemon.OperatorPubKey(ctx)
 	if err != nil {
 		return fmt.Errorf("get operator pubkey: %w", err)

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -536,6 +536,44 @@ func TestPaySessionRejectsUnboundInSwapQuote(t *testing.T) {
 	require.Zero(t, daemonConn.sendPolicyCalls)
 }
 
+// TestPaySessionRejectsUnorderedVHTLC verifies a newly proposed policy is
+// rejected before the client derives or funds its output.
+func TestPaySessionRejectsUnorderedVHTLC(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+	cfg := testInSwapConfig(
+		serverPriv.PubKey(), preimage, time.Now().Add(time.Minute),
+	)
+	cfg.VHTLCConfig.UnilateralClaimDelay = 25
+	cfg.VHTLCConfig.UnilateralRefundDelay = 24
+
+	serverConn := &testInSwapServerConn{cfg: cfg}
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+	}
+	client := configureTestPayClient(
+		NewSwapClient(serverConn, daemonConn, nil, nil),
+	)
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.Nil(t, session)
+	require.ErrorContains(t, err, "unilateral claim delay 25 exceeds")
+	require.Zero(t, daemonConn.sendPolicyCalls)
+}
+
 // TestPaySessionCreditOnlyStartCompletesWithoutVHTLC verifies credit-only
 // pays can complete during creation without forcing the Loop FSM through a
 // vHTLC funding state.

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -483,7 +483,10 @@ func (s *ReceiveSession) Claim(ctx context.Context, outpoint string,
 	}
 
 	if s.state == ReceiveStateHTLCEventAccepted {
-		err := s.validateReceiveFunding(ctx, outpoint, amount)
+		err := s.validateReceiveFunding(ctx, &VTXOInfo{
+			Outpoint:  outpoint,
+			AmountSat: amount,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -878,7 +881,7 @@ func (s *ReceiveSession) waitForFunding(ctx context.Context) error {
 	// the vHTLC. Do not add a wall-clock deadline here: the refund-locktime
 	// guard below is the durable boundary, and backend/indexer outages
 	// should keep retrying until the caller shuts the worker down.
-	outpoint, amount, err := s.client.waitForVHTLC(
+	funding, err := s.client.waitForVHTLC(
 		ctx, s.vhtlcPkScript, time.Time{},
 		s.ensureReceiveFundingStillPossible,
 	)
@@ -890,13 +893,13 @@ func (s *ReceiveSession) waitForFunding(ctx context.Context) error {
 		return fmt.Errorf("wait for vHTLC: %w", err)
 	}
 
-	if err := s.validateReceiveFunding(ctx, outpoint, amount); err != nil {
+	if err := s.validateReceiveFunding(ctx, funding); err != nil {
 		return err
 	}
 
 	err = s.mutateAndPersist(ctx, func() error {
-		s.vhtlcOutpoint = outpoint
-		s.vhtlcAmount = amount
+		s.vhtlcOutpoint = funding.Outpoint
+		s.vhtlcAmount = funding.AmountSat
 
 		return s.transition(receiveEventVHTLCFunded)
 	})
@@ -1056,6 +1059,14 @@ func (s *ReceiveSession) acceptOutSwapHtlcEvent(ctx context.Context,
 	if err := s.validateOnionPayload(event, authKey); err != nil {
 		return s.failTerminal(
 			ctx, "out-swap HTLC onion validation failed", err, nil,
+		)
+	}
+	if err := s.validateReceiveClaimWindow(
+		ctx, event.VHTLCConfig, s.client.recoveryPolicy.WithDefaults().
+			ExitAncestryDelayBlocks,
+	); err != nil {
+		return s.failTerminal(
+			ctx, "out-swap HTLC timing window is invalid", err, nil,
 		)
 	}
 
@@ -1349,6 +1360,14 @@ func (s *ReceiveSession) acceptInArkHtlcEvent(ctx context.Context,
 			ctx, "in-ark HTLC sender pubkey mismatch", nil, nil,
 		)
 	}
+	if err := s.validateReceiveClaimWindow(
+		ctx, cfg, s.client.recoveryPolicy.WithDefaults().
+			ExitAncestryDelayBlocks,
+	); err != nil {
+		return s.failTerminal(
+			ctx, "in-ark HTLC timing window is invalid", err, nil,
+		)
+	}
 	refundNoReceiverDelay := cfg.UnilateralRefundWithoutReceiverDelay
 
 	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
@@ -1506,63 +1525,124 @@ func decodeOutSwapOnion(receiveAuthKey ReceiveAuthKey, paymentHash lntypes.Hash,
 func (s *ReceiveSession) ensureReceiveFundingStillPossible(
 	ctx context.Context) error {
 
-	height, err := s.client.daemon.BlockHeight(ctx)
-	if err != nil {
-		s.client.log.DebugS(
-			ctx,
-			"Unable to query receive refund locktime height",
-			slog.String("err", err.Error()),
-			btclog.Hex("hash", s.PaymentHash[:]),
-		)
-
+	exitDelay := s.client.recoveryPolicy.WithDefaults().
+		ExitAncestryDelayBlocks
+	err := s.validateReceiveClaimWindow(ctx, s.vhtlcConfig, exitDelay)
+	if err == nil {
 		return nil
 	}
 
-	if height+s.client.refundLocktimeBuffer < s.vhtlcConfig.RefundLocktime {
-		return nil
-	}
-
-	return fmt.Errorf("refund locktime %d is imminent or reached before "+
-		"receive funding was observed at height %d: %w",
-		s.vhtlcConfig.RefundLocktime, height, errSwapExpired)
+	return fmt.Errorf("receive funding claim window closed: %w: %w", err,
+		errSwapExpired)
 }
 
 // validateReceiveFunding checks manually or automatically observed funding
 // details before the claim path can reveal the invoice preimage.
 func (s *ReceiveSession) validateReceiveFunding(ctx context.Context,
-	outpoint string, amount int64) error {
+	funding *VTXOInfo) error {
+
+	if funding == nil {
+		return fmt.Errorf("funded vHTLC metadata is required")
+	}
 
 	expectedAmountSat := s.expectedVHTLCSat
 	if expectedAmountSat == 0 {
 		expectedAmountSat = uint64(s.amountSat)
 	}
 
-	if amount != int64(expectedAmountSat) {
+	if funding.AmountSat != int64(expectedAmountSat) {
 		return s.failTerminal(ctx, fmt.Sprintf("funded "+
 			"vHTLC amount %d does not match "+
-			"expected vHTLC amount %d", amount,
-			expectedAmountSat), nil, func() {
-			s.vhtlcOutpoint = outpoint
-			s.vhtlcAmount = amount
+			"expected vHTLC amount %d",
+			funding.AmountSat, expectedAmountSat), nil, func() {
+			s.vhtlcOutpoint = funding.Outpoint
+			s.vhtlcAmount = funding.AmountSat
 		})
+	}
+
+	exitDelay, err := s.receiveExitAncestryDelay(funding)
+	if err != nil {
+		return s.failTerminal(
+			ctx, "funded vHTLC exit metadata is invalid", err,
+			func() {
+				s.vhtlcOutpoint = funding.Outpoint
+				s.vhtlcAmount = funding.AmountSat
+			},
+		)
+	}
+	if err := s.validateReceiveClaimWindow(
+		ctx, s.vhtlcConfig, exitDelay,
+	); err != nil {
+		return s.failTerminal(
+			ctx, "funded vHTLC claim window is invalid", err,
+			func() {
+				s.vhtlcOutpoint = funding.Outpoint
+				s.vhtlcAmount = funding.AmountSat
+			},
+		)
+	}
+
+	return nil
+}
+
+// validateReceiveClaimWindow applies the shared semantic timing check at the
+// current daemon height.
+func (s *ReceiveSession) validateReceiveClaimWindow(ctx context.Context,
+	cfg VHTLCConfig, exitAncestryDelay uint32) error {
+
+	if s == nil || s.client == nil || s.client.daemon == nil {
+		return fmt.Errorf("daemon connection is required for vHTLC " +
+			"timing validation")
 	}
 
 	height, err := s.client.daemon.BlockHeight(ctx)
 	if err != nil {
 		return fmt.Errorf("get block height: %w", err)
 	}
-	if height+s.client.refundLocktimeBuffer >=
-		s.vhtlcConfig.RefundLocktime {
-		return s.failTerminal(ctx, fmt.Sprintf("funded "+
-			"vHTLC observed too close to refund "+
-			"locktime %d at height %d",
-			s.vhtlcConfig.RefundLocktime, height), nil, func() {
-			s.vhtlcOutpoint = outpoint
-			s.vhtlcAmount = amount
-		})
+
+	return (arkscript.VHTLCTiming{
+		RefundLocktime:        cfg.RefundLocktime,
+		UnilateralClaimDelay:  cfg.UnilateralClaimDelay,
+		UnilateralRefundDelay: cfg.UnilateralRefundDelay,
+		UnilateralRefundWithoutReceiverDelay: cfg.
+			UnilateralRefundWithoutReceiverDelay,
+	}).ValidateClaimWindow(arkscript.VHTLCClaimWindow{
+		CurrentHeight:     height,
+		ExitAncestryDelay: exitAncestryDelay,
+		RecoveryMargin: s.client.recoveryPolicy.WithDefaults().
+			MinRecoveryMarginBlocks,
+	})
+}
+
+// receiveExitAncestryDelay combines the conservative pre-funding budget with
+// the funded VTXO's exact critical-exit metadata. A deeper ancestry can only
+// increase the accepted budget.
+func (s *ReceiveSession) receiveExitAncestryDelay(funding *VTXOInfo) (uint32,
+	error) {
+
+	fallback := s.client.recoveryPolicy.WithDefaults().
+		ExitAncestryDelayBlocks
+	if funding == nil || funding.ExpiryInfo == nil {
+		return fallback, nil
 	}
 
-	return nil
+	info := funding.ExpiryInfo
+	// RelativeExpiry is the wrapping VTXO's exit CSV. For a custom vHTLC
+	// policy it can reflect a different branch than the receiver-only claim
+	// CSV, so only use it to remove the CSV component from the daemon's
+	// critical threshold.
+	if info.CriticalThresholdBlocks <= int32(info.RelativeExpiry) {
+		return fallback, nil
+	}
+
+	delay := uint32(
+		info.CriticalThresholdBlocks - int32(info.RelativeExpiry),
+	)
+	if delay < fallback {
+		return fallback, nil
+	}
+
+	return delay, nil
 }
 
 // claimFundedVHTLC reconciles an already-spent vHTLC before sending the claim
@@ -1752,26 +1832,22 @@ func (s *ReceiveSession) ensureClaimReceiveInfo(ctx context.Context) error {
 func (s *ReceiveSession) ensureReceiveClaimStillPossible(
 	ctx context.Context) error {
 
-	height, err := s.client.daemon.BlockHeight(ctx)
-	if err != nil {
-		return fmt.Errorf("get block height: %w", err)
-	}
-
-	if height+s.client.refundLocktimeBuffer < s.vhtlcConfig.RefundLocktime {
+	exitDelay := s.client.recoveryPolicy.WithDefaults().
+		ExitAncestryDelayBlocks
+	err := s.validateReceiveClaimWindow(
+		ctx, s.vhtlcConfig, exitDelay,
+	)
+	if err == nil {
 		return nil
 	}
 
-	// Once the refund locktime is mature, a new receive claim becomes a
-	// late race with the server refund path and should stop durably.
-	reason := fmt.Sprintf("refund locktime %d is imminent or reached "+
-		"before receive claim at height %d",
-		s.vhtlcConfig.RefundLocktime, height)
-	if err := s.mutateAndPersist(ctx, func() error {
+	reason := fmt.Sprintf("receive claim window closed: %v", err)
+	if persistErr := s.mutateAndPersist(ctx, func() error {
 		s.interventionReason = reason
 
 		return s.transition(receiveEventExpired)
-	}); err != nil {
-		return err
+	}); persistErr != nil {
+		return persistErr
 	}
 
 	return fmt.Errorf("%s: %w", reason, errSwapExpired)
@@ -1992,6 +2068,15 @@ func (s *ReceiveSession) reconcileLiveReceiveFunding(
 	if vtxo == nil || vtxo.Outpoint == "" {
 		return nil
 	}
+	exitDelay, err := s.receiveExitAncestryDelay(vtxo)
+	if err != nil {
+		return err
+	}
+	if err := s.validateReceiveClaimWindow(
+		ctx, s.vhtlcConfig, exitDelay,
+	); err != nil {
+		return err
+	}
 	if s.vhtlcAmount != 0 && vtxo.AmountSat != s.vhtlcAmount {
 		s.client.log.WarnS(
 			ctx,
@@ -2032,13 +2117,13 @@ func encodeVHTLCPolicyTemplate(policy *arkscript.VHTLCPolicy) ([]byte, error) {
 // is authoritative enough to proceed, while complete absence remains retryable
 // until the refund-locktime guard expires.
 func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
-	deadline time.Time, keepWaiting func(context.Context) error) (string,
-	int64, error) {
+	deadline time.Time, keepWaiting func(context.Context) error) (*VTXOInfo,
+	error) {
 
 	pkScriptHex := hex.EncodeToString(pkScript)
 	for {
 		if err := ctx.Err(); err != nil {
-			return "", 0, err
+			return nil, err
 		}
 
 		vtxo, err := c.daemon.FindLiveVTXOByPkScript(ctx, pkScript)
@@ -2083,8 +2168,7 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 						),
 					)
 
-					return localVTXO.Outpoint,
-						localVTXO.AmountSat, nil
+					return localVTXO, nil
 				}
 			}
 		}
@@ -2095,17 +2179,17 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 				slog.Int64("amount_sat", vtxo.AmountSat),
 			)
 
-			return vtxo.Outpoint, vtxo.AmountSat, nil
+			return vtxo, nil
 		}
 
 		if keepWaiting != nil {
 			if err := keepWaiting(ctx); err != nil {
-				return "", 0, err
+				return nil, err
 			}
 		}
 
 		if !deadline.IsZero() && !c.currentTime().Before(deadline) {
-			return "", 0, errSwapExpired
+			return nil, errSwapExpired
 		}
 
 		wait := c.waitPollInterval
@@ -2115,7 +2199,7 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 			wait = until
 		}
 		if wait <= 0 {
-			return "", 0, errSwapExpired
+			return nil, errSwapExpired
 		}
 
 		timer := time.NewTimer(wait)
@@ -2123,7 +2207,7 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 		case <-ctx.Done():
 			timer.Stop()
 
-			return "", 0, ctx.Err()
+			return nil, ctx.Err()
 
 		case <-timer.C:
 		}

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1364,17 +1364,36 @@ func (s *ReceiveSession) acceptInArkHtlcEvent(ctx context.Context,
 	}
 	// A legacy direct p2p event describes a vHTLC the sender already
 	// funded, so a short unilateral-exit window cannot undo the exposure
-	// and must not prevent the still-available cooperative claim. The
-	// credit-shaped path remains safe to reject here because its
-	// server-side funding is gated on the acknowledgement below.
-	if creditShaped {
-		if err := s.validateReceiveClaimWindow(
-			ctx, cfg, s.client.recoveryPolicy.WithDefaults().
-				ExitAncestryDelayBlocks,
-		); err != nil {
+	// and must not prevent the still-available cooperative claim. Retain a
+	// warning for operators while keeping the credit-shaped path safe to
+	// reject before its acknowledgement triggers server-side funding.
+	timingErr := s.validateReceiveClaimWindow(
+		ctx, cfg, s.client.recoveryPolicy.WithDefaults().
+			ExitAncestryDelayBlocks,
+	)
+	if timingErr != nil {
+		if creditShaped {
 			return s.failReceiveTimingAdmission(
 				ctx, "in-ark HTLC timing window is invalid",
-				err,
+				timingErr,
+			)
+		}
+
+		var retryable *retryableActionError
+		if errors.As(timingErr, &retryable) {
+			s.client.log.DebugS(
+				ctx,
+				"Unable to evaluate receive vHTLC recovery "+
+					"window",
+				slog.String("err", timingErr.Error()),
+				btclog.Hex("hash", s.PaymentHash[:]),
+			)
+		} else {
+			s.client.log.WarnS(
+				ctx,
+				"Receive vHTLC has limited recovery window",
+				timingErr,
+				btclog.Hex("hash", s.PaymentHash[:]),
 			)
 		}
 	}

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1062,8 +1062,7 @@ func (s *ReceiveSession) acceptOutSwapHtlcEvent(ctx context.Context,
 		)
 	}
 	if err := s.validateReceiveClaimWindow(
-		ctx, event.VHTLCConfig, s.client.recoveryPolicy.WithDefaults().
-			ExitAncestryDelayBlocks,
+		ctx, event.VHTLCConfig,
 	); err != nil {
 		return s.failReceiveTimingAdmission(
 			ctx, "out-swap HTLC timing window is invalid", err,
@@ -1367,10 +1366,7 @@ func (s *ReceiveSession) acceptInArkHtlcEvent(ctx context.Context,
 	// and must not prevent the still-available cooperative claim. Retain a
 	// warning for operators while keeping the credit-shaped path safe to
 	// reject before its acknowledgement triggers server-side funding.
-	timingErr := s.validateReceiveClaimWindow(
-		ctx, cfg, s.client.recoveryPolicy.WithDefaults().
-			ExitAncestryDelayBlocks,
-	)
+	timingErr := s.validateReceiveClaimWindow(ctx, cfg)
 	if timingErr != nil {
 		if creditShaped {
 			return s.failReceiveTimingAdmission(
@@ -1605,7 +1601,7 @@ func (s *ReceiveSession) validateReceiveFunding(ctx context.Context,
 // validateReceiveClaimWindow applies the shared semantic timing check when a
 // server event first asks the receiver to accept a vHTLC policy.
 func (s *ReceiveSession) validateReceiveClaimWindow(ctx context.Context,
-	cfg VHTLCConfig, exitAncestryDelay uint32) error {
+	cfg VHTLCConfig) error {
 
 	if s == nil || s.client == nil || s.client.daemon == nil {
 		return newRetryableActionError(
@@ -1621,18 +1617,24 @@ func (s *ReceiveSession) validateReceiveClaimWindow(ctx context.Context,
 		)
 	}
 
-	return (arkscript.VHTLCTiming{
+	policy := s.client.recoveryPolicy.WithDefaults()
+
+	return vhtlcTiming(cfg).ValidateClaimWindow(arkscript.VHTLCClaimWindow{
+		CurrentHeight:     height,
+		ExitAncestryDelay: policy.ExitAncestryDelayBlocks,
+		RecoveryMargin:    policy.MinRecoveryMarginBlocks,
+	})
+}
+
+// vhtlcTiming projects the wire configuration into the shared timing model.
+func vhtlcTiming(cfg VHTLCConfig) arkscript.VHTLCTiming {
+	return arkscript.VHTLCTiming{
 		RefundLocktime:        cfg.RefundLocktime,
 		UnilateralClaimDelay:  cfg.UnilateralClaimDelay,
 		UnilateralRefundDelay: cfg.UnilateralRefundDelay,
 		UnilateralRefundWithoutReceiverDelay: cfg.
 			UnilateralRefundWithoutReceiverDelay,
-	}).ValidateClaimWindow(arkscript.VHTLCClaimWindow{
-		CurrentHeight:     height,
-		ExitAncestryDelay: exitAncestryDelay,
-		RecoveryMargin: s.client.recoveryPolicy.WithDefaults().
-			MinRecoveryMarginBlocks,
-	})
+	}
 }
 
 // failReceiveTimingAdmission keeps backend availability failures retryable and

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1292,7 +1292,9 @@ func (s *ReceiveSession) acceptInArkHtlcEvent(ctx context.Context,
 		)
 	}
 
-	if event.RequestedAmountSat > 0 || event.AttachedCreditSat > 0 {
+	creditShaped := event.RequestedAmountSat > 0 ||
+		event.AttachedCreditSat > 0
+	if creditShaped {
 		// A credit-shaped event is the swap-server-funded in-ark leg
 		// of a credit-attach receive: amount_sat carries the padded
 		// vHTLC and the event must match the session's route quote
@@ -1360,13 +1362,21 @@ func (s *ReceiveSession) acceptInArkHtlcEvent(ctx context.Context,
 			ctx, "in-ark HTLC sender pubkey mismatch", nil, nil,
 		)
 	}
-	if err := s.validateReceiveClaimWindow(
-		ctx, cfg, s.client.recoveryPolicy.WithDefaults().
-			ExitAncestryDelayBlocks,
-	); err != nil {
-		return s.failReceiveTimingAdmission(
-			ctx, "in-ark HTLC timing window is invalid", err,
-		)
+	// A legacy direct p2p event describes a vHTLC the sender already
+	// funded, so a short unilateral-exit window cannot undo the exposure
+	// and must not prevent the still-available cooperative claim. The
+	// credit-shaped path remains safe to reject here because its
+	// server-side funding is gated on the acknowledgement below.
+	if creditShaped {
+		if err := s.validateReceiveClaimWindow(
+			ctx, cfg, s.client.recoveryPolicy.WithDefaults().
+				ExitAncestryDelayBlocks,
+		); err != nil {
+			return s.failReceiveTimingAdmission(
+				ctx, "in-ark HTLC timing window is invalid",
+				err,
+			)
+		}
 	}
 	refundNoReceiverDelay := cfg.UnilateralRefundWithoutReceiverDelay
 

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1065,8 +1065,8 @@ func (s *ReceiveSession) acceptOutSwapHtlcEvent(ctx context.Context,
 		ctx, event.VHTLCConfig, s.client.recoveryPolicy.WithDefaults().
 			ExitAncestryDelayBlocks,
 	); err != nil {
-		return s.failTerminal(
-			ctx, "out-swap HTLC timing window is invalid", err, nil,
+		return s.failReceiveTimingAdmission(
+			ctx, "out-swap HTLC timing window is invalid", err,
 		)
 	}
 
@@ -1364,8 +1364,8 @@ func (s *ReceiveSession) acceptInArkHtlcEvent(ctx context.Context,
 		ctx, cfg, s.client.recoveryPolicy.WithDefaults().
 			ExitAncestryDelayBlocks,
 	); err != nil {
-		return s.failTerminal(
-			ctx, "in-ark HTLC timing window is invalid", err, nil,
+		return s.failReceiveTimingAdmission(
+			ctx, "in-ark HTLC timing window is invalid", err,
 		)
 	}
 	refundNoReceiverDelay := cfg.UnilateralRefundWithoutReceiverDelay
@@ -1525,15 +1525,25 @@ func decodeOutSwapOnion(receiveAuthKey ReceiveAuthKey, paymentHash lntypes.Hash,
 func (s *ReceiveSession) ensureReceiveFundingStillPossible(
 	ctx context.Context) error {
 
-	exitDelay := s.client.recoveryPolicy.WithDefaults().
-		ExitAncestryDelayBlocks
-	err := s.validateReceiveClaimWindow(ctx, s.vhtlcConfig, exitDelay)
-	if err == nil {
+	height, err := s.client.daemon.BlockHeight(ctx)
+	if err != nil {
+		s.client.log.DebugS(
+			ctx,
+			"Unable to query receive refund locktime height",
+			slog.String("err", err.Error()),
+			btclog.Hex("hash", s.PaymentHash[:]),
+		)
+
 		return nil
 	}
 
-	return fmt.Errorf("receive funding claim window closed: %w: %w", err,
-		errSwapExpired)
+	if height+s.client.refundLocktimeBuffer < s.vhtlcConfig.RefundLocktime {
+		return nil
+	}
+
+	return fmt.Errorf("refund locktime %d is imminent or reached before "+
+		"receive funding was observed at height %d: %w",
+		s.vhtlcConfig.RefundLocktime, height, errSwapExpired)
 }
 
 // validateReceiveFunding checks manually or automatically observed funding
@@ -1560,44 +1570,26 @@ func (s *ReceiveSession) validateReceiveFunding(ctx context.Context,
 		})
 	}
 
-	exitDelay, err := s.receiveExitAncestryDelay(funding)
-	if err != nil {
-		return s.failTerminal(
-			ctx, "funded vHTLC exit metadata is invalid", err,
-			func() {
-				s.vhtlcOutpoint = funding.Outpoint
-				s.vhtlcAmount = funding.AmountSat
-			},
-		)
-	}
-	if err := s.validateReceiveClaimWindow(
-		ctx, s.vhtlcConfig, exitDelay,
-	); err != nil {
-		return s.failTerminal(
-			ctx, "funded vHTLC claim window is invalid", err,
-			func() {
-				s.vhtlcOutpoint = funding.Outpoint
-				s.vhtlcAmount = funding.AmountSat
-			},
-		)
-	}
-
 	return nil
 }
 
-// validateReceiveClaimWindow applies the shared semantic timing check at the
-// current daemon height.
+// validateReceiveClaimWindow applies the shared semantic timing check when a
+// server event first asks the receiver to accept a vHTLC policy.
 func (s *ReceiveSession) validateReceiveClaimWindow(ctx context.Context,
 	cfg VHTLCConfig, exitAncestryDelay uint32) error {
 
 	if s == nil || s.client == nil || s.client.daemon == nil {
-		return fmt.Errorf("daemon connection is required for vHTLC " +
-			"timing validation")
+		return newRetryableActionError(
+			fmt.Errorf("daemon connection is required for vHTLC " +
+				"timing validation"),
+		)
 	}
 
 	height, err := s.client.daemon.BlockHeight(ctx)
 	if err != nil {
-		return fmt.Errorf("get block height: %w", err)
+		return newRetryableActionError(
+			fmt.Errorf("get block height: %w", err),
+		)
 	}
 
 	return (arkscript.VHTLCTiming{
@@ -1614,35 +1606,17 @@ func (s *ReceiveSession) validateReceiveClaimWindow(ctx context.Context,
 	})
 }
 
-// receiveExitAncestryDelay combines the conservative pre-funding budget with
-// the funded VTXO's exact critical-exit metadata. A deeper ancestry can only
-// increase the accepted budget.
-func (s *ReceiveSession) receiveExitAncestryDelay(funding *VTXOInfo) (uint32,
-	error) {
+// failReceiveTimingAdmission keeps backend availability failures retryable and
+// durably rejects only a timing tuple that was evaluated against chain state.
+func (s *ReceiveSession) failReceiveTimingAdmission(ctx context.Context,
+	reason string, err error) error {
 
-	fallback := s.client.recoveryPolicy.WithDefaults().
-		ExitAncestryDelayBlocks
-	if funding == nil || funding.ExpiryInfo == nil {
-		return fallback, nil
+	var retryable *retryableActionError
+	if errors.As(err, &retryable) {
+		return err
 	}
 
-	info := funding.ExpiryInfo
-	// RelativeExpiry is the wrapping VTXO's exit CSV. For a custom vHTLC
-	// policy it can reflect a different branch than the receiver-only claim
-	// CSV, so only use it to remove the CSV component from the daemon's
-	// critical threshold.
-	if info.CriticalThresholdBlocks <= int32(info.RelativeExpiry) {
-		return fallback, nil
-	}
-
-	delay := uint32(
-		info.CriticalThresholdBlocks - int32(info.RelativeExpiry),
-	)
-	if delay < fallback {
-		return fallback, nil
-	}
-
-	return delay, nil
+	return s.failTerminal(ctx, reason, err, nil)
 }
 
 // claimFundedVHTLC reconciles an already-spent vHTLC before sending the claim
@@ -1832,16 +1806,22 @@ func (s *ReceiveSession) ensureClaimReceiveInfo(ctx context.Context) error {
 func (s *ReceiveSession) ensureReceiveClaimStillPossible(
 	ctx context.Context) error {
 
-	exitDelay := s.client.recoveryPolicy.WithDefaults().
-		ExitAncestryDelayBlocks
-	err := s.validateReceiveClaimWindow(
-		ctx, s.vhtlcConfig, exitDelay,
-	)
-	if err == nil {
+	height, err := s.client.daemon.BlockHeight(ctx)
+	if err != nil {
+		return newRetryableActionError(
+			fmt.Errorf("get block height: %w", err),
+		)
+	}
+
+	if height+s.client.refundLocktimeBuffer < s.vhtlcConfig.RefundLocktime {
 		return nil
 	}
 
-	reason := fmt.Sprintf("receive claim window closed: %v", err)
+	// Once the refund locktime is mature, a new receive claim becomes a
+	// late race with the server refund path and should stop durably.
+	reason := fmt.Sprintf("refund locktime %d is imminent or reached "+
+		"before receive claim at height %d",
+		s.vhtlcConfig.RefundLocktime, height)
 	if persistErr := s.mutateAndPersist(ctx, func() error {
 		s.interventionReason = reason
 
@@ -2067,15 +2047,6 @@ func (s *ReceiveSession) reconcileLiveReceiveFunding(
 	}
 	if vtxo == nil || vtxo.Outpoint == "" {
 		return nil
-	}
-	exitDelay, err := s.receiveExitAncestryDelay(vtxo)
-	if err != nil {
-		return err
-	}
-	if err := s.validateReceiveClaimWindow(
-		ctx, s.vhtlcConfig, exitDelay,
-	); err != nil {
-		return err
 	}
 	if s.vhtlcAmount != 0 && vtxo.AmountSat != s.vhtlcAmount {
 		s.client.log.WarnS(

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
+	sdkark "github.com/lightninglabs/wavelength/sdk/ark"
 	"github.com/lightninglabs/wavelength/swaprpc"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightninglabs/wavelength/waverpc"
@@ -501,7 +502,7 @@ func TestReceiveSessionSkipsServerAckForSameArkHTLCEvent(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -572,7 +573,7 @@ func TestReceiveSessionAcksServerForCreditAssistedOutSwap(t *testing.T) {
 	useTestOnionDecoder(client, 300)
 
 	cfg := VHTLCConfig{}
-	cfg.RefundLocktime = 144
+	cfg.RefundLocktime = 300
 	cfg.UnilateralClaimDelay = 12
 	cfg.UnilateralRefundDelay = 24
 	cfg.UnilateralRefundWithoutReceiverDelay = 36
@@ -650,7 +651,7 @@ func TestReceiveSessionAcksServerForCreditAssistedInArk(t *testing.T) {
 	client := NewSwapClient(serverConn, daemonConn, nil, nil)
 
 	cfg := VHTLCConfig{
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -845,7 +846,7 @@ func TestForfeitSignaturePayloadFromVTXORequest(t *testing.T) {
 		Receiver:                             receiver.PubKey(),
 		Server:                               operator.PubKey(),
 		PreimageHash:                         paymentHash,
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 10,
 		UnilateralRefundDelay:                11,
 		UnilateralRefundWithoutReceiverDelay: 12,
@@ -1231,7 +1232,13 @@ func TestReceiveSessionAcceptsCreditAssistedOutSwapHTLC(t *testing.T) {
 
 	preimage := lntypes.Preimage{0x1, 0x2, 0x3}
 	hash := preimage.Hash()
-	client := &SwapClient{}
+	client := NewSwapClient(
+		nil, &testDaemonConn{
+			blockHeight: 100,
+		},
+		nil,
+		nil,
+	)
 	useTestOnionDecoder(client, 300)
 
 	session := &ReceiveSession{
@@ -1266,6 +1273,139 @@ func TestReceiveSessionAcceptsCreditAssistedOutSwapHTLC(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
 	require.Equal(t, SettlementTypeMixed, session.settlementType)
+}
+
+// TestReceiveSessionRejectsUnsafeVHTLCClaimWindow verifies a receive refuses
+// a server event whose refund path can mature before the receiver can expose
+// and claim the vHTLC through its unilateral exit ancestry.
+func TestReceiveSessionRejectsUnsafeVHTLCClaimWindow(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage{0x9, 0x8, 0x7}
+	client := NewSwapClient(
+		nil, &testDaemonConn{
+			blockHeight: 100,
+		},
+		nil,
+		nil,
+	)
+	useTestOnionDecoder(client, 42_000)
+
+	session := &ReceiveSession{
+		client:         client,
+		amountSat:      42_000,
+		state:          ReceiveStateInvoiceCreated,
+		PaymentHash:    preimage.Hash(),
+		clientPubKey:   clientPriv.PubKey(),
+		operatorPubKey: operatorPriv.PubKey(),
+	}
+	cfg := VHTLCConfig{
+		RefundLocktime:                       140,
+		UnilateralClaimDelay:                 144,
+		UnilateralRefundDelay:                144,
+		UnilateralRefundWithoutReceiverDelay: 256,
+		SwapServerPubkey: serverPriv.PubKey().
+			SerializeCompressed(),
+	}
+
+	err = session.acceptOutSwapHtlcEvent(
+		t.Context(), &OutSwapHtlcEvent{
+			PaymentHash: preimage.Hash(),
+			AmountSat:   42_000,
+			VHTLCConfig: cfg,
+		}, &daemonReceiveAuthKey{}, 0,
+	)
+	require.ErrorContains(t, err, "timing window is invalid")
+	require.ErrorContains(t, err, "refund window 40")
+	require.Equal(t, ReceiveStateFailed, session.State())
+}
+
+// TestReceiveSessionRevalidatesVHTLCClaimWindow verifies a once-safe event is
+// rejected after a delayed restart or deeper funded ancestry consumes its
+// remaining recovery budget.
+func TestReceiveSessionRevalidatesVHTLCClaimWindow(t *testing.T) {
+	t.Parallel()
+
+	newSession := func(t *testing.T, refundLocktime uint32) (
+		*ReceiveSession, *testDaemonConn) {
+
+		clientPriv, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		operatorPriv, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		serverPriv, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		preimage := lntypes.Preimage{0x6, 0x5, 0x4}
+		daemon := &testDaemonConn{blockHeight: 100}
+		client := NewSwapClient(nil, daemon, nil, nil)
+		useTestOnionDecoder(client, 42_000)
+
+		session := &ReceiveSession{
+			client:         client,
+			amountSat:      42_000,
+			state:          ReceiveStateInvoiceCreated,
+			PaymentHash:    preimage.Hash(),
+			clientPubKey:   clientPriv.PubKey(),
+			operatorPubKey: operatorPriv.PubKey(),
+		}
+		cfg := VHTLCConfig{
+			RefundLocktime:                       refundLocktime,
+			UnilateralClaimDelay:                 144,
+			UnilateralRefundDelay:                144,
+			UnilateralRefundWithoutReceiverDelay: 256,
+			SwapServerPubkey: serverPriv.PubKey().
+				SerializeCompressed(),
+		}
+		err = session.acceptOutSwapHtlcEvent(
+			t.Context(), &OutSwapHtlcEvent{
+				PaymentHash: preimage.Hash(),
+				AmountSat:   42_000,
+				VHTLCConfig: cfg,
+			}, &daemonReceiveAuthKey{}, 0,
+		)
+		require.NoError(t, err)
+
+		return session, daemon
+	}
+
+	t.Run("delayed restart", func(t *testing.T) {
+		session, daemon := newSession(t, 329)
+		daemon.blockHeight = 101
+
+		err := session.ensureReceiveFundingStillPossible(t.Context())
+		require.ErrorIs(t, err, errSwapExpired)
+		require.ErrorContains(t, err, "refund window 228")
+	})
+
+	t.Run("deeper funded ancestry", func(t *testing.T) {
+		session, _ := newSession(t, 343)
+
+		err := session.validateReceiveFunding(
+			t.Context(), &VTXOInfo{
+				Outpoint:  "funding:0",
+				AmountSat: 42_000,
+				ExpiryInfo: &sdkark.VTXOExpiryInfo{
+					RelativeExpiry:          1_008,
+					CriticalThresholdBlocks: 1_114,
+				},
+			},
+		)
+		require.ErrorContains(t, err, "claim window is invalid")
+		require.ErrorContains(t, err, "refund window 243")
+		require.Equal(t, ReceiveStateFailed, session.State())
+	})
 }
 
 // TestReceiveSessionRejectsCreditAssistedFundingMismatch verifies a
@@ -1659,12 +1799,12 @@ func TestWaitForVHTLCFallsBackToLocalVTXOOnUnregisteredScript(t *testing.T) {
 	}
 	client := NewSwapClient(nil, daemonConn, nil, nil)
 
-	outpoint, amount, err := client.waitForVHTLC(
+	funding, err := client.waitForVHTLC(
 		t.Context(), pkScript, time.Time{}, nil,
 	)
 	require.NoError(t, err)
-	require.Equal(t, localVTXO.Outpoint, outpoint)
-	require.Equal(t, localVTXO.AmountSat, amount)
+	require.Equal(t, localVTXO.Outpoint, funding.Outpoint)
+	require.Equal(t, localVTXO.AmountSat, funding.AmountSat)
 	require.Equal(t, 1, daemonConn.liveLookupCalls)
 }
 
@@ -1711,12 +1851,12 @@ func TestWaitForVHTLCRetriesThroughIndexerRowLag(t *testing.T) {
 	client := NewSwapClient(nil, daemonConn, nil, nil)
 	client.waitPollInterval = time.Millisecond
 
-	outpoint, amount, err := client.waitForVHTLC(
+	fundingInfo, err := client.waitForVHTLC(
 		t.Context(), pkScript, time.Time{}, nil,
 	)
 	require.NoError(t, err)
-	require.Equal(t, funded.Outpoint, outpoint)
-	require.Equal(t, funded.AmountSat, amount)
+	require.Equal(t, funded.Outpoint, fundingInfo.Outpoint)
+	require.Equal(t, funded.AmountSat, fundingInfo.AmountSat)
 	require.Equal(t, lagPolls+1, daemonConn.liveLookupCalls)
 }
 
@@ -1750,7 +1890,7 @@ func TestWaitForVHTLCExpiresOnPersistentUnregisteredScript(t *testing.T) {
 		},
 	}
 
-	_, _, err := client.waitForVHTLC(
+	_, err := client.waitForVHTLC(
 		t.Context(), pkScript, time.Time{},
 		session.ensureReceiveFundingStillPossible,
 	)
@@ -2346,7 +2486,7 @@ func TestReceiveSessionWaitClaimsVHTLC(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -2434,7 +2574,7 @@ func TestReceiveSessionVHTLCInfoWaitsForAcceptedEvent(t *testing.T) {
 	}
 	serverPubKey := serverPriv.PubKey().SerializeCompressed()
 	cfg := VHTLCConfig{
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -2507,7 +2647,7 @@ func TestReceiveSessionRejectsInvalidOnion(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -2583,7 +2723,7 @@ func TestReceiveSessionResumeFromStore(t *testing.T) {
 		},
 		payerFeeMsat: 123_000,
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -2681,7 +2821,7 @@ func TestReceiveSessionCancelDoesNotPersistFailed(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -2747,7 +2887,7 @@ func TestReceiveSessionResumesAfterAckedHTLCEvent(t *testing.T) {
 	}
 	serverPubKey := serverPriv.PubKey().SerializeCompressed()
 	cfg := &VHTLCConfig{
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -2859,7 +2999,7 @@ func TestReceiveSessionWaitForFundingSurvivesIndexerRowLag(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -2931,7 +3071,7 @@ func TestReceiveSessionRetriesAcceptedHTLCAckOnResume(t *testing.T) {
 	}
 	serverPubKey := serverPriv.PubKey().SerializeCompressed()
 	cfg := &VHTLCConfig{
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -3046,7 +3186,7 @@ func TestReceiveSessionRetriesAcceptedHTLCServerAckOnResume(t *testing.T) {
 	}
 	serverPubKey := serverPriv.PubKey().SerializeCompressed()
 	cfg := &VHTLCConfig{
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -3176,7 +3316,7 @@ func TestReceiveSessionClassifiesOutSwapServerAckStatus(t *testing.T) {
 				PubKey().
 				SerializeCompressed()
 			cfg := &VHTLCConfig{
-				RefundLocktime:        144,
+				RefundLocktime:        300,
 				UnilateralClaimDelay:  12,
 				UnilateralRefundDelay: 24,
 			}
@@ -3278,6 +3418,7 @@ func TestReceiveSessionExpiresAtRefundLocktimeWithoutFunding(t *testing.T) {
 		t.Context(), btcutil.Amount(42_000),
 	)
 	require.NoError(t, err)
+	acceptTestOutSwapHtlcEvent(t, client, session, *serverConn.cfg)
 
 	daemonConn.blockHeight = 143
 
@@ -3285,12 +3426,12 @@ func TestReceiveSessionExpiresAtRefundLocktimeWithoutFunding(t *testing.T) {
 		t.Context(), session.PaymentHash,
 	)
 	require.NoError(t, err)
-	require.Equal(t, ReceiveStateInvoiceCreated, resumed.State())
+	require.Equal(t, ReceiveStateHTLCEventAccepted, resumed.State())
 
 	_, _, err = resumed.WaitForFunding(t.Context())
 	require.ErrorIs(t, err, errSwapExpired)
 	require.ErrorContains(
-		t, err, "refund locktime 144 is imminent or reached",
+		t, err, "receive funding claim window closed",
 	)
 	require.Equal(t, ReceiveStateExpired, resumed.State())
 
@@ -3336,7 +3477,7 @@ func TestReceiveSessionExpiresUnpaidInvoiceAtDeadline(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -3424,7 +3565,7 @@ func TestReceiveSessionOverdueInvoiceAcceptsDeliveredEvent(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -3502,7 +3643,7 @@ func TestReceiveSessionFailsOnAmountMismatch(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -3577,7 +3718,7 @@ func TestReceiveSessionWaitReconcilesBeforeExpiry(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -3648,7 +3789,7 @@ func TestReceiveSessionClaimBeforeHTLCEventFailsClearly(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -3711,7 +3852,7 @@ func TestReceiveSessionClaimFailsOnAmountMismatch(t *testing.T) {
 	}
 	serverPubKey := serverPriv.PubKey().SerializeCompressed()
 	cfg := VHTLCConfig{
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -3788,7 +3929,7 @@ func TestReceiveSessionFreshClaimBoundsSpentLookup(t *testing.T) {
 		PreimageHash: lntypes.Hash(
 			sha256.Sum256(preimage[:]),
 		),
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -3828,7 +3969,7 @@ func TestReceiveSessionFreshClaimBoundsSpentLookup(t *testing.T) {
 		vhtlcPolicyTemplate: policyTemplate,
 		vhtlcPkScript:       pkScript,
 		vhtlcConfig: VHTLCConfig{
-			RefundLocktime: 144,
+			RefundLocktime: 300,
 		},
 		vhtlcOutpoint: "funding:0",
 		vhtlcAmount:   42_000,
@@ -3853,7 +3994,7 @@ func TestReceiveSessionFreshClaimBoundsSpentLookup(t *testing.T) {
 			GetVtxoOutpoint(),
 	)
 	require.Equal(
-		t, int32(144), daemonConn.lastArmRecovery.
+		t, int32(300), daemonConn.lastArmRecovery.
 			GetRefundLocktime(),
 	)
 	require.Equal(t, 1, daemonConn.cancelCalls)
@@ -3886,7 +4027,7 @@ func TestReceiveSessionClaimFollowsRefreshedLiveVHTLC(t *testing.T) {
 		PreimageHash: lntypes.Hash(
 			sha256.Sum256(preimage[:]),
 		),
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -3933,7 +4074,7 @@ func TestReceiveSessionClaimFollowsRefreshedLiveVHTLC(t *testing.T) {
 		vhtlcPolicyTemplate: policyTemplate,
 		vhtlcPkScript:       pkScript,
 		vhtlcConfig: VHTLCConfig{
-			RefundLocktime: 144,
+			RefundLocktime: 300,
 		},
 		vhtlcOutpoint: "original:0",
 		vhtlcAmount:   43_000,
@@ -3981,7 +4122,7 @@ func TestReceiveSessionFreshClaimBoundsSpentLookupGRPCDeadline(t *testing.T) {
 		PreimageHash: lntypes.Hash(
 			sha256.Sum256(preimage[:]),
 		),
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -4030,7 +4171,7 @@ func TestReceiveSessionFreshClaimBoundsSpentLookupGRPCDeadline(t *testing.T) {
 		vhtlcPolicyTemplate: policyTemplate,
 		vhtlcPkScript:       pkScript,
 		vhtlcConfig: VHTLCConfig{
-			RefundLocktime: 144,
+			RefundLocktime: 300,
 		},
 		vhtlcOutpoint: "funding:0",
 		vhtlcAmount:   42_000,
@@ -4108,7 +4249,10 @@ func TestReceiveSessionClaimRejectsAfterRefundLocktime(t *testing.T) {
 		vhtlcPolicyTemplate: policyTemplate,
 		vhtlcPkScript:       pkScript,
 		vhtlcConfig: VHTLCConfig{
-			RefundLocktime: 144,
+			RefundLocktime:                       144,
+			UnilateralClaimDelay:                 12,
+			UnilateralRefundDelay:                24,
+			UnilateralRefundWithoutReceiverDelay: 36,
 		},
 		vhtlcOutpoint: "funding:0",
 		vhtlcAmount:   42_000,
@@ -4190,7 +4334,10 @@ func TestReceiveSessionClaimRecoveryCompletionWinsAfterRefundLocktime(
 		vhtlcPolicyTemplate: policyTemplate,
 		vhtlcPkScript:       pkScript,
 		vhtlcConfig: VHTLCConfig{
-			RefundLocktime: 144,
+			RefundLocktime:                       144,
+			UnilateralClaimDelay:                 12,
+			UnilateralRefundDelay:                24,
+			UnilateralRefundWithoutReceiverDelay: 36,
 		},
 		vhtlcOutpoint:   "funding:0",
 		vhtlcAmount:     42_000,
@@ -4231,7 +4378,7 @@ func TestReceiveSessionClaimRejectsSpentVHTLCWithoutPreimage(t *testing.T) {
 		PreimageHash: lntypes.Hash(
 			sha256.Sum256(preimage[:]),
 		),
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -4263,7 +4410,7 @@ func TestReceiveSessionClaimRejectsSpentVHTLCWithoutPreimage(t *testing.T) {
 		vhtlcPolicyTemplate: policyTemplate,
 		vhtlcPkScript:       pkScript,
 		vhtlcConfig: VHTLCConfig{
-			RefundLocktime: 144,
+			RefundLocktime: 300,
 		},
 		vhtlcOutpoint: "funding:0",
 		vhtlcAmount:   42_000,
@@ -4307,7 +4454,7 @@ func TestReceiveSessionClaimIDPreventsDuplicateClaim(t *testing.T) {
 			CltvExpiryDelta: 40,
 		},
 		cfg: &VHTLCConfig{
-			RefundLocktime:                       144,
+			RefundLocktime:                       300,
 			UnilateralClaimDelay:                 12,
 			UnilateralRefundDelay:                24,
 			UnilateralRefundWithoutReceiverDelay: 36,
@@ -4377,7 +4524,7 @@ func TestReceiveSessionClaimReturnsLastSendError(t *testing.T) {
 		PreimageHash: lntypes.Hash(
 			sha256.Sum256(preimage[:]),
 		),
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,
@@ -4444,7 +4591,7 @@ func TestReceiveSessionAcksServerForCreditShapedInArkEvent(t *testing.T) {
 	client := NewSwapClient(serverConn, daemonConn, nil, nil)
 
 	cfg := VHTLCConfig{
-		RefundLocktime:                       144,
+		RefundLocktime:                       300,
 		UnilateralClaimDelay:                 12,
 		UnilateralRefundDelay:                24,
 		UnilateralRefundWithoutReceiverDelay: 36,

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -320,8 +320,9 @@ func TestStartReceiveRejectsDivergentRouteHintPaths(t *testing.T) {
 	require.Nil(t, creator.lastHintPaths)
 }
 
-// TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy verifies that same-Ark
-// receive events are validated directly without requiring a Lightning onion.
+// TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy verifies a pre-funded
+// same-Ark receive keeps its cooperative claim even when the unilateral exit
+// window is already too short for new funding admission.
 func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -337,7 +338,7 @@ func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 	preimage := lntypes.Preimage{1, 2, 3}
 	hash := preimage.Hash()
 	cfg := VHTLCConfig{
-		RefundLocktime:                       900,
+		RefundLocktime:                       180,
 		UnilateralClaimDelay:                 5,
 		UnilateralRefundDelay:                6,
 		UnilateralRefundWithoutReceiverDelay: 7,
@@ -346,7 +347,9 @@ func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 	}
 	session := &ReceiveSession{
 		client: &SwapClient{
-			daemon: &testDaemonConn{},
+			daemon: &testDaemonConn{
+				blockHeight: 100,
+			},
 		},
 		amountSat:      btcutil.Amount(42_000),
 		state:          ReceiveStateInvoiceCreated,
@@ -380,6 +383,59 @@ func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedScript, session.vhtlcPkScript)
 	require.True(t, session.swapServerPubKey.IsEqual(senderPriv.PubKey()))
+}
+
+// TestAcceptInArkHtlcEventRejectsUnsafeCreditWindow verifies the
+// swap-server-funded same-Ark rail still applies the full timing admission
+// budget before its acknowledgement can trigger funding.
+func TestAcceptInArkHtlcEventRejectsUnsafeCreditWindow(t *testing.T) {
+	t.Parallel()
+
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	receiverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage{4, 5, 6}
+	hash := preimage.Hash()
+	session := &ReceiveSession{
+		client: &SwapClient{
+			daemon: &testDaemonConn{
+				blockHeight: 205,
+			},
+			log: btclog.Disabled,
+		},
+		amountSat:         btcutil.Amount(300),
+		attachedCreditSat: 800,
+		expectedVHTLCSat:  1_100,
+		state:             ReceiveStateInvoiceCreated,
+		PaymentHash:       hash,
+		clientPubKey:      receiverPriv.PubKey(),
+		operatorPubKey:    operatorPriv.PubKey(),
+	}
+	cfg := VHTLCConfig{
+		RefundLocktime:                       300,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+		SwapServerPubkey: senderPriv.PubKey().
+			SerializeCompressed(),
+	}
+
+	err = session.acceptInArkHtlcEvent(
+		t.Context(), &InArkHtlcEvent{
+			PaymentHash:        hash,
+			AmountSat:          1_100,
+			RequestedAmountSat: 300,
+			AttachedCreditSat:  800,
+			SenderPubkey:       senderPriv.PubKey(),
+			VHTLCConfig:        cfg,
+		}, 1,
+	)
+	require.ErrorContains(t, err, "timing window is invalid")
+	require.Equal(t, ReceiveStateFailed, session.State())
 }
 
 // TestAcceptInArkHtlcEventRejectsCreditBoundSession verifies a session whose

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
-	sdkark "github.com/lightninglabs/wavelength/sdk/ark"
 	"github.com/lightninglabs/wavelength/swaprpc"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightninglabs/wavelength/waverpc"
@@ -345,8 +344,8 @@ func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 	)
 	cfg := VHTLCConfig{
 		RefundLocktime:                       180,
-		UnilateralClaimDelay:                 5,
-		UnilateralRefundDelay:                6,
+		UnilateralClaimDelay:                 6,
+		UnilateralRefundDelay:                5,
 		UnilateralRefundWithoutReceiverDelay: 7,
 		SwapServerPubkey: senderPriv.PubKey().
 			SerializeCompressed(),
@@ -1413,7 +1412,6 @@ func TestReceiveSessionRetriesAdmissionHeightLookup(t *testing.T) {
 
 	err := session.validateReceiveClaimWindow(
 		t.Context(), VHTLCConfig{},
-		DefaultRecoveryExitAncestryDelayBlocks,
 	)
 	err = session.failReceiveTimingAdmission(
 		t.Context(),
@@ -1513,10 +1511,6 @@ func TestReceiveSessionUsesFullClaimWindowOnlyAtAdmission(t *testing.T) {
 			t.Context(), &VTXOInfo{
 				Outpoint:  "funding:0",
 				AmountSat: 42_000,
-				ExpiryInfo: &sdkark.VTXOExpiryInfo{
-					RelativeExpiry:          1_008,
-					CriticalThresholdBlocks: 1_114,
-				},
 			},
 		)
 		require.NoError(t, err)
@@ -4165,10 +4159,6 @@ func TestReceiveSessionClaimFollowsRefreshedLiveVHTLC(t *testing.T) {
 		Outpoint:  "refreshed:0",
 		AmountSat: 42_000,
 		PkScript:  pkScript,
-		ExpiryInfo: &sdkark.VTXOExpiryInfo{
-			RelativeExpiry:          1_008,
-			CriticalThresholdBlocks: 1_114,
-		},
 	}
 	daemonConn := &testDaemonConn{
 		// The full unilateral window is already closed here, but the

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -1329,10 +1329,40 @@ func TestReceiveSessionRejectsUnsafeVHTLCClaimWindow(t *testing.T) {
 	require.Equal(t, ReceiveStateFailed, session.State())
 }
 
-// TestReceiveSessionRevalidatesVHTLCClaimWindow verifies a once-safe event is
-// rejected after a delayed restart or deeper funded ancestry consumes its
-// remaining recovery budget.
-func TestReceiveSessionRevalidatesVHTLCClaimWindow(t *testing.T) {
+// TestReceiveSessionRetriesAdmissionHeightLookup verifies backend availability
+// cannot be confused with a timing tuple that was evaluated and rejected.
+func TestReceiveSessionRetriesAdmissionHeightLookup(t *testing.T) {
+	t.Parallel()
+
+	heightErr := errors.New("block height unavailable")
+	session := &ReceiveSession{
+		client: NewSwapClient(
+			nil, &testDaemonConn{
+				blockHeightErr: heightErr,
+			}, nil, nil,
+		),
+		state: ReceiveStateInvoiceCreated,
+	}
+
+	err := session.validateReceiveClaimWindow(
+		t.Context(), VHTLCConfig{},
+		DefaultRecoveryExitAncestryDelayBlocks,
+	)
+	err = session.failReceiveTimingAdmission(
+		t.Context(),
+		"vHTLC timing window is invalid", err,
+	)
+
+	var retryable *retryableActionError
+	require.ErrorAs(t, err, &retryable)
+	require.ErrorIs(t, err, heightErr)
+	require.Equal(t, ReceiveStateInvoiceCreated, session.State())
+}
+
+// TestReceiveSessionUsesFullClaimWindowOnlyAtAdmission verifies an accepted
+// receive keeps pursuing its cooperative claim after the unilateral recovery
+// budget closes, until the refund path itself is imminent.
+func TestReceiveSessionUsesFullClaimWindowOnlyAtAdmission(t *testing.T) {
 	t.Parallel()
 
 	newSession := func(t *testing.T, refundLocktime uint32) (
@@ -1380,19 +1410,39 @@ func TestReceiveSessionRevalidatesVHTLCClaimWindow(t *testing.T) {
 		return session, daemon
 	}
 
-	t.Run("delayed restart", func(t *testing.T) {
+	t.Run("cooperative window stays open", func(t *testing.T) {
 		session, daemon := newSession(t, 329)
+		heightErr := errors.New("block height unavailable")
+		daemon.blockHeightErr = heightErr
+
+		require.NoError(
+			t,
+			session.ensureReceiveFundingStillPossible(
+				t.Context(),
+			),
+		)
+		err := session.ensureReceiveClaimStillPossible(t.Context())
+		var retryable *retryableActionError
+		require.ErrorAs(t, err, &retryable)
+		require.ErrorIs(t, err, heightErr)
+		require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+
+		daemon.blockHeightErr = nil
 		daemon.blockHeight = 101
 
-		err := session.ensureReceiveFundingStillPossible(t.Context())
-		require.ErrorIs(t, err, errSwapExpired)
-		require.ErrorContains(t, err, "refund window 228")
-	})
-
-	t.Run("deeper funded ancestry", func(t *testing.T) {
-		session, _ := newSession(t, 343)
-
-		err := session.validateReceiveFunding(
+		require.NoError(
+			t,
+			session.ensureReceiveFundingStillPossible(
+				t.Context(),
+			),
+		)
+		require.NoError(
+			t,
+			session.ensureReceiveClaimStillPossible(
+				t.Context(),
+			),
+		)
+		err = session.validateReceiveFunding(
 			t.Context(), &VTXOInfo{
 				Outpoint:  "funding:0",
 				AmountSat: 42_000,
@@ -1402,9 +1452,12 @@ func TestReceiveSessionRevalidatesVHTLCClaimWindow(t *testing.T) {
 				},
 			},
 		)
-		require.ErrorContains(t, err, "claim window is invalid")
-		require.ErrorContains(t, err, "refund window 243")
-		require.Equal(t, ReceiveStateFailed, session.State())
+		require.NoError(t, err)
+
+		daemon.blockHeight = 328
+		err = session.ensureReceiveClaimStillPossible(t.Context())
+		require.ErrorIs(t, err, errSwapExpired)
+		require.Equal(t, ReceiveStateExpired, session.State())
 	})
 }
 
@@ -1905,6 +1958,7 @@ type testDaemonConn struct {
 	identityKey       *btcec.PublicKey
 	operatorKey       *btcec.PublicKey
 	blockHeight       uint32
+	blockHeightErr    error
 	liveVTXOs         []VTXOInfo
 	spentVTXOs        []VTXOInfo
 	vhtlc             *VTXOInfo
@@ -1972,7 +2026,7 @@ type testDaemonConn struct {
 
 // BlockHeight returns the configured best block height.
 func (d *testDaemonConn) BlockHeight(context.Context) (uint32, error) {
-	return d.blockHeight, nil
+	return d.blockHeight, d.blockHeightErr
 }
 
 // SendOORWithPolicyOptionsDetails records the requested output policy template
@@ -3431,7 +3485,7 @@ func TestReceiveSessionExpiresAtRefundLocktimeWithoutFunding(t *testing.T) {
 	_, _, err = resumed.WaitForFunding(t.Context())
 	require.ErrorIs(t, err, errSwapExpired)
 	require.ErrorContains(
-		t, err, "receive funding claim window closed",
+		t, err, "refund locktime 144 is imminent or reached",
 	)
 	require.Equal(t, ReceiveStateExpired, resumed.State())
 
@@ -4044,9 +4098,15 @@ func TestReceiveSessionClaimFollowsRefreshedLiveVHTLC(t *testing.T) {
 		Outpoint:  "refreshed:0",
 		AmountSat: 42_000,
 		PkScript:  pkScript,
+		ExpiryInfo: &sdkark.VTXOExpiryInfo{
+			RelativeExpiry:          1_008,
+			CriticalThresholdBlocks: 1_114,
+		},
 	}
 	daemonConn := &testDaemonConn{
-		blockHeight: 100,
+		// The full unilateral window is already closed here, but the
+		// cooperative claim remains uncontested until height 300.
+		blockHeight: 205,
 		receiveInfo: &ReceiveInfo{
 			PkScript: []byte{
 				0x51,

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -337,6 +337,12 @@ func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 
 	preimage := lntypes.Preimage{1, 2, 3}
 	hash := preimage.Hash()
+	var logOutput bytes.Buffer
+	log := btclog.NewSLogger(
+		btclog.NewDefaultHandler(
+			&logOutput, btclog.WithNoTimestamp(),
+		),
+	)
 	cfg := VHTLCConfig{
 		RefundLocktime:                       180,
 		UnilateralClaimDelay:                 5,
@@ -350,6 +356,7 @@ func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 			daemon: &testDaemonConn{
 				blockHeight: 100,
 			},
+			log: log,
 		},
 		amountSat:      btcutil.Amount(42_000),
 		state:          ReceiveStateInvoiceCreated,
@@ -383,6 +390,10 @@ func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedScript, session.vhtlcPkScript)
 	require.True(t, session.swapServerPubKey.IsEqual(senderPriv.PubKey()))
+	require.Contains(
+		t, logOutput.String(),
+		"Receive vHTLC has limited recovery window",
+	)
 }
 
 // TestAcceptInArkHtlcEventRejectsUnsafeCreditWindow verifies the

--- a/sdk/swaps/recovery.go
+++ b/sdk/swaps/recovery.go
@@ -122,6 +122,12 @@ const (
 	// lets claim recovery override the wall-clock grace period before a
 	// refund locktime can make waiting unsafe.
 	DefaultRecoveryMinMarginBlocks = uint32(12)
+
+	// DefaultRecoveryExitAncestryDelayBlocks is the conservative budget for
+	// confirming the vHTLC's commitment-tree and OOR ancestry before its
+	// own unilateral claim CSV begins. Exact funded VTXO metadata can
+	// increase this budget when the ancestry is deeper.
+	DefaultRecoveryExitAncestryDelayBlocks = uint32(72)
 )
 
 // RecoveryPolicy controls automatic escalation from cooperative vHTLC retry to
@@ -144,6 +150,11 @@ type RecoveryPolicy struct {
 	// the current height plus this margin reaches the refund locktime.
 	MinRecoveryMarginBlocks uint32
 
+	// ExitAncestryDelayBlocks is the pre-funding block budget reserved for
+	// making the vHTLC output available on chain. Once the funded VTXO is
+	// visible, its exact expiry metadata may require a larger budget.
+	ExitAncestryDelayBlocks uint32
+
 	// MaxFeeRateSatPerKW caps the final recovery exit-spend fee rate. The
 	// recovery row stores this cap at arm time so restart and manual
 	// escalation cannot accidentally use a looser later default.
@@ -154,12 +165,14 @@ type RecoveryPolicy struct {
 func DefaultRecoveryPolicy() RecoveryPolicy {
 	gracePeriod := DefaultRecoveryCooperativeFailureGracePeriod
 	marginBlocks := DefaultRecoveryMinMarginBlocks
+	exitDelay := DefaultRecoveryExitAncestryDelayBlocks
 	feeCap := DefaultRecoveryMaxFeeRateSatPerKW
 
 	return RecoveryPolicy{
 		AutoEscalate:                  false,
 		CooperativeFailureGracePeriod: gracePeriod,
 		MinRecoveryMarginBlocks:       marginBlocks,
+		ExitAncestryDelayBlocks:       exitDelay,
 		MaxFeeRateSatPerKW:            feeCap,
 	}
 }
@@ -170,6 +183,10 @@ func DefaultRecoveryPolicy() RecoveryPolicy {
 func (p RecoveryPolicy) WithDefaults() RecoveryPolicy {
 	if p.MinRecoveryMarginBlocks == 0 {
 		p.MinRecoveryMarginBlocks = DefaultRecoveryMinMarginBlocks
+	}
+	if p.ExitAncestryDelayBlocks == 0 {
+		p.ExitAncestryDelayBlocks =
+			DefaultRecoveryExitAncestryDelayBlocks
 	}
 	if p.MaxFeeRateSatPerKW == 0 {
 		p.MaxFeeRateSatPerKW = DefaultRecoveryMaxFeeRateSatPerKW

--- a/sdk/swaps/recovery.go
+++ b/sdk/swaps/recovery.go
@@ -151,8 +151,8 @@ type RecoveryPolicy struct {
 	MinRecoveryMarginBlocks uint32
 
 	// ExitAncestryDelayBlocks is the pre-funding block budget reserved for
-	// making the vHTLC output available on chain. Once the funded VTXO is
-	// visible, its exact expiry metadata may require a larger budget.
+	// making the vHTLC output available on chain when the receiver first
+	// evaluates a proposed vHTLC policy.
 	ExitAncestryDelayBlocks uint32
 
 	// MaxFeeRateSatPerKW caps the final recovery exit-spend fee rate. The

--- a/waved/mailbox_ingress_compat_test.go
+++ b/waved/mailbox_ingress_compat_test.go
@@ -84,7 +84,7 @@ func newCompatTestServer(t *testing.T,
 
 	t.Helper()
 
-	_, deliveryStore, _ := newSendOORTestStores(t)
+	_, deliveryStore, _, _, _ := newSendOORTestStores(t)
 
 	s := &Server{log: btclog.Disabled}
 

--- a/waved/rpc_oor_idempotency_test.go
+++ b/waved/rpc_oor_idempotency_test.go
@@ -308,7 +308,7 @@ func TestSendOORSubmitsMultipleRecipients(t *testing.T) {
 	)
 	totalAmount := btcutil.Amount(amountA + amountB)
 
-	vtxoStore, _, _ := newSendOORTestStores(t)
+	vtxoStore, _, _, _, _ := newSendOORTestStores(t)
 	desc, _ := newSendOORTestVTXO(
 		t, operatorKey.PubKey(), 0x51, totalAmount,
 	)
@@ -438,7 +438,7 @@ func TestSendOORReservesExactManagedCustomInputs(t *testing.T) {
 		exitDelay       = uint32(10)
 	)
 
-	vtxoStore, _, _ := newSendOORTestStores(t)
+	vtxoStore, _, _, _, _ := newSendOORTestStores(t)
 	input1, _ := newSendOORTestVTXO(
 		t, operatorKey.PubKey(), 0x61, inputAmount,
 	)
@@ -754,7 +754,8 @@ func TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection(
 		idempotencyKey = "rpc-send-oor-idempotency-key"
 	)
 
-	vtxoStore, deliveryStore, registryStore := newSendOORTestStores(t)
+	vtxoStore, deliveryStore, registryStore, packageStore,
+		reservationStore := newSendOORTestStores(t)
 
 	firstDesc, clientKey := newSendOORTestVTXO(
 		t, operatorKey.PubKey(), 0x31, btcutil.Amount(inputAmount),
@@ -790,7 +791,6 @@ func TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection(
 	)
 
 	signer := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
-	packageStore, reservationStore := newSendOORChildStores(t)
 	oorRegistry, err := oor.NewOORRegistryActor(oor.OORRegistryConfig{
 		Log:              fn.Some[btclog.Logger](btclog.Disabled),
 		Signer:           signer,
@@ -1069,7 +1069,8 @@ func TestSendOORUnlocksSelectedInputsForExistingSession(t *testing.T) {
 		exitDelay = uint32(10)
 	)
 
-	vtxoStore, deliveryStore, registryStore := newSendOORTestStores(t)
+	vtxoStore, deliveryStore, registryStore, packageStore,
+		reservationStore := newSendOORTestStores(t)
 
 	desc, clientKey := newSendOORTestVTXO(
 		t, operatorKey.PubKey(), 0x30, btcutil.Amount(amountSat),
@@ -1108,7 +1109,6 @@ func TestSendOORUnlocksSelectedInputsForExistingSession(t *testing.T) {
 	)
 
 	signer := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
-	packageStore, reservationStore := newSendOORChildStores(t)
 	oorRegistry, err := oor.NewOORRegistryActor(oor.OORRegistryConfig{
 		Log:              fn.Some[btclog.Logger](btclog.Disabled),
 		Signer:           signer,
@@ -1204,7 +1204,7 @@ func TestSendOORReturnsPendingKeyedSessionBeforeAttemptCommit(t *testing.T) {
 		exitDelay = uint32(10)
 	)
 
-	vtxoStore, _, registryStore := newSendOORTestStores(t)
+	vtxoStore, _, registryStore, _, _ := newSendOORTestStores(t)
 	desc, _ := newSendOORTestVTXO(
 		t, operatorKey.PubKey(), 0x35, btcutil.Amount(amountSat),
 	)
@@ -1311,7 +1311,8 @@ func TestSendOORRejectsDifferentKeyForExistingSession(t *testing.T) {
 		exitDelay = uint32(10)
 	)
 
-	vtxoStore, deliveryStore, registryStore := newSendOORTestStores(t)
+	vtxoStore, deliveryStore, registryStore, packageStore,
+		reservationStore := newSendOORTestStores(t)
 
 	desc, clientKey := newSendOORTestVTXO(
 		t, operatorKey.PubKey(), 0x31, btcutil.Amount(amountSat),
@@ -1351,7 +1352,6 @@ func TestSendOORRejectsDifferentKeyForExistingSession(t *testing.T) {
 	)
 
 	signer := input.NewMockSigner([]*btcec.PrivateKey{clientKey}, nil)
-	packageStore, reservationStore := newSendOORChildStores(t)
 	oorRegistry, err := oor.NewOORRegistryActor(oor.OORRegistryConfig{
 		Log:              fn.Some[btclog.Logger](btclog.Disabled),
 		Signer:           signer,
@@ -1460,7 +1460,8 @@ func TestSendOORRejectsNewKeyForDispatchedFailedSession(t *testing.T) {
 		exitDelay = uint32(10)
 	)
 
-	vtxoStore, deliveryStore, registryStore := newSendOORTestStores(t)
+	vtxoStore, deliveryStore, registryStore, packageStore,
+		reservationStore := newSendOORTestStores(t)
 	desc, clientKey := newSendOORTestVTXO(
 		t, operatorKey.PubKey(), 0x32, btcutil.Amount(amountSat),
 	)
@@ -1563,7 +1564,6 @@ func TestSendOORRejectsNewKeyForDispatchedFailedSession(t *testing.T) {
 		),
 	)
 
-	packageStore, reservationStore := newSendOORChildStores(t)
 	oorRegistry, err := oor.NewOORRegistryActor(
 		oor.OORRegistryConfig{
 			Log: fn.Some[btclog.Logger](
@@ -1634,7 +1634,7 @@ func TestSendOORWaitCancelDoesNotUnlockSubmittedInputs(t *testing.T) {
 		exitDelay = uint32(10)
 	)
 
-	vtxoStore, _, _ := newSendOORTestStores(t)
+	vtxoStore, _, _, _, _ := newSendOORTestStores(t)
 
 	desc, _ := newSendOORTestVTXO(
 		t, operatorKey.PubKey(), 0x31, btcutil.Amount(amountSat),
@@ -1981,26 +1981,11 @@ func (noopOORHandler) Handle(context.Context, oor.SessionID, oor.OutboxEvent) (
 	return nil, nil
 }
 
-// newSendOORChildStores builds the package and reservation stores the registry
-// constructor now requires. The idempotency pre-flight tests do not drive these
-// paths; the stores exist only to pass construction validation.
-func newSendOORChildStores(t *testing.T) (oor.PackagePersistence,
-	oor.ReservationStore) {
-
-	t.Helper()
-
-	sqlDB := db.NewTestDB(t)
-	dbStore := db.NewStore(
-		sqlDB.DB, sqlDB.Queries, sqlDB.Backend(), btclog.Disabled,
-	)
-	clk := clock.NewDefaultClock()
-
-	return dbStore.NewOORArtifactStore(clk),
-		dbStore.NewSpendingReservationStore(clk)
-}
-
+// newSendOORTestStores builds every SQL-backed OOR test store from one
+// database so each parallel test consumes only one bounded fixture slot.
 func newSendOORTestStores(t *testing.T) (*db.VTXOPersistenceStore,
-	actor.DeliveryStore, *db.OORSessionRegistryStoreDB) {
+	actor.DeliveryStore, *db.OORSessionRegistryStoreDB,
+	oor.PackagePersistence, oor.ReservationStore) {
 
 	t.Helper()
 
@@ -2026,11 +2011,12 @@ func newSendOORTestStores(t *testing.T) (*db.VTXOPersistenceStore,
 	dbStore := db.NewStore(
 		sqlDB.DB, sqlDB.Queries, sqlDB.Backend(), btclog.Disabled,
 	)
-	registryStore := dbStore.NewOORSessionRegistryStore(
-		clock.NewDefaultClock(),
-	)
+	clk := clock.NewDefaultClock()
+	registryStore := dbStore.NewOORSessionRegistryStore(clk)
 
-	return vtxoStore, deliveryStore, registryStore
+	return vtxoStore, deliveryStore, registryStore,
+		dbStore.NewOORArtifactStore(clk),
+		dbStore.NewSpendingReservationStore(clk)
 }
 
 func newSendOORTestVTXO(t *testing.T, operatorKey *btcec.PublicKey,

--- a/waved/rpc_vtxo_forfeit_test.go
+++ b/waved/rpc_vtxo_forfeit_test.go
@@ -129,7 +129,7 @@ func newSignVTXOForfeitFixtureWithLocalVTXO(t *testing.T,
 		},
 	}
 
-	vtxoStore, _, _ := newSendOORTestStores(t)
+	vtxoStore, _, _, _, _ := newSendOORTestStores(t)
 
 	server := &Server{
 		cfg: &Config{


### PR DESCRIPTION
Improves vHTLC timing validation and keeps receive-side lifecycle decisions consistent as chain state changes.

Includes shared timing helpers and focused boundary coverage.