### PR TITLE
lwwallet: optional SQLite backend for the wallet database

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,7 +58,7 @@ package may import from a higher layer.
 | [`serverconn/mailboxpull`](serverconn/mailboxpull/) | Shared exponential-backoff retry primitives for mailbox pull loops (used by serverconn ingress and SDK swap consumers) |
 | [`rpcauth`](rpcauth/) | Shared macaroon and TLS helpers securing gRPC/REST connections |
 | [`metrics`](metrics/) | Prometheus instrumentation namespaced under `waved_`: event-driven counter actor pool plus a scrape-time `SystemCollector` for live gauges, and an opt-in `/metrics` HTTP server |
-| [`internal/sqlbase`](internal/sqlbase/) | `walletdb`-compatible key/value backend over `database/sql` (js/wasm walletdb storage for `lwwallet` browser builds) |
+| [`internal/sqlbase`](internal/sqlbase/) | `walletdb`-compatible key/value backend over `database/sql` (SQL walletdb storage for `lwwallet`) |
 | [`internal/wasmhost`](internal/wasmhost/) | js/wasm host detection (browser vs Node) and the durable SQLite VFS name that follows from it; imported by `db`, `lwwallet`, and `cmd/wavewalletdk-wasm` |
 
 ### Layer 3: Application & Orchestration

--- a/cmd/waved/main.go
+++ b/cmd/waved/main.go
@@ -355,6 +355,10 @@ func registerWalletFlags(f *pflag.FlagSet, cfg *waved.Config) {
 		"esplora REST API URL (required for lwwallet)",
 	)
 	f.String(
+		"wallet.dbbackend", cfg.Wallet.DBBackend,
+		"wallet database backend for lwwallet (bolt, sqlite)",
+	)
+	f.String(
 		"wallet.feeurl", cfg.Wallet.FeeURL,
 		"fee-estimate JSON endpoint URL (required for btcwallet)",
 	)

--- a/cmd/waved/main.go
+++ b/cmd/waved/main.go
@@ -132,42 +132,7 @@ func newRootCmd() *cobra.Command {
 
 	registerArkServerFlags(f, cfg)
 
-	// Wallet backend flags.
-	f.String(
-		"wallet.type", cfg.Wallet.Type,
-		"wallet backend type (lnd, lwwallet, btcwallet)",
-	)
-	f.String(
-		"wallet.esploraurl", cfg.Wallet.EsploraURL,
-		"esplora REST API URL (required for lwwallet)",
-	)
-	f.String(
-		"wallet.feeurl", cfg.Wallet.FeeURL,
-		"fee-estimate JSON endpoint URL (required for btcwallet)",
-	)
-	f.String(
-		"wallet.btcwallet_blockheaderssource",
-		cfg.Wallet.BtcwBlockSource,
-		"block header import source for btcwallet fast sync",
-	)
-	f.String(
-		"wallet.btcwallet_filterheaderssource",
-		cfg.Wallet.BtcwFilterSource,
-		"filter header import source for btcwallet fast sync",
-	)
-	f.Duration(
-		"wallet.pollinterval", cfg.Wallet.PollInterval,
-		"chain poll interval for lwwallet backend",
-	)
-	f.Uint32(
-		"wallet.recoverywindow", cfg.Wallet.RecoveryWindow,
-		"address recovery look-ahead window for lwwallet",
-	)
-	f.String(
-		"wallet.password_file", cfg.Wallet.PasswordFile, "path to "+
-			"file containing wallet password for auto-unlock "+
-			"at startup (lwwallet/btcwallet)",
-	)
+	registerWalletFlags(f, cfg)
 
 	registerBitcoindFlags(f)
 
@@ -375,6 +340,46 @@ func registerDaemonRPCFlags(f *pflag.FlagSet, cfg *waved.Config) {
 	f.StringSlice(
 		"rpc.gateway.allowedorigins", cfg.RPC.Gateway.AllowedOrigins,
 		"trusted browser origins allowed to call the daemon gateway",
+	)
+}
+
+// registerWalletFlags registers the flags of the daemon's wallet
+// backends.
+func registerWalletFlags(f *pflag.FlagSet, cfg *waved.Config) {
+	f.String(
+		"wallet.type", cfg.Wallet.Type,
+		"wallet backend type (lnd, lwwallet, btcwallet)",
+	)
+	f.String(
+		"wallet.esploraurl", cfg.Wallet.EsploraURL,
+		"esplora REST API URL (required for lwwallet)",
+	)
+	f.String(
+		"wallet.feeurl", cfg.Wallet.FeeURL,
+		"fee-estimate JSON endpoint URL (required for btcwallet)",
+	)
+	f.String(
+		"wallet.btcwallet_blockheaderssource",
+		cfg.Wallet.BtcwBlockSource,
+		"block header import source for btcwallet fast sync",
+	)
+	f.String(
+		"wallet.btcwallet_filterheaderssource",
+		cfg.Wallet.BtcwFilterSource,
+		"filter header import source for btcwallet fast sync",
+	)
+	f.Duration(
+		"wallet.pollinterval", cfg.Wallet.PollInterval,
+		"chain poll interval for lwwallet backend",
+	)
+	f.Uint32(
+		"wallet.recoverywindow", cfg.Wallet.RecoveryWindow,
+		"address recovery look-ahead window for lwwallet",
+	)
+	f.String(
+		"wallet.password_file", cfg.Wallet.PasswordFile, "path to "+
+			"file containing wallet password for auto-unlock "+
+			"at startup (lwwallet/btcwallet)",
 	)
 }
 

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -130,6 +130,7 @@ waved \
 | `--wallet.btcwallet_filterheaderssource` | | Filter header import source for btcwallet fast sync |
 | `--wallet.pollinterval` | `30s` | Esplora poll interval (lwwallet only) |
 | `--wallet.recoverywindow` | `100` | Address look-ahead window (lwwallet only) |
+| `--wallet.dbbackend` | `bolt` | Wallet database backend (lwwallet only): `bolt` or `sqlite`; fixed once the wallet is created |
 | `--wallet.password_file` | | Auto-unlock password file path (lwwallet/btcwallet) |
 | `--lnd.host` | `localhost:10009` | lnd gRPC address |
 | `--lnd.tlspath` | | Path to lnd TLS certificate |

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -11,8 +11,9 @@ module.
 - `internal/actortest` — Durable actor integration tests using real DB backends (SQLite, Postgres), verifying at-least-once delivery, exactly-once dedup, FIFO ordering, and atomic state+outbox.
 - `internal/cmd/tools/accounting` — DB-backed admin command that reports ledger balances, event totals, and optional BTC/fiat valuation.
 - `internal/indexerlimits` — Shared client-side bounds for indexer pagination cursors.
-- `internal/sqlbase` — `js && wasm`-only `walletdb`-compatible SQL backend
-  (SQLite over `go-wasmsqlite`), used by `lwwallet` for browser builds.
+- `internal/sqlbase` — `walletdb`-compatible SQL backend, used by `lwwallet`
+  on every platform: SQLite over `go-wasmsqlite` in the browser, over
+  `modernc.org/sqlite` natively.
 - `internal/testutils` — Deterministic key pair and Schnorr signature generation for tests.
 - `internal/wasmhost` — `js && wasm`-only host detection (browser vs Node) and
   the durable SQLite VFS name that follows from it.
@@ -20,7 +21,7 @@ module.
 ## Relationships
 
 - **Depends on**: `baselib/actor`, `db` (real backends for integration tests),
-  `btcwallet/walletdb` (sqlbase's wasm backend).
-- **Depended on by**: internal module packages only, plus `lwwallet` (wasm
-  builds, via `internal/sqlbase` and `internal/wasmhost`), `db` and
-  `cmd/wavewalletdk-wasm` (wasm builds, via `internal/wasmhost`).
+  `btcwallet/walletdb` (the interface sqlbase implements).
+- **Depended on by**: internal module packages only, plus `lwwallet` (all
+  platforms via `internal/sqlbase`, wasm builds via `internal/wasmhost`), `db`
+  and `cmd/wavewalletdk-wasm` (wasm builds, via `internal/wasmhost`).

--- a/internal/CLAUDE.md
+++ b/internal/CLAUDE.md
@@ -11,8 +11,9 @@ module.
 - `internal/actortest` — Durable actor integration tests using real DB backends (SQLite, Postgres), verifying at-least-once delivery, exactly-once dedup, FIFO ordering, and atomic state+outbox.
 - `internal/cmd/tools/accounting` — DB-backed admin command that reports ledger balances, event totals, and optional BTC/fiat valuation.
 - `internal/indexerlimits` — Shared client-side bounds for indexer pagination cursors.
-- `internal/sqlbase` — `js && wasm`-only `walletdb`-compatible SQL backend
-  (SQLite over `go-wasmsqlite`), used by `lwwallet` for browser builds.
+- `internal/sqlbase` — `walletdb`-compatible SQL backend, used by `lwwallet`
+  on every platform: SQLite over `go-wasmsqlite` in the browser, over
+  `modernc.org/sqlite` natively.
 - `internal/testutils` — Deterministic key pair and Schnorr signature generation for tests.
 - `internal/wasmhost` — `js && wasm`-only host detection (browser vs Node) and
   the durable SQLite VFS name that follows from it.
@@ -20,7 +21,7 @@ module.
 ## Relationships
 
 - **Depends on**: `baselib/actor`, `db` (real backends for integration tests),
-  `btcwallet/walletdb` (sqlbase's wasm backend).
-- **Depended on by**: internal module packages only, plus `lwwallet` (wasm
-  builds, via `internal/sqlbase` and `internal/wasmhost`), `db` and
-  `cmd/wavewalletdk-wasm` (wasm builds, via `internal/wasmhost`).
+  `btcwallet/walletdb` (the interface sqlbase implements).
+- **Depended on by**: internal module packages only, plus `lwwallet` (all
+  platforms via `internal/sqlbase`, wasm builds via `internal/wasmhost`), `db`
+  and `cmd/wavewalletdk-wasm` (wasm builds, via `internal/wasmhost`).

--- a/internal/sqlbase/AGENTS.md
+++ b/internal/sqlbase/AGENTS.md
@@ -23,8 +23,12 @@ native builds.
   buckets are simulated as rows in a single `<prefix>_kv` table, with each
   row's `parent_id` self-referencing the row of the bucket it belongs to
   (`NULL` for the top-level bucket).
-- `Init(maxConnections int)` — initializes the process-global connection
-  pool (`dbConnSet`) that dedups connections by DSN across callers.
+- `Init(maxConnections int) error` — initializes the process-global connection
+  pool (`dbConnSet`) that dedups connections by DSN across callers. Repeating
+  the same limit is a no-op; a *different* limit is refused, because the limit
+  is fixed by whoever calls first and a caller that asked for one connection
+  because its store assumes a single writer must not silently end up on a
+  wider pool.
 
 ## Relationships
 

--- a/internal/sqlbase/AGENTS.md
+++ b/internal/sqlbase/AGENTS.md
@@ -2,11 +2,12 @@
 
 ## Purpose
 
-A `walletdb`-compatible key/value backend implemented over `database/sql`,
-built only for `js && wasm` (every file carries that build tag). It emulates
-`btcwallet/walletdb` buckets/cursors on top of a relational table so
-`lwwallet` can run the wallet stack in the browser (SQLite via
-`go-wasmsqlite`), where the native BoltDB/`kvdb` backends are unavailable.
+A `walletdb`-compatible key/value backend implemented over `database/sql`.
+It emulates `btcwallet/walletdb` buckets/cursors on top of a relational
+table so `lwwallet` can run the wallet stack on any `database/sql` driver
+instead of the BoltDB/`kvdb` backends: `go-wasmsqlite` (OPFS) in the
+browser, where BoltDB is unavailable at all, and `modernc.org/sqlite` on
+native builds.
 
 ## Key Types
 
@@ -29,13 +30,10 @@ built only for `js && wasm` (every file carries that build tag). It emulates
 
 - **Depends on**: `btcwallet/walletdb` (interface being implemented),
   `lnd/sqldb` (shared SQL error classification).
-- **Depended on by**: `lwwallet` (wasm builds only, via `internal/sqlbase`).
+- **Depended on by**: `lwwallet` (all platforms).
 
 ## Invariants
 
-- Every file is `//go:build js && wasm`; this package does not build (and
-  cannot be exercised) on native `GOOS`/`GOARCH` — use
-  `GOOS=js GOARCH=wasm go build ./internal/sqlbase` or `go doc` to inspect it.
 - `DefaultNumTxRetries = 50`: `Update`/`View` retry on transaction errors that
   permit repetition, calling the caller's `reset` before each retry.
 - `WithTxLevelLock` serializes all read-write transactions through a single

--- a/internal/sqlbase/CLAUDE.md
+++ b/internal/sqlbase/CLAUDE.md
@@ -23,8 +23,12 @@ native builds.
   buckets are simulated as rows in a single `<prefix>_kv` table, with each
   row's `parent_id` self-referencing the row of the bucket it belongs to
   (`NULL` for the top-level bucket).
-- `Init(maxConnections int)` — initializes the process-global connection
-  pool (`dbConnSet`) that dedups connections by DSN across callers.
+- `Init(maxConnections int) error` — initializes the process-global connection
+  pool (`dbConnSet`) that dedups connections by DSN across callers. Repeating
+  the same limit is a no-op; a *different* limit is refused, because the limit
+  is fixed by whoever calls first and a caller that asked for one connection
+  because its store assumes a single writer must not silently end up on a
+  wider pool.
 
 ## Relationships
 

--- a/internal/sqlbase/CLAUDE.md
+++ b/internal/sqlbase/CLAUDE.md
@@ -2,11 +2,12 @@
 
 ## Purpose
 
-A `walletdb`-compatible key/value backend implemented over `database/sql`,
-built only for `js && wasm` (every file carries that build tag). It emulates
-`btcwallet/walletdb` buckets/cursors on top of a relational table so
-`lwwallet` can run the wallet stack in the browser (SQLite via
-`go-wasmsqlite`), where the native BoltDB/`kvdb` backends are unavailable.
+A `walletdb`-compatible key/value backend implemented over `database/sql`.
+It emulates `btcwallet/walletdb` buckets/cursors on top of a relational
+table so `lwwallet` can run the wallet stack on any `database/sql` driver
+instead of the BoltDB/`kvdb` backends: `go-wasmsqlite` (OPFS) in the
+browser, where BoltDB is unavailable at all, and `modernc.org/sqlite` on
+native builds.
 
 ## Key Types
 
@@ -29,13 +30,10 @@ built only for `js && wasm` (every file carries that build tag). It emulates
 
 - **Depends on**: `btcwallet/walletdb` (interface being implemented),
   `lnd/sqldb` (shared SQL error classification).
-- **Depended on by**: `lwwallet` (wasm builds only, via `internal/sqlbase`).
+- **Depended on by**: `lwwallet` (all platforms).
 
 ## Invariants
 
-- Every file is `//go:build js && wasm`; this package does not build (and
-  cannot be exercised) on native `GOOS`/`GOARCH` — use
-  `GOOS=js GOARCH=wasm go build ./internal/sqlbase` or `go doc` to inspect it.
 - `DefaultNumTxRetries = 50`: `Update`/`View` retry on transaction errors that
   permit repetition, calling the caller's `reset` before each retry.
 - `WithTxLevelLock` serializes all read-write transactions through a single

--- a/internal/sqlbase/db.go
+++ b/internal/sqlbase/db.go
@@ -77,6 +77,8 @@ type db struct {
 	//
 	// TODO: This is an anti-pattern that is in place until the kvdb
 	// interface supports a context.
+	//
+	//nolint:containedctx
 	ctx context.Context
 
 	// db is the underlying database connection instance.
@@ -163,11 +165,6 @@ func (db *db) getTimeoutCtx() (context.Context, func()) {
 	return context.WithTimeout(db.ctx, db.cfg.Timeout)
 }
 
-// getPrefixedTableName returns a table name for this prefix (namespace).
-func (db *db) getPrefixedTableName(table string) string {
-	return fmt.Sprintf("%s_%s", db.prefix, table)
-}
-
 // catchPanic executes the specified function. If a panic occurs, it is returned
 // as an error value.
 func catchPanic(f func() error) (err error) {
@@ -208,9 +205,11 @@ func catchPanic(f func() error) (err error) {
 // expect retries of the f closure (depending on the database backend used), the
 // reset function will be called before each retry respectively.
 func (db *db) View(f func(tx walletdb.ReadTx) error, reset func()) error {
+	// walletdb.ReadWriteTx embeds walletdb.ReadTx, so the read-write
+	// transaction satisfies the read-only callback as-is.
 	return db.executeTransaction(
 		func(tx walletdb.ReadWriteTx) error {
-			return f(tx.(walletdb.ReadTx))
+			return f(tx)
 		},
 		reset, true,
 	)
@@ -245,6 +244,7 @@ func (db *db) executeTransaction(f func(tx walletdb.ReadWriteTx) error,
 		}
 
 		reset()
+
 		return catchPanic(func() error { return f(kvTx) })
 	}
 

--- a/internal/sqlbase/db.go
+++ b/internal/sqlbase/db.go
@@ -1,5 +1,3 @@
-//go:build js && wasm
-
 package sqlbase
 
 import (

--- a/internal/sqlbase/db.go
+++ b/internal/sqlbase/db.go
@@ -101,16 +101,33 @@ var (
 	dbConnsMu sync.Mutex
 )
 
-// Init initializes the global set of database connections.
-func Init(maxConnections int) {
+// Init initializes the global set of database connections. Calling it
+// more than once with the same limit is a no-op, so every caller that
+// opens a database through this package can state the limit it needs.
+//
+// The set is process-global and its limit is fixed by whoever gets
+// there first, so a later call asking for a different limit cannot be
+// honored. It is refused rather than silently ignored: a caller that
+// asked for a single connection because its store assumes one writer
+// would otherwise run on a wider pool than it believes it has.
+func Init(maxConnections int) error {
 	dbConnsMu.Lock()
 	defer dbConnsMu.Unlock()
 
 	if dbConns != nil {
-		return
+		if dbConns.maxConnections != maxConnections {
+			return fmt.Errorf("connection set already "+
+				"initialized with a limit of %d connections, "+
+				"cannot re-initialize it with %d",
+				dbConns.maxConnections, maxConnections)
+		}
+
+		return nil
 	}
 
 	dbConns = newDbConnSet(maxConnections)
+
+	return nil
 }
 
 // NewSqlBackend returns a db object initialized with the passed backend

--- a/internal/sqlbase/db_conn_set.go
+++ b/internal/sqlbase/db_conn_set.go
@@ -1,5 +1,3 @@
-//go:build js && wasm
-
 package sqlbase
 
 import (

--- a/internal/sqlbase/db_test.go
+++ b/internal/sqlbase/db_test.go
@@ -27,7 +27,7 @@ func newTestDB(t *testing.T) (walletdb.DB, string) {
 	// The connection set is process-global and first-call-wins, so
 	// every test in this package shares the single-connection limit
 	// the wallet store asks for.
-	Init(1)
+	require.NoError(t, Init(1))
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	dsn := dbPath +
@@ -354,4 +354,17 @@ func TestUpdateRollback(t *testing.T) {
 			return nil
 		}, func() {}),
 	)
+}
+
+// TestInitConflictingLimit asserts a second Init asking for a
+// different connection limit is refused. The limit is process-global
+// and cannot be changed once set, so silently ignoring the second
+// caller would leave it running on a pool it did not ask for.
+func TestInitConflictingLimit(t *testing.T) {
+	// Deliberately not parallel: this asserts on process-global
+	// state. Whichever test initializes the set first uses a limit
+	// of one, so both expectations below hold in any order.
+	require.NoError(t, Init(1))
+	require.NoError(t, Init(1))
+	require.ErrorContains(t, Init(2), "already initialized")
 }

--- a/internal/sqlbase/db_test.go
+++ b/internal/sqlbase/db_test.go
@@ -1,0 +1,357 @@
+package sqlbase
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// testBucket is the top-level bucket the tests below operate in.
+var testBucket = []byte("top")
+
+// newTestDB opens a SQLite-backed walletdb in a temporary directory,
+// configured the way the wallet store configures it: a single
+// connection, serialized read-write transactions, foreign keys on so
+// nested-bucket deletes cascade.
+func newTestDB(t *testing.T) (walletdb.DB, string) {
+	t.Helper()
+
+	// The connection set is process-global and first-call-wins, so
+	// every test in this package shares the single-connection limit
+	// the wallet store asks for.
+	Init(1)
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	dsn := dbPath +
+		"?_pragma=foreign_keys%3Don&_pragma=journal_mode%3DWAL" +
+		"&_pragma=busy_timeout%3D5000&_txlock=immediate"
+
+	db, err := NewSqlBackend(context.Background(), &Config{
+		DriverName:      "sqlite",
+		Dsn:             dsn,
+		Timeout:         10 * time.Second,
+		TableNamePrefix: "test",
+		WithTxLevelLock: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	return db, dbPath
+}
+
+// countRows returns the number of rows in the key/value table, read
+// through a connection of the test's own so it can see what the
+// walletdb interface deliberately cannot: rows that are still present
+// but no longer reachable from any bucket.
+func countRows(t *testing.T, dbPath string) int {
+	t.Helper()
+
+	raw, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, raw.Close())
+	}()
+
+	var count int
+	require.NoError(
+		t, raw.QueryRow("SELECT COUNT(*) FROM test_kv").Scan(&count),
+	)
+
+	return count
+}
+
+// update runs f in a read-write transaction and requires it to commit.
+func update(t *testing.T, db walletdb.DB,
+	f func(walletdb.ReadWriteBucket) error) {
+
+	t.Helper()
+
+	require.NoError(
+		t, db.Update(func(tx walletdb.ReadWriteTx) error {
+			b, err := tx.CreateTopLevelBucket(testBucket)
+			if err != nil {
+				return err
+			}
+
+			return f(b)
+		}, func() {}),
+	)
+}
+
+// TestBucketRoundTrip covers the basic key/value contract: a value put
+// in a bucket reads back byte-identical, an absent key reads as nil
+// rather than an error, and a deleted key is gone.
+func TestBucketRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	db, _ := newTestDB(t)
+
+	update(t, db, func(b walletdb.ReadWriteBucket) error {
+		require.NoError(t, b.Put([]byte("k"), []byte("v")))
+		require.Equal(t, []byte("v"), b.Get([]byte("k")))
+		require.Nil(t, b.Get([]byte("absent")))
+
+		// An empty value is a value, not an absent key.
+		require.NoError(t, b.Put([]byte("empty"), []byte{}))
+		require.NotNil(t, b.Get([]byte("empty")))
+		require.Empty(t, b.Get([]byte("empty")))
+
+		require.NoError(t, b.Delete([]byte("k")))
+		require.Nil(t, b.Get([]byte("k")))
+
+		return nil
+	})
+
+	// The value survives the commit and a fresh transaction.
+	require.NoError(
+		t, db.View(func(tx walletdb.ReadTx) error {
+			b := tx.ReadBucket(testBucket)
+			require.NotNil(t, b)
+			require.Empty(t, b.Get([]byte("empty")))
+			require.Nil(t, b.Get([]byte("k")))
+
+			return nil
+		}, func() {}),
+	)
+}
+
+// TestNestedBucketCascade asserts a nested bucket's contents disappear
+// with it, physically and not just logically. DeleteNestedBucket
+// removes only the bucket's own row and leans on the schema's
+// ON DELETE CASCADE for the rest, and the difference is invisible
+// through the walletdb interface: orphaned children keep pointing at
+// the deleted row's id, so a recreated bucket gets a new id and reads
+// empty either way. The row count is what distinguishes a cascade that
+// fired from one that silently did not.
+func TestNestedBucketCascade(t *testing.T) {
+	t.Parallel()
+
+	db, dbPath := newTestDB(t)
+
+	update(t, db, func(b walletdb.ReadWriteBucket) error {
+		nested, err := b.CreateBucket([]byte("nested"))
+		require.NoError(t, err)
+		require.NoError(t, nested.Put([]byte("k"), []byte("v")))
+
+		deeper, err := nested.CreateBucket([]byte("deeper"))
+		require.NoError(t, err)
+		require.NoError(t, deeper.Put([]byte("k"), []byte("v")))
+
+		return nil
+	})
+
+	update(t, db, func(b walletdb.ReadWriteBucket) error {
+		require.NotNil(t, b.NestedReadBucket([]byte("nested")))
+		require.NoError(t, b.DeleteNestedBucket([]byte("nested")))
+		require.Nil(t, b.NestedReadBucket([]byte("nested")))
+
+		return nil
+	})
+
+	// Only the top-level bucket's own row is left; the nested bucket,
+	// the bucket below it and both their keys are gone.
+	require.Equal(t, 1, countRows(t, dbPath))
+
+	update(t, db, func(b walletdb.ReadWriteBucket) error {
+		nested, err := b.CreateBucket([]byte("nested"))
+		require.NoError(t, err)
+		require.Nil(t, nested.Get([]byte("k")))
+		require.Nil(t, nested.NestedReadBucket([]byte("deeper")))
+
+		return nil
+	})
+}
+
+// TestForAll covers the optimized bucket walk: it must visit every key
+// in ascending key order, and a callback error must abort the walk and
+// surface unchanged.
+func TestForAll(t *testing.T) {
+	t.Parallel()
+
+	db, _ := newTestDB(t)
+
+	keys := []string{"a", "b", "c", "d"}
+	update(t, db, func(b walletdb.ReadWriteBucket) error {
+		// Insert out of order, so an implementation that returned
+		// insertion order would fail below.
+		for _, k := range []string{"c", "a", "d", "b"} {
+			require.NoError(t, b.Put([]byte(k), []byte(k)))
+		}
+
+		return nil
+	})
+
+	require.NoError(
+		t, db.View(func(tx walletdb.ReadTx) error {
+			var seen []string
+			err := kvdb.ForAll(
+				tx.ReadBucket(testBucket),
+				func(k, v []byte) error {
+					require.Equal(t, k, v)
+					seen = append(seen, string(k))
+
+					return nil
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, keys, seen)
+
+			return nil
+		}, func() {}),
+	)
+
+	// A callback error aborts the walk and is returned as-is.
+	sentinel := errors.New("stop walking")
+	err := db.View(func(tx walletdb.ReadTx) error {
+		var calls int
+
+		return kvdb.ForAll(
+			tx.ReadBucket(testBucket),
+			func(k, v []byte) error {
+				calls++
+				require.Equal(t, 1, calls)
+
+				return sentinel
+			},
+		)
+	}, func() {})
+	require.ErrorIs(t, err, sentinel)
+
+	// Aborting the walk must leave the database usable. The pool has
+	// a single connection, so a result set that outlived its
+	// transaction would starve every later query.
+	require.NoError(
+		t, db.View(func(tx walletdb.ReadTx) error {
+			require.Equal(
+				t, []byte("a"),
+				tx.ReadBucket(
+					testBucket).Get([]byte("a")),
+			)
+
+			return nil
+		}, func() {}),
+	)
+}
+
+// TestCursor covers the cursor's ordering contract, which buckets like
+// the wallet's key-derivation state depend on: seeking lands on the
+// first key at or after the target, and stepping past either end
+// returns nil rather than wrapping around.
+func TestCursor(t *testing.T) {
+	t.Parallel()
+
+	db, _ := newTestDB(t)
+
+	update(t, db, func(b walletdb.ReadWriteBucket) error {
+		for _, k := range []string{"a", "c", "e"} {
+			require.NoError(t, b.Put([]byte(k), []byte(k)))
+		}
+
+		return nil
+	})
+
+	require.NoError(t, db.View(func(tx walletdb.ReadTx) error {
+		c := tx.ReadBucket(testBucket).ReadCursor()
+
+		k, v := c.First()
+		require.Equal(t, "a", string(k))
+		require.Equal(t, "a", string(v))
+
+		k, _ = c.Next()
+		require.Equal(t, "c", string(k))
+
+		k, _ = c.Prev()
+		require.Equal(t, "a", string(k))
+
+		// Stepping off the front yields nothing.
+		k, _ = c.Prev()
+		require.Nil(t, k)
+
+		k, _ = c.Last()
+		require.Equal(t, "e", string(k))
+
+		k, _ = c.Next()
+		require.Nil(t, k)
+
+		// Seek lands on the first key at or after the target.
+		k, _ = c.Seek([]byte("b"))
+		require.Equal(t, "c", string(k))
+
+		k, _ = c.Seek([]byte("c"))
+		require.Equal(t, "c", string(k))
+
+		// Seeking past the last key yields nothing.
+		k, _ = c.Seek([]byte("z"))
+		require.Nil(t, k)
+
+		return nil
+	}, func() {}))
+
+	// Cursor deletion removes the key the cursor sits on.
+	update(t, db, func(b walletdb.ReadWriteBucket) error {
+		c := b.ReadWriteCursor()
+		k, _ := c.First()
+		require.Equal(t, "a", string(k))
+		require.NoError(t, c.Delete())
+
+		return nil
+	})
+
+	require.NoError(
+		t, db.View(func(tx walletdb.ReadTx) error {
+			b := tx.ReadBucket(testBucket)
+			require.Nil(t, b.Get([]byte("a")))
+			k, _ := b.ReadCursor().First()
+			require.Equal(t, "c", string(k))
+
+			return nil
+		}, func() {}),
+	)
+}
+
+// TestUpdateRollback asserts a failed transaction leaves nothing
+// behind: everything the callback wrote before erroring is rolled back.
+func TestUpdateRollback(t *testing.T) {
+	t.Parallel()
+
+	db, _ := newTestDB(t)
+
+	update(t, db, func(b walletdb.ReadWriteBucket) error {
+		return b.Put([]byte("committed"), []byte("v"))
+	})
+
+	sentinel := errors.New("abort")
+	err := db.Update(func(tx walletdb.ReadWriteTx) error {
+		b, err := tx.CreateTopLevelBucket(testBucket)
+		require.NoError(t, err)
+		require.NoError(t, b.Put([]byte("rolled-back"), []byte("v")))
+
+		return sentinel
+	}, func() {})
+	require.ErrorIs(t, err, sentinel)
+
+	require.NoError(
+		t, db.View(func(tx walletdb.ReadTx) error {
+			b := tx.ReadBucket(testBucket)
+			require.Equal(
+				t, []byte("v"),
+				b.Get(
+					[]byte("committed"),
+				),
+			)
+			require.Nil(t, b.Get([]byte("rolled-back")))
+
+			return nil
+		}, func() {}),
+	)
+}

--- a/internal/sqlbase/log.go
+++ b/internal/sqlbase/log.go
@@ -1,5 +1,3 @@
-//go:build js && wasm
-
 package sqlbase
 
 import "github.com/btcsuite/btclog/v2"

--- a/internal/sqlbase/readwrite_bucket.go
+++ b/internal/sqlbase/readwrite_bucket.go
@@ -1,5 +1,3 @@
-//go:build js && wasm
-
 package sqlbase
 
 import (

--- a/internal/sqlbase/readwrite_bucket.go
+++ b/internal/sqlbase/readwrite_bucket.go
@@ -473,6 +473,13 @@ func (b *readWriteBucket) ForAll(cb func(k, v []byte) error) error {
 	}
 	defer cancel()
 
+	// cancel only releases the query's timeout context; the result set
+	// holds a connection from the pool until it is closed explicitly,
+	// which rows.Next() only does for us if it is driven to completion.
+	defer func() {
+		_ = rows.Close()
+	}()
+
 	for rows.Next() {
 		var key, value []byte
 
@@ -487,5 +494,8 @@ func (b *readWriteBucket) ForAll(cb func(k, v []byte) error) error {
 		}
 	}
 
-	return nil
+	// A row error terminates the loop above just like a fully consumed
+	// result set does, so without this check a truncated bucket walk is
+	// indistinguishable from a complete one.
+	return rows.Err()
 }

--- a/internal/sqlbase/readwrite_bucket.go
+++ b/internal/sqlbase/readwrite_bucket.go
@@ -84,7 +84,7 @@ func (b *readWriteBucket) Get(key []byte) []byte {
 	err := row.Scan(&value)
 
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return nil
 
 	case err != nil:
@@ -137,7 +137,7 @@ func (b *readWriteBucket) NestedReadWriteBucket(
 	err := row.Scan(&id)
 
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return nil
 
 	case err != nil:
@@ -173,7 +173,7 @@ func (b *readWriteBucket) CreateBucket(key []byte) (walletdb.ReadWriteBucket,
 	err := row.Scan(&id, &value)
 
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 	case err == nil && value == nil:
 		return nil, walletdb.ErrBucketExists
 
@@ -229,7 +229,7 @@ func (b *readWriteBucket) CreateBucketIfNotExists(key []byte) (
 	switch {
 	// Bucket does not yet exist, so create it now. Postgres will generate a
 	// bucket id for the new bucket.
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		row, cancel := b.tx.QueryRow(
 			"INSERT INTO "+b.table+" (parent_id, key) "+
 				"VALUES($1, $2) RETURNING id",
@@ -365,7 +365,7 @@ func (b *readWriteBucket) Delete(key []byte) error {
 	err := row.Scan(&dummy)
 	switch {
 	// No bucket exists, proceed to deletion of the key.
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 	case err != nil:
 		return err
 
@@ -447,7 +447,7 @@ func (b *readWriteBucket) Sequence() uint64 {
 	err := row.Scan(&seq)
 
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return 0
 
 	case err != nil:

--- a/internal/sqlbase/readwrite_cursor.go
+++ b/internal/sqlbase/readwrite_cursor.go
@@ -1,5 +1,3 @@
-//go:build js && wasm
-
 package sqlbase
 
 import (

--- a/internal/sqlbase/readwrite_cursor.go
+++ b/internal/sqlbase/readwrite_cursor.go
@@ -4,6 +4,7 @@ package sqlbase
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/btcsuite/btcwallet/walletdb"
 )
@@ -39,7 +40,7 @@ func (c *readWriteCursor) First() ([]byte, []byte) {
 	err := row.Scan(&key, &value)
 
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return nil, nil
 
 	case err != nil:
@@ -69,7 +70,7 @@ func (c *readWriteCursor) Last() ([]byte, []byte) {
 	err := row.Scan(&key, &value)
 
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return nil, nil
 
 	case err != nil:
@@ -100,7 +101,7 @@ func (c *readWriteCursor) Next() ([]byte, []byte) {
 	err := row.Scan(&key, &value)
 
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return nil, nil
 
 	case err != nil:
@@ -131,7 +132,7 @@ func (c *readWriteCursor) Prev() ([]byte, []byte) {
 	err := row.Scan(&key, &value)
 
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return nil, nil
 
 	case err != nil:
@@ -169,7 +170,7 @@ func (c *readWriteCursor) Seek(seek []byte) ([]byte, []byte) {
 	err := row.Scan(&key, &value)
 
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return nil, nil
 
 	case err != nil:
@@ -199,7 +200,7 @@ func (c *readWriteCursor) Delete() error {
 	err := row.Scan(&key)
 
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return nil
 
 	case err != nil:

--- a/internal/sqlbase/readwrite_tx.go
+++ b/internal/sqlbase/readwrite_tx.go
@@ -1,5 +1,3 @@
-//go:build js && wasm
-
 package sqlbase
 
 import (

--- a/internal/sqlbase/schema.go
+++ b/internal/sqlbase/schema.go
@@ -1,5 +1,3 @@
-//go:build js && wasm
-
 package sqlbase
 
 import (

--- a/internal/sqlbase/schema.go
+++ b/internal/sqlbase/schema.go
@@ -20,8 +20,7 @@ func newKVSchemaCreationCmd(table, schema string,
 		finalCmd      string
 	)
 	if schema != "" {
-		finalCmd = fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS ` + schema +
-			`;`)
+		finalCmd = `CREATE SCHEMA IF NOT EXISTS ` + schema + `;`
 
 		tableInSchema = fmt.Sprintf("%s.%s", schema, table)
 	}
@@ -43,7 +42,7 @@ func newKVSchemaCreationCmd(table, schema string,
 	//
 	// The replacements map can be used to replace any sqlite keywords.
 	// Callers should note that the sqlite keywords are case-sensitive.
-	finalCmd += fmt.Sprintf(`
+	finalCmd += `
 CREATE TABLE IF NOT EXISTS ` + tableInSchema + `
 (
     key BLOB NOT NULL,
@@ -63,10 +62,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS ` + table + `_up
     (parent_id, key) WHERE parent_id IS NOT NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS ` + table + `_unp 
     ON ` + tableInSchema + ` (key) WHERE parent_id IS NULL;
-`)
+`
 
 	for from, to := range replacements {
-		finalCmd = strings.Replace(finalCmd, from, to, -1)
+		finalCmd = strings.ReplaceAll(finalCmd, from, to)
 	}
 
 	return finalCmd

--- a/lwwallet/AGENTS.md
+++ b/lwwallet/AGENTS.md
@@ -80,9 +80,10 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
 - **Depends on**: `walletcore` (shared HD key mgmt, signing, boarding base —
   also used by `btcwbackend`), `chainsource` (implements `ChainBackend`),
   `wallet` (implements `BoardingBackend`), `chainbackends` (typed
-  `PackageTxError` for package-relay results), and — on `js && wasm` builds
-  only — `internal/sqlbase` (walletdb-compatible SQL backend) plus
-  `internal/wasmhost` (which durable SQLite VFS the host offers).
+  `PackageTxError` for package-relay results), `internal/sqlbase`
+  (walletdb-compatible SQL backend, used by both SQL wallet stores) and —
+  on `js && wasm` builds only — `internal/wasmhost` (which durable SQLite
+  VFS the host offers).
 - **Depended on by**: `waved` (alternative to LND-backed wallet), `sdk`
   (embedded-wallet config references).
 
@@ -125,9 +126,53 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
 - UTXO enumeration queries Esplora directly rather than btcwallet's internal
   UTXO set, because btcwallet does not credit-mark non-default scope outputs.
 - `Stop()` explicitly closes btcwallet's internal database to prevent resource
-  leaks.
+  leaks. That is not optional for the SQL wallet stores: btcwallet's loader
+  only closes a database it opened itself, so nothing else would release an
+  externally supplied handle.
 - Shutdown and startup rollback cancel `EsploraChainService` before stopping
   btcwallet so an active recovery can drain.
+
+### Native wallet store (`walletdb_native.go`)
+
+- `Config.DBBackend` picks the engine btcwallet's wallet database runs on:
+  `DBBackendBolt` (the default) keeps the classic `wallet.db` BoltDB file,
+  `DBBackendSQLite` keeps `wallet.sqlite.db` on `modernc.org/sqlite` through
+  `internal/sqlbase`. Both live under `Config.DBDir`.
+- The two backends use different file names on purpose, and `walletDBPath`
+  refuses to resolve when the other backend's file is present. Switching the
+  backend of an initialized directory would otherwise look exactly like a
+  first start, and btcwallet would create a second, empty wallet beside the
+  existing one.
+- `walletExists` must answer with the same predicate btcwallet's loader
+  applies, because `New` pairs the two: it refuses a seed when a wallet
+  exists and lets a seedless open through when one does. For the SQL
+  backends the database file's presence is *not* that predicate —
+  `newWalletLoaderOptions` creates the file and its schema before btcwallet
+  runs, so an interrupted first run leaves an empty database behind.
+  Reporting "exists" there would refuse the operator's real seed and send
+  the seedless path into `btcwallet.New`, which mints a wallet from a random
+  seed when handed none. The probe therefore shortcuts on a *missing* file
+  (so a fresh directory is never touched) and otherwise opens the database
+  to read btcwallet's marker key, closing it again.
+- The database file is created by `createWalletDBFile` with `0600` before
+  SQLite opens it. SQLite would use `0666 & ~umask`; creating it up front
+  rather than chmod'ing afterwards also covers the `-wal`/`-shm` sidecars,
+  which inherit the main file's mode.
+- The SQLite DSN sets `_txlock=immediate`. The wallet reads before it writes
+  inside one transaction (deriving the next address reads the last-used index,
+  then bumps it), and a deferred transaction that upgrades to a writer after
+  another connection committed fails with `SQLITE_BUSY_SNAPSHOT`, which
+  bypasses the busy handler and is therefore not absorbed by `busy_timeout`.
+- `synchronous=full` and `fullfsync=true` are set explicitly rather than
+  inherited: the wallet's seed and key state have no second copy, so this
+  database does not follow the daemon's configurable `synchronous=normal`
+  default, and on Darwin a plain `fsync` does not reach stable storage.
+- `sqlWalletDBTimeout` stays above `sqlWalletDBBusyTimeout`, or a query that
+  legitimately waits out the busy handler races its own context deadline and
+  reports `context deadline exceeded` instead of `SQLITE_BUSY`.
+- SQLite in WAL mode does not exclude a second OS process the way BoltDB's
+  file lock does, so `DBBackendSQLite` gives up the one-daemon-per-directory
+  guarantee. The storage layer stays consistent; the wallet layer does not.
 
 ### js/wasm wallet store (`walletdb_wasm.go`)
 

--- a/lwwallet/CLAUDE.md
+++ b/lwwallet/CLAUDE.md
@@ -80,9 +80,10 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
 - **Depends on**: `walletcore` (shared HD key mgmt, signing, boarding base —
   also used by `btcwbackend`), `chainsource` (implements `ChainBackend`),
   `wallet` (implements `BoardingBackend`), `chainbackends` (typed
-  `PackageTxError` for package-relay results), and — on `js && wasm` builds
-  only — `internal/sqlbase` (walletdb-compatible SQL backend) plus
-  `internal/wasmhost` (which durable SQLite VFS the host offers).
+  `PackageTxError` for package-relay results), `internal/sqlbase`
+  (walletdb-compatible SQL backend, used by both SQL wallet stores) and —
+  on `js && wasm` builds only — `internal/wasmhost` (which durable SQLite
+  VFS the host offers).
 - **Depended on by**: `waved` (alternative to LND-backed wallet), `sdk`
   (embedded-wallet config references).
 
@@ -125,9 +126,53 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
 - UTXO enumeration queries Esplora directly rather than btcwallet's internal
   UTXO set, because btcwallet does not credit-mark non-default scope outputs.
 - `Stop()` explicitly closes btcwallet's internal database to prevent resource
-  leaks.
+  leaks. That is not optional for the SQL wallet stores: btcwallet's loader
+  only closes a database it opened itself, so nothing else would release an
+  externally supplied handle.
 - Shutdown and startup rollback cancel `EsploraChainService` before stopping
   btcwallet so an active recovery can drain.
+
+### Native wallet store (`walletdb_native.go`)
+
+- `Config.DBBackend` picks the engine btcwallet's wallet database runs on:
+  `DBBackendBolt` (the default) keeps the classic `wallet.db` BoltDB file,
+  `DBBackendSQLite` keeps `wallet.sqlite.db` on `modernc.org/sqlite` through
+  `internal/sqlbase`. Both live under `Config.DBDir`.
+- The two backends use different file names on purpose, and `walletDBPath`
+  refuses to resolve when the other backend's file is present. Switching the
+  backend of an initialized directory would otherwise look exactly like a
+  first start, and btcwallet would create a second, empty wallet beside the
+  existing one.
+- `walletExists` must answer with the same predicate btcwallet's loader
+  applies, because `New` pairs the two: it refuses a seed when a wallet
+  exists and lets a seedless open through when one does. For the SQL
+  backends the database file's presence is *not* that predicate —
+  `newWalletLoaderOptions` creates the file and its schema before btcwallet
+  runs, so an interrupted first run leaves an empty database behind.
+  Reporting "exists" there would refuse the operator's real seed and send
+  the seedless path into `btcwallet.New`, which mints a wallet from a random
+  seed when handed none. The probe therefore shortcuts on a *missing* file
+  (so a fresh directory is never touched) and otherwise opens the database
+  to read btcwallet's marker key, closing it again.
+- The database file is created by `createWalletDBFile` with `0600` before
+  SQLite opens it. SQLite would use `0666 & ~umask`; creating it up front
+  rather than chmod'ing afterwards also covers the `-wal`/`-shm` sidecars,
+  which inherit the main file's mode.
+- The SQLite DSN sets `_txlock=immediate`. The wallet reads before it writes
+  inside one transaction (deriving the next address reads the last-used index,
+  then bumps it), and a deferred transaction that upgrades to a writer after
+  another connection committed fails with `SQLITE_BUSY_SNAPSHOT`, which
+  bypasses the busy handler and is therefore not absorbed by `busy_timeout`.
+- `synchronous=full` and `fullfsync=true` are set explicitly rather than
+  inherited: the wallet's seed and key state have no second copy, so this
+  database does not follow the daemon's configurable `synchronous=normal`
+  default, and on Darwin a plain `fsync` does not reach stable storage.
+- `sqlWalletDBTimeout` stays above `sqlWalletDBBusyTimeout`, or a query that
+  legitimately waits out the busy handler races its own context deadline and
+  reports `context deadline exceeded` instead of `SQLITE_BUSY`.
+- SQLite in WAL mode does not exclude a second OS process the way BoltDB's
+  file lock does, so `DBBackendSQLite` gives up the one-daemon-per-directory
+  guarantee. The storage layer stays consistent; the wallet layer does not.
 
 ### js/wasm wallet store (`walletdb_wasm.go`)
 

--- a/lwwallet/config.go
+++ b/lwwallet/config.go
@@ -56,11 +56,22 @@ type Config struct {
 	// scenarios where previously derived keys must be rediscovered.
 	RecoveryWindow uint32
 
-	// DBDir is the directory for btcwallet's bbolt database. The
+	// DBDir is the directory for btcwallet's wallet database. The
 	// caller owns the lifecycle of this directory: for tests a temp
 	// directory can be created and cleaned up after the wallet stops,
 	// while production callers may use a persistent path.
 	DBDir string
+
+	// DBBackend selects the database engine btcwallet's wallet
+	// database (seed, key state and transaction store) is kept in,
+	// one of DBBackendBolt or DBBackendSQLite. An empty value
+	// resolves to DBBackendBolt. Both backends keep their database
+	// under DBDir, under a backend-specific file name.
+	//
+	// Browser builds ignore the field: there the store is always the
+	// OPFS-backed SQLite database, because BoltDB cannot be used
+	// under js/wasm at all.
+	DBBackend string
 
 	// Log is an optional logger for the wallet and all its sub-components
 	// (chain service, chain backend, boarding backend, Esplora client). If

--- a/lwwallet/wallet.go
+++ b/lwwallet/wallet.go
@@ -80,10 +80,10 @@ var ErrWalletNotFound = errors.New("no wallet database found")
 var ErrWalletExists = errors.New("wallet database already exists")
 
 // WalletExists reports whether a wallet database has already been
-// created for the given configuration. Only ChainParams, RecoveryWindow
-// and DBDir are consulted. Callers use this to decide between the
-// create (seed) and open (password-only) paths before constructing the
-// wallet.
+// created for the given configuration. Only ChainParams, RecoveryWindow,
+// DBDir and DBBackend are consulted. Callers use this to decide between
+// the create (seed) and open (password-only) paths before constructing
+// the wallet.
 func WalletExists(cfg Config) (bool, error) {
 	return walletExists(cfg)
 }
@@ -120,8 +120,8 @@ func checkWalletInvariants(cfg Config) error {
 
 // New creates a new lightweight wallet from the given configuration.
 // The caller must provide a DBDir for btcwallet's wallet database. Native
-// builds use that path for btcwallet's bbolt database, while browser builds
-// derive a stable OPFS SQLite database name from it.
+// builds put the database there under a name chosen by Config.DBBackend,
+// while browser builds derive a stable OPFS SQLite database name from it.
 func New(cfg Config) (*Wallet, error) {
 	// Constructors run before a contextual logger is guaranteed,
 	// so default to a disabled logger when one was not explicitly
@@ -185,8 +185,9 @@ func New(cfg Config) (*Wallet, error) {
 	}, blockCache)
 	if err != nil {
 		// On failure the wallet never adopted the loader's
-		// database handle, so release it here (a no-op natively,
-		// an OPFS handle close in browser builds).
+		// database handle, so release it here (a no-op for the
+		// BoltDB backend, which btcwallet's loader opens and
+		// closes itself, and a handle close for the SQL ones).
 		loaderCleanup()
 
 		return nil, fmt.Errorf("create btcwallet: %w", err)
@@ -252,8 +253,9 @@ func (w *Wallet) Start() error {
 
 	// New opened the wallet database, so a failed start must close
 	// it again or a retried unlock deadlocks on the database's
-	// exclusive lock (bbolt flock natively, EXCLUSIVE OPFS locking
-	// in browser builds). This matters in particular for a wrong
+	// exclusive lock (the BoltDB flock, the SQLite write lock, or
+	// EXCLUSIVE OPFS locking in browser builds). This matters in
+	// particular for a wrong
 	// wallet passphrase, which surfaces from BtcWallet.Start below.
 	// Appended first so the reverse-order unwind runs it last, after
 	// the subsystems armed below have been rolled back.

--- a/lwwallet/wallet_lifecycle_test.go
+++ b/lwwallet/wallet_lifecycle_test.go
@@ -49,7 +49,8 @@ func newTestEsplora(t *testing.T) *httptest.Server {
 }
 
 // testWalletConfig returns a lifecycle-test config for the given
-// database directory, seed, and password.
+// database directory, seed, and password, using the platform's default
+// wallet database backend.
 func testWalletConfig(esploraURL, dbDir string, seed, password []byte) Config {
 	return Config{
 		Seed:           seed,
@@ -65,10 +66,24 @@ func testWalletConfig(esploraURL, dbDir string, seed, password []byte) Config {
 
 // TestWalletCreateOpenLifecycle verifies the create/open contract: a
 // seed creates the wallet database under the supplied passphrase, and
-// subsequent opens need only the passphrase.
+// subsequent opens need only the passphrase. Every supported wallet
+// database backend has to satisfy the same contract, so the test runs
+// once per backend the platform offers.
 func TestWalletCreateOpenLifecycle(t *testing.T) {
 	t.Parallel()
 
+	for _, backend := range testWalletDBBackends {
+		t.Run(backend, func(t *testing.T) {
+			t.Parallel()
+
+			testWalletCreateOpenLifecycle(t, backend)
+		})
+	}
+}
+
+// testWalletCreateOpenLifecycle drives the create/open contract against
+// one wallet database backend.
+func testWalletCreateOpenLifecycle(t *testing.T, backend string) {
 	esplora := newTestEsplora(t)
 	dbDir := t.TempDir()
 
@@ -78,19 +93,24 @@ func TestWalletCreateOpenLifecycle(t *testing.T) {
 	}
 	password := []byte("lifecycle-password")
 
+	walletConfig := func(seed []byte) Config {
+		cfg := testWalletConfig(esplora.URL, dbDir, seed, password)
+		cfg.DBBackend = backend
+
+		return cfg
+	}
+
 	// Opening before any wallet exists must fail loudly rather than
 	// silently creating a wallet with a random seed.
-	_, err := New(testWalletConfig(esplora.URL, dbDir, nil, password))
+	_, err := New(walletConfig(nil))
 	require.ErrorIs(t, err, ErrWalletNotFound)
 
 	// Create the wallet from the seed.
-	exists, err := WalletExists(
-		testWalletConfig(esplora.URL, dbDir, nil, password),
-	)
+	exists, err := WalletExists(walletConfig(nil))
 	require.NoError(t, err)
 	require.False(t, exists)
 
-	w, err := New(testWalletConfig(esplora.URL, dbDir, seed[:], password))
+	w, err := New(walletConfig(seed[:]))
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 
@@ -106,21 +126,19 @@ func TestWalletCreateOpenLifecycle(t *testing.T) {
 
 	w.Stop()
 
-	exists, err = WalletExists(
-		testWalletConfig(esplora.URL, dbDir, nil, password),
-	)
+	exists, err = WalletExists(walletConfig(nil))
 	require.NoError(t, err)
 	require.True(t, exists)
 
 	// Re-creating over an existing wallet database must be refused:
 	// btcwallet would silently ignore the new seed and open the old
 	// wallet.
-	_, err = New(testWalletConfig(esplora.URL, dbDir, seed[:], password))
+	_, err = New(walletConfig(seed[:]))
 	require.ErrorIs(t, err, ErrWalletExists)
 
 	// Reopen with the passphrase only and confirm it is the same
 	// wallet by deriving the same address chain.
-	w, err = New(testWalletConfig(esplora.URL, dbDir, nil, password))
+	w, err = New(walletConfig(nil))
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 	t.Cleanup(w.Stop)
@@ -167,7 +185,7 @@ func TestWalletWrongPasswordRetry(t *testing.T) {
 	require.ErrorContains(t, err, "invalid passphrase")
 
 	// The failed Start must have unwound cleanly: retrying with the
-	// correct password would block on the bbolt file lock if the
+	// correct password would block on the database's file lock if the
 	// database were still open.
 	w, err = New(testWalletConfig(esplora.URL, dbDir, nil, password))
 	require.NoError(t, err)

--- a/lwwallet/walletdb.go
+++ b/lwwallet/walletdb.go
@@ -9,6 +9,25 @@ import (
 )
 
 const (
+	// DBBackendBolt keeps btcwallet's wallet database in the classic
+	// BoltDB file under Config.DBDir. It is the default.
+	DBBackendBolt = "bolt"
+
+	// DBBackendSQLite keeps btcwallet's wallet database in a SQLite
+	// database under Config.DBDir. It lets an embedded daemon hold
+	// all of its state in one storage engine, in a directory the host
+	// application picks, rather than an mmap'd BoltDB file alongside
+	// the SQLite databases every other store already uses.
+	//
+	// Note that this gives up one property BoltDB provides: its file
+	// lock excludes a second OS process, while SQLite in WAL mode
+	// does not. Two daemons on one directory stay safe at the storage
+	// layer but not at the wallet layer, where both would derive the
+	// same addresses and keep their own idea of sync state.
+	DBBackendSQLite = "sqlite"
+)
+
+const (
 	// sqlWalletDBTablePrefix namespaces btcwallet's key/value table
 	// inside the wallet database, so the resulting "walletdb_kv"
 	// table can coexist with tables owned by other stores.

--- a/lwwallet/walletdb.go
+++ b/lwwallet/walletdb.go
@@ -42,9 +42,12 @@ const (
 func openSQLWalletDB(ctx context.Context, driverName,
 	dsn string) (walletdb.DB, error) {
 
-	// The connection set is process-global and initialized exactly
-	// once; a later call with a different limit is a no-op.
-	sqlbase.Init(sqlWalletDBMaxConnections)
+	// The connection set is process-global and its limit is fixed by
+	// the first caller, so this fails rather than hand back a pool
+	// wider than the wallet store's single-writer assumption.
+	if err := sqlbase.Init(sqlWalletDBMaxConnections); err != nil {
+		return nil, err
+	}
 
 	return sqlbase.NewSqlBackend(ctx, &sqlbase.Config{
 		DriverName:      driverName,

--- a/lwwallet/walletdb.go
+++ b/lwwallet/walletdb.go
@@ -1,0 +1,56 @@
+package lwwallet
+
+import (
+	"context"
+	"time"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightninglabs/wavelength/internal/sqlbase"
+)
+
+const (
+	// sqlWalletDBTablePrefix namespaces btcwallet's key/value table
+	// inside the wallet database, so the resulting "walletdb_kv"
+	// table can coexist with tables owned by other stores.
+	sqlWalletDBTablePrefix = "walletdb"
+
+	// sqlWalletDBBusyTimeout is how long SQLite waits for a lock held
+	// by another connection to the same database before failing the
+	// query.
+	sqlWalletDBBusyTimeout = 30 * time.Second
+
+	// sqlWalletDBTimeout is the per-query timeout applied to the
+	// wallet database. It has to stay comfortably above
+	// sqlWalletDBBusyTimeout: a query that legitimately waits out the
+	// busy handler would otherwise race its own context deadline, and
+	// the caller would see "context deadline exceeded" instead of the
+	// SQLITE_BUSY that names the actual problem.
+	sqlWalletDBTimeout = 2 * sqlWalletDBBusyTimeout
+
+	// sqlWalletDBMaxConnections bounds the connection pool sqlbase
+	// keeps per DSN. The walletdb emulation funnels its read-write
+	// transactions through a single in-process lock anyway, so a
+	// second connection would only add contention on the database's
+	// own write lock.
+	sqlWalletDBMaxConnections = 1
+)
+
+// openSQLWalletDB opens, creating it if needed, btcwallet's wallet
+// database on the given database/sql driver and DSN. The driver must
+// already be registered by the caller. The returned handle is owned by
+// the caller and must be closed once the wallet has stopped.
+func openSQLWalletDB(ctx context.Context, driverName,
+	dsn string) (walletdb.DB, error) {
+
+	// The connection set is process-global and initialized exactly
+	// once; a later call with a different limit is a no-op.
+	sqlbase.Init(sqlWalletDBMaxConnections)
+
+	return sqlbase.NewSqlBackend(ctx, &sqlbase.Config{
+		DriverName:      driverName,
+		Dsn:             dsn,
+		Timeout:         sqlWalletDBTimeout,
+		TableNamePrefix: sqlWalletDBTablePrefix,
+		WithTxLevelLock: true,
+	})
+}

--- a/lwwallet/walletdb_native.go
+++ b/lwwallet/walletdb_native.go
@@ -3,33 +3,185 @@
 package lwwallet
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 
+	btcwalletbase "github.com/btcsuite/btcwallet/wallet"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
+	_ "modernc.org/sqlite" // Register the native SQLite driver.
 )
 
-// newWalletLoaderOptions returns the native btcwallet bbolt loader
-// options. The cleanup func is a no-op: the local database is opened
-// (and closed on failure) by btcwallet's own loader.
+const (
+	// boltWalletDBTimeout is how long the BoltDB backend waits for
+	// the database file lock before giving up.
+	boltWalletDBTimeout = 60 * time.Second
+
+	// sqliteWalletDBDriverName is the database/sql driver registered
+	// by modernc.org/sqlite.
+	sqliteWalletDBDriverName = "sqlite"
+
+	// sqliteWalletDBFileName is the SQLite wallet database's file
+	// name under Config.DBDir. It deliberately differs from
+	// btcwallet's BoltDB file name, so that neither backend can ever
+	// be pointed at a database written by the other.
+	sqliteWalletDBFileName = "wallet.sqlite.db"
+)
+
+// walletDBPath returns the path of the wallet database file the
+// configured backend uses, and fails on an unknown backend so a typo
+// cannot silently resolve to the default.
+//
+// Resolution also fails when the other backend's database file already
+// exists in DBDir. The two backends store the wallet under different
+// names, so without this check switching the backend of an initialized
+// wallet directory looks exactly like a first start: btcwallet would
+// happily create a second, empty wallet next to the existing — and
+// possibly funded — one.
+func walletDBPath(cfg Config) (string, error) {
+	var backend, other string
+	switch cfg.DBBackend {
+	case "", DBBackendBolt:
+		backend, other = DBBackendBolt, DBBackendSQLite
+
+	case DBBackendSQLite:
+		backend, other = DBBackendSQLite, DBBackendBolt
+
+	default:
+		return "", fmt.Errorf("unknown wallet database backend %q, "+
+			"must be %q or %q", cfg.DBBackend, DBBackendBolt,
+			DBBackendSQLite)
+	}
+
+	otherPath := walletDBFilePath(cfg.DBDir, other)
+	otherExists, err := walletDBExists(otherPath)
+	if err != nil {
+		return "", err
+	}
+	if otherExists {
+		return "", fmt.Errorf("wallet database %s exists but the %q "+
+			"database backend is selected; set the backend to %q",
+			otherPath, backend, other)
+	}
+
+	return walletDBFilePath(cfg.DBDir, backend), nil
+}
+
+// walletDBFilePath returns the file the given backend keeps the wallet
+// database in.
+func walletDBFilePath(dbDir, backend string) string {
+	if backend == DBBackendSQLite {
+		return filepath.Join(dbDir, sqliteWalletDBFileName)
+	}
+
+	return filepath.Join(dbDir, btcwalletbase.WalletDBName)
+}
+
+// newWalletLoaderOptions returns the btcwallet loader options for the
+// configured wallet database backend, plus a func that releases
+// whatever the resolution opened.
 func newWalletLoaderOptions(cfg Config) ([]btcwallet.LoaderOption, func(),
 	error) {
 
+	// Resolving the path is also what validates the backend and
+	// rejects a directory that already holds the other backend's
+	// database.
+	dbPath, err := walletDBPath(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// BoltDB is opened (and closed on failure) by btcwallet's own
+	// loader, so there is nothing for the cleanup func to release.
+	if cfg.DBBackend != DBBackendSQLite {
+		return []btcwallet.LoaderOption{
+			btcwallet.LoaderWithLocalWalletDB(
+				cfg.DBDir, false, boltWalletDBTimeout,
+			),
+		}, func() {}, nil
+	}
+
+	if err := os.MkdirAll(cfg.DBDir, 0700); err != nil {
+		return nil, nil, fmt.Errorf("create wallet database dir: %w",
+			err)
+	}
+
+	// Create the database file ourselves before SQLite gets a chance
+	// to. SQLite would create it with 0666 & ~umask, which under the
+	// common umask 0022 leaves the encrypted seed, the key state and
+	// the full transaction history world-readable; btcwallet passes
+	// 0600 explicitly for its BoltDB file and the two backends should
+	// not differ here. Doing it up front rather than chmod'ing
+	// afterwards also covers the -wal and -shm sidecars, which SQLite
+	// creates with the mode of the main database file.
+	if err := createWalletDBFile(dbPath); err != nil {
+		return nil, nil, err
+	}
+
+	db, err := openSQLWalletDB(
+		context.Background(), sqliteWalletDBDriverName,
+		sqliteWalletDBDSN(dbPath),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open SQLite wallet database: %w",
+			err)
+	}
+
+	// btcwallet's loader only closes a wallet database it created
+	// itself, so a constructor failure after this point would leak
+	// this handle, and its lock on the database file, for the process
+	// lifetime.
+	cleanup := func() {
+		_ = db.Close()
+	}
+
 	return []btcwallet.LoaderOption{
-		btcwallet.LoaderWithLocalWalletDB(
-			cfg.DBDir, false, 60*time.Second,
-		),
-	}, func() {}, nil
+		btcwallet.LoaderWithExternalWalletDB(db),
+	}, cleanup, nil
 }
 
-// walletExists reports whether a btcwallet bbolt database already
-// exists in the configured directory. For local databases the loader
-// only checks file existence, so this probe does not take the bbolt
-// file lock.
+// walletExists reports whether a wallet has already been created in
+// the configured backend's database.
+//
+// The predicate has to be the same one btcwallet's loader will apply,
+// because New pairs them: it refuses a seed when a wallet exists and
+// lets a seedless open through when one does. btcwallet answers from a
+// marker key committed inside the database once the wallet itself
+// exists, and for the SQL backends that is not the same as the database
+// file being there — openSQLWalletDB creates the file and its schema
+// before btcwallet ever runs, so an interrupted first run leaves an
+// empty database behind. Answering "exists" for that state would refuse
+// the operator's real seed and send the seedless path into
+// btcwallet.New, which creates a wallet from a random seed when handed
+// no seed of its own.
 func walletExists(cfg Config) (bool, error) {
-	opts, _, err := newWalletLoaderOptions(cfg)
+	dbPath, err := walletDBPath(cfg)
 	if err != nil {
 		return false, err
 	}
+
+	// A missing database file settles the question without opening
+	// anything, which is what keeps a probe of a fresh directory from
+	// creating the very database it is asking about.
+	exists, err := walletDBExists(dbPath)
+	if err != nil || !exists {
+		return false, err
+	}
+
+	opts, cleanup, err := newWalletLoaderOptions(cfg)
+	if err != nil {
+		return false, err
+	}
+
+	// A probe must not hand the wallet database on to anyone, so a
+	// handle opened above is closed again here. It would otherwise
+	// hold the database's write lock until the process exits, and the
+	// real open in New would be the one to fail on it.
+	defer cleanup()
 
 	loader, err := btcwallet.NewWalletLoader(
 		cfg.ChainParams, cfg.RecoveryWindow, opts...,
@@ -39,4 +191,100 @@ func walletExists(cfg Config) (bool, error) {
 	}
 
 	return loader.WalletExists()
+}
+
+// sqliteWalletDBDSN returns the modernc.org/sqlite DSN for the wallet
+// database at the given path.
+func sqliteWalletDBDSN(dbPath string) string {
+	pragmas := make(url.Values)
+	for _, pragma := range []string{
+		// The key/value schema nests buckets through a parent_id
+		// self-reference, and relies on the cascade to drop a
+		// deleted bucket's children instead of leaving them
+		// behind as unreachable rows.
+		"foreign_keys=on",
+
+		// WAL lets the wallet's reads proceed against the last
+		// committed snapshot while a write transaction is open,
+		// and keeps a crash from tearing a commit.
+		"journal_mode=WAL",
+
+		// The wallet's seed and key state have no second copy
+		// anywhere, so this database does not follow the
+		// daemon's configurable synchronous=normal default. FULL
+		// is also SQLite's own default; it is set explicitly so
+		// the guarantee does not rest on a driver default.
+		"synchronous=full",
+
+		// fullfsync only matters on Darwin, where a plain fsync
+		// does not reach stable storage. The daemon's own SQLite
+		// store enables it for exactly that reason, and an
+		// embedded daemon on a mobile platform is squarely in
+		// that case, so the wallet database must not end up with
+		// weaker flush semantics than the databases beside it.
+		"fullfsync=true",
+	} {
+		pragmas.Add("_pragma", pragma)
+	}
+
+	// busy_timeout caps how long SQLite waits for a lock held by
+	// another connection to the same file, such as a backup tool,
+	// before failing the query.
+	pragmas.Add(
+		"_pragma",
+		fmt.Sprintf(
+			"busy_timeout=%d",
+			sqlWalletDBBusyTimeout.Milliseconds(),
+		),
+	)
+
+	// Take the write lock when a write transaction begins rather than
+	// on its first write statement. The wallet reads before it writes
+	// within a single transaction — deriving the next address reads
+	// the last-used index and then bumps it — and a deferred
+	// transaction that tries to upgrade to a writer after another
+	// connection committed in the meantime fails with
+	// SQLITE_BUSY_SNAPSHOT. That error bypasses the busy handler, so
+	// busy_timeout above would not absorb it.
+	return fmt.Sprintf("%s?%s&_txlock=immediate", dbPath, pragmas.Encode())
+}
+
+// createWalletDBFile creates the wallet database file with owner-only
+// permissions if it does not exist yet. An existing file is left alone,
+// including its mode: a database created by an older version stays
+// readable rather than being silently tightened underneath a caller
+// that may have chosen its own permissions.
+func createWalletDBFile(dbPath string) error {
+	// The path is the daemon's own wallet database under the
+	// configured data directory, not caller-supplied input.
+	//
+	//nolint:gosec // G304: path is composed from DBDir and a constant
+	f, err := os.OpenFile(dbPath, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("create wallet database file: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close wallet database file: %w", err)
+	}
+
+	return nil
+}
+
+// walletDBExists reports whether a wallet database exists at the given
+// path. An unexpected stat failure is returned as an error rather than
+// as a missing database: reading, say, a permission problem as "no
+// wallet here" would send the caller down the create path.
+func walletDBExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	switch {
+	case err == nil:
+		return true, nil
+
+	case errors.Is(err, os.ErrNotExist):
+		return false, nil
+
+	default:
+		return false, err
+	}
 }

--- a/lwwallet/walletdb_native_test.go
+++ b/lwwallet/walletdb_native_test.go
@@ -1,0 +1,253 @@
+//go:build !js || !wasm
+
+package lwwallet
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	btcwalletbase "github.com/btcsuite/btcwallet/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// testWalletDBBackends lists the wallet database backends the platform
+// supports, so backend-agnostic tests can assert the same contract for
+// each of them.
+var testWalletDBBackends = []string{DBBackendBolt, DBBackendSQLite}
+
+// TestWalletDBPath asserts how the configured backend maps to a wallet
+// database file, and in particular that a database left behind by the
+// other backend is refused instead of ignored.
+func TestWalletDBPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+
+		// backend is the configured Config.DBBackend value.
+		backend string
+
+		// existingFile, when set, is created in the wallet
+		// database directory before resolution runs.
+		existingFile string
+
+		// wantFile is the expected database file name.
+		wantFile string
+
+		// wantErr is a substring the error must contain.
+		wantErr string
+	}{{
+		name:     "empty backend defaults to bolt",
+		backend:  "",
+		wantFile: btcwalletbase.WalletDBName,
+	}, {
+		name:     "bolt",
+		backend:  DBBackendBolt,
+		wantFile: btcwalletbase.WalletDBName,
+	}, {
+		name:     "sqlite",
+		backend:  DBBackendSQLite,
+		wantFile: sqliteWalletDBFileName,
+	}, {
+		name:         "bolt with existing bolt database",
+		backend:      DBBackendBolt,
+		existingFile: btcwalletbase.WalletDBName,
+		wantFile:     btcwalletbase.WalletDBName,
+	}, {
+		name:         "sqlite with existing sqlite database",
+		backend:      DBBackendSQLite,
+		existingFile: sqliteWalletDBFileName,
+		wantFile:     sqliteWalletDBFileName,
+	}, {
+		name:         "bolt with existing sqlite database",
+		backend:      DBBackendBolt,
+		existingFile: sqliteWalletDBFileName,
+		wantErr:      sqliteWalletDBFileName,
+	}, {
+		name:         "sqlite with existing bolt database",
+		backend:      DBBackendSQLite,
+		existingFile: btcwalletbase.WalletDBName,
+		wantErr:      btcwalletbase.WalletDBName,
+	}, {
+		name:    "unknown backend",
+		backend: "postgres",
+		wantErr: "unknown wallet database backend",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dbDir := t.TempDir()
+			if tc.existingFile != "" {
+				path := filepath.Join(dbDir, tc.existingFile)
+				require.NoError(
+					t, os.WriteFile(
+						path, nil, 0600,
+					),
+				)
+			}
+
+			path, err := walletDBPath(Config{
+				DBDir:     dbDir,
+				DBBackend: tc.backend,
+			})
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(
+				t, filepath.Join(dbDir, tc.wantFile), path,
+			)
+		})
+	}
+}
+
+// TestSQLiteWalletDBPermissions asserts the wallet database and its WAL
+// sidecars are owner-only. SQLite creates files with 0666 & ~umask,
+// which under a typical umask would leave the encrypted seed and key
+// state world-readable, where btcwallet's BoltDB file is 0600.
+func TestSQLiteWalletDBPermissions(t *testing.T) {
+	t.Parallel()
+
+	esplora := newTestEsplora(t)
+	dbDir := t.TempDir()
+
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(i + 7)
+	}
+
+	cfg := testWalletConfig(
+		esplora.URL, dbDir, seed[:], []byte("perms-password"),
+	)
+	cfg.DBBackend = DBBackendSQLite
+
+	w, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, w.Start())
+
+	// Check while the wallet is running, so the -wal and -shm
+	// sidecars are still on disk; a clean shutdown removes them.
+	dbPath := filepath.Join(dbDir, sqliteWalletDBFileName)
+	for _, path := range []string{
+		dbPath, dbPath + "-wal", dbPath + "-shm",
+	} {
+		info, err := os.Stat(path)
+		require.NoError(t, err, "expected %s to exist", path)
+		require.Equal(
+			t, os.FileMode(0600), info.Mode().Perm(),
+			"unexpected mode for %s", path,
+		)
+	}
+
+	w.Stop()
+}
+
+// TestSQLiteWalletDBInterruptedCreate covers the state an interrupted
+// first run leaves behind: the SQLite database file and its schema
+// exist, but no wallet was ever committed inside them. The wallet probe
+// has to agree with btcwallet's own here, because New pairs the two
+// decisions — a probe that reported an existing wallet would refuse the
+// operator's real seed and send the seedless path into btcwallet.New,
+// which creates a wallet from a random seed when handed none.
+func TestSQLiteWalletDBInterruptedCreate(t *testing.T) {
+	t.Parallel()
+
+	esplora := newTestEsplora(t)
+	dbDir := t.TempDir()
+
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(i + 5)
+	}
+
+	cfg := testWalletConfig(
+		esplora.URL, dbDir, nil, []byte("interrupted-password"),
+	)
+	cfg.DBBackend = DBBackendSQLite
+
+	// Open and close the wallet database without creating a wallet in
+	// it, which is the on-disk state New leaves behind if it is killed
+	// between opening the database and btcwallet committing the
+	// wallet.
+	dbPath, err := walletDBPath(cfg)
+	require.NoError(t, err)
+	db, err := openSQLWalletDB(
+		context.Background(), sqliteWalletDBDriverName,
+		sqliteWalletDBDSN(dbPath),
+	)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	require.FileExists(t, dbPath)
+
+	// The database file is there, so a file-presence probe would claim
+	// a wallet exists. None does.
+	exists, err := WalletExists(cfg)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	// The seedless open path must fail loudly instead of minting a
+	// wallet from a seed nobody has a copy of.
+	_, err = New(cfg)
+	require.ErrorIs(t, err, ErrWalletNotFound)
+
+	// The operator who does hold the seed must be able to recover in
+	// place, without deleting the database by hand first.
+	cfg.Seed = seed[:]
+	w, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, w.Start())
+	t.Cleanup(w.Stop)
+
+	exists, err = WalletExists(cfg)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+// TestSQLiteWalletDBLayout asserts that the SQLite backend keeps the
+// wallet entirely inside its own database file, and in particular that
+// it leaves no BoltDB database behind: a caller switching back to the
+// default backend must not find one and open an empty wallet from it.
+func TestSQLiteWalletDBLayout(t *testing.T) {
+	t.Parallel()
+
+	esplora := newTestEsplora(t)
+	dbDir := t.TempDir()
+
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(i + 3)
+	}
+
+	cfg := testWalletConfig(
+		esplora.URL, dbDir, seed[:], []byte("sqlite-password"),
+	)
+	cfg.DBBackend = DBBackendSQLite
+
+	// A probe on a fresh directory must not create the database it is
+	// asking about, or the guard against mixing up the two backends
+	// would trip on a database that never held a wallet.
+	exists, err := WalletExists(cfg)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	entries, err := os.ReadDir(dbDir)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+
+	w, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, w.Start())
+	w.Stop()
+
+	require.FileExists(t, filepath.Join(dbDir, sqliteWalletDBFileName))
+	require.NoFileExists(
+		t, filepath.Join(dbDir, btcwalletbase.WalletDBName),
+	)
+}

--- a/lwwallet/walletdb_wasm.go
+++ b/lwwallet/walletdb_wasm.go
@@ -8,22 +8,18 @@ import (
 	"hash/fnv"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/lightninglabs/go-wasmsqlite"
-	"github.com/lightninglabs/wavelength/internal/sqlbase"
 	"github.com/lightninglabs/wavelength/internal/wasmhost"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
 )
 
 const (
 	wasmWalletDBDriverName      = "wasmsqlite"
-	wasmWalletDBTablePrefix     = "walletdb"
-	wasmWalletDBTimeout         = 30 * time.Second
-	wasmWalletDBBusyTimeoutMS   = "30000"
-	wasmWalletDBMaxConnections  = 1
 	wasmWalletDBFileNamePattern = "/wallet-%016x.db"
 
 	// nodeWalletDBFileName is the wallet store's name on a real filesystem,
@@ -83,19 +79,13 @@ func walletExists(cfg Config) (bool, error) {
 // openWASMWalletDB opens btcwallet's walletdb on top of the same browser
 // SQLite/OPFS driver used by the daemon and swap stores.
 func openWASMWalletDB(dbDir string) (walletdb.DB, error) {
-	sqlbase.Init(wasmWalletDBMaxConnections)
-
-	cfg := &sqlbase.Config{
-		DriverName:      wasmWalletDBDriverName,
-		Dsn:             wasmWalletDBDSN(dbDir),
-		Timeout:         wasmWalletDBTimeout,
-		TableNamePrefix: wasmWalletDBTablePrefix,
-		WithTxLevelLock: true,
-	}
+	dsn := wasmWalletDBDSN(dbDir)
 
 	var lastErr error
 	for attempt := 0; attempt < 25; attempt++ {
-		db, err := sqlbase.NewSqlBackend(context.Background(), cfg)
+		db, err := openSQLWalletDB(
+			context.Background(), wasmWalletDBDriverName, dsn,
+		)
 		if err == nil {
 			return db, nil
 		}
@@ -126,7 +116,12 @@ func wasmWalletDBDSN(dbDir string) string {
 		values.Set("file", wasmWalletDBFileName(dbDir))
 	}
 	values.Set("mode", "rwc")
-	values.Set("busy_timeout", wasmWalletDBBusyTimeoutMS)
+	values.Set(
+		"busy_timeout",
+		strconv.FormatInt(
+			sqlWalletDBBusyTimeout.Milliseconds(), 10,
+		),
+	)
 
 	// WAL survives here only because of the locking_mode=EXCLUSIVE pragma
 	// below. No wasm VFS implements xShmMap, so this is the WAL mode SQLite

--- a/lwwallet/walletdb_wasm_test.go
+++ b/lwwallet/walletdb_wasm_test.go
@@ -1,0 +1,9 @@
+//go:build js && wasm
+
+package lwwallet
+
+// testWalletDBBackends lists the wallet database backends the platform
+// supports. Browser builds have exactly one: BoltDB cannot be used
+// under js/wasm, so Config.DBBackend is ignored there and the store is
+// always the OPFS-backed SQLite database.
+var testWalletDBBackends = []string{""}

--- a/sample-waved.conf
+++ b/sample-waved.conf
@@ -199,6 +199,20 @@
 # Address recovery look-ahead window for lwwallet.
 # wallet.recoverywindow=100
 
+# Database backend for the lwwallet wallet database: bolt or sqlite.
+#
+# This cannot be changed once the wallet has been created. The daemon refuses
+# to start when it finds the other backend's database file, and there is no
+# migration between the two: the only way across is a fresh data directory
+# restored from the seed.
+#
+# Both backends keep the database in the network data directory. Pick sqlite so
+# the directory holds one storage engine instead of two. Note that a running
+# daemon leaves -wal and -shm files beside each SQLite database, so a copy taken
+# while it runs has to include them, and that sqlite gives up BoltDB's file
+# lock, which is what stops a second daemon from opening the same directory.
+# wallet.dbbackend=bolt
+
 # Path to a file containing the wallet password for auto-unlock at startup.
 # wallet.password_file=
 

--- a/waved/config.go
+++ b/waved/config.go
@@ -1142,6 +1142,13 @@ type WalletConfig struct {
 	// automatically without requiring an UnlockWallet RPC call.
 	PasswordFile string `mapstructure:"password_file"`
 
+	// DBBackend selects the database engine the lwwallet backend
+	// keeps btcwallet's wallet database in: "bolt" (the default) uses
+	// the classic BoltDB file, "sqlite" uses a SQLite database so the
+	// network directory holds no BoltDB file at all. Both live in the
+	// network directory. Only used when Type is "lwwallet".
+	DBBackend string `mapstructure:"dbbackend"`
+
 	// BtcwalletPeers is a list of host:port addresses for neutrino
 	// to connect to exclusively (no DNS seeding). Only used when
 	// Type is "btcwallet".
@@ -1217,6 +1224,7 @@ func DefaultConfig() *Config {
 			Type:           DefaultWalletType,
 			PollInterval:   DefaultEsploraPollInterval,
 			RecoveryWindow: DefaultRecoveryWindow,
+			DBBackend:      lwwallet.DBBackendBolt,
 		},
 		Swap: &SwapConfig{
 			ServerTransport: RPCTransportGRPC,
@@ -1423,6 +1431,20 @@ func (c *Config) validateWalletConfig() error {
 					"required when wallet.type is lwwallet")
 			}
 			c.Wallet.EsploraURL = esploraURL
+		}
+
+		// Reject an unknown database backend here rather than at
+		// wallet-unlock time: a typo would otherwise only surface
+		// once the operator tries to use the wallet.
+		switch c.Wallet.DBBackend {
+		case "", lwwallet.DBBackendBolt, lwwallet.DBBackendSQLite:
+			// An empty value keeps the lwwallet default.
+
+		default:
+			return fmt.Errorf("unknown wallet.dbbackend %q, valid "+
+				"values: %s, %s", c.Wallet.DBBackend,
+				lwwallet.DBBackendBolt,
+				lwwallet.DBBackendSQLite)
 		}
 
 	case WalletTypeBtcwallet:

--- a/waved/config_wallet_dbbackend_test.go
+++ b/waved/config_wallet_dbbackend_test.go
@@ -1,0 +1,59 @@
+package waved
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/wavelength/lwwallet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigValidateWalletDBBackend checks that the lwwallet database
+// backend selector only accepts the backends lwwallet implements, so a
+// typo fails at startup instead of at wallet-unlock time.
+func TestConfigValidateWalletDBBackend(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		backend string
+		wantErr string
+	}{
+		{
+			name: "unset keeps the default",
+		},
+		{
+			name:    "bolt",
+			backend: lwwallet.DBBackendBolt,
+		},
+		{
+			name:    "sqlite",
+			backend: lwwallet.DBBackendSQLite,
+		},
+		{
+			name:    "unknown backend",
+			backend: "postgres",
+			wantErr: "unknown wallet.dbbackend",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := DefaultConfig()
+			cfg.Network = "regtest"
+			cfg.Wallet.Type = WalletTypeLwwallet
+			cfg.Wallet.EsploraURL = "http://127.0.0.1:3000"
+			cfg.Wallet.DBBackend = tc.backend
+
+			err := cfg.Validate()
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/waved/rpc_wallet.go
+++ b/waved/rpc_wallet.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -459,7 +460,7 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 	rollbackState := func() WalletState {
 		target := WalletStateNone
 
-		exists, err := r.server.selfManagedWalletExists()
+		exists, err := r.server.selfManagedWalletExists(ctx)
 		switch {
 		case err != nil:
 			r.server.log.WarnS(ctx, "Failed to probe wallet "+
@@ -694,20 +695,31 @@ func isWrongPassphraseErr(err error) bool {
 	return false
 }
 
-// selfManagedWalletExists probes whether a wallet database has been
-// created for the configured self-managed wallet backend. Only the
-// chain params and data directory are consulted; the probe does not
-// open the database on native builds.
-func (s *Server) selfManagedWalletExists() (bool, error) {
+// selfManagedWalletExists probes whether a wallet has been created for
+// the configured self-managed wallet backend. Only the chain params,
+// data directory and database backend are consulted, and a backend
+// whose database does not exist yet is never opened.
+//
+// The wallet backends own the lifetime of any database handle the probe
+// needs, so the caller's context is not theirs to inherit; it is used
+// here only for the log line.
+//
+//nolint:contextcheck // wallet database handles outlive the request
+func (s *Server) selfManagedWalletExists(ctx context.Context) (bool, error) {
+	var (
+		exists bool
+		err    error
+	)
 	switch s.cfg.Wallet.Type {
 	case WalletTypeLwwallet:
-		return lwwallet.WalletExists(lwwallet.Config{
+		exists, err = lwwallet.WalletExists(lwwallet.Config{
 			ChainParams: s.chainParams,
 			DBDir:       s.cfg.NetworkDir(),
+			DBBackend:   s.cfg.Wallet.DBBackend,
 		})
 
 	case WalletTypeBtcwallet:
-		return btcwbackend.WalletExists(btcwbackend.Config{
+		exists, err = btcwbackend.WalletExists(btcwbackend.Config{
 			Config: walletcore.Config{
 				ChainParams: s.chainParams,
 				DBDir:       s.cfg.NetworkDir(),
@@ -718,6 +730,20 @@ func (s *Server) selfManagedWalletExists() (bool, error) {
 		return false, fmt.Errorf("unsupported wallet type %q",
 			s.cfg.Wallet.Type)
 	}
+	if err != nil {
+		return false, err
+	}
+
+	// This answer picks the create path over the open path, and a
+	// wrong one only becomes visible in what the daemon does several
+	// steps later, so record it where the decision is made.
+	s.log.DebugS(ctx, "Probed wallet database",
+		slog.String("wallet_type", s.cfg.Wallet.Type),
+		slog.String("db_backend", s.cfg.Wallet.DBBackend),
+		slog.Bool("exists", exists),
+	)
+
+	return exists, nil
 }
 
 // isSelfManagedWallet returns true if the wallet type manages its

--- a/waved/server.go
+++ b/waved/server.go
@@ -1865,7 +1865,7 @@ func (s *Server) tryAutoUnlockLwwallet(ctx context.Context) {
 	// Probe for an existing wallet database. This decides between
 	// the create path (seed required) and the open path (password
 	// only).
-	exists, err := s.selfManagedWalletExists()
+	exists, err := s.selfManagedWalletExists(ctx)
 	if err != nil {
 		s.log.ErrorS(ctx, "Failed to probe wallet database", err)
 
@@ -2005,6 +2005,7 @@ func (s *Server) startLwwallet(ctx context.Context, seed []byte,
 		PollInterval:   pollInterval,
 		RecoveryWindow: recoveryWindow,
 		DBDir:          networkDir,
+		DBBackend:      s.cfg.Wallet.DBBackend,
 		Log:            fn.Some(s.subLogger(lwwallet.Subsystem)),
 	})
 	if err != nil {
@@ -2080,7 +2081,7 @@ func (s *Server) tryAutoUnlockBtcwallet(ctx context.Context) {
 	// Probe for an existing wallet database. This decides between
 	// the create path (seed required) and the open path (password
 	// only).
-	exists, err := s.selfManagedWalletExists()
+	exists, err := s.selfManagedWalletExists(ctx)
 	if err != nil {
 		s.log.ErrorS(ctx, "Failed to probe wallet database", err)
 


### PR DESCRIPTION

Lets `lwwallet` keep btcwallet's wallet database in SQLite instead of
BoltDB, selectable via `wallet.dbbackend` (`bolt`, the unchanged
default, or `sqlite`). Both databases live in the network directory as
before.

## Why

For a daemon embedded in a mobile application, the host application
decides which directory the platform includes in its cloud backup, and
everything in that directory should be one storage engine a backup can
capture consistently. BoltDB's mmap'd, free-list-bearing file is the odd
one out among the daemon's databases: it has to be special-cased by
whatever copies the directory, and it is the reason a daemon that
otherwise speaks only SQL still links BoltDB.

The `walletdb`-over-`database/sql` implementation this uses is not new —
`internal/sqlbase` has been backing the browser wallet store all along.
It was simply tagged `js && wasm`.

## Commits

1. `sqlbase: close the result set and check row errors in ForAll` —
   standalone bug fix. `ForAll` leaked the `*sql.Rows`, and its pooled
   connection, whenever the caller's callback failed, and reported a
   result set truncated by a row error as a fully enumerated bucket.
   Affects the browser build today.
2. `sqlbase: address linter findings in the package` — no functional
   change. The build tags kept the package out of `golangci-lint`, which
   only sees the host platform.
3. `sqlbase: drop the js && wasm build tags` — nothing in the package is
   browser-specific; the tags recorded its first consumer, not a platform
   restriction. Also ends the package's blind spot for `go build ./...`
   and the linter.
4. `lwwallet: extract the SQL wallet database opener` — no functional
   change; moves the platform-independent sqlbase wiring out of the
   browser-only file.
5. `lwwallet: add a SQLite wallet database backend` — the feature.
6. `cmd/waved: group the wallet backend flags into a registrar` — the
   wallet flags were the last group still inline in `newRootCmd`, which
   sat exactly at the `funlen` limit.
7. `waved: add wallet.dbbackend for the lwwallet backend` — config
   option, CLI flag, validation, sample config, CLI guide.

## Notes for review

- **Backend mix-ups fail loudly.** The two backends use different file
  names on purpose, and resolution fails when the other backend's file
  is present. Switching backends on an initialized directory would
  otherwise look exactly like a first start, and btcwallet would create
  a second, empty wallet beside the existing — possibly funded — one.
- **The existence probe has no side effects.** It answers from the
  database file's presence on both backends, as btcwallet's own probe for
  a local database does. Opening the database to look inside would create
  the very database the caller is asking about and hold its write lock.
- **The SQLite DSN sets `_txlock=immediate`.** The wallet reads before it
  writes inside one transaction (deriving the next address reads the
  last-used index, then bumps it), and a deferred transaction that
  upgrades to a writer after another connection committed fails with
  `SQLITE_BUSY_SNAPSHOT`, which bypasses the busy handler and so is not
  absorbed by `busy_timeout`.
- **One database file per store**, rather than sharing the daemon's
  `waved.db`. That keeps the wallet's pool the sole writer of its file,
  which is what makes the hazard above a non-issue.

## Testing

The create/open lifecycle test is parameterized over the backends the
platform offers, so the SQLite store has to satisfy the same contract as
BoltDB rather than only the parts a new test remembers to cover. New
tests cover backend-to-file resolution, the mix-up guard, and that a
SQLite wallet leaves no BoltDB file behind. Default behavior is
unchanged.
