### PR TITLE
docs: nightly doc-gardening sweep 2026-08-26

### DIFF
--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -125,6 +125,20 @@ crash-safe at-least-once delivery with exactly-once deduplication.
   is bounded to the correlation key, not the mailbox; consumers are
   already strictly serial per mailbox so this does not regress
   throughput.
+- **`MaxAttempts` is a hard ceiling that outranks `TellRetryPolicy`.**
+  `handleResultInTx` consults the policy on a failed delivery but only
+  retries when `Delivery.ShouldDeadLetter()` is still false, so a policy
+  that keeps returning `retry=true` can stop retries early yet never
+  extend the durable budget; past the ceiling the message dead-letters
+  with a `max attempts reached:` reason instead. The clamp is required
+  because both claim queries gate on `attempts < max_attempts`
+  (`LeaseNextMailboxMessage` and the leaseless `PeekNextMessage` in
+  `db/actordelivery/queries/mailbox.sql`). Nacking a row that has already
+  exhausted its budget would release it into a state no query can ever
+  select again — a silently stranded message rather than an observable
+  dead letter. `ShouldDeadLetter` compares `EffectiveAttempts()`, which
+  adds the uncounted in-flight attempt on the leaseless path, so the
+  leased and leaseless paths share one boundary.
 
 ## Deep Docs
 

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -125,6 +125,20 @@ crash-safe at-least-once delivery with exactly-once deduplication.
   is bounded to the correlation key, not the mailbox; consumers are
   already strictly serial per mailbox so this does not regress
   throughput.
+- **`MaxAttempts` is a hard ceiling that outranks `TellRetryPolicy`.**
+  `handleResultInTx` consults the policy on a failed delivery but only
+  retries when `Delivery.ShouldDeadLetter()` is still false, so a policy
+  that keeps returning `retry=true` can stop retries early yet never
+  extend the durable budget; past the ceiling the message dead-letters
+  with a `max attempts reached:` reason instead. The clamp is required
+  because both claim queries gate on `attempts < max_attempts`
+  (`LeaseNextMailboxMessage` and the leaseless `PeekNextMessage` in
+  `db/actordelivery/queries/mailbox.sql`). Nacking a row that has already
+  exhausted its budget would release it into a state no query can ever
+  select again — a silently stranded message rather than an observable
+  dead letter. `ShouldDeadLetter` compares `EffectiveAttempts()`, which
+  adds the uncounted in-flight attempt on the leaseless path, so the
+  leased and leaseless paths share one boundary.
 
 ## Deep Docs
 

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -64,6 +64,17 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   `CountLedgerEntries`/`ListAccounts`.
 - `UTXOAuditStoreDB` — implements `ledger.UTXOAuditStore` via
   `sqlc.InsertWalletUTXOLog` (ON CONFLICT DO NOTHING).
+- `ActivityStore` / `BatchedActivityStore` / `ActivityPersistenceStore` —
+  query interface, batched-tx variant, and concrete store for the canonical
+  activity log laid down by `000010_activity_log`: the `activity_entries`
+  current-state projection plus the append-only `activity_events` transition
+  log. Read/write API: `ProjectEntry` (upsert + transition, atomically),
+  `GetEntry`, `RemoveEntry`, `CountByStatus`, `ListEntries`,
+  `ListEntriesByKindStatus`, `PullEvents` (cursor replay).
+- `ActivityProjection` — the projector's input: a normalized snapshot of one
+  activity row at a single lifecycle transition, so callers never touch sqlc
+  params. Empty BLOB handles MUST be nil, never a zero-length slice (the
+  Postgres BYTEA `x''` pitfall).
 - `UnilateralExitStore` / `UnilateralExitPersistenceStore` —
   control-plane store: `Upsert` / `Get` / `ListNonTerminal` /
   `MarkTerminal`.
@@ -177,6 +188,15 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   replacement. After takeover, the incoming lifecycle's current status and
   snapshot are the state that boot restore must resume; the separate dispatch
   row still answers keyed replay.
+- **`ProjectEntry` is change-suppressed, so the event log stays a true
+  transition log.** It loads the existing `activity_entries` row first and
+  returns event_seq 0 without appending when `ActivityProjection.changesRow`
+  reports no observable difference. Redundant re-emits are routine — the
+  startup activity backfill runs on every wallet-ready start and the swap
+  monitor replays with include-existing — so without the guard a resumable
+  `PullEvents` subscriber would later replay bogus transitions for states
+  that never actually changed. A projection carrying `PendingStatus` is also
+  suppressed when it would move an already-advanced row back to pending.
 - `unilateral_exit_jobs.exit_policy_kind` and `exit_policy_ref`
   persist the durable final spend policy identity. Standard timeout
   jobs use `standard_vtxo_timeout` with an empty ref; policy-specific

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -64,6 +64,17 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   `CountLedgerEntries`/`ListAccounts`.
 - `UTXOAuditStoreDB` — implements `ledger.UTXOAuditStore` via
   `sqlc.InsertWalletUTXOLog` (ON CONFLICT DO NOTHING).
+- `ActivityStore` / `BatchedActivityStore` / `ActivityPersistenceStore` —
+  query interface, batched-tx variant, and concrete store for the canonical
+  activity log laid down by `000010_activity_log`: the `activity_entries`
+  current-state projection plus the append-only `activity_events` transition
+  log. Read/write API: `ProjectEntry` (upsert + transition, atomically),
+  `GetEntry`, `RemoveEntry`, `CountByStatus`, `ListEntries`,
+  `ListEntriesByKindStatus`, `PullEvents` (cursor replay).
+- `ActivityProjection` — the projector's input: a normalized snapshot of one
+  activity row at a single lifecycle transition, so callers never touch sqlc
+  params. Empty BLOB handles MUST be nil, never a zero-length slice (the
+  Postgres BYTEA `x''` pitfall).
 - `UnilateralExitStore` / `UnilateralExitPersistenceStore` —
   control-plane store: `Upsert` / `Get` / `ListNonTerminal` /
   `MarkTerminal`.
@@ -177,6 +188,15 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   replacement. After takeover, the incoming lifecycle's current status and
   snapshot are the state that boot restore must resume; the separate dispatch
   row still answers keyed replay.
+- **`ProjectEntry` is change-suppressed, so the event log stays a true
+  transition log.** It loads the existing `activity_entries` row first and
+  returns event_seq 0 without appending when `ActivityProjection.changesRow`
+  reports no observable difference. Redundant re-emits are routine — the
+  startup activity backfill runs on every wallet-ready start and the swap
+  monitor replays with include-existing — so without the guard a resumable
+  `PullEvents` subscriber would later replay bogus transitions for states
+  that never actually changed. A projection carrying `PendingStatus` is also
+  suppressed when it would move an already-advanced row back to pending.
 - `unilateral_exit_jobs.exit_policy_kind` and `exit_policy_ref`
   persist the durable final spend policy identity. Standard timeout
   jobs use `standard_vtxo_timeout` with an empty ref; policy-specific

--- a/docs/durable_actor_architecture.md
+++ b/docs/durable_actor_architecture.md
@@ -227,9 +227,9 @@ sequenceDiagram
                 C->>DB: MarkProcessed(id)
                 C->>DB: Ack(id, token)
             else Failure (Tell)
-                alt Retry Policy Says Retry
+                alt Retry Policy Says Retry AND attempts < max_attempts
                     C->>DB: Nack(id, token, delay)
-                else Max Attempts Exceeded
+                else Policy Gives Up OR Max Attempts Exceeded
                     C->>DL: MoveToDeadLetter(id, reason)
                     C->>DB: DeleteMessage(id)
                 end
@@ -268,7 +268,13 @@ debug delivery issues and design retry strategies.
 
 7. **Dead Letter**: After `max_attempts` failures, the message is moved to
    `dead_letters` with the failure reason. Dead letters require manual inspection
-   and can be replayed or deleted.
+   and can be replayed or deleted. `max_attempts` is a hard ceiling rather than
+   a hint the retry policy can negotiate: the consumer only Nacks when the
+   policy asks to retry *and* `Delivery.ShouldDeadLetter()` is still false, and
+   a message that trips the ceiling dead-letters with a `max attempts reached:`
+   reason. This ordering matters because both claim queries gate on
+   `attempts < max_attempts`, so releasing an exhausted message back to the
+   mailbox would strand it where nothing can ever claim it again.
 
 ---
 

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -150,6 +150,15 @@ result into an `IncomingVHTLCNotification`.
   `ExistingOnly`: an existing keyed winner is recovered and protected, a
   daemon `NotFound` expires the swap, and unavailable or pending results remain
   retryable. A post-deadline reconciliation must never admit a new vHTLC.
+- **Resuming a terminal session is a pure reload, never a replay of work.**
+  `runUntil` checks `PayState.IsTerminal()` / `ReceiveState.IsTerminal()`
+  *before* advancing the FSM, returning `nil` for `PayStateCompleted` and
+  `terminalErr()` otherwise, so a restart against an already-terminal row
+  issues no funding submit and no recovery arm or cancel. `eventForProgress`
+  independently maps a terminal state to `loopfsm.NoOp`. Reloading a
+  completed swap must yield a byte-identical result (same preimage, funding
+  session ID, and vHTLC outpoint), and reloading a failed one must preserve
+  the original authoritative failure rather than re-deriving it.
 - The store is optional — both `NewSwapClient` and
   `NewSwapClientWithStore` are valid; `persist()` is a no-op when
   `store == nil`.

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -150,6 +150,15 @@ result into an `IncomingVHTLCNotification`.
   `ExistingOnly`: an existing keyed winner is recovered and protected, a
   daemon `NotFound` expires the swap, and unavailable or pending results remain
   retryable. A post-deadline reconciliation must never admit a new vHTLC.
+- **Resuming a terminal session is a pure reload, never a replay of work.**
+  `runUntil` checks `PayState.IsTerminal()` / `ReceiveState.IsTerminal()`
+  *before* advancing the FSM, returning `nil` for `PayStateCompleted` and
+  `terminalErr()` otherwise, so a restart against an already-terminal row
+  issues no funding submit and no recovery arm or cancel. `eventForProgress`
+  independently maps a terminal state to `loopfsm.NoOp`. Reloading a
+  completed swap must yield a byte-identical result (same preimage, funding
+  session ID, and vHTLC outpoint), and reloading a failed one must preserve
+  the original authoritative failure rather than re-deriving it.
 - The store is optional — both `NewSwapClient` and
   `NewSwapClientWithStore` are valid; `persist()` is a no-op when
   `store == nil`.

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -170,6 +170,17 @@ default builds avoid the swap executor's dependency graph.
   to the next round without a separate CLI step. If the implicit join fails,
   the error carries the explicit recovery hint (`ark rounds join`) so the
   leave intent — already queued in the round actor — is not stranded silently.
+- **`backfillActivity` runs on every wallet-ready start and must stay
+  event-neutral for rows that did not move.** It reprojects the
+  derive-on-read collectors into the canonical store so current state is
+  present before any new transition lands, which means a restart replays
+  every already-terminal swap through `ProjectEntry`. Emitting one activity
+  event per terminal swap per boot is the failure this guards against: a
+  settled pay recovered across restart must land exactly one COMPLETE
+  transition, with `amount_sat` the negative VTXO debit and the operator
+  cost separated into `fee_sat`. The suppression lives in `db`'s
+  `ActivityProjection.changesRow`, not here, so a new projector field must
+  be added there too or it will silently stop triggering transitions.
 - `ListView` defaults to Activity. Only Activity honors
   `pending_only` and `kinds`; those filters are ignored for VTXOs
   and Onchain.

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -170,6 +170,17 @@ default builds avoid the swap executor's dependency graph.
   to the next round without a separate CLI step. If the implicit join fails,
   the error carries the explicit recovery hint (`ark rounds join`) so the
   leave intent — already queued in the round actor — is not stranded silently.
+- **`backfillActivity` runs on every wallet-ready start and must stay
+  event-neutral for rows that did not move.** It reprojects the
+  derive-on-read collectors into the canonical store so current state is
+  present before any new transition lands, which means a restart replays
+  every already-terminal swap through `ProjectEntry`. Emitting one activity
+  event per terminal swap per boot is the failure this guards against: a
+  settled pay recovered across restart must land exactly one COMPLETE
+  transition, with `amount_sat` the negative VTXO debit and the operator
+  cost separated into `fee_sat`. The suppression lives in `db`'s
+  `ActivityProjection.changesRow`, not here, so a new projector field must
+  be added there too or it will silently stop triggering transitions.
 - `ListView` defaults to Activity. Only Activity honors
   `pending_only` and `kinds`; those filters are ignored for VTXOs
   and Onchain.


### PR DESCRIPTION
Automated nightly doc-gardening sweep of the per-package documentation graph (`CLAUDE.md`/`AGENTS.md`), `docs/`, and `ARCHITECTURE.md`.

Workflow run: https://github.com/lightninglabs/wavelength/actions

Baseline for this sweep was `5f3c3ec` (merge of the 2026-08-21 sweep). No code has landed since the 2026-08-24 sweep, so this pass re-audited that window and closed three gaps it left behind:

- **`baselib/actor`** — `MaxAttempts` is a hard ceiling that outranks `TellRetryPolicy`. Both claim queries in `db/actordelivery/queries/mailbox.sql` gate on remaining attempts, so nacking an exhausted row strands it where nothing can claim it again. Also corrected the `docs/durable_actor_architecture.md` sequence diagram, which read as if the retry policy alone decided the dead-letter branch.
- **`sdk/swaps`** — resuming a terminal session is a pure reload: `runUntil` short-circuits on `IsTerminal()` before advancing the FSM, so no funding submit and no recovery arm/cancel can replay. This was the only changed package in-window whose docs were untouched.
- **`db`** — `ActivityPersistenceStore` / `ActivityStore` / `ActivityProjection` were missing from Key Types entirely, despite the `000010_activity_log` migration already being documented. Added them plus the `ProjectEntry` change-suppression invariant, and the matching consumer-side note in `swapwallet` (`backfillActivity` runs on every wallet-ready start and must stay event-neutral).

`make doc-check` passes. Please review the updated `CLAUDE.md`/`AGENTS.md` and `ARCHITECTURE.md` diffs — every claim above was verified against source, but the invariant wording is worth a maintainer eye.

Note: the commit body carries the run-link template unexpanded (`${SERVER_URL}/...`); this sandbox blocked environment access, and `git commit --amend` was blocked by policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)