### PR TITLE
build: Enable wallet RPCs in release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ DB_CONNECTIONSTRING ?= sqlite://./wavelength.db
 DEV_TAGS := dev
 LOG_TAGS := nolog
 TEST_FLAGS :=
-RELEASE_TAGS :=
+RELEASE_TAGS := wavewalletrpc swapruntime
 
 # Build flags for debug builds (similar to lnd).
 DEV_GCFLAGS := -gcflags "all=-N -l"
@@ -583,7 +583,8 @@ docker-release: #? Same as release but within a docker container to support repr
 	$(DOCKER) run $(DOCKER_RELEASE_ARGS) \
 		-v $(shell pwd):/tmp/build/wavelength \
 		wavelength-release-helper \
-		make release tag="$(tag)" sys="$(sys)" COMMIT="$(COMMIT)"
+		make release tag="$(tag)" sys="$(sys)" \
+		RELEASE_TAGS="$(RELEASE_TAGS)" COMMIT="$(COMMIT)"
 
 # ============
 # CLEANUP

--- a/docs/release.md
+++ b/docs/release.md
@@ -58,6 +58,11 @@ archives of the release binaries (`waved` and `wavecli`) for each
 supported operating system and architecture, and a manifest file containing
 the hash of each archive.
 
+Both release commands build `waved` and `wavecli` with the `wavewalletrpc` and
+`swapruntime` tags. The Docker command passes the same release tags into its
+container, so both commands produce identical binaries for the same source and
+target platform.
+
 ## Publishing a Release
 
 Pushing a `v*` tag starts the Release Build workflow


### PR DESCRIPTION
## The problem

Release binaries omitted the wallet RPC and swap runtime because
`RELEASE_TAGS` was empty by default. `docker-release` also did not forward the
host release tags to its inner `make release`, so native and Docker builds
could use different tag sets.

The [v0.1.2-rc3 release instructions](https://github.com/lightninglabs/wavelength/releases/tag/v0.1.2-rc3)
present both commands as ways to reproduce the same archives.

## The fix

- Default release builds to `wavewalletrpc swapruntime`.
- Pass the resolved `RELEASE_TAGS` into the Docker container, including manual
  overrides.
- Document that native and Docker releases use the same production tags.

## Tests

- `make -n release tag=v0.1.2-rc3 sys=linux-amd64`
- `make -n docker-release tag=v0.1.2-rc3 sys=linux-amd64`
- `make cross-release-install sys=linux-amd64`
- `go version -m` confirms both binaries contain
  `-tags=wavewalletrpc,swapruntime`
- Docker release output confirms the inner build receives
  `wavewalletrpc swapruntime`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make commitmsg-lint range="origin/main..HEAD"`
