### PR TITLE
logging: stop retrying dead subscribers

### DIFF
--- a/chainsource/block_epoch_actor.go
+++ b/chainsource/block_epoch_actor.go
@@ -2,6 +2,7 @@ package chainsource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -353,11 +354,30 @@ func (a *BlockEpochActor) monitorBlocks() {
 					),
 				)
 
+				notifyActorStopped := false
 				notifyRef := func(
 					ref actor.TellOnlyRef[BlockEpoch]) {
 
 					err := ref.Tell(a.ctx, blockEpoch)
-					if err != nil {
+					switch {
+					case errors.Is(
+						err, actor.ErrActorTerminated,
+					), errors.Is(
+						err, actor.ErrMailboxClosed,
+					):
+
+						notifyActorStopped = true
+						log.DebugS(
+							a.ctx,
+							"Block epoch notify actor "+
+								"stopped; ending subscription",
+							slog.String(
+								"notify_actor",
+								ref.ID(),
+							),
+						)
+
+					case err != nil:
 						log.WarnS(
 							a.ctx,
 							"Failed to deliver "+
@@ -367,6 +387,15 @@ func (a *BlockEpochActor) monitorBlocks() {
 					}
 				}
 				a.notifyActor.WhenSome(notifyRef)
+				if notifyActorStopped {
+					// The notify target is the owner of
+					// this actor-mode subscription. End the
+					// component-owned context when that
+					// target can no longer receive events.
+					a.cancel()
+
+					return
+				}
 			}
 
 		case <-a.ctx.Done():

--- a/chainsource/chainsource_test.go
+++ b/chainsource/chainsource_test.go
@@ -52,6 +52,28 @@ type reconnectBlockBackend struct {
 	registrations chan *blockEpochRegistration
 }
 
+// stoppedBlockNotifyRef models an actor that has already terminated.
+type stoppedBlockNotifyRef struct {
+	attempts atomic.Int32
+}
+
+// ID returns the stopped actor's stable subscriber ID.
+func (s *stoppedBlockNotifyRef) ID() string {
+	return "stopped-block-notify"
+}
+
+// Tell records an attempt and reports that the actor has terminated.
+func (s *stoppedBlockNotifyRef) Tell(context.Context, BlockEpoch) error {
+	s.attempts.Add(1)
+
+	return actor.ErrActorTerminated
+}
+
+// TryTell reports the same permanent failure without blocking.
+func (s *stoppedBlockNotifyRef) TryTell(context.Context, BlockEpoch) error {
+	return actor.ErrActorTerminated
+}
+
 // newMockBackend creates a new mock backend for testing.
 func newMockBackend() *mockBackend {
 	return &mockBackend{
@@ -1386,6 +1408,41 @@ func TestBlockEpochActorNotifyMode(t *testing.T) {
 	require.True(t, ok, "timeout waiting for notification")
 	require.Equal(t, int32(150), event.Height)
 	require.Equal(t, hash, event.Hash)
+}
+
+// TestBlockEpochActorStopsForTerminatedNotifyActor verifies that a dead
+// subscriber ends its backend subscription. Retrying the same Tell on every
+// block cannot recover and leaks both the registration and warning logs.
+func TestBlockEpochActorStopsForTerminatedNotifyActor(t *testing.T) {
+	t.Parallel()
+
+	backend := newMockBackend()
+	epochActor := NewBlockEpochActor(BlockEpochConfig{Backend: backend})
+	defer epochActor.Stop()
+
+	notifier := &stoppedBlockNotifyRef{}
+	result := epochActor.Receive(t.Context(), &SubscribeBlocksRequest{
+		CallerID: "test-stopped-epoch-notify",
+		NotifyActor: fn.Some(
+			actor.TellOnlyRef[BlockEpoch](notifier),
+		),
+	})
+	require.True(t, result.IsOk())
+
+	backend.epochChan <- &BlockEpoch{Height: 150}
+
+	select {
+	case <-backend.epochCancel:
+	case <-time.After(time.Second):
+		t.Fatal("backend registration was not canceled")
+	}
+	require.ErrorIs(t, epochActor.ctx.Err(), context.Canceled)
+
+	require.Equal(t, int32(1), notifier.attempts.Load())
+	backend.epochChan <- &BlockEpoch{Height: 151}
+	require.Never(t, func() bool {
+		return notifier.attempts.Load() > 1
+	}, 50*time.Millisecond, 5*time.Millisecond)
 }
 
 // TestBlockEpochActorReconnectsAfterBackendStreamCloses reproduces the

--- a/round/actor.go
+++ b/round/actor.go
@@ -2941,12 +2941,21 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 			m.RoundID.WhenSome(func(id RoundID) {
 				roundIDStr = id.String()
 			})
-			a.log.WarnS(ctx, "Round failed",
-				m.OriginalError,
-				slog.String("round_id", roundIDStr),
-				slog.String("reason", m.Reason),
-				slog.Bool("recoverable", m.Recoverable),
-			)
+			if m.Recoverable {
+				a.log.InfoS(ctx, "Round failed",
+					slog.Any("err", m.OriginalError),
+					slog.String("round_id", roundIDStr),
+					slog.String("reason", m.Reason),
+					slog.Bool("recoverable", true),
+				)
+			} else {
+				a.log.WarnS(ctx, "Round failed",
+					m.OriginalError,
+					slog.String("round_id", roundIDStr),
+					slog.String("reason", m.Reason),
+					slog.Bool("recoverable", false),
+				)
+			}
 
 			// Count the failed round for observability. The
 			// counter pairs with the confirmed branch above so an

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -328,6 +328,27 @@ type terminalNotifyResultMsg struct {
 	err          error
 }
 
+// terminalNotifyOutcome describes the synchronous result of one terminal-shape
+// notification attempt. A stopped target is distinct from a delivered message:
+// both end retries, but a stopped subscriber must not remain attached for the
+// reorg-aware tail of a confirmed transaction.
+type terminalNotifyOutcome uint8
+
+const (
+	// terminalNotifyPending means delivery failed transiently or continues
+	// on the bounded async completion path, so the subscriber must remain
+	// for a later retry.
+	terminalNotifyPending terminalNotifyOutcome = iota
+
+	// terminalNotifyDelivered means the subscriber accepted the
+	// notification.
+	terminalNotifyDelivered
+
+	// terminalNotifySubscriberStopped means the subscriber actor terminated
+	// or closed its mailbox and can never accept another notification.
+	terminalNotifySubscriberStopped
+)
+
 // MessageType returns the stable message type identifier.
 func (m *terminalNotifyResultMsg) MessageType() string {
 	return "terminalNotifyResultMsg"
@@ -367,12 +388,13 @@ func NewTxBroadcasterActor(cfg Config) *TxBroadcasterActor {
 	// The fanout FSM shares the broadcaster's per-parent reservation map,
 	// so it is constructed from the broadcaster rather than alongside it.
 	broadcaster := NewCPFPBroadcaster(BroadcasterConfig{
-		ChainSource:                    cfg.ChainSource,
-		Wallet:                         cfg.Wallet,
-		Log:                            cfg.Log,
-		MaxFeeRateSatPerVByte:          cfg.MaxFeeRateSatPerVByte,
-		IncrementalRelayFeeSatPerVByte: cfg.IncrementalRelayFeeSatPerVByte,
-		PreSubmitTestMempoolAccept:     cfg.PreSubmitTestMempoolAccept,
+		ChainSource:           cfg.ChainSource,
+		Wallet:                cfg.Wallet,
+		Log:                   cfg.Log,
+		MaxFeeRateSatPerVByte: cfg.MaxFeeRateSatPerVByte,
+		IncrementalRelayFeeSatPerVByte: cfg.
+			IncrementalRelayFeeSatPerVByte,
+		PreSubmitTestMempoolAccept: cfg.PreSubmitTestMempoolAccept,
 	})
 
 	log := cfg.Log.UnwrapOr(btclog.Disabled)
@@ -1326,12 +1348,21 @@ func (a *TxBroadcasterActor) handleBlockObserved(ctx context.Context,
 				// so it is logged at debug to avoid emitting a
 				// warning every interval for the tx's whole
 				// lifetime (wavelength#403).
-				if errors.Is(err, ErrFeeRateCapReached) {
+				switch {
+				case errors.Is(err, ErrFeeRateCapReached):
 					a.log.DebugS(ctx, "Fee bump held at the "+
 						"max fee rate cap; leaving tx at "+
 						"its last in-cap fee",
 						"txid", entry.data.Txid)
-				} else {
+
+				case errors.Is(err, ErrParentAlreadyBroadcast):
+					a.log.DebugS(ctx, "Fee bump child rejected "+
+						"after parent reached the network; "+
+						"will retry",
+						"txid", entry.data.Txid,
+						slog.Any("err", err))
+
+				default:
 					a.log.WarnS(ctx, "Fee bump failed, "+
 						"will retry", err,
 						"txid", entry.data.Txid)
@@ -1384,18 +1415,26 @@ func (a *TxBroadcasterActor) attachExistingSubscriber(
 		}
 
 		// Reliable replay of the at-least-once TxConfirmed contract.
-		// The subscriber is retained in the map regardless of
-		// delivery outcome so it also receives any later TxReorged
-		// or TxFinalized on this entry, and on timeout the per-tick
-		// retryLifecycleNotifications re-attempts delivery via
-		// the still-true pendingConfirmed flag until it lands.
-		if a.notifyOneConfirmed(
+		// A live subscriber is retained so it receives any later
+		// TxReorged or TxFinalized, and on timeout the per-tick
+		// retryLifecycleNotifications re-attempts delivery via the
+		// still-true pendingConfirmed flag until it lands. A stopped
+		// subscriber is not attached because it cannot recover.
+		outcome := a.notifyOneConfirmed(
 			ctx, subscriber.Ref, entry.data.Txid, txConfirmed,
-		) {
-
+		)
+		switch outcome {
+		case terminalNotifyDelivered:
 			subscriber.pendingConfirmed = false
+			entry.subscribers[subID] = subscriber
+
+		case terminalNotifyPending:
+			entry.subscribers[subID] = subscriber
+
+		case terminalNotifySubscriberStopped:
+			// The new subscriber was never inserted, so there is no
+			// tracked interest to remove.
 		}
-		entry.subscribers[subID] = subscriber
 
 	case *trackedTxStateFinalized:
 		// Finalized is terminal. Deliver TxFinalized reliably and
@@ -1406,19 +1445,19 @@ func (a *TxBroadcasterActor) attachExistingSubscriber(
 		// it (sweep-finality gates etc.) can recover without an
 		// out-of-band lookup.
 		subscriber.pendingConfirmed = false
-		if !a.notifyOneFinalized(
+		if a.notifyOneFinalized(
 			ctx, subscriber.Ref, entry.data.Txid,
 			state.ConfirmHeight, entry.data.TargetConfs,
-		) {
+		) == terminalNotifyPending {
 
 			entry.subscribers[subID] = subscriber
 		}
 
 	case *trackedTxStateFailed:
 		reason, _ := trackedTxFailureReason(state)
-		if !a.notifyOneFailed(
+		if a.notifyOneFailed(
 			ctx, subscriber.Ref, entry.data.Txid, reason,
-		) {
+		) == terminalNotifyPending {
 
 			entry.subscribers[subID] = subscriber
 		}
@@ -1974,13 +2013,38 @@ func (a *TxBroadcasterActor) retryConfirmedRedelivery(ctx context.Context,
 			BlockHash:   confirmBlockHash,
 			NumConfs:    entry.data.TargetConfs,
 		}
-		if a.notifyOneConfirmed(
+		outcome := a.notifyOneConfirmed(
 			ctx, subscriber.Ref, entry.data.Txid, txConfirmed,
-		) {
-
+		)
+		switch outcome {
+		case terminalNotifyDelivered:
 			subscriber.pendingConfirmed = false
 			entry.subscribers[id] = subscriber
+
+		case terminalNotifySubscriberStopped:
+			a.removeStoppedConfirmedSubscriber(ctx, entry, id)
+
+		case terminalNotifyPending:
+			// Keep pendingConfirmed set for the next actor tick.
 		}
+	}
+}
+
+// removeStoppedConfirmedSubscriber removes a dead subscriber from a confirmed
+// entry. handleCancel also releases confirmation and fee-bump resources when
+// this was the final subscriber.
+func (a *TxBroadcasterActor) removeStoppedConfirmedSubscriber(
+	ctx context.Context, entry *trackedTx, subscriberID string) {
+
+	_, err := a.handleCancel(ctx, &CancelInterestReq{
+		Txid:         entry.data.Txid,
+		SubscriberID: subscriberID,
+	})
+	if err != nil {
+		a.log.WarnS(ctx, "Failed to remove stopped confirmed tx "+
+			"subscriber",
+			err, "txid", entry.data.Txid,
+			"subscriber_id", subscriberID)
 	}
 }
 
@@ -2008,6 +2072,29 @@ func (a *TxBroadcasterActor) handleTerminalNotifyResult(ctx context.Context,
 	delete(a.terminalNotifyInflight, msg.inflightKey)
 
 	if msg.err != nil {
+		if errors.Is(msg.err, actor.ErrActorTerminated) ||
+			errors.Is(msg.err, actor.ErrMailboxClosed) {
+
+			a.log.DebugS(ctx, "Terminal tx subscriber stopped "+
+				"after deferred delivery; dropping subscription",
+				"txid", msg.txid,
+				"subscriber_id", msg.subscriberID,
+				"notification_kind", msg.kind,
+				slog.Any("err", msg.err))
+
+			_, err := a.handleCancel(ctx, &CancelInterestReq{
+				Txid:         msg.txid,
+				SubscriberID: msg.subscriberID,
+			})
+			if err != nil {
+				a.log.WarnS(ctx, "Failed to remove stopped terminal "+
+					"tx subscriber", err, "txid", msg.txid,
+					"subscriber_id", msg.subscriberID)
+			}
+
+			return
+		}
+
 		a.log.WarnS(ctx, "Terminal notification failed after "+
 			"actor-path timeout", msg.err, "txid", msg.txid,
 			"subscriber_id", msg.subscriberID,
@@ -2089,9 +2176,9 @@ func (a *TxBroadcasterActor) handleTerminalNotifyResult(ctx context.Context,
 // the authoritative height / numConfs so a missed re-confirmation is
 // not load-bearing.
 //
-// Subscribers are never deleted from the map by this function — that
-// happens only on TxFinalized / TxFailed acknowledgment, which is
-// when the reorg-aware lifecycle reaches a truly terminal state.
+// Live subscribers are deleted only on TxFinalized / TxFailed acknowledgment.
+// A stopped subscriber is removed immediately because it cannot receive the
+// rest of the reorg-aware lifecycle.
 func (a *TxBroadcasterActor) notifyConfirmed(ctx context.Context,
 	entry *trackedTx, blockHeight int32, blockHash chainhash.Hash,
 	numConfs uint32) {
@@ -2113,12 +2200,19 @@ func (a *TxBroadcasterActor) notifyConfirmed(ctx context.Context,
 			continue
 		}
 
-		if a.notifyOneConfirmed(
+		outcome := a.notifyOneConfirmed(
 			ctx, subscriber.Ref, entry.data.Txid, txConfirmed,
-		) {
-
+		)
+		switch outcome {
+		case terminalNotifyDelivered:
 			subscriber.pendingConfirmed = false
 			entry.subscribers[id] = subscriber
+
+		case terminalNotifySubscriberStopped:
+			a.removeStoppedConfirmedSubscriber(ctx, entry, id)
+
+		case terminalNotifyPending:
+			// Keep pendingConfirmed set for the next actor tick.
 		}
 	}
 }
@@ -2130,7 +2224,7 @@ func (a *TxBroadcasterActor) notifyConfirmed(ctx context.Context,
 // TxConfirmed delivery.
 func (a *TxBroadcasterActor) notifyOneConfirmed(ctx context.Context,
 	subscriber actor.TellOnlyRef[Notification], txid chainhash.Hash,
-	notification *TxConfirmed) bool {
+	notification *TxConfirmed) terminalNotifyOutcome {
 
 	return a.notifyOneTerminal(
 		ctx, subscriber, txid, "confirmed",
@@ -2248,7 +2342,7 @@ func (a *TxBroadcasterActor) notifyFinalized(ctx context.Context,
 
 	for id, subscriber := range entry.subscribers {
 		if subscriber.pendingConfirmed {
-			if a.notifyOneConfirmed(
+			outcome := a.notifyOneConfirmed(
 				ctx, subscriber.Ref, entry.data.Txid,
 				&TxConfirmed{
 					Txid:        entry.data.Txid,
@@ -2256,11 +2350,17 @@ func (a *TxBroadcasterActor) notifyFinalized(ctx context.Context,
 					BlockHash:   confirmBlockHash,
 					NumConfs:    entry.data.TargetConfs,
 				},
-			) {
-
+			)
+			switch outcome {
+			case terminalNotifyDelivered:
 				subscriber.pendingConfirmed = false
 				entry.subscribers[id] = subscriber
-			} else {
+
+			case terminalNotifySubscriberStopped:
+				delete(entry.subscribers, id)
+				continue
+
+			case terminalNotifyPending:
 				// Hold until the next tick — we must not
 				// deliver TxFinalized before the documented
 				// initial TxConfirmed has landed.
@@ -2268,11 +2368,11 @@ func (a *TxBroadcasterActor) notifyFinalized(ctx context.Context,
 			}
 		}
 
-		ok := a.notifyOneFinalized(
+		outcome := a.notifyOneFinalized(
 			ctx, subscriber.Ref, entry.data.Txid, confirmHeight,
 			entry.data.TargetConfs,
 		)
-		if !ok {
+		if outcome == terminalNotifyPending {
 			continue
 		}
 
@@ -2295,10 +2395,10 @@ func (a *TxBroadcasterActor) notifyFailed(ctx context.Context, entry *trackedTx,
 	entry.sealed.Store(true)
 
 	for id, subscriber := range entry.subscribers {
-		ok := a.notifyOneFailed(
+		outcome := a.notifyOneFailed(
 			ctx, subscriber.Ref, entry.data.Txid, reason,
 		)
-		if !ok {
+		if outcome == terminalNotifyPending {
 			continue
 		}
 
@@ -2316,7 +2416,7 @@ func (a *TxBroadcasterActor) notifyFailed(ctx context.Context, entry *trackedTx,
 // the authoritative confirmation height.
 func (a *TxBroadcasterActor) notifyOneFinalized(ctx context.Context,
 	subscriber actor.TellOnlyRef[Notification], txid chainhash.Hash,
-	blockHeight int32, numConfs uint32) bool {
+	blockHeight int32, numConfs uint32) terminalNotifyOutcome {
 
 	return a.notifyOneTerminal(
 		ctx, subscriber, txid, "finalized",
@@ -2333,7 +2433,7 @@ func (a *TxBroadcasterActor) notifyOneFinalized(ctx context.Context,
 // notifyOneFailed delivers one terminal failure notification.
 func (a *TxBroadcasterActor) notifyOneFailed(ctx context.Context,
 	subscriber actor.TellOnlyRef[Notification], txid chainhash.Hash,
-	reason string) bool {
+	reason string) terminalNotifyOutcome {
 
 	return a.notifyOneTerminal(
 		ctx, subscriber, txid, "failed",
@@ -2350,12 +2450,13 @@ func (a *TxBroadcasterActor) notifyOneFailed(ctx context.Context,
 // durable subscriber block txconfirm's actor loop indefinitely.
 func (a *TxBroadcasterActor) notifyOneTerminal(ctx context.Context,
 	subscriber actor.TellOnlyRef[Notification], txid chainhash.Hash,
-	kind string, deliver func(context.Context) error) bool {
+	kind string,
+	deliver func(context.Context) error) terminalNotifyOutcome {
 
 	subscriberID := subscriber.ID()
 	inflightKey := terminalNotifyKey(txid, subscriberID, kind)
 	if _, ok := a.terminalNotifyInflight[inflightKey]; ok {
-		return false
+		return terminalNotifyPending
 	}
 
 	notifyCtx, cancel := terminalNotifyContext(ctx, inflightKey)
@@ -2368,15 +2469,31 @@ func (a *TxBroadcasterActor) notifyOneTerminal(ctx context.Context,
 	case err := <-errChan:
 		cancel()
 		if err != nil {
+			// A stopped subscriber can never accept the terminal
+			// notification. Report it separately from successful
+			// delivery so confirmed entries do not retain it for
+			// the reorg-aware tail.
+			if errors.Is(err, actor.ErrActorTerminated) ||
+				errors.Is(err, actor.ErrMailboxClosed) {
+
+				a.log.DebugS(ctx, "Terminal tx subscriber stopped; "+
+					"dropping subscription", "txid", txid,
+					"subscriber_id", subscriberID,
+					"notification_kind", kind,
+					slog.Any("err", err))
+
+				return terminalNotifySubscriberStopped
+			}
+
 			a.log.WarnS(ctx, "Failed to deliver terminal tx "+
 				"notification", err, "txid", txid,
 				"subscriber_id", subscriberID,
 				"notification_kind", kind)
 
-			return false
+			return terminalNotifyPending
 		}
 
-		return true
+		return terminalNotifyDelivered
 
 	case <-notifyCtx.Done():
 		a.terminalNotifyInflight[inflightKey] = struct{}{}
@@ -2391,7 +2508,7 @@ func (a *TxBroadcasterActor) notifyOneTerminal(ctx context.Context,
 			"notification_kind", kind,
 		)
 
-		return false
+		return terminalNotifyPending
 	}
 }
 

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -109,6 +109,33 @@ type contextInspectNotifyRef struct {
 	msgs   []Notification
 }
 
+// stoppedNotifyRef models a subscriber that permanently rejects delivery
+// because its actor or mailbox has stopped.
+type stoppedNotifyRef struct {
+	id       string
+	err      error
+	attempts atomic.Int32
+}
+
+// ID returns the stopped subscriber ID.
+func (s *stoppedNotifyRef) ID() string {
+	return s.id
+}
+
+// Tell records an attempt and returns the configured terminal actor error.
+func (s *stoppedNotifyRef) Tell(context.Context, Notification) error {
+	s.attempts.Add(1)
+
+	return s.err
+}
+
+// TryTell uses the same immediate terminal result as Tell.
+func (s *stoppedNotifyRef) TryTell(context.Context, Notification) error {
+	s.attempts.Add(1)
+
+	return s.err
+}
+
 // newRetryNotifyRef creates a subscriber that fails the first failures calls.
 func newRetryNotifyRef(id string, failures int) *retryNotifyRef {
 	return &retryNotifyRef{
@@ -176,7 +203,8 @@ func (b *blockingNotifyRef) attemptsCount() int {
 // notification, producing a terminalNotifyResultMsg{err: nil} that the
 // actor mailbox processes via handleTerminalNotifyResult.
 type deferringNotifyRef struct {
-	id string
+	id  string
+	err error
 
 	started chan struct{}
 	release chan struct{}
@@ -202,9 +230,9 @@ func (d *deferringNotifyRef) ID() string {
 	return d.id
 }
 
-// Tell blocks until release is closed, records the notification, and
-// returns nil. ctx cancellation is intentionally ignored so the test can
-// drive the "Tell eventually succeeded" path even after the actor-side
+// Tell blocks until release is closed, then returns the configured result. A
+// successful delivery records the notification. Context cancellation is
+// intentionally ignored so the test can drive completion after the actor-side
 // notifyCtx timed out.
 func (d *deferringNotifyRef) Tell(_ context.Context, n Notification) error {
 	d.mu.Lock()
@@ -216,6 +244,9 @@ func (d *deferringNotifyRef) Tell(_ context.Context, n Notification) error {
 	})
 
 	<-d.release
+	if d.err != nil {
+		return d.err
+	}
 
 	d.mu.Lock()
 	d.msgs = append(d.msgs, n)
@@ -1131,10 +1162,10 @@ func TestTerminalNotificationsDoNotInheritCallerContext(t *testing.T) {
 
 	txid := chainhash.Hash{1}
 	finalizedSub := &contextInspectNotifyRef{id: "finalized-sub"}
-	ok := behavior.notifyOneFinalized(
+	outcome := behavior.notifyOneFinalized(
 		ctx, finalizedSub, txid, 101, 1,
 	)
-	require.True(t, ok)
+	require.Equal(t, terminalNotifyDelivered, outcome)
 
 	hasTx, ctxErr, msgs := finalizedSub.snapshot()
 	require.False(t, hasTx)
@@ -1143,8 +1174,8 @@ func TestTerminalNotificationsDoNotInheritCallerContext(t *testing.T) {
 	require.IsType(t, &TxFinalized{}, msgs[0])
 
 	failedSub := &contextInspectNotifyRef{id: "failed-sub"}
-	ok = behavior.notifyOneFailed(ctx, failedSub, txid, "boom")
-	require.True(t, ok)
+	outcome = behavior.notifyOneFailed(ctx, failedSub, txid, "boom")
+	require.Equal(t, terminalNotifyDelivered, outcome)
 
 	hasTx, ctxErr, msgs = failedSub.snapshot()
 	require.False(t, hasTx)
@@ -1183,10 +1214,10 @@ func TestTerminalNotificationTimeoutDoesNotBlockActor(t *testing.T) {
 	}()
 
 	start := time.Now()
-	ok := behavior.notifyOneFinalized(
+	outcome := behavior.notifyOneFinalized(
 		context.Background(), sub, txid, 101, 1,
 	)
-	require.False(t, ok)
+	require.Equal(t, terminalNotifyPending, outcome)
 	require.Less(t, time.Since(start), testTimeout)
 	require.True(t, <-started)
 
@@ -2047,6 +2078,61 @@ func TestEnsureConfirmedDefersToExistingParentBroadcast(t *testing.T) {
 	mustHaveNoNotification(t, sub)
 }
 
+// TestFeeBumpExistingParentLogsAtDebug verifies that a later fee bump does
+// not warn when another path already placed the parent in the mempool. The
+// original transaction remains live and the actor keeps its confirmation
+// watch, so this is an expected retry state.
+func TestFeeBumpExistingParentLogsAtDebug(t *testing.T) {
+	var buf bytes.Buffer
+	logger := btclog.NewSLogger(btclog.NewDefaultHandler(&buf))
+	logger.SetLevel(btclog.LevelTrace)
+
+	chain := newFakeChainSourceRef(100)
+	walletRef := &fakeWallet{
+		utxos: []*walletcore.Utxo{
+			makeWalletUTXO(t),
+		},
+	}
+	ref, _ := newTestActor(t, Config{
+		ChainSource:           chain,
+		Wallet:                walletRef,
+		FeeBumpIntervalBlocks: 1,
+		Log:                   fn.Some[btclog.Logger](logger),
+	})
+
+	tx := makeTestTx(true)
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub-a", 4)
+	resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+	require.Equal(t, TxStateAwaitingConfirmation, resp.State)
+
+	chain.packageErr = errors.Join(
+		chainbackends.NewPackageTxError(
+			"W1", tx.TxHash(),
+			"txn-already-known",
+		),
+		chainbackends.NewPackageTxError(
+			"W2", chainhash.Hash{0xab},
+			"bad-txns-inputs-missingorspent",
+		),
+	)
+	chain.emitBlock(t, 101)
+
+	require.Equal(
+		t, TxStateAwaitingConfirmation,
+		mustTrackedState(
+			t, ref.Ref(), tx, sub,
+		),
+	)
+	require.NotContains(t, buf.String(), "Fee bump failed, will retry")
+	require.Contains(
+		t, buf.String(),
+		"Fee bump child rejected after parent",
+	)
+}
+
 // TestEnsureConfirmedEscalatesAfterRepeatedFailures verifies that repeated
 // total broadcast failures escalate to an operator-visible warning once the
 // configured threshold is crossed, while the tx keeps retrying and never
@@ -2170,6 +2256,152 @@ func TestEnsureConfirmedFailsPermanentBroadcastError(t *testing.T) {
 
 	failed := mustAwaitNotification(t, sub)
 	require.IsType(t, &TxFailed{}, failed)
+}
+
+// TestNotifyOneTerminalClassifiesStoppedSubscriber verifies that permanent
+// actor errors are distinct from both successful and retryable delivery.
+func TestNotifyOneTerminalClassifiesStoppedSubscriber(t *testing.T) {
+	actorBehavior := NewTxBroadcasterActor(Config{})
+	subscriber := actor.NewChannelTellOnlyRef[Notification]("stopped", 1)
+	txid := chainhash.Hash{0x01}
+
+	tests := []struct {
+		name    string
+		err     error
+		outcome terminalNotifyOutcome
+	}{
+		{
+			name:    "actor terminated",
+			err:     actor.ErrActorTerminated,
+			outcome: terminalNotifySubscriberStopped,
+		},
+		{
+			name:    "mailbox closed",
+			err:     actor.ErrMailboxClosed,
+			outcome: terminalNotifySubscriberStopped,
+		},
+		{
+			name:    "retryable delivery failure",
+			err:     actor.ErrMailboxFull,
+			outcome: terminalNotifyPending,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			outcome := actorBehavior.notifyOneTerminal(
+				t.Context(), subscriber, txid, "finalized",
+				func(context.Context) error {
+					return test.err
+				},
+			)
+			require.Equal(t, test.outcome, outcome)
+		})
+	}
+}
+
+// TestNotifyConfirmedDropsStoppedSubscriber verifies that an immediate
+// terminal actor error removes a confirmed subscriber instead of treating the
+// undelivered TxConfirmed as accepted and retaining the dead lifecycle tail.
+func TestNotifyConfirmedDropsStoppedSubscriber(t *testing.T) {
+	tx := makeTestTx(false)
+	txid := tx.TxHash()
+	entry := newTrackedTxForState(t, &trackedTxStateConfirmed{
+		trackedTxData: trackedTxData{
+			Tx:          tx,
+			Txid:        txid,
+			TargetConfs: 1,
+		},
+		ConfirmHeight: 101,
+	})
+
+	stopped := &stoppedNotifyRef{
+		id:  "stopped",
+		err: actor.ErrActorTerminated,
+	}
+	live := actor.NewChannelTellOnlyRef[Notification]("live", 1)
+	entry.subscribers[stopped.ID()] = trackedSubscriber{
+		Ref:              stopped,
+		pendingConfirmed: true,
+	}
+	entry.subscribers[live.ID()] = trackedSubscriber{
+		Ref:              live,
+		pendingConfirmed: true,
+	}
+
+	behavior := NewTxBroadcasterActor(Config{})
+	behavior.tracked[txid] = entry
+	behavior.notifyConfirmed(
+		t.Context(), entry, 101, chainhash.Hash{1}, 1,
+	)
+
+	require.Equal(t, int32(1), stopped.attempts.Load())
+	require.NotContains(t, entry.subscribers, stopped.ID())
+	require.Contains(t, entry.subscribers, live.ID())
+	require.False(t, entry.subscribers[live.ID()].pendingConfirmed)
+	require.IsType(t, &TxConfirmed{}, mustAwaitNotification(t, live))
+}
+
+// TestDeferredStoppedSubscriberIsRemoved verifies that a terminal actor error
+// arriving after the synchronous delivery budget removes the dead subscriber
+// when the deferred result returns through the txconfirm mailbox.
+func TestDeferredStoppedSubscriberIsRemoved(t *testing.T) {
+	oldTimeout := terminalNotifyTimeout
+	terminalNotifyTimeout = 20 * time.Millisecond
+	t.Cleanup(func() {
+		terminalNotifyTimeout = oldTimeout
+	})
+
+	tx := makeTestTx(false)
+	txid := tx.TxHash()
+	entry := newTrackedTxForState(t, &trackedTxStateConfirmed{
+		trackedTxData: trackedTxData{
+			Tx:          tx,
+			Txid:        txid,
+			TargetConfs: 1,
+		},
+		ConfirmHeight: 101,
+	})
+
+	stopped := newDeferringNotifyRef("async-stopped")
+	stopped.err = actor.ErrActorTerminated
+	live := actor.NewChannelTellOnlyRef[Notification]("live", 1)
+	entry.subscribers[stopped.ID()] = trackedSubscriber{
+		Ref:              stopped,
+		pendingConfirmed: true,
+	}
+	entry.subscribers[live.ID()] = trackedSubscriber{
+		Ref:              live,
+		pendingConfirmed: false,
+	}
+
+	behavior := NewTxBroadcasterActor(Config{})
+	selfRef := actor.NewChannelTellOnlyRef[Msg]("txconfirm", 1)
+	behavior.SetSelfRef(selfRef)
+	behavior.tracked[txid] = entry
+
+	outcome := behavior.notifyOneConfirmed(
+		t.Context(), stopped, txid, &TxConfirmed{
+			Txid:        txid,
+			BlockHeight: 101,
+			NumConfs:    1,
+		},
+	)
+	require.Equal(t, terminalNotifyPending, outcome)
+	stopped.waitStarted(t)
+	stopped.releaseTell()
+
+	msg, ok := selfRef.AwaitMessage(testTimeout)
+	require.True(t, ok, "expected deferred terminal result")
+	result, ok := msg.(*terminalNotifyResultMsg)
+	require.True(t, ok)
+	require.ErrorIs(t, result.err, actor.ErrActorTerminated)
+
+	behavior.handleTerminalNotifyResult(t.Context(), result)
+	require.NotContains(t, entry.subscribers, stopped.ID())
+	require.Contains(t, entry.subscribers, live.ID())
+	_, inflight := behavior.terminalNotifyInflight[result.inflightKey]
+	require.False(t, inflight)
 }
 
 // TestInitialConfirmedAsyncDeliveryRetainsSubscriber regression-tests an


### PR DESCRIPTION
## Summary

- stop block-epoch forwarding when its notify actor has terminated
- remove stopped transaction subscribers without retrying impossible delivery
- distinguish delivered, pending, and stopped transaction notifications
- log `ErrParentAlreadyBroadcast` fee-bump retries at debug
- log recoverable round failures at info

## Why

The staging and testnet log-alert rollout exposed repeated warnings with no recovery path:

- block-epoch and terminal transaction delivery retried dead actors on every block
- a fee-bump child rejection warned even though the parent transaction was already live
- client-recoverable round failures warned even though the client could retry

The actor API defines `ErrActorTerminated` and `ErrMailboxClosed` as terminal. The cleanup now follows that contract. Delivered, retryable, and stopped transaction notification outcomes remain distinct, so a dead subscriber is not mistaken for one that accepted `TxConfirmed` and retained for the reorg-aware lifecycle.

Other delivery failures, fee-bump failures, and non-recoverable round failures still warn. Full error details remain in structured fields when a message is demoted.

This is the Wavelength source cleanup for [lightning-infra#3786](https://github.com/lightninglabs/lightning-infra/pull/3786).

## Validation

- `go test ./txconfirm ./chainsource ./round`
- `go test -race ./txconfirm ./chainsource ./round`
- `make lint-changed-local base=origin/main`
- `make fmt-changed-check base=origin/main`
- `make tidy-module-check`
- `git diff --check origin/main...HEAD`

New tests cover existing-parent fee-bump log severity, terminal transaction delivery classification, immediate stopped-subscriber cleanup, async confirmed delivery retention, and block-subscription cleanup after its target actor stops.
