### PR TITLE
waved: fix seed recovery missing live VTXOs

### DIFF
--- a/waved/wallet_recovery.go
+++ b/waved/wallet_recovery.go
@@ -41,6 +41,16 @@ const (
 	recoveryIndexerRetryMax      = 5 * time.Second
 )
 
+// recoveryIndexedVTXOFamilies lists the key families seed recovery scans
+// against the operator's indexer. OOR receive scripts must be included: a
+// VTXO settled into a round after an OOR receive stays on its OOR receive
+// script, and the mailbox replay pass never learns whether the operator
+// still holds it.
+var recoveryIndexedVTXOFamilies = []keychain.KeyFamily{
+	libtypes.VTXOOwnerKeyFamily,
+	oorReceiveKeyFamily,
+}
+
 // WalletRecoveryResult reports the state discovered by one idempotent wallet
 // recovery scan. Counters describe artifacts found and persisted during that
 // scan; on a retry, some artifacts may already have existed locally.
@@ -141,10 +151,13 @@ func (r *RPCServer) recoverWalletState(ctx context.Context, window uint32) (
 	); err != nil {
 		return nil, fmt.Errorf("recover boarding keys: %w", err)
 	}
-	if err := r.recoverIndexedVTXOs(
-		ctx, terms, window, &result,
-	); err != nil {
-		return nil, fmt.Errorf("recover indexed VTXOs: %w", err)
+	for _, family := range recoveryIndexedVTXOFamilies {
+		if err := r.recoverIndexedVTXOs(
+			ctx, terms, family, window, &result,
+		); err != nil {
+			return nil, fmt.Errorf("recover indexed VTXOs for key "+
+				"family %d: %w", family, err)
+		}
 	}
 	if err := r.recoverOORReceiveScripts(
 		ctx, terms, window, &result,
@@ -254,13 +267,13 @@ func (s *Server) recoveryBoardingBackend() (wallet.BoardingBackend, error) {
 }
 
 func (r *RPCServer) recoverIndexedVTXOs(ctx context.Context,
-	terms *libtypes.OperatorTerms, window uint32,
+	terms *libtypes.OperatorTerms, family keychain.KeyFamily, window uint32,
 	result *WalletRecoveryResult) error {
 
 	for i := uint32(0); i < window; i++ {
 		keyDesc, err := r.server.proofKeyBackend.DeriveKey(
 			ctx, keychain.KeyLocator{
-				Family: libtypes.VTXOOwnerKeyFamily,
+				Family: family,
 				Index:  i,
 			},
 		)
@@ -395,10 +408,11 @@ func recoveryDescriptorFromIndexer(indexed *arkrpc.VTXO,
 		}
 	}
 
-	exitDelay := indexed.GetRelativeExpiry()
-	if exitDelay == 0 {
-		exitDelay = terms.VTXOExitDelay
-	}
+	// The indexer's relative_expiry is the batch's relative expiry, not
+	// the script's exit delay. The matched pk script was derived with
+	// terms.VTXOExitDelay, so the tapscript must use the same delay or the
+	// operator rejects every join naming this VTXO.
+	exitDelay := terms.VTXOExitDelay
 
 	tapscript, err := arkscript.VTXOTapScript(
 		keyDesc.PubKey, operatorKey, exitDelay,

--- a/waved/wallet_recovery_descriptor_test.go
+++ b/waved/wallet_recovery_descriptor_test.go
@@ -1,0 +1,72 @@
+package waved
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/lightninglabs/wavelength/arkrpc"
+	libtypes "github.com/lightninglabs/wavelength/lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecoveryDescriptorFromIndexerRebuildsIndexerScript verifies a recovered
+// descriptor's tapscript hashes back to the pk script the operator holds when
+// the indexer's relative_expiry differs from the operator's VTXO exit delay.
+func TestRecoveryDescriptorFromIndexerRebuildsIndexerScript(t *testing.T) {
+	t.Parallel()
+
+	clientKey := testKeyDescriptor(t, 210)
+	operatorKey := testKeyDescriptor(t, 211)
+	terms := &libtypes.OperatorTerms{
+		PubKey:        operatorKey.PubKey,
+		VTXOExitDelay: recoveryTestExitDelay,
+	}
+
+	pkScript, err := BuildPubKeyVTXOReceiveScript(
+		clientKey.PubKey, terms.PubKey, terms.VTXOExitDelay,
+	)
+	require.NoError(t, err)
+
+	const batchRelativeExpiry = 1008
+	require.NotEqual(
+		t, uint32(batchRelativeExpiry), terms.VTXOExitDelay,
+	)
+
+	commitmentTxID := chainhash.Hash{0xcc}
+	outpointTxID := chainhash.Hash{0xdd}
+	indexed := &arkrpc.VTXO{
+		Outpoint: &arkrpc.OutPoint{
+			Txid: outpointTxID[:],
+			Vout: 0,
+		},
+		ValueSat:          28674,
+		PkScript:          pkScript,
+		Status:            arkrpc.VTXOStatus_VTXO_STATUS_LIVE,
+		RoundId:           "round-1",
+		CommitmentTxid:    commitmentTxID[:],
+		CreatedHeight:     964273,
+		BatchExpiryHeight: 965281,
+		RelativeExpiry:    batchRelativeExpiry,
+		AncestryPaths: []*arkrpc.AncestryPath{
+			recoveryTestAncestryPath(t, commitmentTxID),
+		},
+	}
+
+	desc, ok, err := recoveryDescriptorFromIndexer(
+		indexed, clientKey, terms,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// The same check the operator runs when validating a join request.
+	tapKey, err := desc.TapScript.TaprootKey()
+	require.NoError(t, err)
+
+	rebuilt, err := txscript.PayToTaprootScript(tapKey)
+	require.NoError(t, err)
+	require.Equal(t, desc.PkScript, rebuilt)
+	require.Equal(t, pkScript, rebuilt)
+
+	require.Equal(t, terms.VTXOExitDelay, desc.RelativeExpiry)
+}

--- a/waved/wallet_recovery_oor_family_test.go
+++ b/waved/wallet_recovery_oor_family_test.go
@@ -1,0 +1,289 @@
+package waved
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/indexer"
+	libtree "github.com/lightninglabs/wavelength/lib/tree"
+	libtypes "github.com/lightninglabs/wavelength/lib/types"
+	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
+	"github.com/lightningnetwork/lnd/clock"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// recoveryTestExitDelay is the operator's VTXO exit delay used to build the
+// receive scripts under test.
+const recoveryTestExitDelay = 144
+
+// recoveryTestAncestryPath builds the minimal valid ancestry path an indexer
+// VTXO needs to survive recovery's conversion step.
+func recoveryTestAncestryPath(t *testing.T,
+	commitmentTxID chainhash.Hash) *arkrpc.AncestryPath {
+
+	t.Helper()
+
+	tree := &libtree.Tree{
+		Root: &libtree.Node{},
+		BatchOutpoint: wire.OutPoint{
+			Hash: commitmentTxID,
+		},
+	}
+
+	path, err := arkrpc.AncestryPathFromTree(
+		tree, commitmentTxID, []uint32{0},
+	)
+	require.NoError(t, err)
+
+	return path
+}
+
+// recoveryKeyBackend derives a distinct deterministic key per key locator so a
+// test can tell the families recovery scans apart by the scripts they produce.
+type recoveryKeyBackend struct{}
+
+// DeriveKey returns a deterministic key for the requested locator.
+func (b *recoveryKeyBackend) DeriveKey(_ context.Context,
+	loc keychain.KeyLocator) (*keychain.KeyDescriptor, error) {
+
+	seed := byte(uint32(loc.Family)*31 + loc.Index + 1)
+	privKey, _ := btcec.PrivKeyFromBytes([]byte{
+		seed, seed, seed, seed, seed, seed, seed, seed,
+		seed, seed, seed, seed, seed, seed, seed, seed,
+		seed, seed, seed, seed, seed, seed, seed, seed,
+		seed, seed, seed, seed, seed, seed, seed, seed,
+	})
+
+	return &keychain.KeyDescriptor{
+		KeyLocator: loc,
+		PubKey:     privKey.PubKey(),
+	}, nil
+}
+
+// DeriveNextKey is unused by the indexed-VTXO scan.
+func (b *recoveryKeyBackend) DeriveNextKey(_ context.Context,
+	_ keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
+
+	return nil, nil
+}
+
+// ProofSigner returns a canned proof signer for the requested wallet key.
+func (b *recoveryKeyBackend) ProofSigner(
+	keyDesc keychain.KeyDescriptor) indexer.SchnorrSigner {
+
+	return &testOwnedReceiveScriptSigner{
+		keyDesc: keyDesc,
+		tagSig:  make([]byte, 64),
+	}
+}
+
+// recoveryIndexerStub answers indexer queries from a fixed script-to-VTXO map,
+// so a scan only finds a VTXO if it actually asked about the right script.
+type recoveryIndexerStub struct {
+	mu        sync.Mutex
+	byScript  map[string]*arkrpc.VTXO
+	lastReq   proto.Message
+	askedFor  [][]byte
+	registers int
+}
+
+// SendRPC records the outgoing request and returns a static correlation pair.
+func (s *recoveryIndexerStub) SendRPC(_ context.Context,
+	_ mailboxrpc.ServiceMethod, req proto.Message,
+	_ mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.lastReq = proto.Clone(req)
+	switch typed := s.lastReq.(type) {
+	case *arkrpc.RegisterReceiveScriptRequest:
+		s.registers++
+
+	case *arkrpc.ListVTXOsByScriptsRequest:
+		for _, scope := range typed.GetScripts() {
+			s.askedFor = append(
+				s.askedFor,
+				append(
+					[]byte(nil), scope.GetPkScript()...,
+				),
+			)
+		}
+	}
+
+	return mailboxrpc.SendResult{
+		CorrelationID:  "corr-1",
+		IdempotencyKey: "idemp-1",
+	}, nil
+}
+
+// AwaitRPC answers the recorded request. A list query returns the configured
+// VTXO for the queried script and nothing for any other script.
+func (s *recoveryIndexerStub) AwaitRPC(_ context.Context, _ string,
+	resp proto.Message) error {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	listResp, ok := resp.(*arkrpc.ListVTXOsByScriptsResponse)
+	if !ok {
+		return nil
+	}
+
+	listReq, ok := s.lastReq.(*arkrpc.ListVTXOsByScriptsRequest)
+	if !ok {
+		return nil
+	}
+
+	for _, scope := range listReq.GetScripts() {
+		indexed, ok := s.byScript[string(scope.GetPkScript())]
+		if !ok {
+			continue
+		}
+
+		listResp.Vtxos = append(listResp.Vtxos, indexed)
+	}
+
+	return nil
+}
+
+// scriptQueried reports whether the scan asked the indexer about pkScript.
+func (s *recoveryIndexerStub) scriptQueried(pkScript []byte) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, asked := range s.askedFor {
+		if string(asked) == string(pkScript) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// newRecoveryScanServer builds an RPC server wired to a real VTXO store and a
+// stub indexer holding one live VTXO on the supplied script.
+func newRecoveryScanServer(t *testing.T, liveScript []byte,
+	live *arkrpc.VTXO) (*RPCServer, *recoveryIndexerStub) {
+
+	t.Helper()
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+
+	stub := &recoveryIndexerStub{
+		byScript: map[string]*arkrpc.VTXO{
+			string(liveScript): live,
+		},
+	}
+	// The indexer validates registration expiry against the wall clock.
+	clk := clock.NewTestClock(time.Now())
+	sqliteDB := db.NewTestDB(t)
+
+	// The scan only touches vtxoStore; leaving the concrete db field unset
+	// keeps this buildable under both database tags.
+	return NewRPCServer(&Server{
+		walletReady: walletReady,
+		clk:         clk,
+		vtxoStore: db.NewStore(
+			sqliteDB.DB, sqliteDB.Queries, sqliteDB.Backend(),
+			btclog.Disabled,
+		).NewVTXOStore(clk),
+		proofKeyBackend: &recoveryKeyBackend{},
+		indexer: indexer.New(
+			stub, nil, "test-server", "client:test",
+			fn.None[btclog.Logger](),
+		),
+	}), stub
+}
+
+// TestRecoverIndexedVTXOsCoversOORReceiveScripts verifies seed recovery finds
+// a live VTXO sitting on an OOR receive script, which the VTXO-owner family
+// scan alone misses.
+func TestRecoverIndexedVTXOsCoversOORReceiveScripts(t *testing.T) {
+	t.Parallel()
+
+	operatorKey := testKeyDescriptor(t, 200)
+	terms := &libtypes.OperatorTerms{
+		PubKey:        operatorKey.PubKey,
+		VTXOExitDelay: recoveryTestExitDelay,
+	}
+
+	backend := &recoveryKeyBackend{}
+	oorKey, err := backend.DeriveKey(t.Context(), keychain.KeyLocator{
+		Family: oorReceiveKeyFamily,
+		Index:  0,
+	})
+	require.NoError(t, err)
+
+	oorScript, err := BuildPubKeyVTXOReceiveScript(
+		oorKey.PubKey, terms.PubKey, terms.VTXOExitDelay,
+	)
+	require.NoError(t, err)
+
+	commitmentTxID := chainhash.Hash{0xaa}
+	outpointTxID := chainhash.Hash{0xbb}
+	live := &arkrpc.VTXO{
+		Outpoint: &arkrpc.OutPoint{
+			Txid: outpointTxID[:],
+			Vout: 0,
+		},
+		ValueSat:          28674,
+		PkScript:          oorScript,
+		Status:            arkrpc.VTXOStatus_VTXO_STATUS_LIVE,
+		RoundId:           "round-1",
+		CommitmentTxid:    commitmentTxID[:],
+		CreatedHeight:     964273,
+		BatchExpiryHeight: 965281,
+		RelativeExpiry:    recoveryTestExitDelay,
+		AncestryPaths: []*arkrpc.AncestryPath{
+			recoveryTestAncestryPath(t, commitmentTxID),
+		},
+	}
+
+	// The VTXO-owner family alone never queries the OOR receive script.
+	ownerOnly, ownerStub := newRecoveryScanServer(t, oorScript, live)
+	var ownerResult WalletRecoveryResult
+	require.NoError(
+		t,
+		ownerOnly.recoverIndexedVTXOs(
+			t.Context(), terms, libtypes.VTXOOwnerKeyFamily, 1,
+			&ownerResult,
+		),
+	)
+	require.Zero(t, ownerResult.VTXOs)
+	require.False(t, ownerStub.scriptQueried(oorScript))
+
+	// The full family list finds and persists it.
+	full, fullStub := newRecoveryScanServer(t, oorScript, live)
+	var fullResult WalletRecoveryResult
+	for _, family := range recoveryIndexedVTXOFamilies {
+		require.NoError(
+			t,
+			full.recoverIndexedVTXOs(
+				t.Context(), terms, family, 1, &fullResult,
+			),
+		)
+	}
+	require.Equal(t, uint32(1), fullResult.VTXOs)
+	require.True(t, fullStub.scriptQueried(oorScript))
+
+	outpoint, err := recoveryOutpoint(live.GetOutpoint())
+	require.NoError(t, err)
+
+	saved, err := full.server.vtxoStore.GetVTXO(t.Context(), outpoint)
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	require.Equal(t, oorScript, saved.PkScript)
+}


### PR DESCRIPTION
## Problem

A wallet restored from seed reports zero balance for funds the operator still holds, and cannot spend them once found:

- `recoverIndexedVTXOs` scans the indexer under the VTXO-owner key family only. A VTXO settled into a round after an OOR receive stays on its OOR receive script, which is never queried. The mailbox replay pass rebuilds spent history but never learns what is still live, so recovery returns `recovered_vtxos: 0` as success.
- `recoveryDescriptorFromIndexer` rebuilds the tapscript from the indexer's `relative_expiry`, which is the batch's relative expiry, not the script's exit delay (1008 vs 144 in practice). The witness program does not hash to the script the operator holds, so every join naming a recovered VTXO is rejected with a script validation failure.

## Fix

Scan both key families, and build the tapscript from `terms.VTXOExitDelay`, the delay the matched pk script was derived with.

## Testing

Both tests fail without their fix. The stub indexer only answers for the exact script queried, so a scan that skips the OOR script cannot pass. The descriptor test reruns the operator's join script validation.

Note: the OOR family is now walked by both the indexed scan and `recoverOORReceiveScripts`, and the scan registers receive scripts for every index in the window. Folding the live-VTXO query into `recoverOORReceiveScripts` would avoid that at the cost of a larger diff; happy to switch if preferred.
