### PR TITLE
multi: reduce recoverable alert noise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,10 @@ This file is a **map**, not a manual. Follow links for details.
 - Function **definitions**: first param on same line, closing `)` with last param.
 - Structured logging: use `InfoS`/`DebugS`/etc. with static messages and
   `slog.Int()`/`btclog.Fmt()` key-value pairs. See [`docs/structured-logging.md`](docs/structured-logging.md).
-- `error` log level is **only** for internal bugs, never external triggers.
+- Production `Warn`, `Error`, and `Critical` logs alert a human. Use them
+  only when the event is actionable at that severity. Expected client input,
+  policy rejection, safe fallback, and repeated retry noise belong at
+  `Info`/`Debug` ([`docs/structured-logging.md`](docs/structured-logging.md)).
 
 Full style guide with examples: [`docs/development_guidelines.md`](docs/development_guidelines.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,10 @@ This file is a **map**, not a manual. Follow links for details.
 - Function **definitions**: first param on same line, closing `)` with last param.
 - Structured logging: use `InfoS`/`DebugS`/etc. with static messages and
   `slog.Int()`/`btclog.Fmt()` key-value pairs. See [`docs/structured-logging.md`](docs/structured-logging.md).
-- `error` log level is **only** for internal bugs, never external triggers.
+- Production `Warn`, `Error`, and `Critical` logs alert a human. Use them
+  only when the event is actionable at that severity. Expected client input,
+  policy rejection, safe fallback, and repeated retry noise belong at
+  `Info`/`Debug` ([`docs/structured-logging.md`](docs/structured-logging.md)).
 
 Full style guide with examples: [`docs/development_guidelines.md`](docs/development_guidelines.md)
 

--- a/chainfees/min_estimator.go
+++ b/chainfees/min_estimator.go
@@ -94,13 +94,15 @@ func (e *MinEstimator) EstimateFeePerKW(confTarget uint32) (
 		}
 
 		if rate < chainfee.FeePerKwFloor {
-			e.log.WarnS(context.Background(),
+			e.log.InfoS(context.Background(),
 				"Fee provider returned sub-floor rate; "+
 					"clamping",
-				fmt.Errorf("rate %d below floor %d", rate,
-					chainfee.FeePerKwFloor),
 				slog.String("provider", child.Name),
 				slog.Int64("raw_sat_kw", int64(rate)),
+				slog.Int64(
+					"floor_sat_kw",
+					int64(chainfee.FeePerKwFloor),
+				),
 			)
 			rate = chainfee.FeePerKwFloor
 		}

--- a/chainfees/min_estimator.go
+++ b/chainfees/min_estimator.go
@@ -94,9 +94,13 @@ func (e *MinEstimator) EstimateFeePerKW(confTarget uint32) (
 		}
 
 		if rate < chainfee.FeePerKwFloor {
-			e.log.InfoS(context.Background(),
+			err := fmt.Errorf("fee provider %s returned %d sat/kw "+
+				"below relay floor %d sat/kw", child.Name, rate,
+				chainfee.FeePerKwFloor)
+			e.log.WarnS(context.Background(),
 				"Fee provider returned sub-floor rate; "+
 					"clamping",
+				err,
 				slog.String("provider", child.Name),
 				slog.Int64("raw_sat_kw", int64(rate)),
 				slog.Int64(

--- a/chainfees/min_estimator.go
+++ b/chainfees/min_estimator.go
@@ -82,10 +82,10 @@ func (e *MinEstimator) EstimateFeePerKW(confTarget uint32) (
 		rate, err := child.Estimator.EstimateFeePerKW(confTarget)
 		if err != nil {
 			lastErr = err
-			e.log.WarnS(
+			e.log.InfoS(
 				context.Background(),
 				"Fee provider estimate failed",
-				err,
+				slog.Any("err", err),
 				slog.String("provider", child.Name),
 				slog.Uint64("conf_target", uint64(confTarget)),
 			)

--- a/docs/structured-logging.md
+++ b/docs/structured-logging.md
@@ -28,18 +28,37 @@ log.InfoS(ctx, "Channel open performed",
 - Lines can exceed 80 chars for structured logging.
 - Closing `)` stays on the same line as the last attribute.
 
-## Error Log Levels
+## Production Severity Contract
 
-**CRITICAL**: Only use `error` level for **internal errors never expected during
-normal operation**.
+Production `Warn`, `Error`, and `Critical` logs alert a human. Choose the
+level from the action the operator must take, not from whether a Go call
+returned an error.
 
 | Scenario | Level |
 |----------|-------|
-| Internal bug, impossible state | `error` |
-| RPC failure to external service | `warn` |
-| Chain backend disconnection | `warn` |
-| Peer disconnect | `info` or `debug` |
-| User-triggered condition | `info` or `debug` |
+| Immediate funds, security, or process-integrity threat | `critical` |
+| Internal invariant, durable-state failure, or exhausted recovery that requires intervention | `error` |
+| Actionable degradation or first occurrence of a dependency failure | `warn` |
+| Expected lifecycle, policy rejection, safe fallback, or recovery | `info` |
+| Repeated retry, high-volume protocol detail, or diagnostic state | `debug` |
 
-**Rule of thumb:** if a user or external system could cause it, it is not an
-error-level log.
+Client validation failures, capacity admission, idempotent duplicates, stale
+requests, peer behavior, and a fallback that repairs the condition in the same
+call are not alerts. Keep them at `Info` or `Debug`.
+
+For recurring work:
+
+1. Warn on the first actionable failure.
+2. Warn again if the failure cause changes materially.
+3. Log identical retries at debug.
+4. Log recovery at info.
+5. Escalate to error only at an explicit retry, time, or safety threshold.
+
+Every new `WarnS`, `ErrorS`, or `CriticalS` must have a bounded trigger and
+an operator action. Explain both in the commit message or PR description.
+Static messages define alert identity; put variable values in attributes so
+one incident cannot create unbounded alert groups.
+
+Do not add unit tests that only pin a log level or message. Explain pure
+severity changes in the commit and PR. Add tests when the change introduces
+classification, retry, threshold, or recovery logic.

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -918,8 +918,9 @@ func (s *IntentSentState) processEvent(ctx context.Context, event ClientEvent,
 		timeoutErr := fmt.Errorf("server did not acknowledge join " +
 			"request before registration timeout")
 
-		env.Log.WarnS(ctx, "Round admission timed out; failing round "+
-			"and releasing forfeit reservation", timeoutErr,
+		env.Log.InfoS(ctx, "Round admission timed out; failing round "+
+			"and releasing forfeit reservation",
+			slog.Any("err", timeoutErr),
 			slog.Int("forfeit_count", len(s.Intents.Forfeits)),
 		)
 

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -693,9 +693,9 @@ func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
 	case errors.Is(err, ErrParentAlreadyBroadcast):
 		// A live parent exists on another path, so the conf watch can
 		// ride to confirmation. Advance to AwaitingConfirmation.
-		a.log.WarnS(ctx,
+		a.log.DebugS(ctx,
 			"Initial anchor broadcast deferring to existing path",
-			err, "txid", entry.data.Txid,
+			"txid", entry.data.Txid, slog.Any("err", err),
 		)
 
 		_ = a.advanceTrackedTxFSM(

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -2034,15 +2034,12 @@ func TestEnsureConfirmedRetriesWhenFirstAttemptFailsAtHeightZero(t *testing.T) {
 	mustHaveNoNotification(t, sub)
 }
 
-// TestEnsureConfirmedDefersToExistingParentAtDebug verifies that an initial
-// package replacement race advances to AwaitingConfirmation without emitting
-// an operator warning. The existing parent remains live under the confirmation
-// watch, so the rejected duplicate child needs no operator action.
-func TestEnsureConfirmedDefersToExistingParentAtDebug(t *testing.T) {
-	var buf bytes.Buffer
-	logger := btclog.NewSLogger(btclog.NewDefaultHandler(&buf))
-	logger.SetLevel(btclog.LevelInfo)
-
+// TestEnsureConfirmedDefersToExistingParentBroadcast verifies that when the
+// package submission reports the parent is already known on another path (and
+// only the child failed), the tx advances to AwaitingConfirmation rather than
+// staying in Broadcasting — the conf watch rides the existing parent to
+// confirmation.
+func TestEnsureConfirmedDefersToExistingParentBroadcast(t *testing.T) {
 	chain := newFakeChainSourceRef(100)
 
 	tx := makeTestTx(true)
@@ -2065,7 +2062,6 @@ func TestEnsureConfirmedDefersToExistingParentAtDebug(t *testing.T) {
 	ref, _ := newTestActor(t, Config{
 		ChainSource: chain,
 		Wallet:      walletRef,
-		Log:         fn.Some[btclog.Logger](logger),
 	})
 
 	tx2 := tx
@@ -2080,10 +2076,6 @@ func TestEnsureConfirmedDefersToExistingParentAtDebug(t *testing.T) {
 	require.Equal(t, TxStateAwaitingConfirmation, resp.State)
 	require.Equal(t, 1, chain.packageCallCount())
 	mustHaveNoNotification(t, sub)
-	require.NotContains(
-		t, buf.String(),
-		"Initial anchor broadcast deferring to existing path",
-	)
 }
 
 // TestFeeBumpExistingParentLogsAtDebug verifies that a later fee bump does

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -2034,12 +2034,15 @@ func TestEnsureConfirmedRetriesWhenFirstAttemptFailsAtHeightZero(t *testing.T) {
 	mustHaveNoNotification(t, sub)
 }
 
-// TestEnsureConfirmedDefersToExistingParentBroadcast verifies that when the
-// package submission reports the parent is already known on another path (and
-// only the child failed), the tx advances to AwaitingConfirmation rather than
-// staying in Broadcasting — the conf watch rides the existing parent to
-// confirmation.
-func TestEnsureConfirmedDefersToExistingParentBroadcast(t *testing.T) {
+// TestEnsureConfirmedDefersToExistingParentAtDebug verifies that an initial
+// package replacement race advances to AwaitingConfirmation without emitting
+// an operator warning. The existing parent remains live under the confirmation
+// watch, so the rejected duplicate child needs no operator action.
+func TestEnsureConfirmedDefersToExistingParentAtDebug(t *testing.T) {
+	var buf bytes.Buffer
+	logger := btclog.NewSLogger(btclog.NewDefaultHandler(&buf))
+	logger.SetLevel(btclog.LevelInfo)
+
 	chain := newFakeChainSourceRef(100)
 
 	tx := makeTestTx(true)
@@ -2062,6 +2065,7 @@ func TestEnsureConfirmedDefersToExistingParentBroadcast(t *testing.T) {
 	ref, _ := newTestActor(t, Config{
 		ChainSource: chain,
 		Wallet:      walletRef,
+		Log:         fn.Some[btclog.Logger](logger),
 	})
 
 	tx2 := tx
@@ -2076,6 +2080,10 @@ func TestEnsureConfirmedDefersToExistingParentBroadcast(t *testing.T) {
 	require.Equal(t, TxStateAwaitingConfirmation, resp.State)
 	require.Equal(t, 1, chain.packageCallCount())
 	mustHaveNoNotification(t, sub)
+	require.NotContains(
+		t, buf.String(),
+		"Initial anchor broadcast deferring to existing path",
+	)
 }
 
 // TestFeeBumpExistingParentLogsAtDebug verifies that a later fee bump does

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -156,6 +156,7 @@ type behavior struct {
 	blockSubActive             bool
 	spendWatchActive           bool
 	proofSpendWatches          map[wire.OutPoint]struct{}
+	proofNodeFloorWarned       bool
 	terminalNotified           bool
 	exitCostNotified           bool
 	abandonedBroadcastsRemoved bool
@@ -858,9 +859,12 @@ func (b *behavior) proofNodeConfHeightHint(ctx context.Context,
 	// confirmation height. Once the VTXO's age reaches the lookback the
 	// floor sits at or above it, so an ancestor that confirmed earlier can
 	// escape the rescan window.
-	if b.desc != nil && b.desc.CreatedHeight > 0 {
+	if !b.proofNodeFloorWarned && b.desc != nil &&
+		b.desc.CreatedHeight > 0 {
+
 		age := int64(currentHeight) - int64(b.desc.CreatedHeight)
 		if age >= int64(proofNodeHeightHintLookback) {
+			b.proofNodeFloorWarned = true
 			b.log.WarnS(ctx, "Proof-node confirmation floor may "+
 				"exceed ancestor height; exit could stall",
 				nil,

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -1832,6 +1832,42 @@ func TestProofNodeHeightHintFallsBackWithoutCommitmentHeight(t *testing.T) {
 	require.Equal(t, startHeight-proofNodeHeightHintLookback, hint)
 }
 
+// TestProofNodeHeightHintWarnsOncePerActor verifies an old VTXO without a
+// commitment height emits one operator warning even when several proof-node
+// watches ask for the same fallback floor.
+func TestProofNodeHeightHintWarnsOncePerActor(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 1
+
+	var buf bytes.Buffer
+	logger := btclog.NewSLogger(btclog.NewDefaultHandler(&buf))
+	logger.SetLevel(btclog.LevelInfo)
+
+	const startHeight uint32 = 850_000
+
+	unrollActor, behavior, _, _ := newActorHarness(t, proof, desc)
+	behavior.log = logger
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  int32(startHeight),
+		Trigger: TriggerManual,
+	})
+
+	behavior.proofNodeConfHeightHint(t.Context(), chainhash.Hash{1})
+	behavior.proofNodeConfHeightHint(t.Context(), chainhash.Hash{2})
+
+	require.Equal(
+		t, 1,
+		bytes.Count(
+			buf.Bytes(), []byte(
+				"Proof-node confirmation floor may exceed "+
+					"ancestor height",
+			),
+		),
+	)
+}
+
 // TestFraudTriggerDefersReadyCheckpoint verifies fraud-triggered recovery
 // watches a ready checkpoint before asking txconfirm to broadcast it.
 func TestFraudTriggerDefersReadyCheckpoint(t *testing.T) {

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -910,8 +910,7 @@ func (m *Manager) handleVTXOCreated(ctx context.Context,
 		outpoint := clientVTXO.Outpoint
 
 		if _, exists := m.actors[outpoint]; exists {
-			m.logger(ctx).WarnS(ctx, "VTXO actor already exists",
-				nil,
+			m.logger(ctx).DebugS(ctx, "VTXO actor already exists",
 				slog.String("outpoint", outpoint.String()),
 			)
 
@@ -972,8 +971,7 @@ func (m *Manager) handleVTXOsMaterialized(ctx context.Context,
 
 		outpoint := descriptor.Outpoint
 		if _, exists := m.actors[outpoint]; exists {
-			m.logger(ctx).WarnS(ctx, "VTXO actor already exists",
-				nil,
+			m.logger(ctx).DebugS(ctx, "VTXO actor already exists",
 				slog.String("outpoint", outpoint.String()),
 			)
 


### PR DESCRIPTION
## Problem

Several normal recovery paths are logged as warnings and trigger the product
log alert:

- txconfirm loses a CPFP child replacement race after the parent is already in
  a mempool;
- idempotent VTXO materialization finds an actor that already exists;
- a recovered round admission timeout releases its reservation;
- an old VTXO without a commitment height warns once per proof node;
- one child fee estimator fails while another still supplies a usable rate.

These conditions need no immediate operator action. The old-VTXO floor and a
sub-floor fee provider remain real liveness risks, but their warnings are
bounded to actionable signals.

## Changes

- Log the typed `ErrParentAlreadyBroadcast` path at debug while preserving the
  parent confirmation watch.
- Log duplicate VTXO actor delivery at debug.
- Log recovered round admission timeout at info.
- Keep the old-VTXO confirmation-floor warning at warning, but emit it once per
  unroll actor.
- Log individual fee-provider failures at info when another provider can still
  supply a rate.
- Keep a sub-floor provider at warning. Clamping makes the rate relay-valid but
  the provider can still win minimum selection and pin the aggregate at the
  floor.
- Define `Warn`/`Error`/`Critical` as a human-page contract in
  `AGENTS.md`, `CLAUDE.md`, and the structured logging guide.

The transaction, actor, round, exit, and fee-selection state transitions are
unchanged.

## Safety

Only the typed already-broadcast race is demoted in txconfirm. Other package
failures retain their warning and escalation behavior.

The old-VTXO warning remains visible because its bounded confirmation floor can
miss an ancestor. Restarting the actor may emit it again.

The package-race unit test protects the state-machine invariant: the actor
advances to `AwaitingConfirmation` and keeps watching the existing parent. It
deliberately does not pin log severity. A severity-only assertion would also
pass if the diagnostic were deleted and is not product behavior.

Each pure severity change has its own commit and rationale. No unit test was
added only to pin a log level.

## Verification

- `go test ./txconfirm ./chainfees`
- `make fmt-changed-check`
- `make lint-changed-local`

## Compatibility

No protocol, persistence, transaction, or rollout compatibility change.
