### PR TITLE
round: separate VTXO activation from input maturity

### DIFF
--- a/arkrpc/ark.pb.go
+++ b/arkrpc/ark.pb.go
@@ -251,8 +251,12 @@ type GetInfoResponse struct {
 	// The number of blocks before batch expiry in which a pure refresh
 	// qualifies for a complete fee waiver. Zero disables the waiver.
 	FreeRefreshWindowBlocks uint32 `protobuf:"varint,23,opt,name=free_refresh_window_blocks,json=freeRefreshWindowBlocks,proto3" json:"free_refresh_window_blocks,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// The confirmations required before clients may use VTXOs created by a
+	// round. This is independent of min_confirmations, which protects the
+	// on-chain boarding inputs consumed by a new round.
+	VtxoConfirmations uint32 `protobuf:"varint,24,opt,name=vtxo_confirmations,json=vtxoConfirmations,proto3" json:"vtxo_confirmations,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *GetInfoResponse) Reset() {
@@ -421,6 +425,13 @@ func (x *GetInfoResponse) GetArkVersionPolicies() []*ArkVersionPolicy {
 func (x *GetInfoResponse) GetFreeRefreshWindowBlocks() uint32 {
 	if x != nil {
 		return x.FreeRefreshWindowBlocks
+	}
+	return 0
+}
+
+func (x *GetInfoResponse) GetVtxoConfirmations() uint32 {
+	if x != nil {
+		return x.VtxoConfirmations
 	}
 	return 0
 }
@@ -611,7 +622,7 @@ const file_ark_proto_rawDesc = "" +
 	"\x05State\x12\x15\n" +
 	"\x11STATE_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fSTATE_ACTIVE\x10\x01\x12\x12\n" +
-	"\x0eSTATE_DISABLED\x10\x02\"\xd3\x06\n" +
+	"\x0eSTATE_DISABLED\x10\x02\"\x82\a\n" +
 	"\x0fGetInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
 	"\x06pubkey\x18\x02 \x01(\fR\x06pubkey\x12\x18\n" +
@@ -635,7 +646,8 @@ const file_ark_proto_rawDesc = "" +
 	"\x10max_user_balance\x18\x14 \x01(\x03R\x0emaxUserBalance\x120\n" +
 	"\x14selected_ark_version\x18\x15 \x01(\rR\x12selectedArkVersion\x12J\n" +
 	"\x14ark_version_policies\x18\x16 \x03(\v2\x18.arkrpc.ArkVersionPolicyR\x12arkVersionPolicies\x12;\n" +
-	"\x1afree_refresh_window_blocks\x18\x17 \x01(\rR\x17freeRefreshWindowBlocks\"\x7f\n" +
+	"\x1afree_refresh_window_blocks\x18\x17 \x01(\rR\x17freeRefreshWindowBlocks\x12-\n" +
+	"\x12vtxo_confirmations\x18\x18 \x01(\rR\x11vtxoConfirmations\"\x7f\n" +
 	"\x12EstimateFeeRequest\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x01 \x01(\x03R\tamountSat\x12\x1f\n" +

--- a/arkrpc/ark.proto
+++ b/arkrpc/ark.proto
@@ -139,6 +139,11 @@ message GetInfoResponse {
     // The number of blocks before batch expiry in which a pure refresh
     // qualifies for a complete fee waiver. Zero disables the waiver.
     uint32 free_refresh_window_blocks = 23;
+
+    // The confirmations required before clients may use VTXOs created by a
+    // round. This is independent of min_confirmations, which protects the
+    // on-chain boarding inputs consumed by a new round.
+    uint32 vtxo_confirmations = 24;
 }
 
 // EstimateFeeRequest asks the server to estimate the fee for a

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -81,6 +81,10 @@ type OperatorTerms struct {
 	// MinConfirmations is the minimum confs required on boarding inputs.
 	MinConfirmations uint32
 
+	// VTXOConfirmations is the confirmation depth at which VTXOs created by
+	// a round become available for off-chain spending.
+	VTXOConfirmations uint32
+
 	// MaxOORLineageVBytes is the operator-published cap on the
 	// cumulative on-chain virtual bytes a recipient must publish to
 	// claim a VTXO produced by an OOR submit unilaterally. Clients
@@ -104,6 +108,21 @@ func (t *OperatorTerms) MinVTXOAmountFloor() btcutil.Amount {
 	}
 
 	return t.MinVTXOAmount
+}
+
+// VTXOTargetConfirmations returns the depth at which round VTXOs become
+// available. A zero split field preserves the legacy policy that reused the
+// boarding-input minimum for commitment outputs.
+func (t *OperatorTerms) VTXOTargetConfirmations() uint32 {
+	if t == nil {
+		return 0
+	}
+
+	if t.VTXOConfirmations == 0 {
+		return t.MinConfirmations
+	}
+
+	return t.VTXOConfirmations
 }
 
 // JoinRoundRequest represents a participant's request to join a round.

--- a/lib/types/boarding_test.go
+++ b/lib/types/boarding_test.go
@@ -134,3 +134,46 @@ func TestVTXORequestValidateAssetFields(t *testing.T) {
 		})
 	}
 }
+
+// TestOperatorTermsVTXOTargetConfirmations pins the legacy fallback and the
+// explicit split activation depth used by round confirmation watches.
+func TestOperatorTermsVTXOTargetConfirmations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		terms *OperatorTerms
+		want  uint32
+	}{
+		{
+			name: "nil terms",
+			want: 0,
+		},
+		{
+			name: "legacy fallback",
+			terms: &OperatorTerms{
+				MinConfirmations: 6,
+			},
+			want: 6,
+		},
+		{
+			name: "explicit activation depth",
+			terms: &OperatorTerms{
+				MinConfirmations:  6,
+				VTXOConfirmations: 1,
+			},
+			want: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, tc.want, tc.terms.VTXOTargetConfirmations(),
+			)
+		})
+	}
+}

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -151,6 +151,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
 - Terminal rows (completed and failed) are retained in
   `oor_session_registry` for status/diagnostics; reaping only removes the
   in-memory child, never the row.
+- Pending submit retries persist their delay and typed rejection reason in the
+  outgoing snapshot. `GetOORSession` exposes the reason while status remains
+  pending, so callers can distinguish a recoverable chain pause from failure.
 - Outgoing finalize ordering: input-spend completion runs inline with no OOR
   writer transaction held, because its write commits in the VTXO manager's
   own transaction; awaiting that second writer under a held OOR writer lock

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -151,6 +151,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
 - Terminal rows (completed and failed) are retained in
   `oor_session_registry` for status/diagnostics; reaping only removes the
   in-memory child, never the row.
+- Pending submit retries persist their delay and typed rejection reason in the
+  outgoing snapshot. `GetOORSession` exposes the reason while status remains
+  pending, so callers can distinguish a recoverable chain pause from failure.
 - Outgoing finalize ordering: input-spend completion runs inline with no OOR
   writer transaction held, because its write commits in the VTXO manager's
   own transaction; awaiting that second writer under a held OOR writer lock

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -169,6 +169,8 @@ func NewOutgoingSnapshot(sessionID SessionID,
 		snap.DispatchRequestData = append(
 			[]byte(nil), s.DispatchRequestData...,
 		)
+		snap.RetryAfter = s.RetryAfter
+		snap.FailReason = s.RetryReason
 		snap.FirstRejectUnixNanos = s.FirstRejectUnixNanos
 
 		if err := assignPSBTArtifacts(
@@ -341,6 +343,8 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 			DispatchRequestData: append(
 				[]byte(nil), snapshot.DispatchRequestData...,
 			),
+			RetryAfter:           snapshot.RetryAfter,
+			RetryReason:          snapshot.FailReason,
 			FirstRejectUnixNanos: snapshot.FirstRejectUnixNanos,
 		}, nil
 

--- a/oor/outgoing_snapshot_test.go
+++ b/oor/outgoing_snapshot_test.go
@@ -149,6 +149,8 @@ func TestOutgoingRegistryRecordSuppliesNormalizedReplayProof(t *testing.T) {
 	require.NoError(t, err)
 	awaiting, ok := submit.NextState.(*AwaitingSubmitAccepted)
 	require.True(t, ok)
+	awaiting.RetryAfter = 15 * time.Second
+	awaiting.RetryReason = "input not spendable"
 
 	sessionID, err := sessionIDFromArk(awaiting.ArkPSBT)
 	require.NoError(t, err)
@@ -159,6 +161,10 @@ func TestOutgoingRegistryRecordSuppliesNormalizedReplayProof(t *testing.T) {
 	proofRecord, err := outgoingRegistryRecord(sessionID, awaiting)
 	require.NoError(t, err)
 	require.NotEmpty(t, proofRecord.DispatchRequestData)
+	persisted, err := decodeOutgoingSnapshot(proofRecord.SnapshotData)
+	require.NoError(t, err)
+	require.Equal(t, 15*time.Second, persisted.RetryAfter)
+	require.Equal(t, "input not spendable", persisted.FailReason)
 
 	recipients, err := OutgoingReplayRecipients(
 		proofRecord.DispatchRequestData,

--- a/oor/states.go
+++ b/oor/states.go
@@ -1,6 +1,8 @@
 package oor
 
 import (
+	"time"
+
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/lightninglabs/wavelength/baselib/protofsm"
 	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
@@ -106,6 +108,12 @@ type AwaitingSubmitAccepted struct {
 
 	// DispatchRequestData is the normalized caller-recipient proof.
 	DispatchRequestData []byte
+
+	// RetryAfter and RetryReason describe the latest pending submit retry.
+	// They are persisted so operation status can expose a transient typed
+	// rejection without turning it into a terminal failure.
+	RetryAfter  time.Duration
+	RetryReason string
 
 	// FirstRejectUnixNanos is the Unix-nanosecond timestamp of the first
 	// transient submit rejection observed while awaiting submit acceptance,

--- a/oor/submit_retry_budget_test.go
+++ b/oor/submit_retry_budget_test.go
@@ -88,6 +88,8 @@ func TestHandleSubmitOutboxErrorReschedulesWithinBudget(t *testing.T) {
 	next, ok := transition.NextState.(*AwaitingSubmitAccepted)
 	require.True(t, ok)
 	require.Equal(t, start.UnixNano(), next.FirstRejectUnixNanos)
+	require.Equal(t, 15*time.Second, next.RetryAfter)
+	require.Equal(t, "input not spendable", next.RetryReason)
 
 	// The source state must not be mutated in place.
 	require.Zero(t, current.FirstRejectUnixNanos)
@@ -115,6 +117,8 @@ func TestHandleSubmitOutboxErrorReschedulesWithinBudget(t *testing.T) {
 	next2, ok := transition.NextState.(*AwaitingSubmitAccepted)
 	require.True(t, ok)
 	require.Equal(t, start.UnixNano(), next2.FirstRejectUnixNanos)
+	require.Equal(t, 15*time.Second, next2.RetryAfter)
+	require.Equal(t, "input not spendable", next2.RetryReason)
 	require.Len(t, transition.NewEvents.UnwrapOr(EmittedEvent{}).Outbox, 1)
 }
 

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -711,6 +711,8 @@ func handleSubmitOutboxError(env *Environment, current *AwaitingSubmitAccepted,
 	if after == 0 {
 		after = defaultRetryDelay
 	}
+	next.RetryAfter = after
+	next.RetryReason = evt.ErrorReason
 
 	return &StateTransition{
 		NextState: &next,

--- a/round/actor.go
+++ b/round/actor.go
@@ -1308,7 +1308,7 @@ func (a *RoundClientActor) registerCommitmentConfirmation(ctx context.Context,
 		CallerID:    callerID,
 		Txid:        &txid,
 		PkScript:    pkScript,
-		TargetConfs: a.cfg.OperatorTerms.MinConfirmations,
+		TargetConfs: a.cfg.OperatorTerms.VTXOTargetConfirmations(),
 		HeightHint:  heightHint,
 		NotifyActor: fn.Some(mappedRef),
 	}

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
 	tapsdk "github.com/lightninglabs/tap-sdk"
@@ -697,6 +698,30 @@ func TestActorConfirmation(t *testing.T) {
 // lifecycle events, and server communication.
 func TestActorProcessOutbox(t *testing.T) {
 	t.Parallel()
+
+	t.Run("commitment uses VTXO activation depth", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+		h.operatorTerms.MinConfirmations = 6
+		h.operatorTerms.VTXOConfirmations = 1
+
+		err := h.start()
+		require.NoError(t, err)
+
+		h.chainSource.registrations = nil
+		txid := chainhash.HashH([]byte("split-confirmation-depth"))
+		h.actor.registerCommitmentConfirmation(
+			h.ctx, txid, fn.None[*psbt.Packet](), nil,
+		)
+
+		require.Len(t, h.chainSource.registrations, 1)
+		require.Equal(
+			t, uint32(1),
+			h.chainSource.registrations[0].TargetConfs,
+		)
+	})
 
 	t.Run("register_confirmation_request", func(t *testing.T) {
 		t.Parallel()

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -3154,11 +3154,12 @@ func (s *ForfeitSignaturesCollectingState) forfeitCollectionOutbox(
 	}
 
 	return append(outboxMsgs, &RegisterConfirmationRequest{
-		CallerID:    callerID,
-		Txid:        &txid,
-		PkScript:    pkScript,
-		TargetConfs: env.OperatorTerms.MinConfirmations,
-		HeightHint:  env.StartHeight,
+		CallerID: callerID,
+		Txid:     &txid,
+		PkScript: pkScript,
+		TargetConfs: env.OperatorTerms.
+			VTXOTargetConfirmations(),
+		HeightHint: env.StartHeight,
 	})
 }
 
@@ -3592,7 +3593,10 @@ func (s *PartialSigsSentState) processEvent(ctx context.Context,
 			slog.Int("pkscript_len", len(pkScript)),
 			slog.Int(
 				"target_confs",
-				int(env.OperatorTerms.MinConfirmations),
+				int(
+					env.OperatorTerms.
+						VTXOTargetConfirmations(),
+				),
 			),
 		)
 
@@ -3624,11 +3628,12 @@ func (s *PartialSigsSentState) processEvent(ctx context.Context,
 			outboxMsgs,
 			forfeitSigReq,
 			&RegisterConfirmationRequest{
-				CallerID:    callerID,
-				Txid:        &txid,
-				PkScript:    pkScript,
-				TargetConfs: env.OperatorTerms.MinConfirmations,
-				HeightHint:  env.StartHeight,
+				CallerID: callerID,
+				Txid:     &txid,
+				PkScript: pkScript,
+				TargetConfs: env.OperatorTerms.
+					VTXOTargetConfirmations(),
+				HeightHint: env.StartHeight,
 			},
 		)
 

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -1917,6 +1917,8 @@ func TestPartialSigsSentState(t *testing.T) {
 
 		h.setupMockWalletForBoardingSigning()
 		h.setupMockRoundStoreForCommit()
+		h.env.OperatorTerms.MinConfirmations = 6
+		h.env.OperatorTerms.VTXOConfirmations = 1
 		h.withState(state)
 
 		event := &OperatorSigned{
@@ -1937,6 +1939,11 @@ func TestPartialSigsSentState(t *testing.T) {
 
 		h.assertOutboxContainsType("*round.SubmitForfeitSigRequest")
 		h.assertOutboxContainsType("*round.RegisterConfirmationRequest")
+		registration, ok := findOutbox[*RegisterConfirmationRequest](
+			h.outboxMessages,
+		)
+		require.True(t, ok)
+		require.Equal(t, uint32(1), registration.TargetConfs)
 	})
 
 	t.Run("OperatorSigned_propagates_sigs_to_extracted_client_tree",

--- a/round/vtxo_tree_binding_test.go
+++ b/round/vtxo_tree_binding_test.go
@@ -347,12 +347,14 @@ func TestConfirmationWatchScriptUsesBatchOutput(t *testing.T) {
 			},
 		},
 	}
-	const targetConfs = 6
+	const minConfs = 6
+	const targetConfs = 1
 	const startHeight = 123
 	outbox := state.forfeitCollectionOutbox(
 		&ClientEnvironment{
 			OperatorTerms: &types.OperatorTerms{
-				MinConfirmations: targetConfs,
+				MinConfirmations:  minConfs,
+				VTXOConfirmations: targetConfs,
 			},
 			StartHeight:            startHeight,
 			StatusReconcileTimeout: time.Minute,

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -164,6 +164,10 @@ type ServerInfo struct {
 	// inputs.
 	MinConfirmations uint32
 
+	// VTXOConfirmations is the confirmation depth at which VTXOs created by
+	// a round become available for off-chain spending.
+	VTXOConfirmations uint32
+
 	// MaxUserBalance is the maximum total balance in satoshis a single
 	// user should hold in the system. A value of zero means no cap.
 	MaxUserBalance uint64
@@ -470,6 +474,7 @@ func (c *Client) GetInfo(ctx context.Context) (*Info, error) {
 			MinOperatorFee:          serverInfo.MinOperatorFee,
 			FreeRefreshWindowBlocks: freeRefreshWindow,
 			MinConfirmations:        serverInfo.MinConfirmations,
+			VTXOConfirmations:       serverInfo.VtxoConfirmations,
 			MaxUserBalance:          serverInfo.MaxUserBalance,
 		}
 	}

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -143,6 +143,7 @@ func newFakeDaemonService() *fakeDaemonService {
 				MinOperatorFee:          20,
 				FreeRefreshWindowBlocks: 120,
 				MinConfirmations:        2,
+				VtxoConfirmations:       1,
 			},
 		},
 		listVtxosResp: &waverpc.ListVTXOsResponse{
@@ -685,6 +686,8 @@ func TestDialRemoteGetInfo(t *testing.T) {
 	require.Equal(t, uint32(120),
 		info.ServerInfo.FreeRefreshWindowBlocks,
 	)
+	require.Equal(t, uint32(2), info.ServerInfo.MinConfirmations)
+	require.Equal(t, uint32(1), info.ServerInfo.VTXOConfirmations)
 }
 
 // TestDialRemoteCoversFacadeMethods verifies the thin SDK wrappers beyond

--- a/waved/operator_negotiation.go
+++ b/waved/operator_negotiation.go
@@ -54,6 +54,14 @@ func operatorTermsFromResponse(resp *arkrpc.GetInfoResponse) (
 		minVTXOAmount = resp.DustLimit
 	}
 
+	vtxoConfirmations := resp.VtxoConfirmations
+	if vtxoConfirmations == 0 {
+		// Older operators used MinConfirmations for both boarding
+		// inputs and commitment outputs. Preserve that behavior until
+		// the server explicitly advertises the split policy.
+		vtxoConfirmations = resp.MinConfirmations
+	}
+
 	// The forfeit penalty key, sweep key and sweep delay are no longer
 	// global operator terms; they are delivered per round in the batch
 	// info, so GetInfo no longer carries them.
@@ -69,6 +77,7 @@ func operatorTermsFromResponse(resp *arkrpc.GetInfoResponse) (
 		MinOperatorFee:          btcutil.Amount(resp.MinOperatorFee),
 		FreeRefreshWindowBlocks: resp.FreeRefreshWindowBlocks,
 		MinConfirmations:        resp.MinConfirmations,
+		VTXOConfirmations:       vtxoConfirmations,
 		MaxOORLineageVBytes:     resp.MaxOorLineageVbytes,
 		MaxUserBalance:          btcutil.Amount(resp.MaxUserBalance),
 	}, nil

--- a/waved/operator_negotiation_test.go
+++ b/waved/operator_negotiation_test.go
@@ -180,6 +180,34 @@ func TestOperatorTermsFreeRefreshWindow(t *testing.T) {
 	require.Equal(t, uint32(72), terms.FreeRefreshWindowBlocks)
 }
 
+// TestOperatorTermsVTXOConfirmations verifies new operators can advertise a
+// shallow VTXO activation depth without weakening boarding-input maturity.
+func TestOperatorTermsVTXOConfirmations(t *testing.T) {
+	t.Parallel()
+
+	terms, err := operatorTermsFromResponse(&arkrpc.GetInfoResponse{
+		Pubkey:            testOperatorPubKeyBytes(t),
+		MinConfirmations:  6,
+		VtxoConfirmations: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint32(6), terms.MinConfirmations)
+	require.Equal(t, uint32(1), terms.VTXOConfirmations)
+}
+
+// TestOperatorTermsVTXOConfirmationsLegacyFallback verifies a new client
+// preserves the old coupled policy when the additive field is absent.
+func TestOperatorTermsVTXOConfirmationsLegacyFallback(t *testing.T) {
+	t.Parallel()
+
+	terms, err := operatorTermsFromResponse(&arkrpc.GetInfoResponse{
+		Pubkey:           testOperatorPubKeyBytes(t),
+		MinConfirmations: 3,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint32(3), terms.VTXOConfirmations)
+}
+
 // TestNegotiateArkBootstrapZeroSelection proves the client refuses to bootstrap
 // when the operator returns a zero selection (no common version, or a
 // pre-versioning server). There is no legacy fallback.

--- a/waved/rpc_operation_status_test.go
+++ b/waved/rpc_operation_status_test.go
@@ -3,9 +3,64 @@ package waved
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/oor"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/stretchr/testify/require"
 )
+
+// TestOORSessionSummaryToProtoProjectsRetryReason verifies the RPC projection
+// exposes a pending retry reason without misclassifying it as terminal, while
+// preserving the same field for a terminal failure.
+func TestOORSessionSummaryToProtoProjectsRetryReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		summary    oor.SessionSummary
+		wantStatus waverpc.OORSessionStatus
+	}{
+		{
+			name: "pending retry",
+			summary: oor.SessionSummary{
+				SessionID: oor.SessionID(chainhash.Hash{1}),
+				Direction: oor.SessionDirectionOutgoing,
+				Phase: string(
+					oor.OutgoingPhaseSubmitSent,
+				),
+				Pending:     true,
+				RetryReason: "input not spendable",
+			},
+			wantStatus: waverpc.
+				OORSessionStatus_OOR_SESSION_STATUS_PENDING,
+		},
+		{
+			name: "terminal failure",
+			summary: oor.SessionSummary{
+				SessionID:   oor.SessionID(chainhash.Hash{2}),
+				Direction:   oor.SessionDirectionOutgoing,
+				Phase:       string(oor.OutgoingPhaseFailed),
+				RetryReason: "retry budget exhausted",
+			},
+			wantStatus: waverpc.
+				OORSessionStatus_OOR_SESSION_STATUS_FAILED,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			info := oorSessionSummaryToProto(test.summary)
+			require.Equal(t, test.wantStatus, info.GetStatus())
+			require.Equal(
+				t, test.summary.RetryReason,
+				info.GetFailureReason(),
+			)
+		})
+	}
+}
 
 // TestPageOORSessionsUsesSessionCursor asserts OOR pagination resumes after
 // the last session id returned to the caller.

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -754,6 +754,7 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *waverpc.GetInfoRequest) (
 			FeeRate:           uint64(terms.FeeRate),
 			MinOperatorFee:    uint64(terms.MinOperatorFee),
 			MinConfirmations:  terms.MinConfirmations,
+			VtxoConfirmations: terms.VTXOTargetConfirmations(),
 			MinVtxoAmountSat:  uint64(minVTXOAmount),
 			MaxUserBalance:    uint64(terms.MaxUserBalance),
 		}

--- a/waved/rpc_server_test.go
+++ b/waved/rpc_server_test.go
@@ -955,6 +955,7 @@ func TestGetInfoIncludesServerInfo(t *testing.T) {
 		MinOperatorFee:          btcutil.Amount(34),
 		FreeRefreshWindowBlocks: 72,
 		MinConfirmations:        2,
+		VTXOConfirmations:       1,
 	})
 	r := &RPCServer{server: server}
 
@@ -984,6 +985,7 @@ func TestGetInfoIncludesServerInfo(t *testing.T) {
 		t, uint32(72), resp.ServerInfo.FreeRefreshWindowBlocks,
 	)
 	require.Equal(t, uint32(2), resp.ServerInfo.MinConfirmations)
+	require.Equal(t, uint32(1), resp.ServerInfo.VtxoConfirmations)
 }
 
 // TestGetInfoUsesCachedIdentityKey verifies ordinary status reads do not

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -1079,8 +1079,11 @@ type ServerInfo struct {
 	// free_refresh_window_blocks is the operator's late-lifetime refresh
 	// waiver window. Zero disables the policy.
 	FreeRefreshWindowBlocks uint32 `protobuf:"varint,15,opt,name=free_refresh_window_blocks,json=freeRefreshWindowBlocks,proto3" json:"free_refresh_window_blocks,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// vtxo_confirmations is the confirmation depth at which new round VTXOs
+	// become available for off-chain spending.
+	VtxoConfirmations uint32 `protobuf:"varint,16,opt,name=vtxo_confirmations,json=vtxoConfirmations,proto3" json:"vtxo_confirmations,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *ServerInfo) Reset() {
@@ -1193,6 +1196,13 @@ func (x *ServerInfo) GetMaxUserBalance() uint64 {
 func (x *ServerInfo) GetFreeRefreshWindowBlocks() uint32 {
 	if x != nil {
 		return x.FreeRefreshWindowBlocks
+	}
+	return 0
+}
+
+func (x *ServerInfo) GetVtxoConfirmations() uint32 {
+	if x != nil {
+		return x.VtxoConfirmations
 	}
 	return 0
 }
@@ -10741,7 +10751,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0fidentity_pubkey\x18\n" +
 	" \x01(\tR\x0eidentityPubkey\x124\n" +
 	"\vserver_info\x18\v \x01(\v2\x13.waverpc.ServerInfoR\n" +
-	"serverInfo\"\x8c\x04\n" +
+	"serverInfo\"\xbb\x04\n" +
 	"\n" +
 	"ServerInfo\x12'\n" +
 	"\x0foperator_pubkey\x18\x01 \x01(\fR\x0eoperatorPubkey\x12.\n" +
@@ -10757,7 +10767,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x11min_confirmations\x18\f \x01(\rR\x10minConfirmations\x12-\n" +
 	"\x13min_vtxo_amount_sat\x18\r \x01(\x04R\x10minVtxoAmountSat\x12(\n" +
 	"\x10max_user_balance\x18\x0e \x01(\x04R\x0emaxUserBalance\x12;\n" +
-	"\x1afree_refresh_window_blocks\x18\x0f \x01(\rR\x17freeRefreshWindowBlocks\"9\n" +
+	"\x1afree_refresh_window_blocks\x18\x0f \x01(\rR\x17freeRefreshWindowBlocks\x12-\n" +
+	"\x12vtxo_confirmations\x18\x10 \x01(\rR\x11vtxoConfirmations\"9\n" +
 	"\x0eGenSeedRequest\x12'\n" +
 	"\x0fseed_passphrase\x18\x01 \x01(\fR\x0eseedPassphrase\"V\n" +
 	"\x0fGenSeedResponse\x12\x1a\n" +

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -433,6 +433,10 @@ message ServerInfo {
     // free_refresh_window_blocks is the operator's late-lifetime refresh
     // waiver window. Zero disables the policy.
     uint32 free_refresh_window_blocks = 15;
+
+    // vtxo_confirmations is the confirmation depth at which new round VTXOs
+    // become available for off-chain spending.
+    uint32 vtxo_confirmations = 16;
 }
 
 message GenSeedRequest {


### PR DESCRIPTION
## The problem

An Ark operator has two different confirmation policies:

- boarding inputs must be mature enough to enter a new commitment;
- VTXOs created by a confirmed commitment must become available to clients.

Wavelength previously used `min_confirmations` for both. Raising the input
maturity policy therefore delayed every new VTXO, while lowering it also let
young boarding inputs enter rounds.

A separate observability gap hid the reason for a retryable out-of-round (OOR)
submission rejection. The session stayed pending and retried correctly, but
callers could not see why it was waiting.

## The fix

The operator now advertises `vtxo_confirmations` separately from
`min_confirmations`. Wavelength carries both values through daemon and SDK
responses, and the round actor uses the VTXO target for its existing commitment
confirmation watch.

When an older operator omits the new field, the effective VTXO target falls
back to `min_confirmations`. The daemon reports that effective value rather
than exposing a raw zero.

Retryable OOR rejections now retain their reason and retry delay in the pending
state and existing v5 snapshot fields. Restored sessions expose the same reason
and continue the existing retry loop.

## Safety rule

The operator owns both confirmation policies. The client must preserve the old
coupled behavior when the new field is absent, and a retryable OOR rejection
must never become a terminal failure.

## What does not change

- The round still has one confirmation watch and one confirmed transition.
- Old clients ignore the additive field and keep using `min_confirmations`.
- Old operators remain compatible through the fallback.
- OOR retries keep the same session identity and existing submit/finalize flow.
- No database migration or new OOR RPC field is required.

## Tests

The tests cover:

- nil, legacy-fallback, and explicit split confirmation terms;
- the exact target sent by the round actor when input maturity is 6 and VTXO
  activation is 1;
- daemon and SDK reporting of both policies;
- OOR rejection reason propagation in memory and across v5 snapshot restore;
- normal retry behavior after a retryable rejection.

Local verification:

- `go test ./lib/types ./round ./waved ./oor ./sdk/ark -count=1`
- `make lint-changed-local base=origin/main`
- `make fmt-changed-check base=origin/main`
- `make tidy-module-check`
- `make commitmsg-lint range="origin/main..HEAD"`

## Compatibility and rollout

| Operator | Client | Result |
|---|---|---|
| old | old | Existing coupled policy. |
| old | new | Zero/absent VTXO depth falls back to `min_confirmations`. |
| new | old | Unknown field is ignored; the client keeps the coupled policy. |
| new | new | Boarding maturity and VTXO activation use separate depths. |

Operators can advertise the new field before every client upgrades. Clients
that understand it may also upgrade first because the legacy fallback remains
the default.
