### PR TITLE
docs: nightly doc-gardening sweep 2026-08-27

### DIFF
--- a/chainsource/AGENTS.md
+++ b/chainsource/AGENTS.md
@@ -45,6 +45,13 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- **An actor-mode subscription dies with its notify target.** In actor mode the
+  `NotifyActor` ref *is* the subscription's owner, so when a `Tell` fails with
+  `actor.ErrActorTerminated` or `actor.ErrMailboxClosed`, `BlockEpochActor`
+  cancels its own component-owned context and returns instead of logging a
+  warning per block forever. Transient `Tell` errors are still only logged and
+  retried on the next epoch — only the two "this ref can never accept
+  anything again" sentinels end the subscription.
 
 ## Deep Docs
 

--- a/chainsource/CLAUDE.md
+++ b/chainsource/CLAUDE.md
@@ -45,6 +45,13 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- **An actor-mode subscription dies with its notify target.** In actor mode the
+  `NotifyActor` ref *is* the subscription's owner, so when a `Tell` fails with
+  `actor.ErrActorTerminated` or `actor.ErrMailboxClosed`, `BlockEpochActor`
+  cancels its own component-owned context and returns instead of logging a
+  warning per block forever. Transient `Tell` errors are still only logged and
+  retried on the next epoch — only the two "this ref can never accept
+  anything again" sentinels end the subscription.
 
 ## Deep Docs
 

--- a/docs/swap_system.md
+++ b/docs/swap_system.md
@@ -470,6 +470,28 @@ production default is conservative:
   manual escalation months later cannot quietly spend at a looser rate than the
   client originally consented to.
 
+The same policy also supplies the *admission* budget, one lifecycle stage
+earlier. Before a receiver accepts a proposed vHTLC at all,
+`validateReceiveClaimWindow` asks
+[`arkscript.VHTLCTiming.ValidateClaimWindow`](../lib/arkscript/vhtlc_timing.go)
+whether the remaining `RefundLocktime - height` budget strictly exceeds
+`ExitAncestryDelayBlocks` (72 — confirming the vHTLC's commitment-tree and OOR
+ancestry) plus the vHTLC's own `UnilateralClaimDelay` plus
+`MinRecoveryMarginBlocks` (12). A vHTLC that fails this check could be accepted
+and then discovered, too late, to have no room for the on-chain rung described
+above — so it is rejected up front rather than armed and escalated into a
+window that was never wide enough.
+
+Two exceptions keep that check from destroying value. A backend that cannot
+answer `BlockHeight` yields a *retryable* error, never a terminal one — an
+unreachable node is not a bad vHTLC. And a **legacy direct-p2p in-Ark** event
+describes a vHTLC the sender has *already funded*: refusing it cannot undo the
+exposure, and would forfeit a cooperative claim that is still available, so the
+session logs `Receive vHTLC has limited recovery window` and proceeds.
+Credit-shaped in-Ark events and Lightning out-swap events both fail closed,
+because in those flows the rejection lands before the acknowledgement that
+triggers server-side funding.
+
 ### 5.6 The recovery row's life, and how cooperation cancels it
 
 A recovery row moves through a small state machine: it starts **ARMED**

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -16,6 +16,9 @@ message interfaces, and core Ark types.
 ### lib/arkscript
 - `Node` — Sealed AST interface for tapscript spending conditions (Multisig, CSV, Condition, etc.).
 - `VTXOPolicy` / `VHTLCPolicy` / `CheckpointPolicy` — High-level policy templates.
+- `VHTLCTiming` / `VHTLCClaimWindow` — Shared vHTLC block-timing model with
+  `ValidateOrder` (structural) and `ValidateClaimWindow` (chain-relative)
+  admission checks; `DecodeVHTLCTiming` recovers the tuple from a template.
 - `CompiledPolicy` — Fully compiled taproot tree with canonical leaf ordering.
 - `PolicyTemplate` / `StandardVTXOParams` — Serializable policy template with helpers for encoding, decoding, and deriving pkScripts.
 - `SpendInfo` / `AnchorPkScript` — Taproot spend helpers and standardized P2A anchor output construction.

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -16,6 +16,9 @@ message interfaces, and core Ark types.
 ### lib/arkscript
 - `Node` — Sealed AST interface for tapscript spending conditions (Multisig, CSV, Condition, etc.).
 - `VTXOPolicy` / `VHTLCPolicy` / `CheckpointPolicy` — High-level policy templates.
+- `VHTLCTiming` / `VHTLCClaimWindow` — Shared vHTLC block-timing model with
+  `ValidateOrder` (structural) and `ValidateClaimWindow` (chain-relative)
+  admission checks; `DecodeVHTLCTiming` recovers the tuple from a template.
 - `CompiledPolicy` — Fully compiled taproot tree with canonical leaf ordering.
 - `PolicyTemplate` / `StandardVTXOParams` — Serializable policy template with helpers for encoding, decoding, and deriving pkScripts.
 - `SpendInfo` / `AnchorPkScript` — Taproot spend helpers and standardized P2A anchor output construction.

--- a/lib/arkscript/AGENTS.md
+++ b/lib/arkscript/AGENTS.md
@@ -23,6 +23,27 @@ validated invariants.
   Provides `CollabSpendInfo()` and `ExitSpendInfo()`.
 - `VHTLCPolicy` — 6-leaf vHTLC policy with claim/refund/unilateral paths for
   hash-time-locked conditional transfers.
+- `VHTLCTiming` — the four block-based constraints in a vHTLC policy
+  (`RefundLocktime`, `UnilateralClaimDelay`, `UnilateralRefundDelay`,
+  `UnilateralRefundWithoutReceiverDelay`), projected from a live policy via
+  `VHTLCOpts.Timing()` or recovered from a persisted template via
+  `DecodeVHTLCTiming`. Two checks hang off it:
+  - `ValidateOrder()` — structural only. Rejects a tuple whose branches drop
+    cooperation requirements out of order (claim delay ≤ refund delay ≤
+    refund-without-receiver delay).
+  - `ValidateClaimWindow(VHTLCClaimWindow)` — chain-relative. Requires the
+    remaining `RefundLocktime - CurrentHeight` budget to strictly exceed
+    `ExitAncestryDelay + UnilateralClaimDelay + RecoveryMargin`, so a receiver
+    can publish the exit ancestry, wait out its own claim CSV, and still keep
+    margin before the sender/operator refund branch opens.
+- `VHTLCClaimWindow` — caller-supplied chain budget for
+  `ValidateClaimWindow`: `CurrentHeight`, `ExitAncestryDelay`,
+  `RecoveryMargin`.
+- `DecodeVHTLCTiming(*PolicyTemplate)` — recognizes the canonical six-leaf
+  vHTLC semantic shape and returns its timing tuple. Binds all six branches to
+  one sender/receiver/operator key set, payment hash, and refund locktime;
+  any other custom policy shape is rejected so vHTLC assumptions cannot be
+  applied to it.
 - `CheckpointPolicy` — Parameters for OOR checkpoint taproot tree construction. `CheckpointTapScript` / `CheckpointPkScript` derive the checkpoint output.
 - `SpendInfo` — Witness script + control block needed to spend a specific leaf. Methods: `BuildSignDescriptor`, `CollabWitness`, `TimeoutWitness`.
 - `SpendPath` — Serializable spend path (leaf index + encoded leaf data) with `Witness` and `AttachTapLeafScript` helpers for PSBT integration.
@@ -95,6 +116,18 @@ validated invariants.
   (collaborative) and at least one non-operator leaf (exit/unilateral).
 - Exit delay must be >= `MinExitDelay` when `ValidateStandardVTXOPolicy` is
   used; `ValidatePolicy` with `MinExitDelay = 0` skips this check.
+- **Policy construction does not validate timing.** `NewVHTLCPolicy` compiles
+  whatever timing tuple it is given; suitability depends on the lifecycle
+  boundary and the current chain height, which the compiler does not know.
+  Callers *admitting* a new policy must call `VHTLCTiming.ValidateOrder` or
+  `ValidateClaimWindow` themselves. This separation is deliberate: an
+  already-funded policy must still be reconstructible (and therefore
+  spendable) even once its remaining timing window is no longer admissible —
+  refusing to rebuild it would strand funds rather than protect them.
+- `DecodeVHTLCTiming` reports the committed script exactly and applies no
+  policy judgement. Admission callers layer `ValidateOrder` /
+  `ValidateClaimWindow` on top; recovery callers deliberately do not, so a
+  legacy on-chain policy can still be reconstructed.
 - Decode budget: policy template decode caps at `MaxPolicyTemplateBytes` /
   `MaxPolicyLeaves` / `MaxPolicyDepth` / `MaxPolicyNodes`; a single budget is
   shared across all leaves of one policy so an adversary cannot multiply work by

--- a/lib/arkscript/CLAUDE.md
+++ b/lib/arkscript/CLAUDE.md
@@ -23,6 +23,27 @@ validated invariants.
   Provides `CollabSpendInfo()` and `ExitSpendInfo()`.
 - `VHTLCPolicy` — 6-leaf vHTLC policy with claim/refund/unilateral paths for
   hash-time-locked conditional transfers.
+- `VHTLCTiming` — the four block-based constraints in a vHTLC policy
+  (`RefundLocktime`, `UnilateralClaimDelay`, `UnilateralRefundDelay`,
+  `UnilateralRefundWithoutReceiverDelay`), projected from a live policy via
+  `VHTLCOpts.Timing()` or recovered from a persisted template via
+  `DecodeVHTLCTiming`. Two checks hang off it:
+  - `ValidateOrder()` — structural only. Rejects a tuple whose branches drop
+    cooperation requirements out of order (claim delay ≤ refund delay ≤
+    refund-without-receiver delay).
+  - `ValidateClaimWindow(VHTLCClaimWindow)` — chain-relative. Requires the
+    remaining `RefundLocktime - CurrentHeight` budget to strictly exceed
+    `ExitAncestryDelay + UnilateralClaimDelay + RecoveryMargin`, so a receiver
+    can publish the exit ancestry, wait out its own claim CSV, and still keep
+    margin before the sender/operator refund branch opens.
+- `VHTLCClaimWindow` — caller-supplied chain budget for
+  `ValidateClaimWindow`: `CurrentHeight`, `ExitAncestryDelay`,
+  `RecoveryMargin`.
+- `DecodeVHTLCTiming(*PolicyTemplate)` — recognizes the canonical six-leaf
+  vHTLC semantic shape and returns its timing tuple. Binds all six branches to
+  one sender/receiver/operator key set, payment hash, and refund locktime;
+  any other custom policy shape is rejected so vHTLC assumptions cannot be
+  applied to it.
 - `CheckpointPolicy` — Parameters for OOR checkpoint taproot tree construction. `CheckpointTapScript` / `CheckpointPkScript` derive the checkpoint output.
 - `SpendInfo` — Witness script + control block needed to spend a specific leaf. Methods: `BuildSignDescriptor`, `CollabWitness`, `TimeoutWitness`.
 - `SpendPath` — Serializable spend path (leaf index + encoded leaf data) with `Witness` and `AttachTapLeafScript` helpers for PSBT integration.
@@ -95,6 +116,18 @@ validated invariants.
   (collaborative) and at least one non-operator leaf (exit/unilateral).
 - Exit delay must be >= `MinExitDelay` when `ValidateStandardVTXOPolicy` is
   used; `ValidatePolicy` with `MinExitDelay = 0` skips this check.
+- **Policy construction does not validate timing.** `NewVHTLCPolicy` compiles
+  whatever timing tuple it is given; suitability depends on the lifecycle
+  boundary and the current chain height, which the compiler does not know.
+  Callers *admitting* a new policy must call `VHTLCTiming.ValidateOrder` or
+  `ValidateClaimWindow` themselves. This separation is deliberate: an
+  already-funded policy must still be reconstructible (and therefore
+  spendable) even once its remaining timing window is no longer admissible —
+  refusing to rebuild it would strand funds rather than protect them.
+- `DecodeVHTLCTiming` reports the committed script exactly and applies no
+  policy judgement. Admission callers layer `ValidateOrder` /
+  `ValidateClaimWindow` on top; recovery callers deliberately do not, so a
+  legacy on-chain policy can still be reconstructed.
 - Decode budget: policy template decode caps at `MaxPolicyTemplateBytes` /
   `MaxPolicyLeaves` / `MaxPolicyDepth` / `MaxPolicyNodes`; a single budget is
   shared across all leaves of one policy so an adversary cannot multiply work by

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -86,7 +86,14 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/swap
   DTOs. `SwapSummary` — flat list view for persisted sessions.
 - `RecoveryPolicy` / `DefaultRecoveryPolicy` — governs auto-escalation
   from cooperative vHTLC retry to daemon-owned on-chain recovery
-  (arm/escalate/cancel via `DaemonConn`'s VHTLC recovery RPCs).
+  (arm/escalate/cancel via `DaemonConn`'s VHTLC recovery RPCs). Also
+  supplies the receive-side timing admission budget:
+  `ExitAncestryDelayBlocks` (default
+  `DefaultRecoveryExitAncestryDelayBlocks` = 72 — the conservative
+  block budget for confirming the vHTLC's commitment-tree and OOR
+  ancestry before its own claim CSV starts) and
+  `MinRecoveryMarginBlocks` (default `DefaultRecoveryMinMarginBlocks`
+  = 12). `WithDefaults()` fills any zero field.
 - `ForfeitSignaturePayload` / `ForfeitParticipantSignature` /
   `OutSwapForfeitSignatureReceiver` / `OutSwapForfeitSignatureNotification`
   — server-pushed out-swap vHTLC refresh signing requests.
@@ -110,7 +117,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/swap
 ## Relationships
 
 - **Depends on**: `lib/arkscript` (vHTLC policy + claim/refund
-  tapscript paths), `sdk/ark` (type aliases), `swaprpc` (gRPC stubs),
+  tapscript paths, plus the shared `VHTLCTiming` admission model),
+  `sdk/ark` (type aliases), `swaprpc` (gRPC stubs),
   `vtxo` (forfeit sign-request conversion), `mailbox/pb` (edge
   pull/ack), `serverconn` + `serverconn/mailboxpull` (`CompoundMailboxID`,
   `PubKeyMailboxID`, mailbox pull backoff), `db` + `db/migrate` +
@@ -176,6 +184,34 @@ result into an `IncomingVHTLCNotification`.
 - `RecoveryPolicy.MaxFeeRateSatPerKW` is captured at arm time and
   stored on the recovery row, so a later, looser default cannot
   silently raise the exit-spend fee cap for an already-armed job.
+- **vHTLC timing is validated at the admission boundary, via
+  `lib/arkscript`.** `vhtlcTiming(VHTLCConfig)` projects the wire DTO into
+  `arkscript.VHTLCTiming`. Pay-side `createSwap` calls `ValidateOrder()`
+  before it will fund. Receive-side `validateReceiveClaimWindow` calls
+  `ValidateClaimWindow` with the current daemon height and the recovery
+  policy's `ExitAncestryDelayBlocks` / `MinRecoveryMarginBlocks`, at the
+  moment a server event first asks the receiver to accept a policy. Never
+  re-derive these thresholds locally — the shared model is the one place
+  the branch ordering and window arithmetic live.
+- **A retryable backend failure must not durably reject a swap.**
+  `validateReceiveClaimWindow` wraps `BlockHeight` errors (and a missing
+  daemon conn) in `newRetryableActionError`, and
+  `failReceiveTimingAdmission` returns those untouched instead of calling
+  `failTerminal`. Only a timing tuple actually evaluated against chain state
+  fails the session. A node that cannot reach its backend is not a node
+  holding a bad vHTLC.
+- **Pre-funded in-Ark claims are warned about, not rejected.** For a
+  credit-shaped `InArkHtlcEvent` (`RequestedAmountSat > 0 ||
+  AttachedCreditSat > 0`) a bad claim window fails the session, because the
+  rejection lands *before* the ACK that triggers server-side funding. For a
+  legacy direct-p2p in-Ark event the sender has already funded the vHTLC, so
+  refusing it cannot undo the exposure and would only forfeit a still-available
+  cooperative claim: the session logs `Receive vHTLC has limited recovery
+  window` at warn (or debug when the window could not be evaluated) and
+  proceeds. Out-swap HTLC events always fail closed — nothing is funded yet.
+- `SwapClient.waitForVHTLC` returns the full `*VTXOInfo` (not a detached
+  outpoint/amount pair) so funding validation sees the whole observed VTXO;
+  `validateReceiveFunding` requires it to be non-nil.
 - **Account-scoped requests are signed, and the signature is per request.**
   `authorizeCreditAccountRequest` stamps a fresh `CreditAccountAuthorization`
   (1 min TTL, 32 bytes of `crypto/rand` nonce) onto `RequestChannelId`,

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -86,7 +86,14 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/swap
   DTOs. `SwapSummary` — flat list view for persisted sessions.
 - `RecoveryPolicy` / `DefaultRecoveryPolicy` — governs auto-escalation
   from cooperative vHTLC retry to daemon-owned on-chain recovery
-  (arm/escalate/cancel via `DaemonConn`'s VHTLC recovery RPCs).
+  (arm/escalate/cancel via `DaemonConn`'s VHTLC recovery RPCs). Also
+  supplies the receive-side timing admission budget:
+  `ExitAncestryDelayBlocks` (default
+  `DefaultRecoveryExitAncestryDelayBlocks` = 72 — the conservative
+  block budget for confirming the vHTLC's commitment-tree and OOR
+  ancestry before its own claim CSV starts) and
+  `MinRecoveryMarginBlocks` (default `DefaultRecoveryMinMarginBlocks`
+  = 12). `WithDefaults()` fills any zero field.
 - `ForfeitSignaturePayload` / `ForfeitParticipantSignature` /
   `OutSwapForfeitSignatureReceiver` / `OutSwapForfeitSignatureNotification`
   — server-pushed out-swap vHTLC refresh signing requests.
@@ -110,7 +117,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/swap
 ## Relationships
 
 - **Depends on**: `lib/arkscript` (vHTLC policy + claim/refund
-  tapscript paths), `sdk/ark` (type aliases), `swaprpc` (gRPC stubs),
+  tapscript paths, plus the shared `VHTLCTiming` admission model),
+  `sdk/ark` (type aliases), `swaprpc` (gRPC stubs),
   `vtxo` (forfeit sign-request conversion), `mailbox/pb` (edge
   pull/ack), `serverconn` + `serverconn/mailboxpull` (`CompoundMailboxID`,
   `PubKeyMailboxID`, mailbox pull backoff), `db` + `db/migrate` +
@@ -176,6 +184,34 @@ result into an `IncomingVHTLCNotification`.
 - `RecoveryPolicy.MaxFeeRateSatPerKW` is captured at arm time and
   stored on the recovery row, so a later, looser default cannot
   silently raise the exit-spend fee cap for an already-armed job.
+- **vHTLC timing is validated at the admission boundary, via
+  `lib/arkscript`.** `vhtlcTiming(VHTLCConfig)` projects the wire DTO into
+  `arkscript.VHTLCTiming`. Pay-side `createSwap` calls `ValidateOrder()`
+  before it will fund. Receive-side `validateReceiveClaimWindow` calls
+  `ValidateClaimWindow` with the current daemon height and the recovery
+  policy's `ExitAncestryDelayBlocks` / `MinRecoveryMarginBlocks`, at the
+  moment a server event first asks the receiver to accept a policy. Never
+  re-derive these thresholds locally — the shared model is the one place
+  the branch ordering and window arithmetic live.
+- **A retryable backend failure must not durably reject a swap.**
+  `validateReceiveClaimWindow` wraps `BlockHeight` errors (and a missing
+  daemon conn) in `newRetryableActionError`, and
+  `failReceiveTimingAdmission` returns those untouched instead of calling
+  `failTerminal`. Only a timing tuple actually evaluated against chain state
+  fails the session. A node that cannot reach its backend is not a node
+  holding a bad vHTLC.
+- **Pre-funded in-Ark claims are warned about, not rejected.** For a
+  credit-shaped `InArkHtlcEvent` (`RequestedAmountSat > 0 ||
+  AttachedCreditSat > 0`) a bad claim window fails the session, because the
+  rejection lands *before* the ACK that triggers server-side funding. For a
+  legacy direct-p2p in-Ark event the sender has already funded the vHTLC, so
+  refusing it cannot undo the exposure and would only forfeit a still-available
+  cooperative claim: the session logs `Receive vHTLC has limited recovery
+  window` at warn (or debug when the window could not be evaluated) and
+  proceeds. Out-swap HTLC events always fail closed — nothing is funded yet.
+- `SwapClient.waitForVHTLC` returns the full `*VTXOInfo` (not a detached
+  outpoint/amount pair) so funding validation sees the whole observed VTXO;
+  `validateReceiveFunding` requires it to be non-nil.
 - **Account-scoped requests are signed, and the signature is per request.**
   `authorizeCreditAccountRequest` stamps a fresh `CreditAccountAuthorization`
   (1 min TTL, 32 bytes of `crypto/rand` nonce) onto `RequestChannelId`,

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -163,6 +163,24 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   wallet leases), and deletes the tracked-tx entry. Late callers
   after eviction re-register from scratch and receive an immediate
   `TxConfirmed` via the normal path if the tx is already on chain.
+- **A stopped subscriber is dropped, not retried.** Terminal delivery is
+  three-valued (`terminalNotifyOutcome`: `Pending` / `Delivered` /
+  `SubscriberStopped`), not a bool. A `Tell` failing with
+  `actor.ErrActorTerminated` or `actor.ErrMailboxClosed` can never succeed,
+  so the subscriber is removed immediately rather than being retained for the
+  reorg-aware `TxReorged` / `TxFinalized` tail — otherwise a dead subscriber
+  keeps a confirmed entry (and its fee-input reservations and wallet leases)
+  alive forever while `retryLifecycleNotifications` re-warns every tick. On
+  the confirmed path, removal goes through `handleCancel`, so a dead *final*
+  subscriber also releases the entry's resources. Only `Pending` — a
+  transient failure or a delivery still running on the bounded async path —
+  keeps `pendingConfirmed` set for the next tick. The same split applies on
+  the deferred `handleTerminalNotifyResult` path, where a post-timeout stop
+  is logged at debug and cancelled rather than warned.
+- **Attach never inserts a dead subscriber**: `attachExistingSubscriber` only
+  writes the subscriber into `entry.subscribers` on `Delivered` or `Pending`.
+  On `SubscriberStopped` there is no tracked interest to unwind, because it
+  was never recorded.
 
 ## Deep Docs
 

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -163,6 +163,24 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   wallet leases), and deletes the tracked-tx entry. Late callers
   after eviction re-register from scratch and receive an immediate
   `TxConfirmed` via the normal path if the tx is already on chain.
+- **A stopped subscriber is dropped, not retried.** Terminal delivery is
+  three-valued (`terminalNotifyOutcome`: `Pending` / `Delivered` /
+  `SubscriberStopped`), not a bool. A `Tell` failing with
+  `actor.ErrActorTerminated` or `actor.ErrMailboxClosed` can never succeed,
+  so the subscriber is removed immediately rather than being retained for the
+  reorg-aware `TxReorged` / `TxFinalized` tail — otherwise a dead subscriber
+  keeps a confirmed entry (and its fee-input reservations and wallet leases)
+  alive forever while `retryLifecycleNotifications` re-warns every tick. On
+  the confirmed path, removal goes through `handleCancel`, so a dead *final*
+  subscriber also releases the entry's resources. Only `Pending` — a
+  transient failure or a delivery still running on the bounded async path —
+  keeps `pendingConfirmed` set for the next tick. The same split applies on
+  the deferred `handleTerminalNotifyResult` path, where a post-timeout stop
+  is logged at debug and cancelled rather than warned.
+- **Attach never inserts a dead subscriber**: `attachExistingSubscriber` only
+  writes the subscriber into `entry.subscribers` on `Delivered` or `Pending`.
+  On `SubscriberStopped` there is no tracked interest to unwind, because it
+  was never recorded.
 
 ## Deep Docs
 


### PR DESCRIPTION
Automated nightly doc-gardening sweep: brings the per-package
documentation graph back in line with code that landed since the last
merged sweep.

**Baseline:** `5f3c3ec3` (last merged nightly sweep, 2026-08-21).

**Workflow run:** unavailable — the workflow environment variables
(`RUN_ID` / `SERVER_URL` / `REPO_NAME`) were not readable from the sweep
sandbox, so the run link could not be generated rather than guessed.

### What changed

| Doc | Why |
|---|---|
| `lib/arkscript/{CLAUDE,AGENTS}.md` | New `VHTLCTiming` / `VHTLCClaimWindow` timing model, `DecodeVHTLCTiming`, and the invariant that policy construction deliberately does **not** validate timing (so an already-funded policy stays reconstructible instead of stranding funds). |
| `lib/{CLAUDE,AGENTS}.md` | Sub-package summary picks up the timing model. |
| `sdk/swaps/{CLAUDE,AGENTS}.md` | `RecoveryPolicy.ExitAncestryDelayBlocks`, the receive-side claim-window admission boundary, the retryable-vs-terminal split for backend failures, and why pre-funded legacy in-Ark claims warn instead of failing. |
| `chainsource/{CLAUDE,AGENTS}.md` | An actor-mode block-epoch subscription now ends when its notify target terminates. |
| `txconfirm/{CLAUDE,AGENTS}.md` | Terminal delivery became three-valued; a stopped subscriber is dropped rather than retried forever. |
| `docs/swap_system.md` | Section 5.5 extended with the admission-time claim-window budget and its two value-preserving exceptions. |

No new packages were found, so `ARCHITECTURE.md` needed no layer-table
change and every `docs/*.md` was already listed in `docs/index.md`.

`make doc-check` passes.

### Review focus

Please review the updated **CLAUDE.md / AGENTS.md** and
**docs/swap_system.md** diffs — in particular whether the newly written
invariants match the intent of the code they describe. The
`CLAUDE.md`/`AGENTS.md` pairs are byte-identical mirrors, so each pair
only needs reading once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
