### PR TITLE
docs: nightly doc-gardening sweep 2026-08-31

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -218,11 +218,15 @@ corresponding state transition being durable.
 
 ### Round FSM
 ```
-Idle → PendingRoundAssembly → RegistrationSent → RoundJoined →
+Idle → PendingRoundAssembly → IntentSent → QuoteReceived → RoundJoined →
 CommitmentTxReceived → CommitmentTxValidated → NoncesSent →
 NoncesAggregated → PartialSigsSent → [ForfeitSignaturesCollecting] →
 InputSigSent → Confirmed → Idle
 ```
+The concrete state types carry a `State` suffix (`IntentSentState`,
+`QuoteReceivedState`, …); `IntentSent` is the state older comments call
+"RegistrationSent". A `JoinRoundQuoteReceived` with a strictly higher
+`SealPass` can walk `RoundJoined` back to `QuoteReceived` for a reseal.
 ForfeitSignaturesCollecting is entered only when `len(ForfeitMappings) > 0`
 (i.e., the round includes refresh or leave VTXOs). Boarding-only rounds
 skip directly from PartialSigsSent to InputSigSent. Forfeit collection
@@ -234,10 +238,21 @@ once new ones are confirmed signed.
 Live → PendingForfeit → Forfeiting → Forfeited
 Live → Forfeiting → Forfeited  (fast path: ForfeitRequestEvent in LiveState)
 PendingForfeit → UnilateralExit  (critical expiry while pending)
-Live → UnilateralExit  (critical expiry)
+Live → UnilateralExit  (critical expiry, exit package fundable)
+Live → PendingForfeit  (critical expiry, exit package NOT fundable)
 Live → Spent
 Any → Failed
 ```
+At critical expiry the VTXO actor first consults the optional
+`vtxo.CriticalExitAssessor` (wired by `waved` to the same
+`unroll.PlanExitFunding` verdict the manual exit path uses). Only an
+explicitly infeasible verdict diverts to continued cooperative refresh; a
+nil assessor, an assessor error, or a feasible verdict all take the
+unilateral-exit edge, so an unavailable assessment never suppresses the
+safety path. The check repeats every block, so funding the backing wallet
+restores the exit edge without another transition. Past the batch deadline
+`PendingForfeit` stops escalating entirely — the in-flight cooperative spend
+is the only recovery that can still land.
 
 ### OOR FSM
 Manages outgoing/incoming transfer state through checkpoint signing with

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -167,6 +167,22 @@ state transitions and validation rules live under [Invariants](#invariants).
 - Round state is checkpointed atomically after tree validation — a
   crash before checkpoint means the client has no record of sent
   signatures.
+- **The FSM outbox is the single owner of commitment-confirmation
+  registration.** `processOutbox`'s `RoundCheckpointedNotification` branch
+  only records `commitmentTxIndex[txid] = keyStr` (so the confirmation the
+  FSM's own `RegisterConfirmationRequest` triggers can be routed back to the
+  right round); it must **not** call `registerCommitmentConfirmation` itself.
+  Doing both opened two notifier subscriptions for one commitment tx. Restart
+  recovery is unaffected: `Start` re-registers every active round.
+- **The forfeit-collection timeout is armed before any fallible external
+  effect.** `forfeitCollectionOutbox` emits `StartTimeoutReq`
+  (`TimeoutPhaseForfeitCollection`) first, then `SubmitVTXOForfeitSigsToServer`,
+  then the optional `SubmitForfeitSigRequest` for boarding inputs, and only
+  last the `RegisterConfirmationRequest`. `processOutbox` stops at the first
+  error, so ordering the timeout after a submission or the chain registration
+  would strand the round in forfeit collection with no reconciliation path.
+  The two submissions keep their relative order because that is the sequence
+  the server expects.
 - Primary FSM handles interactive phases (through `InputSigSent`); a
   dedicated FSM per round handles confirmation monitoring.
 - The round actor does **not** mark VTXOs as `PendingForfeit` — the

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -167,6 +167,22 @@ state transitions and validation rules live under [Invariants](#invariants).
 - Round state is checkpointed atomically after tree validation — a
   crash before checkpoint means the client has no record of sent
   signatures.
+- **The FSM outbox is the single owner of commitment-confirmation
+  registration.** `processOutbox`'s `RoundCheckpointedNotification` branch
+  only records `commitmentTxIndex[txid] = keyStr` (so the confirmation the
+  FSM's own `RegisterConfirmationRequest` triggers can be routed back to the
+  right round); it must **not** call `registerCommitmentConfirmation` itself.
+  Doing both opened two notifier subscriptions for one commitment tx. Restart
+  recovery is unaffected: `Start` re-registers every active round.
+- **The forfeit-collection timeout is armed before any fallible external
+  effect.** `forfeitCollectionOutbox` emits `StartTimeoutReq`
+  (`TimeoutPhaseForfeitCollection`) first, then `SubmitVTXOForfeitSigsToServer`,
+  then the optional `SubmitForfeitSigRequest` for boarding inputs, and only
+  last the `RegisterConfirmationRequest`. `processOutbox` stops at the first
+  error, so ordering the timeout after a submission or the chain registration
+  would strand the round in forfeit collection with no reconciliation path.
+  The two submissions keep their relative order because that is the sequence
+  the server expects.
 - Primary FSM handles interactive phases (through `InputSigSent`); a
   dedicated FSM per round handles confirmation monitoring.
 - The round actor does **not** mark VTXOs as `PendingForfeit` — the

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -121,7 +121,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `PlanExitFunding(desc, mat, feeRate, ...) ExitFundingPlan` —
   derives the wallet fee-input amount an operator/caller should fund
   before starting the exit; `RecommendedExitFeeInputAmount` reads the
-  verdict for the same number.
+  verdict for the same number. The resulting `Feasibility` is also what
+  `waved` adapts into `vtxo.CriticalExitAssessor`, so the **automatic**
+  critical-expiry path decision (unilateral exit vs. continued cooperative
+  refresh) is scored by the same verdict the manual `GetExitPlan` / `Unroll`
+  path reports.
 - `ExitProgress` (in `GetStatusResp`) — `ConfirmedTxs`/`InFlightTxs`/
   `ReadyTxs`/`BlockedTxs` counts over the proof graph, for status
   probes.

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -121,7 +121,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `PlanExitFunding(desc, mat, feeRate, ...) ExitFundingPlan` —
   derives the wallet fee-input amount an operator/caller should fund
   before starting the exit; `RecommendedExitFeeInputAmount` reads the
-  verdict for the same number.
+  verdict for the same number. The resulting `Feasibility` is also what
+  `waved` adapts into `vtxo.CriticalExitAssessor`, so the **automatic**
+  critical-expiry path decision (unilateral exit vs. continued cooperative
+  refresh) is scored by the same verdict the manual `GetExitPlan` / `Unroll`
+  path reports.
 - `ExitProgress` (in `GetStatusResp`) — `ConfirmedTxs`/`InFlightTxs`/
   `ReadyTxs`/`BlockedTxs` counts over the proof graph, for status
   probes.

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -28,9 +28,10 @@ when the local wallet owns the receive script.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, `FetchOperatorKey`,
-  `ForfeitParticipantSigner`, `TerminalVTXOObserver`, `ExitOutcomeResolver`,
-  and `ReservationStore`. Confirmed exit-cost accounting is emitted by unroll
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, `CriticalExitAssessor`,
+  `FetchOperatorKey`, `ForfeitParticipantSigner`, `TerminalVTXOObserver`,
+  `ExitOutcomeResolver`, and `ReservationStore`.
+  Confirmed exit-cost accounting is emitted by unroll
   after final sweep confirmation. `ForfeitVTXOActorAskTimeout`
   (default 5 s) bounds forfeit and refresh child asks so a blocked child actor
   cannot monopolize the manager until the outer RPC deadline. Zero uses the
@@ -39,6 +40,9 @@ when the local wallet owns the receive script.
   refresh-join time so the new VTXO output's policy binds it (the old VTXO's
   stored key is never reused). `ForfeitParticipantSigner` collects non-local
   participant signatures for custom VTXO policies after connector assignment.
+  `CriticalExitAssessor` is propagated verbatim to every spawned `VTXOActor`,
+  so automatic critical-expiry handling can ask whether the backing wallet can
+  actually execute the exit package before committing to it.
   `TerminalVTXOObserver` fires with the outpoint whenever a VTXO leaves the
   active set. `ExitOutcomeResolver` is called at startup to reconcile VTXOs
   still persisted in `VTXOStatusUnilateralExit` with their terminal job
@@ -96,10 +100,31 @@ when the local wallet owns the receive script.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
 - `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory preview** before each auto-refresh emission to estimate the per-input operator fee for UX surfaces. Under the seal-time fee handshake (#270) the server is the binding fee authority — the quoter's return value is no longer attached to the wire intent. Nil quoter (legacy and test paths) yields `OperatorFee=0` on the harness-local `RefreshVTXORequest`, which has no effect on the round protocol.
+- `CriticalExitAssessor` — Function type
+  `func(ctx, *Descriptor) (CriticalExitAssessment, error)`. Optional hook on
+  `VTXOActorConfig` (and on `ManagerConfig`, which fans it out to every child),
+  consulted on each `BlockEpochEvent` once `CheckExpiry` reports
+  `ExpiryStatusCritical`. It answers whether the backing wallet can fund and
+  relay the whole unilateral-exit package at the current fee rate. In
+  production it is `waved`'s `RPCServer.assessAutomaticCriticalExit`, which
+  derives its verdict from the same `unroll.PlanExitFunding` call the manual
+  `GetExitPlan` / `Unroll` path uses, so automatic and manual admission cannot
+  disagree about whether an exit is executable.
+- `CriticalExitAssessment` — The verdict: `Feasible bool` plus a short, stable
+  `Reason string`. `Reason` is diagnostic only — it is rendered into the
+  structured "Automatic expiry decision" log record and never drives control
+  flow.
+- `criticalRefreshEvent` (unexported, `events.go`) — Actor-local event that
+  `VTXOActor.preflightCriticalExit` substitutes for a `BlockEpochEvent` when
+  the assessment came back explicitly infeasible. `LiveState` stamps
+  `LastCheckedHeight` and takes `autoRefreshTransition` (cooperative refresh);
+  `PendingForfeitState` self-loops to keep waiting on the round it already
+  joined. It is deliberately unexported and never crosses a package boundary —
+  external block notifications stay `BlockEpochEvent`.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/types` (`Ancestry`), `lib/arkscript` (taproot construction and policy helpers in `IncomingVTXOHandler`), `lib/actormsg` (admission and custom-forfeit message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs), `coinselect` (largest-first VTXO selection), `metrics` (optional `OORTransferReceivedMsg` sink), `ledger` (`Sink` type for compatibility with manager wiring), `unroll` (via `ExitOutcomeResolver` callback wired by `waved`).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/types` (`Ancestry`), `lib/arkscript` (taproot construction and policy helpers in `IncomingVTXOHandler`), `lib/actormsg` (admission and custom-forfeit message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs), `coinselect` (largest-first VTXO selection), `metrics` (optional `OORTransferReceivedMsg` sink), `ledger` (`Sink` type for compatibility with manager wiring), `unroll` (via the `ExitOutcomeResolver` and `CriticalExitAssessor` callbacks wired by `waved` — both are function seams, so there is no compile-time `vtxo → unroll` import edge).
 - **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `waved` (wiring, owned-script adapters, incoming event route, and `CheckForfeitAdmission` for the leave filter and exit-plan advisory), `sdk/swaps` (forfeit sign-request conversion).
 - **Sends**:
   - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`
@@ -162,6 +187,34 @@ when the local wallet owns the receive script.
 - When the cached boundary fires, auto-refresh fetches fresh operator terms
   before reserving the VTXO. A later still-safe boundary leaves the VTXO live;
   a disabled or unsafe-late window preserves the ordinary paid refresh path.
+- **Critical expiry no longer escalates unconditionally.**
+  `ExpiryStatusCritical` now means "the unilateral time budget is active", not
+  "go to chain". When `CriticalExitAssessor` is set,
+  `VTXOActor.preflightCriticalExit` runs the assessment before the FSM sees the
+  block, and only an **explicitly infeasible** verdict diverts the event to
+  `criticalRefreshEvent` so the VTXO keeps trying the cooperative path. A nil
+  assessor, an assessor **error**, and a feasible verdict all retain the
+  pre-existing direct unilateral-exit transition — an unavailable assessment
+  must never suppress the safety path. The check is repeated on every critical
+  block, so funding the backing wallet restores the unilateral path with no
+  extra state transition and no operator action. Only `LiveState` and
+  `PendingForfeitState` are ever diverted; any other state passes the block
+  through untouched.
+- **Diverting to cooperative refresh is a liveness choice, not a safety
+  regression.** Entering `UnilateralExitState` with a wallet that cannot fund
+  the exit package strands the coin in a state that makes no progress and
+  blocks the cooperative recovery that could still succeed. Continued refresh
+  is therefore strictly better while the package is not executable; the
+  assessment is re-run each block precisely so the exit is taken the moment it
+  becomes viable.
+- **Past-expiry `PendingForfeitState` still stays put.** `handleBlockEpoch`
+  escalates only inside the critical window: once the batch deadline has
+  passed, an exit would have to confirm the entire ancestry and then wait out
+  the exit CSV while racing an already-spendable operator sweep, and
+  escalating would abort the in-flight cooperative spend that *is* the
+  recovery. This is the same rule as before the assessor was introduced —
+  the branch was extracted into `handleBlockEpoch` /
+  `handleCriticalRefresh` helpers without changing it.
 - Once ForfeitedState is reached, the old VTXO is unspendable; the new VTXO is available only after round confirmation.
 - SpendingState is persisted as VTXOStatusSpending and survives restarts.
 - OOR completion transitions VTXOs to SpentState through the VTXO actor FSM, not by direct store writes.

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -28,9 +28,10 @@ when the local wallet owns the receive script.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, `FetchOperatorKey`,
-  `ForfeitParticipantSigner`, `TerminalVTXOObserver`, `ExitOutcomeResolver`,
-  and `ReservationStore`. Confirmed exit-cost accounting is emitted by unroll
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, `CriticalExitAssessor`,
+  `FetchOperatorKey`, `ForfeitParticipantSigner`, `TerminalVTXOObserver`,
+  `ExitOutcomeResolver`, and `ReservationStore`.
+  Confirmed exit-cost accounting is emitted by unroll
   after final sweep confirmation. `ForfeitVTXOActorAskTimeout`
   (default 5 s) bounds forfeit and refresh child asks so a blocked child actor
   cannot monopolize the manager until the outer RPC deadline. Zero uses the
@@ -39,6 +40,9 @@ when the local wallet owns the receive script.
   refresh-join time so the new VTXO output's policy binds it (the old VTXO's
   stored key is never reused). `ForfeitParticipantSigner` collects non-local
   participant signatures for custom VTXO policies after connector assignment.
+  `CriticalExitAssessor` is propagated verbatim to every spawned `VTXOActor`,
+  so automatic critical-expiry handling can ask whether the backing wallet can
+  actually execute the exit package before committing to it.
   `TerminalVTXOObserver` fires with the outpoint whenever a VTXO leaves the
   active set. `ExitOutcomeResolver` is called at startup to reconcile VTXOs
   still persisted in `VTXOStatusUnilateralExit` with their terminal job
@@ -96,10 +100,31 @@ when the local wallet owns the receive script.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
 - `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory preview** before each auto-refresh emission to estimate the per-input operator fee for UX surfaces. Under the seal-time fee handshake (#270) the server is the binding fee authority — the quoter's return value is no longer attached to the wire intent. Nil quoter (legacy and test paths) yields `OperatorFee=0` on the harness-local `RefreshVTXORequest`, which has no effect on the round protocol.
+- `CriticalExitAssessor` — Function type
+  `func(ctx, *Descriptor) (CriticalExitAssessment, error)`. Optional hook on
+  `VTXOActorConfig` (and on `ManagerConfig`, which fans it out to every child),
+  consulted on each `BlockEpochEvent` once `CheckExpiry` reports
+  `ExpiryStatusCritical`. It answers whether the backing wallet can fund and
+  relay the whole unilateral-exit package at the current fee rate. In
+  production it is `waved`'s `RPCServer.assessAutomaticCriticalExit`, which
+  derives its verdict from the same `unroll.PlanExitFunding` call the manual
+  `GetExitPlan` / `Unroll` path uses, so automatic and manual admission cannot
+  disagree about whether an exit is executable.
+- `CriticalExitAssessment` — The verdict: `Feasible bool` plus a short, stable
+  `Reason string`. `Reason` is diagnostic only — it is rendered into the
+  structured "Automatic expiry decision" log record and never drives control
+  flow.
+- `criticalRefreshEvent` (unexported, `events.go`) — Actor-local event that
+  `VTXOActor.preflightCriticalExit` substitutes for a `BlockEpochEvent` when
+  the assessment came back explicitly infeasible. `LiveState` stamps
+  `LastCheckedHeight` and takes `autoRefreshTransition` (cooperative refresh);
+  `PendingForfeitState` self-loops to keep waiting on the round it already
+  joined. It is deliberately unexported and never crosses a package boundary —
+  external block notifications stay `BlockEpochEvent`.
 
 ## Relationships
 
-- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/types` (`Ancestry`), `lib/arkscript` (taproot construction and policy helpers in `IncomingVTXOHandler`), `lib/actormsg` (admission and custom-forfeit message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs), `coinselect` (largest-first VTXO selection), `metrics` (optional `OORTransferReceivedMsg` sink), `ledger` (`Sink` type for compatibility with manager wiring), `unroll` (via `ExitOutcomeResolver` callback wired by `waved`).
+- **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/types` (`Ancestry`), `lib/arkscript` (taproot construction and policy helpers in `IncomingVTXOHandler`), `lib/actormsg` (admission and custom-forfeit message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs), `coinselect` (largest-first VTXO selection), `metrics` (optional `OORTransferReceivedMsg` sink), `ledger` (`Sink` type for compatibility with manager wiring), `unroll` (via the `ExitOutcomeResolver` and `CriticalExitAssessor` callbacks wired by `waved` — both are function seams, so there is no compile-time `vtxo → unroll` import edge).
 - **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `waved` (wiring, owned-script adapters, incoming event route, and `CheckForfeitAdmission` for the leave filter and exit-plan advisory), `sdk/swaps` (forfeit sign-request conversion).
 - **Sends**:
   - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`
@@ -162,6 +187,34 @@ when the local wallet owns the receive script.
 - When the cached boundary fires, auto-refresh fetches fresh operator terms
   before reserving the VTXO. A later still-safe boundary leaves the VTXO live;
   a disabled or unsafe-late window preserves the ordinary paid refresh path.
+- **Critical expiry no longer escalates unconditionally.**
+  `ExpiryStatusCritical` now means "the unilateral time budget is active", not
+  "go to chain". When `CriticalExitAssessor` is set,
+  `VTXOActor.preflightCriticalExit` runs the assessment before the FSM sees the
+  block, and only an **explicitly infeasible** verdict diverts the event to
+  `criticalRefreshEvent` so the VTXO keeps trying the cooperative path. A nil
+  assessor, an assessor **error**, and a feasible verdict all retain the
+  pre-existing direct unilateral-exit transition — an unavailable assessment
+  must never suppress the safety path. The check is repeated on every critical
+  block, so funding the backing wallet restores the unilateral path with no
+  extra state transition and no operator action. Only `LiveState` and
+  `PendingForfeitState` are ever diverted; any other state passes the block
+  through untouched.
+- **Diverting to cooperative refresh is a liveness choice, not a safety
+  regression.** Entering `UnilateralExitState` with a wallet that cannot fund
+  the exit package strands the coin in a state that makes no progress and
+  blocks the cooperative recovery that could still succeed. Continued refresh
+  is therefore strictly better while the package is not executable; the
+  assessment is re-run each block precisely so the exit is taken the moment it
+  becomes viable.
+- **Past-expiry `PendingForfeitState` still stays put.** `handleBlockEpoch`
+  escalates only inside the critical window: once the batch deadline has
+  passed, an exit would have to confirm the entire ancestry and then wait out
+  the exit CSV while racing an already-spendable operator sweep, and
+  escalating would abort the in-flight cooperative spend that *is* the
+  recovery. This is the same rule as before the assessor was introduced —
+  the branch was extracted into `handleBlockEpoch` /
+  `handleCriticalRefresh` helpers without changing it.
 - Once ForfeitedState is reached, the old VTXO is unspendable; the new VTXO is available only after round confirmation.
 - SpendingState is persisted as VTXOStatusSpending and survives restarts.
 - OOR completion transitions VTXOs to SpentState through the VTXO actor FSM, not by direct store writes.

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -138,6 +138,20 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   cycle) into `unroll.StartTrigger`; an empty or unknown trigger admits as
   critical expiry. A `None` exit policy leaves the registry on its standard
   VTXO timeout policy.
+- `ManagerConfig.CriticalExitAssessor` is wired to
+  `RPCServer.assessAutomaticCriticalExit`, closing the loop in the other
+  direction: before a critically-expiring VTXO escalates itself into
+  unilateral exit, the VTXO actor asks waved whether the backing wallet can
+  actually fund and relay the exit package. Both that callback and the manual
+  `GetExitPlan` / `Unroll` path route through the single
+  `assessUnrollFeasibility` helper (wallet snapshot → `resolveExitLineage` →
+  `unroll.PlanExitFunding`), so automatic and hand-typed admission cannot
+  disagree about executability. `automaticExitDecisionReason` renders the
+  first failed `unroll.ExitFeasibility` invariant into the short string the
+  VTXO actor logs. Because this is a plain function seam, `vtxo` gains no
+  compile-time dependency on `unroll` or `waved`. An error from the helper is
+  returned as-is and the VTXO actor deliberately falls back to the direct
+  exit, so a wallet-query failure can never suppress the safety path.
 - The fraud watcher (`initFraudWatcher`) is wired with `VTXOManagerRef`, so
   fraud spends drive exits through the VTXO manager — the same admission path
   as manual, critical-expiry, and vHTLC recovery exits — rather than talking to

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -138,6 +138,20 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   cycle) into `unroll.StartTrigger`; an empty or unknown trigger admits as
   critical expiry. A `None` exit policy leaves the registry on its standard
   VTXO timeout policy.
+- `ManagerConfig.CriticalExitAssessor` is wired to
+  `RPCServer.assessAutomaticCriticalExit`, closing the loop in the other
+  direction: before a critically-expiring VTXO escalates itself into
+  unilateral exit, the VTXO actor asks waved whether the backing wallet can
+  actually fund and relay the exit package. Both that callback and the manual
+  `GetExitPlan` / `Unroll` path route through the single
+  `assessUnrollFeasibility` helper (wallet snapshot → `resolveExitLineage` →
+  `unroll.PlanExitFunding`), so automatic and hand-typed admission cannot
+  disagree about executability. `automaticExitDecisionReason` renders the
+  first failed `unroll.ExitFeasibility` invariant into the short string the
+  VTXO actor logs. Because this is a plain function seam, `vtxo` gains no
+  compile-time dependency on `unroll` or `waved`. An error from the helper is
+  returned as-is and the VTXO actor deliberately falls back to the direct
+  exit, so a wallet-query failure can never suppress the safety path.
 - The fraud watcher (`initFraudWatcher`) is wired with `VTXOManagerRef`, so
   fraud spends drive exits through the VTXO manager — the same admission path
   as manual, critical-expiry, and vHTLC recovery exits — rather than talking to


### PR DESCRIPTION
Automated nightly doc-gardening sweep (`.claude/skills/doc-gardening`, scope `all`), anchored to the last merged nightly `5f3c3ec3` (2026-08-21) — 65 commits of drift.

**Workflow run:** unavailable — the workflow env vars (`RUN_ID`/`SERVER_URL`/`REPO_NAME`) were not readable from the sweep sandbox, so no run URL could be recorded. Same limitation as the 2026-08-27 sweep.

### What changed

- **`vtxo`** — documents the new `CriticalExitAssessor` / `CriticalExitAssessment` seam and the actor-local `criticalRefreshEvent`, plus the invariant that `ExpiryStatusCritical` no longer escalates unconditionally: only an *explicitly infeasible* funding verdict diverts to cooperative refresh, while a nil assessor, an assessor **error**, and a feasible verdict all retain the direct unilateral-exit path.
- **`round`** — records that the FSM outbox is the single owner of commitment-confirmation registration (`processOutbox` only indexes the txid), and that `forfeitCollectionOutbox` arms the reconciliation timeout ahead of every fallible external effect.
- **`waved`** — documents that `ManagerConfig.CriticalExitAssessor` is wired to `assessAutomaticCriticalExit`, so automatic and manual exit admission score executability from one shared `unroll.PlanExitFunding` verdict.
- **`unroll`** — notes that the `PlanExitFunding` feasibility verdict now also drives the automatic critical-expiry path decision.
- **`ARCHITECTURE.md`** — corrects the VTXO FSM sketch for the new conditional critical-expiry edges, and the round FSM sketch to use the real `IntentSent` / `QuoteReceived` state names.

No new packages this window, so no new `CLAUDE.md` files and no `docs/index.md` entries were needed. Packages whose only change was log-level demotion (`chainfees`, `chainbackends`, `serverconn`) were reviewed and deliberately left alone — no invariant moved.

### Review notes

Please review the updated **`CLAUDE.md`/`AGENTS.md`** and **`ARCHITECTURE.md`** diffs. The `vtxo` invariant edits and the `ARCHITECTURE.md` VTXO FSM edges are the substantive claims here and are worth a careful read: they assert a *safety-relevant* fallback ordering (assessor error ⇒ still exit), so a reviewer familiar with the critical-expiry path should confirm the wording matches intent.

Each `CLAUDE.md` was mirrored byte-identically to its sibling `AGENTS.md`, and `make doc-check` passes. Only `*.md` files are staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
