### PR TITLE
docs: nightly doc-gardening sweep 2026-08-30

### DIFF
--- a/chainbackends/AGENTS.md
+++ b/chainbackends/AGENTS.md
@@ -10,9 +10,13 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
 
 - `LNDBackend` — Full-node backend wrapping lnd's chain notification and fee
   estimation interfaces. Accepts an optional `PackageSubmitter` for v3 CPFP
-  package relay (set via `SetPackageSubmitter`).
+  package relay (set via `SetPackageSubmitter`). Also implements
+  `chainsource.TxRemover` via `RemoveTx`.
 - `TxBroadcaster` — Interface over transaction broadcasting (wraps
-  lndclient.WalletKitClient or in-process lnd).
+  lndclient.WalletKitClient or in-process lnd). Carries
+  `PublishTransaction(ctx, tx, label)` and `RemoveTransaction(ctx, txid)`;
+  the latter abandons a transaction (and its descendants) so the wallet stops
+  rebroadcasting it from its unconfirmed queue (wavelength#609).
 - `PackageSubmitter` — Optional interface for v3 package relay:
   `SubmitPackage(ctx, parents, child, maxFeeRate)`. Used by backends that need
   a direct bitcoind path for atomic parent+child submission; absent in
@@ -43,6 +47,27 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
   joined error tree. Use this instead of `errors.As` when all per-tx entries
   must be inspected (e.g. to distinguish parent-known vs. child-fee
   classification).
+- `reorgSignalBufferSize = 8` (unexported, `lnd.go`) — depth of the buffered
+  `Reorged` channel handed to each conf/spend registration. Reorg signals are
+  coalescing (the consumer re-queries chain state), so the buffer only needs
+  to be deep enough to keep the forwarder from stalling on a multi-block
+  reorg burst, not to record every event.
+
+## Reorg & Finality Forwarding
+
+`RegisterConf` / `RegisterSpend` bridge lnd's notifier events into the
+reorg-aware `chainsource` registration lifecycle. lnd signals a reorg by
+firing `ConfirmationEvent.NegativeConf` (conf) or `SpendEvent.Reorg` (spend);
+a single per-registration forwarder goroutine translates those into the
+backend-agnostic `Reorged` channel while also forwarding `Confirmed`/`Spend`
+and `Done`.
+
+Because Go's `select` picks randomly among ready channels, the forwarder
+routes every lifecycle fact through `chainsource.PositiveDoneOrder`
+(`ObservePositive` / `ObserveReorg` / `ObserveDone`) so the causal
+positive-before-`Done` contract survives the transport boundary. Delivery uses
+`forwardValue`, which drops the send if the registration context was cancelled
+first.
 
 ## Relationships
 
@@ -53,6 +78,13 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
   `LNDBackend` via lndclient for system tests), `btcwbackend` / `lwwallet` /
   `txconfirm` (reuse `PackageSubmitter`, `PackageTxError`, and
   `WalkPackageTxErrors` to classify per-tx package-relay results).
+- **Sends → `chainsource`** (as registration channel payloads):
+  `BlockRegistration`, `ConfRegistration`, `SpendRegistration` — each
+  carrying `Confirmed`/`Spend`, `Reorged`, and `Done`.
+- **Receives ← `chainsource`** (via the actor, on behalf of `unroll`):
+  `RemoveTxRequest` → `LNDBackend.RemoveTx`. Backends without a
+  rebroadcasting wallet do not implement `TxRemover` and the request is a
+  no-op for them.
 
 ## Invariants
 
@@ -65,7 +97,17 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
   sets the same field); otherwise, for an LND wallet it falls back to
   `chainbackends/lndsubmitter.New(lndSvc.WalletKit)` as the default.
 - `LndClientChainNotifier` enforces a 15-second timeout on registration to
-  prevent hanging under LND block load.
+  prevent hanging under LND block load (`lndRegistrationTimeout`).
+- One forwarder goroutine per conf/spend registration owns ordering. Never
+  emit `Confirmed`/`Spend`, `Reorged`, and `Done` from separate goroutines —
+  the `PositiveDoneOrder` state machine is what makes the ordering contract
+  hold, and it is not safe for concurrent use.
+- A `Canceled` status from lnd is only demoted to `Debug` when the owning
+  registration context is *also* done (`isBlockEpochShutdownError`). Round
+  completion stops each VTXO's block subscription, so an in-flight block can
+  lose that race; that is expected shutdown, not an operator-actionable event.
+  A `Canceled` status from a still-live subscription — and every other
+  notifier or block-hash failure — stays at `Warn`.
 - Log messages use canonical txid strings (not reversed byte slices).
 
 ## Deep Docs

--- a/chainbackends/CLAUDE.md
+++ b/chainbackends/CLAUDE.md
@@ -10,9 +10,13 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
 
 - `LNDBackend` — Full-node backend wrapping lnd's chain notification and fee
   estimation interfaces. Accepts an optional `PackageSubmitter` for v3 CPFP
-  package relay (set via `SetPackageSubmitter`).
+  package relay (set via `SetPackageSubmitter`). Also implements
+  `chainsource.TxRemover` via `RemoveTx`.
 - `TxBroadcaster` — Interface over transaction broadcasting (wraps
-  lndclient.WalletKitClient or in-process lnd).
+  lndclient.WalletKitClient or in-process lnd). Carries
+  `PublishTransaction(ctx, tx, label)` and `RemoveTransaction(ctx, txid)`;
+  the latter abandons a transaction (and its descendants) so the wallet stops
+  rebroadcasting it from its unconfirmed queue (wavelength#609).
 - `PackageSubmitter` — Optional interface for v3 package relay:
   `SubmitPackage(ctx, parents, child, maxFeeRate)`. Used by backends that need
   a direct bitcoind path for atomic parent+child submission; absent in
@@ -43,6 +47,27 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
   joined error tree. Use this instead of `errors.As` when all per-tx entries
   must be inspected (e.g. to distinguish parent-known vs. child-fee
   classification).
+- `reorgSignalBufferSize = 8` (unexported, `lnd.go`) — depth of the buffered
+  `Reorged` channel handed to each conf/spend registration. Reorg signals are
+  coalescing (the consumer re-queries chain state), so the buffer only needs
+  to be deep enough to keep the forwarder from stalling on a multi-block
+  reorg burst, not to record every event.
+
+## Reorg & Finality Forwarding
+
+`RegisterConf` / `RegisterSpend` bridge lnd's notifier events into the
+reorg-aware `chainsource` registration lifecycle. lnd signals a reorg by
+firing `ConfirmationEvent.NegativeConf` (conf) or `SpendEvent.Reorg` (spend);
+a single per-registration forwarder goroutine translates those into the
+backend-agnostic `Reorged` channel while also forwarding `Confirmed`/`Spend`
+and `Done`.
+
+Because Go's `select` picks randomly among ready channels, the forwarder
+routes every lifecycle fact through `chainsource.PositiveDoneOrder`
+(`ObservePositive` / `ObserveReorg` / `ObserveDone`) so the causal
+positive-before-`Done` contract survives the transport boundary. Delivery uses
+`forwardValue`, which drops the send if the registration context was cancelled
+first.
 
 ## Relationships
 
@@ -53,6 +78,13 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
   `LNDBackend` via lndclient for system tests), `btcwbackend` / `lwwallet` /
   `txconfirm` (reuse `PackageSubmitter`, `PackageTxError`, and
   `WalkPackageTxErrors` to classify per-tx package-relay results).
+- **Sends → `chainsource`** (as registration channel payloads):
+  `BlockRegistration`, `ConfRegistration`, `SpendRegistration` — each
+  carrying `Confirmed`/`Spend`, `Reorged`, and `Done`.
+- **Receives ← `chainsource`** (via the actor, on behalf of `unroll`):
+  `RemoveTxRequest` → `LNDBackend.RemoveTx`. Backends without a
+  rebroadcasting wallet do not implement `TxRemover` and the request is a
+  no-op for them.
 
 ## Invariants
 
@@ -65,7 +97,17 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
   sets the same field); otherwise, for an LND wallet it falls back to
   `chainbackends/lndsubmitter.New(lndSvc.WalletKit)` as the default.
 - `LndClientChainNotifier` enforces a 15-second timeout on registration to
-  prevent hanging under LND block load.
+  prevent hanging under LND block load (`lndRegistrationTimeout`).
+- One forwarder goroutine per conf/spend registration owns ordering. Never
+  emit `Confirmed`/`Spend`, `Reorged`, and `Done` from separate goroutines —
+  the `PositiveDoneOrder` state machine is what makes the ordering contract
+  hold, and it is not safe for concurrent use.
+- A `Canceled` status from lnd is only demoted to `Debug` when the owning
+  registration context is *also* done (`isBlockEpochShutdownError`). Round
+  completion stops each VTXO's block subscription, so an in-flight block can
+  lose that race; that is expected shutdown, not an operator-actionable event.
+  A `Canceled` status from a still-live subscription — and every other
+  notifier or block-hash failure — stays at `Warn`.
 - Log messages use canonical txid strings (not reversed byte slices).
 
 ## Deep Docs

--- a/chainfees/AGENTS.md
+++ b/chainfees/AGENTS.md
@@ -39,6 +39,23 @@ on-chain transactions from wallet and daemon chain backends.
 - `MempoolSpaceEstimator` rejects non-HTTPS URLs except for loopback hosts, to
   avoid tampering with fee data in transit.
 
+## Log Severity
+
+This package is deliberate about which fee conditions page a human (see
+[`docs/structured-logging.md`](../docs/structured-logging.md)).
+
+- An individual child-provider failure inside `MinEstimator` is `Info`.
+  Failing over to the remaining providers is the design, not an incident.
+- Providers whose estimates diverge is `Info`, and the selected provider is
+  `Info` — both are routine observability, not an alert.
+- A **sub-floor** provider rate — one clamped up to `chainfee.FeePerKwFloor` —
+  stays at `Warn`. Clamping makes the returned rate relay-valid but does not
+  repair *selection*: the clamped provider becomes the minimum candidate and
+  can pin the whole aggregate at the relay floor indefinitely, so persistent
+  fee underpayment needs operator action.
+- `Warn` is otherwise reserved for the case where *every* provider failed and
+  the estimator falls back to its last successful rate.
+
 ## Deep Docs
 
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map

--- a/chainfees/CLAUDE.md
+++ b/chainfees/CLAUDE.md
@@ -39,6 +39,23 @@ on-chain transactions from wallet and daemon chain backends.
 - `MempoolSpaceEstimator` rejects non-HTTPS URLs except for loopback hosts, to
   avoid tampering with fee data in transit.
 
+## Log Severity
+
+This package is deliberate about which fee conditions page a human (see
+[`docs/structured-logging.md`](../docs/structured-logging.md)).
+
+- An individual child-provider failure inside `MinEstimator` is `Info`.
+  Failing over to the remaining providers is the design, not an incident.
+- Providers whose estimates diverge is `Info`, and the selected provider is
+  `Info` — both are routine observability, not an alert.
+- A **sub-floor** provider rate — one clamped up to `chainfee.FeePerKwFloor` —
+  stays at `Warn`. Clamping makes the returned rate relay-valid but does not
+  repair *selection*: the clamped provider becomes the minimum candidate and
+  can pin the whole aggregate at the relay floor indefinitely, so persistent
+  fee underpayment needs operator action.
+- `Warn` is otherwise reserved for the case where *every* provider failed and
+  the estimator falls back to its last successful rate.
+
 ## Deep Docs
 
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -159,6 +159,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
 - Postgres test fixture slots bound Docker startup and migrations only. Helpers
   release the slot before returning the initialized store; retaining it until
   test cleanup can deadlock Go's parallel-test barrier.
+- `TestPgFixture` enforces its lifetime with a `time.AfterFunc` timer that
+  calls `KillContainer`, **not** dockertest's `Resource.Expire`. `Expire`
+  calls Docker's stop endpoint immediately and treats the duration as the
+  *graceful-stop timeout*, so on daemons that serialize stop requests it can
+  block every fixture slot until that timeout elapses. `TearDown` stops the
+  timer before purging.
 - `ledger_entries.entry_id` and `wallet_utxo_log.entry_id` use
   `INTEGER PRIMARY KEY AUTOINCREMENT` to prevent rowid reuse after
   deletion, preserving append-only ordering.

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -159,6 +159,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
 - Postgres test fixture slots bound Docker startup and migrations only. Helpers
   release the slot before returning the initialized store; retaining it until
   test cleanup can deadlock Go's parallel-test barrier.
+- `TestPgFixture` enforces its lifetime with a `time.AfterFunc` timer that
+  calls `KillContainer`, **not** dockertest's `Resource.Expire`. `Expire`
+  calls Docker's stop endpoint immediately and treats the duration as the
+  *graceful-stop timeout*, so on daemons that serialize stop requests it can
+  block every fixture slot until that timeout elapses. `TearDown` stops the
+  timer before purging.
 - `ledger_entries.entry_id` and `wallet_utxo_log.entry_id` use
   `INTEGER PRIMARY KEY AUTOINCREMENT` to prevent rowid reuse after
   deletion, preserving append-only ordering.

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -23,15 +23,20 @@ state transitions and validation rules live under [Invariants](#invariants).
   `RecoveryInitiatedState`.
 - `ClientEvent` — sealed inbound event interface. Notable members:
   `JoinRoundQuoteReceived` (carries reseal `SealPass`), `QuoteAccepted`,
-  `QuoteRejected`, `ForfeitCollectionTimedOut`, `ForfeitSignatureResponse`,
-  `ConnectorLeafInfo`, `IntentPackage` (atomic delivery of all intent
-  types).
+  `QuoteRejected`, `ForfeitCollectionTimedOut`, `RegistrationTimedOut`,
+  `ForfeitSignatureResponse`, `ConnectorLeafInfo`, `IntentPackage` (atomic
+  delivery of all intent types), `StatusReconcileTimedOut` and
+  `RoundStatusReported` (the wavelength#844 status reconcile, below).
 - `ClientOutMsg` — sealed outbox interface. Members:
-  `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`,
-  `SubmitForfeitSigRequest`, `StartTimeoutReq`, `CancelTimeoutReq`,
+  `JoinRoundRequest`, `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`,
+  `SubmitNoncesRequest`, `SubmitPartialSigRequest`,
+  `SubmitForfeitSigRequest`, `SubmitVTXOForfeitSigsToServer`,
+  `RegisterConfirmationRequest`, `StartTimeoutReq`, `CancelTimeoutReq`,
+  `ReleaseForfeitReservation`, `DropCustomForfeitReservation`,
+  `QueryRoundStatusOutbox`, `VTXOCreatedNotification`,
   `RoundCheckpointedNotification`, `RoundCompletedNotification`,
-  `RoundFailedNotification`, `ForfeitRequestToVTXO`,
-  `ForfeitConfirmedToVTXO`.
+  `RoundFailedNotification`, `TerminalJobFailedNotification`,
+  `ForfeitRequestToVTXO`, `ForfeitConfirmedToVTXO`.
 
 ### Quote & Intent (`interfaces.go`, `events.go`)
 
@@ -81,7 +86,14 @@ state transitions and validation rules live under [Invariants](#invariants).
 - `RefreshVTXORequest` — per-VTXO refresh. Under the seal-time fee
   handshake (#270) `OperatorFee` is **advisory only**: the FSM does NOT
   subtract it from `Amount`. The actor's `designateChangeMarker` stamps
-  exactly one `IsChange=true` across the assembled intent.
+  exactly one `IsChange=true` across the assembled intent. Expiry-driven
+  auto-refreshes additionally carry `BatchExpiry` (the maintenance cohort
+  key), `ExpandCohort` (local-only coordination provenance), the leader's
+  operator-key snapshot, `PolicyTemplate`, and `OwnerKey`.
+- `RefreshVTXOCohortRequest` — local-only message that atomically adds a
+  manager-coordinated maintenance cohort (`Requests
+  []*RefreshVTXORequest`) to a single assembling round, so cohort members
+  cannot be split across rounds or pay per-member operator fees.
 - `ConfirmationEvent`, `TimeoutMsg` — chain confirmation / timeout
   delivery to the actor.
 - VTXO-actor messages (`vtxo_messages.go`): `ForfeitRequestEvent`,
@@ -92,13 +104,17 @@ state transitions and validation rules live under [Invariants](#invariants).
 
 ### Misc
 
-- `TimeoutPhase` (`fsm_timeouts.go`) — `TimeoutPhaseForfeitCollection`
-  (forfeit-signature collection window) and `TimeoutPhaseRegistration`
-  (IntentSentState admission window; on expiry the FSM fails the round
-  recoverably and emits `ReleaseForfeitReservation` so forfeit-reserved
-  inputs are not stranded — wavelength#653). Timeout outbox messages
-  (`StartTimeoutReq`/`CancelTimeoutReq`) key on `RoundKeyStr` so temp-keyed
-  rounds (pre-admission) can be timed.
+- `TimeoutPhase` (`fsm_timeouts.go`) — four phases:
+  `TimeoutPhaseForfeitCollection` (forfeit-signature collection window),
+  `TimeoutPhaseRegistration` (IntentSentState admission window; on expiry
+  the FSM fails the round recoverably and emits
+  `ReleaseForfeitReservation` so forfeit-reserved inputs are not
+  stranded — wavelength#653), `TimeoutPhaseRefreshRegistration` (the quiet
+  period that coalesces expiry-driven refreshes into one round), and
+  `TimeoutPhaseStatusReconcile` (the wavelength#844 probe window). Timeout
+  outbox messages (`StartTimeoutReq`/`CancelTimeoutReq`) key on
+  `RoundKeyStr` so temp-keyed rounds (pre-admission) can be timed, and the
+  distinct phase keys let two timers coexist on one round.
 - `MaxQuoteEntriesPerClient = 1024` (`from_proto.go`) — bounds quote
   entry decoding to reject malformed envelopes before allocating slices.
 - `FromProto` methods on `JoinRoundQuoteReceived`, `RoundJoined`,
@@ -114,6 +130,23 @@ state transitions and validation rules live under [Invariants](#invariants).
   selects `defaultRegistrationTimeout` (60 s); negative disables the timeout
   (round waits indefinitely). Bounds how long forfeit-reserved inputs sit
   stranded when the server never responds (wavelength#653).
+- `RoundClientConfig.StatusReconcileTimeout` — window a forfeit-bearing
+  round in `InputSigSentState` waits before probing the operator with
+  `QueryRoundStatusOutbox`; doubles as the retry interval between probes
+  (exponential backoff capped at 16× the base). Zero selects
+  `defaultStatusReconcileTimeout` (90 s); non-positive opts out entirely.
+- `RoundClientConfig.WalletAskTimeout` — bounds *every* Ask this actor
+  makes into the wallet actor, covering both the enqueue and the Await.
+  Zero selects `defaultWalletAskTimeout` (30 s). Applied by the
+  `askWallet` helper.
+- `RoundClientConfig.AutoRefreshFeeFloor` / `AutoRefreshFeeRatePPM` —
+  the unattended-maintenance fee budget curve (floor plus proportional
+  rate over preserved value). See `autoRefreshFeeBudget` under
+  [Invariants](#invariants). Both zero disables the curve and falls back
+  to `MaxOperatorFee` alone.
+- `defaultRefreshRegistrationDelay` (500 ms) — quiet period used to
+  coalesce back-to-back expiry-driven refreshes (one per VTXO actor on a
+  block epoch) into a single round registration.
 - `computeClientOperatorFee(intents, ownedVTXOs) int64` —
   Σ(boarding inputs) + Σ(forfeited VTXOs) − Σ(owned output VTXOs) −
   Σ(cooperative leave outputs), clamped to zero. Carried on
@@ -131,7 +164,8 @@ state transitions and validation rules live under [Invariants](#invariants).
 - **Sends → `serverconn`**: `JoinRoundRequest`,
   `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`,
   `SubmitNoncesRequest`, `SubmitPartialSigRequest`,
-  `SubmitForfeitSigRequest`, `SubmitVTXOForfeitSigsToServer`.
+  `SubmitForfeitSigRequest`, `SubmitVTXOForfeitSigsToServer`,
+  `QueryRoundStatusOutbox` (→ `roundpb.MethodQueryRoundStatus`).
 - **Sends → `vtxo`**: forfeit/spend/block-epoch events listed above;
   manager-level `VTXOCreatedNotification`, `VTXOTerminatedMsg`.
 - **Sends → `wallet`**: `RegisterConfirmationRequest`.
@@ -146,8 +180,11 @@ state transitions and validation rules live under [Invariants](#invariants).
   `OperatorFeeSat > 0` and any refresh-origin VTXO was emitted.
 - **Receives ← `serverconn`** (via `ServerMessageNotification`):
   `CommitmentTxBuilt`, `NoncesAggregated`, `OperatorSigned`,
-  `RoundJoined`, `BoardingFailed`, `JoinRoundQuoteReceived`.
-- **Receives ← `vtxo`**: `ForfeitSignatureResponse` (via manager).
+  `RoundJoined`, `BoardingFailed`, `JoinRoundQuoteReceived`,
+  `RoundStatusReported`.
+- **Receives ← `vtxo`**: `ForfeitSignatureResponse` (via manager),
+  `RefreshVTXORequest` (per-VTXO expiry refresh) and
+  `RefreshVTXOCohortRequest` (manager-coordinated maintenance cohort).
 - **Receives ← `wallet`** (via `lib/actormsg`): `RegisterIntentMsg`
   (pre-admitted intent packages), `TriggerBoardMsg`. Boarding UTXO
   confirmations arrive wrapped in `WalletBoardingConfirmed`.
@@ -248,6 +285,86 @@ state transitions and validation rules live under [Invariants](#invariants).
   collaborative leaf when the live output uses a custom script policy;
   without it the VTXO actor would build a forfeit against the wrong
   tapscript branch.
+- **Forfeit release past `PartialSigsSent` goes through a status
+  reconcile, never a blind release** (wavelength#844).
+  `releaseForfeitsOnFailure` (the #653 rollback wrapper) deliberately
+  stops at `PartialSigsSentState`, because beyond that point the operator
+  may hold fully-signed forfeit txs and an unconditional release risks a
+  double-spend. A `BoardingFailed` landing in `InputSigSentState` with
+  forfeits at stake therefore parks in `InputSigSentState.PendingFailure`
+  while `QueryRoundStatusOutbox` probes the operator. Only a
+  `ROUND_STATUS_DEAD` answer — proof the commitment can never confirm,
+  since the operator persists a finalized round atomically with its VTXOs
+  *before* broadcasting — releases the reservations. Any other answer
+  holds them.
+- The `TimeoutPhaseStatusReconcile` timer never releases anything on its
+  own; expiry only re-emits the probe. It exists to cover the silent
+  operator (lumos#618): a crashed operator sends no failure at all, so
+  without the timer the FSM would wait forever for an event that is not
+  coming. It is armed when forfeit signatures are emitted, re-armed per
+  probe, and re-armed on restart reload. `InputSigSentState.PendingFailure`
+  and `ReconcileProbes` are **in-memory only** — a restart resets the probe
+  count and relies on the re-armed timer.
+- **Arm status reconciliation before any fallible outbox effect.**
+  `processOutbox` stops at the first failed external effect, so a transient
+  failure while submitting forfeit signatures or registering the chain
+  watch would otherwise skip arming the timeout *after* signatures had
+  already left the client, stranding reserved inputs with no reconciliation
+  path. The forfeit-collection outbox order is: cancel the
+  forfeit-collection timeout, arm status reconciliation, then VTXO forfeit
+  signatures → optional boarding signatures → chain registration.
+- **Exactly one commitment-confirmation watch per round.** The FSM outbox
+  emits `RegisterConfirmationRequest` after committing the durable
+  `InputSigSent` state; checkpoint handling only installs the routing
+  index, and restart recovery re-registers from durable state. Registering
+  again from the checkpoint notification produced a second subscription
+  under a different caller ID — the first completed the round and the
+  second reported the tx as no longer indexed. The FSM request uses the
+  validated batch-output script and the operator's minimum confirmation
+  target, matching restart recovery.
+- **`SweepDelay` must survive a restart** (`rounds.sweep_delay`). The
+  confirmation handler derives each new VTXO's absolute batch expiry as
+  `confirmation_height + SweepDelay`, and a round checkpointed at
+  `input_sig_sent` can confirm long afterwards. The upsert only adopts a
+  non-zero incoming delay — the value is fixed for the life of a round, so
+  a later checkpoint must never clear what an earlier one recorded. Rounds
+  checkpointed before the migration have no recorded delay; for those the
+  confirmation path leaves the expiry **unstamped** (logging at error
+  level) rather than stamping `BatchExpiry == CreatedHeight`, which the
+  wallet would read back as already expired. An unstamped expiry
+  classifies as `ExpiryStatusUnknown`, so the VTXO stays live and spendable
+  with only expiry monitoring disabled.
+- **Every round → wallet `Ask` is bounded** by `askWallet`, which applies
+  one `WithTimeout` covering both the enqueue and the `Await`. The wallet's
+  own handlers Ask the round actor back, so two full mailboxes could
+  otherwise produce a circular wait that parks the receive loop forever.
+  Bounding one direction breaks the cycle; the wallet → round direction is
+  left unbounded **deliberately**, because an Ask's context becomes the
+  receiver's turn context and a deadline there would bound money-path FSM
+  registration work. The actor lifecycle context stays the parent so
+  shutdown still cancels a pending Ask.
+- Call sites that scan every tracked round share **one** deadline per scan
+  rather than paying the per-query budget per FSM. With N rounds
+  mid-transition a single message could otherwise spend N × the per-query
+  budget, and `OnStop` could burn its whole cleanup budget on queries and
+  strand external-signer session cleanup. Every scanning caller already
+  degrades by skipping an unreadable round, so the shared budget changes
+  worst-case latency, not behaviour.
+- **Automatic (expiry-driven) refreshes are cohort-scoped.** Members of
+  one `BatchExpiry` cohort are handed to a round atomically via
+  `RefreshVTXOCohortRequest`, reusing the leader's operator-key snapshot so
+  a single registration cannot mix operator terms or spend its deadline on
+  repeated `GetInfo` calls. If the round handoff fails, the leader is
+  released together with its reserved siblings.
+- **Auto-refresh fee budget** (`autoRefreshFeeBudget`): the allowance is
+  `max(AutoRefreshFeeFloor, autoValue × AutoRefreshFeeRatePPM / 1e6)`,
+  clamped to `MaxOperatorFee`, which remains the hard global ceiling. The
+  floor covers fixed costs for small VTXOs without giving large cohorts an
+  unbounded allowance. It **fails closed**: with a configured policy and a
+  non-positive automatic value (malformed or overflowed intents) the budget
+  is zero, not unlimited. The denominator counts only automatic-maintenance
+  outputs, but the resulting cap applies to the entire realised round fee.
+  A `ratePPM > 1_000_000` is rejected outright.
 
 ## Deep Docs
 

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -23,15 +23,20 @@ state transitions and validation rules live under [Invariants](#invariants).
   `RecoveryInitiatedState`.
 - `ClientEvent` — sealed inbound event interface. Notable members:
   `JoinRoundQuoteReceived` (carries reseal `SealPass`), `QuoteAccepted`,
-  `QuoteRejected`, `ForfeitCollectionTimedOut`, `ForfeitSignatureResponse`,
-  `ConnectorLeafInfo`, `IntentPackage` (atomic delivery of all intent
-  types).
+  `QuoteRejected`, `ForfeitCollectionTimedOut`, `RegistrationTimedOut`,
+  `ForfeitSignatureResponse`, `ConnectorLeafInfo`, `IntentPackage` (atomic
+  delivery of all intent types), `StatusReconcileTimedOut` and
+  `RoundStatusReported` (the wavelength#844 status reconcile, below).
 - `ClientOutMsg` — sealed outbox interface. Members:
-  `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`,
-  `SubmitForfeitSigRequest`, `StartTimeoutReq`, `CancelTimeoutReq`,
+  `JoinRoundRequest`, `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`,
+  `SubmitNoncesRequest`, `SubmitPartialSigRequest`,
+  `SubmitForfeitSigRequest`, `SubmitVTXOForfeitSigsToServer`,
+  `RegisterConfirmationRequest`, `StartTimeoutReq`, `CancelTimeoutReq`,
+  `ReleaseForfeitReservation`, `DropCustomForfeitReservation`,
+  `QueryRoundStatusOutbox`, `VTXOCreatedNotification`,
   `RoundCheckpointedNotification`, `RoundCompletedNotification`,
-  `RoundFailedNotification`, `ForfeitRequestToVTXO`,
-  `ForfeitConfirmedToVTXO`.
+  `RoundFailedNotification`, `TerminalJobFailedNotification`,
+  `ForfeitRequestToVTXO`, `ForfeitConfirmedToVTXO`.
 
 ### Quote & Intent (`interfaces.go`, `events.go`)
 
@@ -81,7 +86,14 @@ state transitions and validation rules live under [Invariants](#invariants).
 - `RefreshVTXORequest` — per-VTXO refresh. Under the seal-time fee
   handshake (#270) `OperatorFee` is **advisory only**: the FSM does NOT
   subtract it from `Amount`. The actor's `designateChangeMarker` stamps
-  exactly one `IsChange=true` across the assembled intent.
+  exactly one `IsChange=true` across the assembled intent. Expiry-driven
+  auto-refreshes additionally carry `BatchExpiry` (the maintenance cohort
+  key), `ExpandCohort` (local-only coordination provenance), the leader's
+  operator-key snapshot, `PolicyTemplate`, and `OwnerKey`.
+- `RefreshVTXOCohortRequest` — local-only message that atomically adds a
+  manager-coordinated maintenance cohort (`Requests
+  []*RefreshVTXORequest`) to a single assembling round, so cohort members
+  cannot be split across rounds or pay per-member operator fees.
 - `ConfirmationEvent`, `TimeoutMsg` — chain confirmation / timeout
   delivery to the actor.
 - VTXO-actor messages (`vtxo_messages.go`): `ForfeitRequestEvent`,
@@ -92,13 +104,17 @@ state transitions and validation rules live under [Invariants](#invariants).
 
 ### Misc
 
-- `TimeoutPhase` (`fsm_timeouts.go`) — `TimeoutPhaseForfeitCollection`
-  (forfeit-signature collection window) and `TimeoutPhaseRegistration`
-  (IntentSentState admission window; on expiry the FSM fails the round
-  recoverably and emits `ReleaseForfeitReservation` so forfeit-reserved
-  inputs are not stranded — wavelength#653). Timeout outbox messages
-  (`StartTimeoutReq`/`CancelTimeoutReq`) key on `RoundKeyStr` so temp-keyed
-  rounds (pre-admission) can be timed.
+- `TimeoutPhase` (`fsm_timeouts.go`) — four phases:
+  `TimeoutPhaseForfeitCollection` (forfeit-signature collection window),
+  `TimeoutPhaseRegistration` (IntentSentState admission window; on expiry
+  the FSM fails the round recoverably and emits
+  `ReleaseForfeitReservation` so forfeit-reserved inputs are not
+  stranded — wavelength#653), `TimeoutPhaseRefreshRegistration` (the quiet
+  period that coalesces expiry-driven refreshes into one round), and
+  `TimeoutPhaseStatusReconcile` (the wavelength#844 probe window). Timeout
+  outbox messages (`StartTimeoutReq`/`CancelTimeoutReq`) key on
+  `RoundKeyStr` so temp-keyed rounds (pre-admission) can be timed, and the
+  distinct phase keys let two timers coexist on one round.
 - `MaxQuoteEntriesPerClient = 1024` (`from_proto.go`) — bounds quote
   entry decoding to reject malformed envelopes before allocating slices.
 - `FromProto` methods on `JoinRoundQuoteReceived`, `RoundJoined`,
@@ -114,6 +130,23 @@ state transitions and validation rules live under [Invariants](#invariants).
   selects `defaultRegistrationTimeout` (60 s); negative disables the timeout
   (round waits indefinitely). Bounds how long forfeit-reserved inputs sit
   stranded when the server never responds (wavelength#653).
+- `RoundClientConfig.StatusReconcileTimeout` — window a forfeit-bearing
+  round in `InputSigSentState` waits before probing the operator with
+  `QueryRoundStatusOutbox`; doubles as the retry interval between probes
+  (exponential backoff capped at 16× the base). Zero selects
+  `defaultStatusReconcileTimeout` (90 s); non-positive opts out entirely.
+- `RoundClientConfig.WalletAskTimeout` — bounds *every* Ask this actor
+  makes into the wallet actor, covering both the enqueue and the Await.
+  Zero selects `defaultWalletAskTimeout` (30 s). Applied by the
+  `askWallet` helper.
+- `RoundClientConfig.AutoRefreshFeeFloor` / `AutoRefreshFeeRatePPM` —
+  the unattended-maintenance fee budget curve (floor plus proportional
+  rate over preserved value). See `autoRefreshFeeBudget` under
+  [Invariants](#invariants). Both zero disables the curve and falls back
+  to `MaxOperatorFee` alone.
+- `defaultRefreshRegistrationDelay` (500 ms) — quiet period used to
+  coalesce back-to-back expiry-driven refreshes (one per VTXO actor on a
+  block epoch) into a single round registration.
 - `computeClientOperatorFee(intents, ownedVTXOs) int64` —
   Σ(boarding inputs) + Σ(forfeited VTXOs) − Σ(owned output VTXOs) −
   Σ(cooperative leave outputs), clamped to zero. Carried on
@@ -131,7 +164,8 @@ state transitions and validation rules live under [Invariants](#invariants).
 - **Sends → `serverconn`**: `JoinRoundRequest`,
   `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`,
   `SubmitNoncesRequest`, `SubmitPartialSigRequest`,
-  `SubmitForfeitSigRequest`, `SubmitVTXOForfeitSigsToServer`.
+  `SubmitForfeitSigRequest`, `SubmitVTXOForfeitSigsToServer`,
+  `QueryRoundStatusOutbox` (→ `roundpb.MethodQueryRoundStatus`).
 - **Sends → `vtxo`**: forfeit/spend/block-epoch events listed above;
   manager-level `VTXOCreatedNotification`, `VTXOTerminatedMsg`.
 - **Sends → `wallet`**: `RegisterConfirmationRequest`.
@@ -146,8 +180,11 @@ state transitions and validation rules live under [Invariants](#invariants).
   `OperatorFeeSat > 0` and any refresh-origin VTXO was emitted.
 - **Receives ← `serverconn`** (via `ServerMessageNotification`):
   `CommitmentTxBuilt`, `NoncesAggregated`, `OperatorSigned`,
-  `RoundJoined`, `BoardingFailed`, `JoinRoundQuoteReceived`.
-- **Receives ← `vtxo`**: `ForfeitSignatureResponse` (via manager).
+  `RoundJoined`, `BoardingFailed`, `JoinRoundQuoteReceived`,
+  `RoundStatusReported`.
+- **Receives ← `vtxo`**: `ForfeitSignatureResponse` (via manager),
+  `RefreshVTXORequest` (per-VTXO expiry refresh) and
+  `RefreshVTXOCohortRequest` (manager-coordinated maintenance cohort).
 - **Receives ← `wallet`** (via `lib/actormsg`): `RegisterIntentMsg`
   (pre-admitted intent packages), `TriggerBoardMsg`. Boarding UTXO
   confirmations arrive wrapped in `WalletBoardingConfirmed`.
@@ -248,6 +285,86 @@ state transitions and validation rules live under [Invariants](#invariants).
   collaborative leaf when the live output uses a custom script policy;
   without it the VTXO actor would build a forfeit against the wrong
   tapscript branch.
+- **Forfeit release past `PartialSigsSent` goes through a status
+  reconcile, never a blind release** (wavelength#844).
+  `releaseForfeitsOnFailure` (the #653 rollback wrapper) deliberately
+  stops at `PartialSigsSentState`, because beyond that point the operator
+  may hold fully-signed forfeit txs and an unconditional release risks a
+  double-spend. A `BoardingFailed` landing in `InputSigSentState` with
+  forfeits at stake therefore parks in `InputSigSentState.PendingFailure`
+  while `QueryRoundStatusOutbox` probes the operator. Only a
+  `ROUND_STATUS_DEAD` answer — proof the commitment can never confirm,
+  since the operator persists a finalized round atomically with its VTXOs
+  *before* broadcasting — releases the reservations. Any other answer
+  holds them.
+- The `TimeoutPhaseStatusReconcile` timer never releases anything on its
+  own; expiry only re-emits the probe. It exists to cover the silent
+  operator (lumos#618): a crashed operator sends no failure at all, so
+  without the timer the FSM would wait forever for an event that is not
+  coming. It is armed when forfeit signatures are emitted, re-armed per
+  probe, and re-armed on restart reload. `InputSigSentState.PendingFailure`
+  and `ReconcileProbes` are **in-memory only** — a restart resets the probe
+  count and relies on the re-armed timer.
+- **Arm status reconciliation before any fallible outbox effect.**
+  `processOutbox` stops at the first failed external effect, so a transient
+  failure while submitting forfeit signatures or registering the chain
+  watch would otherwise skip arming the timeout *after* signatures had
+  already left the client, stranding reserved inputs with no reconciliation
+  path. The forfeit-collection outbox order is: cancel the
+  forfeit-collection timeout, arm status reconciliation, then VTXO forfeit
+  signatures → optional boarding signatures → chain registration.
+- **Exactly one commitment-confirmation watch per round.** The FSM outbox
+  emits `RegisterConfirmationRequest` after committing the durable
+  `InputSigSent` state; checkpoint handling only installs the routing
+  index, and restart recovery re-registers from durable state. Registering
+  again from the checkpoint notification produced a second subscription
+  under a different caller ID — the first completed the round and the
+  second reported the tx as no longer indexed. The FSM request uses the
+  validated batch-output script and the operator's minimum confirmation
+  target, matching restart recovery.
+- **`SweepDelay` must survive a restart** (`rounds.sweep_delay`). The
+  confirmation handler derives each new VTXO's absolute batch expiry as
+  `confirmation_height + SweepDelay`, and a round checkpointed at
+  `input_sig_sent` can confirm long afterwards. The upsert only adopts a
+  non-zero incoming delay — the value is fixed for the life of a round, so
+  a later checkpoint must never clear what an earlier one recorded. Rounds
+  checkpointed before the migration have no recorded delay; for those the
+  confirmation path leaves the expiry **unstamped** (logging at error
+  level) rather than stamping `BatchExpiry == CreatedHeight`, which the
+  wallet would read back as already expired. An unstamped expiry
+  classifies as `ExpiryStatusUnknown`, so the VTXO stays live and spendable
+  with only expiry monitoring disabled.
+- **Every round → wallet `Ask` is bounded** by `askWallet`, which applies
+  one `WithTimeout` covering both the enqueue and the `Await`. The wallet's
+  own handlers Ask the round actor back, so two full mailboxes could
+  otherwise produce a circular wait that parks the receive loop forever.
+  Bounding one direction breaks the cycle; the wallet → round direction is
+  left unbounded **deliberately**, because an Ask's context becomes the
+  receiver's turn context and a deadline there would bound money-path FSM
+  registration work. The actor lifecycle context stays the parent so
+  shutdown still cancels a pending Ask.
+- Call sites that scan every tracked round share **one** deadline per scan
+  rather than paying the per-query budget per FSM. With N rounds
+  mid-transition a single message could otherwise spend N × the per-query
+  budget, and `OnStop` could burn its whole cleanup budget on queries and
+  strand external-signer session cleanup. Every scanning caller already
+  degrades by skipping an unreadable round, so the shared budget changes
+  worst-case latency, not behaviour.
+- **Automatic (expiry-driven) refreshes are cohort-scoped.** Members of
+  one `BatchExpiry` cohort are handed to a round atomically via
+  `RefreshVTXOCohortRequest`, reusing the leader's operator-key snapshot so
+  a single registration cannot mix operator terms or spend its deadline on
+  repeated `GetInfo` calls. If the round handoff fails, the leader is
+  released together with its reserved siblings.
+- **Auto-refresh fee budget** (`autoRefreshFeeBudget`): the allowance is
+  `max(AutoRefreshFeeFloor, autoValue × AutoRefreshFeeRatePPM / 1e6)`,
+  clamped to `MaxOperatorFee`, which remains the hard global ceiling. The
+  floor covers fixed costs for small VTXOs without giving large cohorts an
+  unbounded allowance. It **fails closed**: with a configured policy and a
+  non-positive automatic value (malformed or overflowed intents) the budget
+  is zero, not unlimited. The denominator counts only automatic-maintenance
+  outputs, but the resulting cap applies to the entire realised round fee.
+  A `ratePPM > 1_000_000` is rejected outright.
 
 ## Deep Docs
 

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -103,6 +103,15 @@ background ingress polling with event routing.
   only when the caller leaves `RPCOptions.IdempotencyKey` empty, which is
   correct for a single-shot call and defeats deduplication for a retry.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
+- The ingress loop keeps **two** failure counters and they are not
+  interchangeable. `failCount` drives the shared exponential backoff across
+  every transport and checkpoint failure; `pullFailCount` is pull-only and
+  exists solely to scope alerting to one remote-pull outage. Only the first
+  failure of an episode logs `Pull failed, retrying` at `Warn` (so a real
+  dependency outage stays visible); later attempts log at `Debug` with a
+  `consecutive_failures` count, and a successful pull resets the counter so a
+  later outage warns again. Reusing the shared `failCount` here would let an
+  unrelated backoff suppress the first alert of a genuine pull outage.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.
 - `DurableUnaryQuery` implementations must produce stable identity bytes in `BuildBody` so that `MsgID` and `IdempotencyKey` are deterministic across restarts (auto-derived via `mailboxconn.StableEventMsgID` / `StableEventIdempotencyKey` when the caller leaves them empty).
 - `ServerConnectionActor` runs a background heartbeat goroutine (`DefaultHeartbeatInterval` = 30s) to keep the mailbox session alive.

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -103,6 +103,15 @@ background ingress polling with event routing.
   only when the caller leaves `RPCOptions.IdempotencyKey` empty, which is
   correct for a single-shot call and defeats deduplication for a retry.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
+- The ingress loop keeps **two** failure counters and they are not
+  interchangeable. `failCount` drives the shared exponential backoff across
+  every transport and checkpoint failure; `pullFailCount` is pull-only and
+  exists solely to scope alerting to one remote-pull outage. Only the first
+  failure of an episode logs `Pull failed, retrying` at `Warn` (so a real
+  dependency outage stays visible); later attempts log at `Debug` with a
+  `consecutive_failures` count, and a successful pull resets the counter so a
+  later outage warns again. Reusing the shared `failCount` here would let an
+  unrelated backoff suppress the first alert of a genuine pull outage.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.
 - `DurableUnaryQuery` implementations must produce stable identity bytes in `BuildBody` so that `MsgID` and `IdempotencyKey` are deterministic across restarts (auto-derived via `mailboxconn.StableEventMsgID` / `StableEventIdempotencyKey` when the caller leaves them empty).
 - `ServerConnectionActor` runs a background heartbeat goroutine (`DefaultHeartbeatInterval` = 30s) to keep the mailbox session alive.

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -101,7 +101,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   overcome. Only a structurally permanent error
   (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`) fails
   terminally; `ErrParentAlreadyBroadcast` advances to
-  `AwaitingConfirmation` (a live parent exists on another path). Rationale:
+  `AwaitingConfirmation` (a live parent exists on another path) and is logged
+  at `Debug`, not `Warn`, on **both** the initial-broadcast and fee-bump
+  paths. Losing the package race to an existing broadcast leaves the parent
+  under its confirmation watch, so the rejected duplicate child needs no
+  operator action. Rationale:
   a fraud-response checkpoint must land before the counterparty's
   CSV-timeout path, so the actor escalates to operators rather than
   silently aborting.

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -101,7 +101,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   overcome. Only a structurally permanent error
   (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`) fails
   terminally; `ErrParentAlreadyBroadcast` advances to
-  `AwaitingConfirmation` (a live parent exists on another path). Rationale:
+  `AwaitingConfirmation` (a live parent exists on another path) and is logged
+  at `Debug`, not `Warn`, on **both** the initial-broadcast and fee-bump
+  paths. Losing the package race to an existing broadcast leaves the parent
+  under its confirmation watch, so the rejected duplicate child needs no
+  operator action. Rationale:
   a fraud-response checkpoint must land before the counterparty's
   CSV-timeout path, so the actor escalates to operators rather than
   silently aborting.

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -29,8 +29,8 @@ when the local wallet owns the receive script.
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
   `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, `FetchOperatorKey`,
-  `ForfeitParticipantSigner`, `TerminalVTXOObserver`, `ExitOutcomeResolver`,
-  and `ReservationStore`. Confirmed exit-cost accounting is emitted by unroll
+  `ForfeitParticipantSigner`, `CriticalExitAssessor`, `TerminalVTXOObserver`,
+  `ExitOutcomeResolver`, and `ReservationStore`. Confirmed exit-cost accounting is emitted by unroll
   after final sweep confirmation. `ForfeitVTXOActorAskTimeout`
   (default 5 s) bounds forfeit and refresh child asks so a blocked child actor
   cannot monopolize the manager until the outer RPC deadline. Zero uses the
@@ -84,6 +84,11 @@ when the local wallet owns the receive script.
   `ErrVTXOLiquidityLocked` (`admission_errors.go`) — admission sentinels;
   match with `errors.Is`.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
+- `CohortRefreshEvent` — Asks an eligible sibling VTXO from the same
+  `BatchExpiry` batch to join an automatic refresh another VTXO already
+  triggered. The manager sends these with bounded Ask backpressure and the
+  member returns its constructed `round.RefreshVTXORequest` directly in the
+  Ask response, so no recursive manager-mailbox re-entry occurs.
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
 - `GetActiveVTXOCountRequest` / `GetActiveVTXOCountResponse` — Ask-message for querying active VTXO count from the manager.
@@ -95,6 +100,11 @@ when the local wallet owns the receive script.
 - `VTXOSaver` — Narrow persistence interface (`SaveVTXO(ctx, *Descriptor)`) the incoming handler uses; the production implementation is the `db` VTXO store, which serializes a missing tree path as an empty blob.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
+- `CriticalExitAssessor` / `CriticalExitAssessment` — Function type
+  `func(ctx, *Descriptor) (CriticalExitAssessment, error)` and its result
+  (`Feasible bool`, `Reason string`). Set on `ManagerConfig` and propagated to
+  every spawned `VTXOActor`; consulted before a critical-expiry VTXO enters
+  automatic unilateral exit. See the viable-recovery invariant below.
 - `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory preview** before each auto-refresh emission to estimate the per-input operator fee for UX surfaces. Under the seal-time fee handshake (#270) the server is the binding fee authority — the quoter's return value is no longer attached to the wire intent. Nil quoter (legacy and test paths) yields `OperatorFee=0` on the harness-local `RefreshVTXORequest`, which has no effect on the round protocol.
 
 ## Relationships
@@ -103,6 +113,9 @@ when the local wallet owns the receive script.
 - **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `waved` (wiring, owned-script adapters, incoming event route, and `CheckForfeitAdmission` for the leave filter and exit-plan advisory), `sdk/swaps` (forfeit sign-request conversion).
 - **Sends**:
   - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`
+  - → `round`: `RefreshVTXORequest` (single expiry-driven refresh) or
+    `RefreshVTXOCohortRequest` (a coordinated same-`BatchExpiry` maintenance
+    cohort, sent atomically so members cannot be split across rounds)
   - → `db` (via outbox): `VTXOStatusUpdate`
   - → `vtxo` manager: `VTXOTerminatedNotification`, `RelayToRoundMsg`, `VTXOsMaterializedNotification` (from `IncomingVTXOHandler`)
   - → `ledger` actor: no direct messages; unroll emits confirmed
@@ -155,6 +168,17 @@ when the local wallet owns the receive script.
 - VTXO actor state is the single source of truth for availability.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
+- **Automatic refresh coordinates a cohort, best-effort and bounded.**
+  `coordinateAutoRefreshCohort` pulls eligible live and pending-forfeit
+  siblings sharing the leader's `BatchExpiry` into one round so the batch pays
+  one operator fee instead of N. It is capped at `maxAutoRefreshCohortSize`
+  (32) and runs every child Ask sequentially under **one** aggregate deadline
+  (`ForfeitVTXOActorAskTimeout`), not a per-child budget. All of it is
+  best-effort: a store failure or a declining child must never delay the
+  leader's own maintenance attempt, and each child independently refuses
+  stale, critical, reserved, or non-live requests. The leader snapshots the
+  operator key once and reuses it for every member, so a single registration
+  cannot mix operator terms.
 - Auto-refresh delays to an advertised fee-waiver boundary only when the
   boundary remains at least `MinRefreshBuffer` blocks above the dynamic
   critical threshold. An overly late window never weakens unilateral-exit or
@@ -162,6 +186,23 @@ when the local wallet owns the receive script.
 - When the cached boundary fires, auto-refresh fetches fresh operator terms
   before reserving the VTXO. A later still-safe boundary leaves the VTXO live;
   a disabled or unsafe-late window preserves the ordinary paid refresh path.
+- **Critical expiry prefers a recovery path that can actually execute.**
+  `preflightCriticalExit` intercepts a `BlockEpochEvent` that would take a
+  `LiveState` or `PendingForfeitState` VTXO into unilateral exit at
+  `ExpiryStatusCritical`, and runs `CriticalExitAssessor` over the whole exit
+  package. An explicitly infeasible verdict (the backing wallet cannot fund
+  the package at the current fee rate) is rewritten into the actor-local
+  `criticalRefreshEvent`, which starts cooperative refresh from `LiveState`
+  and keeps waiting for the round from `PendingForfeitState`. Without this,
+  a critical VTXO entered an exit that could only retry while a cooperative
+  round was still available.
+  **The check fails open**: a nil assessor, an assessment error, or a
+  feasible verdict all retain the existing direct unilateral-exit
+  transition — an unavailable assessment must never suppress the safety
+  path. The assessment repeats on every block, so funding the wallet
+  restores the unilateral path with no extra state transition.
+  `criticalRefreshEvent` is actor-local; external block notifications stay
+  `BlockEpochEvent`.
 - Once ForfeitedState is reached, the old VTXO is unspendable; the new VTXO is available only after round confirmation.
 - SpendingState is persisted as VTXOStatusSpending and survives restarts.
 - OOR completion transitions VTXOs to SpentState through the VTXO actor FSM, not by direct store writes.

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -29,8 +29,8 @@ when the local wallet owns the receive script.
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
   `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, `FetchOperatorKey`,
-  `ForfeitParticipantSigner`, `TerminalVTXOObserver`, `ExitOutcomeResolver`,
-  and `ReservationStore`. Confirmed exit-cost accounting is emitted by unroll
+  `ForfeitParticipantSigner`, `CriticalExitAssessor`, `TerminalVTXOObserver`,
+  `ExitOutcomeResolver`, and `ReservationStore`. Confirmed exit-cost accounting is emitted by unroll
   after final sweep confirmation. `ForfeitVTXOActorAskTimeout`
   (default 5 s) bounds forfeit and refresh child asks so a blocked child actor
   cannot monopolize the manager until the outer RPC deadline. Zero uses the
@@ -84,6 +84,11 @@ when the local wallet owns the receive script.
   `ErrVTXOLiquidityLocked` (`admission_errors.go`) — admission sentinels;
   match with `errors.Is`.
 - `VTXOEvent` — Inbound events (BlockEpochEvent, ForfeitRequest, ForfeitConfirmed, SpendReserveEvent, SpendCompletedEvent, etc.).
+- `CohortRefreshEvent` — Asks an eligible sibling VTXO from the same
+  `BatchExpiry` batch to join an automatic refresh another VTXO already
+  triggered. The manager sends these with bounded Ask backpressure and the
+  member returns its constructed `round.RefreshVTXORequest` directly in the
+  Ask response, so no recursive manager-mailbox re-entry occurs.
 - `VTXOOutMsg` — Outbound messages (ForfeitRequest, ExpiringNotify, StatusUpdate, Terminated).
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
 - `GetActiveVTXOCountRequest` / `GetActiveVTXOCountResponse` — Ask-message for querying active VTXO count from the manager.
@@ -95,6 +100,11 @@ when the local wallet owns the receive script.
 - `VTXOSaver` — Narrow persistence interface (`SaveVTXO(ctx, *Descriptor)`) the incoming handler uses; the production implementation is the `db` VTXO store, which serializes a missing tree path as an empty blob.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
+- `CriticalExitAssessor` / `CriticalExitAssessment` — Function type
+  `func(ctx, *Descriptor) (CriticalExitAssessment, error)` and its result
+  (`Feasible bool`, `Reason string`). Set on `ManagerConfig` and propagated to
+  every spawned `VTXOActor`; consulted before a critical-expiry VTXO enters
+  automatic unilateral exit. See the viable-recovery invariant below.
 - `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory preview** before each auto-refresh emission to estimate the per-input operator fee for UX surfaces. Under the seal-time fee handshake (#270) the server is the binding fee authority — the quoter's return value is no longer attached to the wire intent. Nil quoter (legacy and test paths) yields `OperatorFee=0` on the harness-local `RefreshVTXORequest`, which has no effect on the round protocol.
 
 ## Relationships
@@ -103,6 +113,9 @@ when the local wallet owns the receive script.
 - **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `waved` (wiring, owned-script adapters, incoming event route, and `CheckForfeitAdmission` for the leave filter and exit-plan advisory), `sdk/swaps` (forfeit sign-request conversion).
 - **Sends**:
   - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`
+  - → `round`: `RefreshVTXORequest` (single expiry-driven refresh) or
+    `RefreshVTXOCohortRequest` (a coordinated same-`BatchExpiry` maintenance
+    cohort, sent atomically so members cannot be split across rounds)
   - → `db` (via outbox): `VTXOStatusUpdate`
   - → `vtxo` manager: `VTXOTerminatedNotification`, `RelayToRoundMsg`, `VTXOsMaterializedNotification` (from `IncomingVTXOHandler`)
   - → `ledger` actor: no direct messages; unroll emits confirmed
@@ -155,6 +168,17 @@ when the local wallet owns the receive script.
 - VTXO actor state is the single source of truth for availability.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
+- **Automatic refresh coordinates a cohort, best-effort and bounded.**
+  `coordinateAutoRefreshCohort` pulls eligible live and pending-forfeit
+  siblings sharing the leader's `BatchExpiry` into one round so the batch pays
+  one operator fee instead of N. It is capped at `maxAutoRefreshCohortSize`
+  (32) and runs every child Ask sequentially under **one** aggregate deadline
+  (`ForfeitVTXOActorAskTimeout`), not a per-child budget. All of it is
+  best-effort: a store failure or a declining child must never delay the
+  leader's own maintenance attempt, and each child independently refuses
+  stale, critical, reserved, or non-live requests. The leader snapshots the
+  operator key once and reuses it for every member, so a single registration
+  cannot mix operator terms.
 - Auto-refresh delays to an advertised fee-waiver boundary only when the
   boundary remains at least `MinRefreshBuffer` blocks above the dynamic
   critical threshold. An overly late window never weakens unilateral-exit or
@@ -162,6 +186,23 @@ when the local wallet owns the receive script.
 - When the cached boundary fires, auto-refresh fetches fresh operator terms
   before reserving the VTXO. A later still-safe boundary leaves the VTXO live;
   a disabled or unsafe-late window preserves the ordinary paid refresh path.
+- **Critical expiry prefers a recovery path that can actually execute.**
+  `preflightCriticalExit` intercepts a `BlockEpochEvent` that would take a
+  `LiveState` or `PendingForfeitState` VTXO into unilateral exit at
+  `ExpiryStatusCritical`, and runs `CriticalExitAssessor` over the whole exit
+  package. An explicitly infeasible verdict (the backing wallet cannot fund
+  the package at the current fee rate) is rewritten into the actor-local
+  `criticalRefreshEvent`, which starts cooperative refresh from `LiveState`
+  and keeps waiting for the round from `PendingForfeitState`. Without this,
+  a critical VTXO entered an exit that could only retry while a cooperative
+  round was still available.
+  **The check fails open**: a nil assessor, an assessment error, or a
+  feasible verdict all retain the existing direct unilateral-exit
+  transition — an unavailable assessment must never suppress the safety
+  path. The assessment repeats on every block, so funding the wallet
+  restores the unilateral path with no extra state transition.
+  `criticalRefreshEvent` is actor-local; external block notifications stay
+  `BlockEpochEvent`.
 - Once ForfeitedState is reached, the old VTXO is unspendable; the new VTXO is available only after round confirmation.
 - SpendingState is persisted as VTXOStatusSpending and survives restarts.
 - OOR completion transitions VTXOs to SpentState through the VTXO actor FSM, not by direct store writes.

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -45,6 +45,22 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 
 ## Invariants
 
+- **Manual and automatic exit admission share one feasibility model.**
+  `assessUnrollFeasibility` gathers the wallet snapshot, fee rate, and OOR
+  lineage for a single unilateral package and returns
+  `unroll.PlanExitFunding(...).Feasibility`. Both consumers go through it:
+  `preflightUnrollFeasibility` (the manual `Unroll` RPC admission gate) and
+  `assessAutomaticCriticalExit`, which `Server.initVTXOManager` wires onto
+  `vtxo.ManagerConfig.CriticalExitAssessor`. Keeping one model is the point —
+  the manual gate and the VTXO actor's critical-expiry path selection must not
+  be able to disagree about whether the wallet can execute an exit. The
+  adapter is a plain function value, so the VTXO manager gets the verdict
+  without an import cycle back into `waved`.
+- `automaticExitDecisionReason` renders the first failed feasibility invariant
+  with concrete values (`sweep_below_dust`, `uneconomical`,
+  `wallet_underfunded`, `wallet_too_few_inputs`) so the automatic path choice
+  is diagnosable from one structured log entry. A feasible verdict returns a
+  stable short label because the VTXO actor logs the chosen action separately.
 - The lnd wallet account (`lnd.account`, empty = lnd's `default`) bounds what
   this daemon may **spend**: `ListWalletUnspent` (fee inputs and the exit
   preflight), `NewWalletAddress` (the deposit address), and the

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -45,6 +45,22 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 
 ## Invariants
 
+- **Manual and automatic exit admission share one feasibility model.**
+  `assessUnrollFeasibility` gathers the wallet snapshot, fee rate, and OOR
+  lineage for a single unilateral package and returns
+  `unroll.PlanExitFunding(...).Feasibility`. Both consumers go through it:
+  `preflightUnrollFeasibility` (the manual `Unroll` RPC admission gate) and
+  `assessAutomaticCriticalExit`, which `Server.initVTXOManager` wires onto
+  `vtxo.ManagerConfig.CriticalExitAssessor`. Keeping one model is the point —
+  the manual gate and the VTXO actor's critical-expiry path selection must not
+  be able to disagree about whether the wallet can execute an exit. The
+  adapter is a plain function value, so the VTXO manager gets the verdict
+  without an import cycle back into `waved`.
+- `automaticExitDecisionReason` renders the first failed feasibility invariant
+  with concrete values (`sweep_below_dust`, `uneconomical`,
+  `wallet_underfunded`, `wallet_too_few_inputs`) so the automatic path choice
+  is diagnosable from one structured log entry. A feasible verdict returns a
+  stable short label because the VTXO actor logs the chosen action separately.
 - The lnd wallet account (`lnd.account`, empty = lnd's `default`) bounds what
   this daemon may **spend**: `ListWalletUnspent` (fee inputs and the exit
   preflight), `NewWalletAddress` (the deposit address), and the


### PR DESCRIPTION
Automated nightly documentation sweep via `.claude/skills/doc-gardening`.

Workflow run: https://github.com/lightninglabs/wavelength/actions

## Scope

Baseline was the last merged nightly sweep, `5f3c3ec3`
(`nightly-2026-08-21`). Every Go package already had a `CLAUDE.md`, so this
sweep is entirely staleness refresh — 8 packages whose Go source moved ahead
of their docs:

| Package | What changed |
|---|---|
| `chainbackends` | `TxBroadcaster.RemoveTransaction` / `chainsource.TxRemover`; reorg & finality forwarding via `PositiveDoneOrder`; shutdown-race log demotion |
| `round` | wavelength#844 status reconcile, `SweepDelay` persistence, single commitment watch, bounded wallet asks, cohort-aware auto-refresh + fee budget |
| `vtxo` | `CriticalExitAssessor` viable-recovery preflight; `CohortRefreshEvent` and cohort coordination |
| `waved` | shared `assessUnrollFeasibility` model behind both manual and automatic exit admission |
| `serverconn` | pull-only failure counter and its alerting contract |
| `chainfees` | new "Log Severity" section pinning which fee conditions page a human |
| `txconfirm` | `ErrParentAlreadyBroadcast` is `Debug` on both broadcast paths |
| `db` | `TestPgFixture` uses a `KillContainer` timer, not `Resource.Expire` |

No new `docs/*.md` files and no package added, removed, or relayered, so
`docs/index.md` and `ARCHITECTURE.md` are unchanged.

## Review notes

Please review the updated `CLAUDE.md` / `AGENTS.md` diffs — in particular the
new **Invariants** entries, which are the parts an agent will act on. Each
`CLAUDE.md` is mirrored byte-identically to its sibling `AGENTS.md`.

`make doc-check` passes. Docs-only: the commit stages `*.md` exclusively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
