### PR TITLE
multi: repair legacy commitment-height recovery

### DIFF
--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -95,6 +95,16 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   committed). `groupAncestryRowsWithCache` /
   `loadAncestryPathsWithCache` accept the cache to avoid
   re-deserializing the same fragment across `ListLiveVTXOs` batches.
+- `BackfillVTXOCommitmentHeights` — atomically fills legacy zero heights from
+  indexed ancestry. Fragments are matched by `AncestryFragmentKey` (commitment
+  transaction plus serialized tree path), then a height-only update changes
+  the matching row without rewriting any local proof columns. It never
+  overwrites a known height. The caller supplies the current local chain tip;
+  the store rejects a candidate above that tip. For single-fragment ancestry,
+  it also rejects a candidate above the VTXO's known creation height. Any
+  missing, duplicate, heightless, or out-of-bounds indexed fragment aborts the
+  full repair, and empty local ancestry is an error rather than a silent no-op.
+  Returns the number of local fragments repaired.
 - `isDBClosedError(err) bool` — classifies teardown-path errors for
   demotion to debug-level logging.
 - `MaxTreeDeserializeDepth = 32` / `MaxTreeChildrenPerNode = 64` —

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -95,6 +95,16 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   committed). `groupAncestryRowsWithCache` /
   `loadAncestryPathsWithCache` accept the cache to avoid
   re-deserializing the same fragment across `ListLiveVTXOs` batches.
+- `BackfillVTXOCommitmentHeights` — atomically fills legacy zero heights from
+  indexed ancestry. Fragments are matched by `AncestryFragmentKey` (commitment
+  transaction plus serialized tree path), then a height-only update changes
+  the matching row without rewriting any local proof columns. It never
+  overwrites a known height. The caller supplies the current local chain tip;
+  the store rejects a candidate above that tip. For single-fragment ancestry,
+  it also rejects a candidate above the VTXO's known creation height. Any
+  missing, duplicate, heightless, or out-of-bounds indexed fragment aborts the
+  full repair, and empty local ancestry is an error rather than a silent no-op.
+  Returns the number of local fragments repaired.
 - `isDBClosedError(err) bool` — classifies teardown-path errors for
   demotion to debug-level logging.
 - `MaxTreeDeserializeDepth = 32` / `MaxTreeChildrenPerNode = 64` —

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -182,6 +182,12 @@ type RoundStore interface {
 	InsertVTXOAncestryPath(ctx context.Context,
 		arg sqlc.InsertVTXOAncestryPathParams) error
 
+	UpdateVTXOAncestryCommitmentHeight(ctx context.Context,
+		arg sqlc.UpdateVTXOAncestryCommitmentHeightParams) (
+		int64,
+		error,
+	)
+
 	DeleteVTXOAncestryPaths(ctx context.Context,
 		arg sqlc.DeleteVTXOAncestryPathsParams) error
 

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -411,6 +411,10 @@ type Querier interface {
 	UpdateBoardingIntentStatus(ctx context.Context, arg UpdateBoardingIntentStatusParams) error
 	UpdateRoundBoardingIntentSignature(ctx context.Context, arg UpdateRoundBoardingIntentSignatureParams) error
 	UpdateRoundStatus(ctx context.Context, arg UpdateRoundStatusParams) error
+	// UpdateVTXOAncestryCommitmentHeight fills one legacy zero commitment height
+	// without rewriting the local commitment transaction, tree path, or other
+	// proof fields. The zero-height predicate prevents overwriting known data.
+	UpdateVTXOAncestryCommitmentHeight(ctx context.Context, arg UpdateVTXOAncestryCommitmentHeightParams) (int64, error)
 	// UpdateVTXOStatus atomically updates a VTXO's status. This is the primary
 	// method for state transitions that don't require additional data.
 	UpdateVTXOStatus(ctx context.Context, arg UpdateVTXOStatusParams) error

--- a/db/sqlc/queries/round.sql
+++ b/db/sqlc/queries/round.sql
@@ -205,6 +205,17 @@ INSERT INTO vtxo_ancestry_paths (
     $1, $2, $3, $4, $5, $6, $7, $8
 );
 
+-- name: UpdateVTXOAncestryCommitmentHeight :execrows
+-- UpdateVTXOAncestryCommitmentHeight fills one legacy zero commitment height
+-- without rewriting the local commitment transaction, tree path, or other
+-- proof fields. The zero-height predicate prevents overwriting known data.
+UPDATE vtxo_ancestry_paths
+SET commitment_height = $4
+WHERE vtxo_outpoint_hash = $1
+  AND vtxo_outpoint_index = $2
+  AND path_order = $3
+  AND commitment_height = 0;
+
 -- name: DeleteVTXOAncestryPaths :exec
 -- DeleteVTXOAncestryPaths removes every ancestry row for the given VTXO.
 -- Used as the first half of an upsert when the VTXO manager fills in

--- a/db/sqlc/round.sql.go
+++ b/db/sqlc/round.sql.go
@@ -1274,3 +1274,35 @@ func (q *Queries) UpdateRoundStatus(ctx context.Context, arg UpdateRoundStatusPa
 	_, err := q.db.ExecContext(ctx, UpdateRoundStatus, arg.RoundID, arg.Status, arg.LastUpdateTime)
 	return err
 }
+
+const UpdateVTXOAncestryCommitmentHeight = `-- name: UpdateVTXOAncestryCommitmentHeight :execrows
+UPDATE vtxo_ancestry_paths
+SET commitment_height = $4
+WHERE vtxo_outpoint_hash = $1
+  AND vtxo_outpoint_index = $2
+  AND path_order = $3
+  AND commitment_height = 0
+`
+
+type UpdateVTXOAncestryCommitmentHeightParams struct {
+	VtxoOutpointHash  []byte
+	VtxoOutpointIndex int32
+	PathOrder         int32
+	CommitmentHeight  int32
+}
+
+// UpdateVTXOAncestryCommitmentHeight fills one legacy zero commitment height
+// without rewriting the local commitment transaction, tree path, or other
+// proof fields. The zero-height predicate prevents overwriting known data.
+func (q *Queries) UpdateVTXOAncestryCommitmentHeight(ctx context.Context, arg UpdateVTXOAncestryCommitmentHeightParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, UpdateVTXOAncestryCommitmentHeight,
+		arg.VtxoOutpointHash,
+		arg.VtxoOutpointIndex,
+		arg.PathOrder,
+		arg.CommitmentHeight,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -217,6 +217,153 @@ func (s *VTXOPersistenceStore) GetVTXO(ctx context.Context,
 	return result, err
 }
 
+// BackfillVTXOCommitmentHeights fills unknown ancestry commitment heights from
+// an indexed copy of the same VTXO. Fragment identity includes both the
+// commitment transaction and serialized tree path, so two leaves from one
+// commitment cannot be confused. Existing positive heights and all local proof
+// material remain authoritative and are never overwritten.
+//
+// The full repair is atomic. If any local fragment with an unknown height is
+// absent from indexedAncestry, the indexed copy also lacks a height, or a
+// candidate height exceeds the current local chain tip or, for single-fragment
+// ancestry, the VTXO's known creation height, no row is changed. The return
+// value is the number of local fragments repaired.
+func (s *VTXOPersistenceStore) BackfillVTXOCommitmentHeights(
+	ctx context.Context, outpoint wire.OutPoint,
+	indexedAncestry []vtxo.Ancestry, bestHeight int32) (int, error) {
+
+	if bestHeight <= 0 {
+		return 0, fmt.Errorf("invalid local best height %d", bestHeight)
+	}
+
+	type heightUpdate struct {
+		pathOrder int32
+		height    int32
+	}
+
+	writeTxOpts := WriteTxOption()
+	repairedCount := 0
+
+	err := s.db.ExecTx(ctx, writeTxOpts, func(q RoundStore) error {
+		txRepairedCount := 0
+		outpointIndex := int32(outpoint.Index)
+		vtxoRow, err := q.GetVTXO(ctx, sqlc.GetVTXOParams{
+			OutpointHash:  outpoint.Hash[:],
+			OutpointIndex: outpointIndex,
+		})
+		if err != nil {
+			return fmt.Errorf("load local VTXO: %w", err)
+		}
+
+		localAncestry, err := loadAncestryPaths(
+			ctx, q, outpoint.Hash[:], outpointIndex,
+		)
+		if err != nil {
+			return fmt.Errorf("load local ancestry: %w", err)
+		}
+		if len(localAncestry) == 0 {
+			return fmt.Errorf("local ancestry is empty")
+		}
+
+		heightCeiling := bestHeight
+		if len(localAncestry) == 1 && vtxoRow.CreatedHeight > 0 &&
+			vtxoRow.CreatedHeight < heightCeiling {
+
+			heightCeiling = vtxoRow.CreatedHeight
+		}
+
+		indexedHeights := make(map[[32]byte]int32, len(indexedAncestry))
+		for i, ancestry := range indexedAncestry {
+			key, err := AncestryFragmentKey(ancestry)
+			if err != nil {
+				return fmt.Errorf("index indexed "+
+					"ancestry[%d]: %w", i, err)
+			}
+			if _, ok := indexedHeights[key]; ok {
+				return fmt.Errorf("indexed ancestry[%d] "+
+					"duplicates a commitment/tree fragment",
+					i)
+			}
+
+			indexedHeights[key] = ancestry.CommitmentHeight
+		}
+
+		updates := make([]heightUpdate, 0, len(localAncestry))
+
+		for i, ancestry := range localAncestry {
+			if ancestry.CommitmentHeight > 0 {
+				continue
+			}
+
+			key, err := AncestryFragmentKey(ancestry)
+			if err != nil {
+				return fmt.Errorf("index local "+
+					"ancestry[%d]: %w", i, err)
+			}
+
+			height, ok := indexedHeights[key]
+			if !ok {
+				return fmt.Errorf("indexed ancestry missing "+
+					"local fragment[%d]", i)
+			}
+			if height <= 0 {
+				return fmt.Errorf("indexed ancestry "+
+					"fragment[%d] has unknown "+
+					"commitment height", i)
+			}
+			if height > heightCeiling {
+				return fmt.Errorf("indexed ancestry "+
+					"fragment[%d] commitment height %d "+
+					"exceeds local ceiling %d", i, height,
+					heightCeiling)
+			}
+
+			updates = append(updates, heightUpdate{
+				pathOrder: int32(i),
+				height:    height,
+			})
+		}
+
+		if len(updates) == 0 {
+			repairedCount = 0
+
+			return nil
+		}
+
+		for _, update := range updates {
+			params := sqlc.UpdateVTXOAncestryCommitmentHeightParams{
+				VtxoOutpointHash:  outpoint.Hash[:],
+				VtxoOutpointIndex: outpointIndex,
+				PathOrder:         update.pathOrder,
+				CommitmentHeight:  update.height,
+			}
+			rows, err := q.UpdateVTXOAncestryCommitmentHeight(
+				ctx, params,
+			)
+			if err != nil {
+				return fmt.Errorf("update ancestry path %d "+
+					"height: %w", update.pathOrder, err)
+			}
+			if rows != 1 {
+				return fmt.Errorf("update ancestry path %d "+
+					"height: updated %d rows, want 1",
+					update.pathOrder, rows)
+			}
+
+			txRepairedCount++
+		}
+
+		repairedCount = txRepairedCount
+
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return repairedCount, nil
+}
+
 // ListLiveVTXOs returns all VTXOs not in a terminal state. Used during startup
 // to recover active VTXO actors after restart. Issues exactly two queries —
 // the parent VTXO list and a batched ancestry-paths fetch — so descriptor

--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"database/sql"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/google/uuid"
+	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/db/sqlc"
 	"github.com/lightninglabs/wavelength/ledger"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
@@ -137,6 +139,323 @@ func createTestVTXODescriptor(
 		CreatedHeight:  500 + int32(idx*10),
 		Status:         vtxo.VTXOStatusLive,
 	}
+}
+
+// TestBackfillVTXOCommitmentHeights verifies that legacy zero heights are
+// filled only from an exact indexed fragment match. A mismatched tree leaves
+// the local proof and height untouched.
+func TestBackfillVTXOCommitmentHeights(t *testing.T) {
+	t.Parallel()
+
+	store, _, baseDB := newVTXOStoreForTest(t)
+	desc := createTestVTXODescriptor(
+		t, testRoundIDDB("commitment-height-backfill"), 41,
+	)
+
+	// Use a multi-child proof tree so the local database decoder and the
+	// indexer RPC decoder exercise independent, non-trivial encodings
+	// before the exact fragment match.
+	left := &tree.Node{
+		Input: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0xa1,
+			},
+			Index: 1,
+		},
+		Outputs: []*wire.TxOut{{
+			Value: 40_000,
+			PkScript: []byte{
+				0x51,
+			},
+		}},
+		CoSigners: []*btcec.PublicKey{
+			desc.OperatorKey,
+		},
+		Children: map[uint32]*tree.Node{},
+		Amount:   40_000,
+	}
+	right := &tree.Node{
+		Input: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0xa2,
+			},
+			Index: 2,
+		},
+		Outputs: []*wire.TxOut{{
+			Value: 60_000,
+			PkScript: []byte{
+				0x51,
+				0x20,
+			},
+		}},
+		CoSigners: []*btcec.PublicKey{
+			desc.OperatorKey,
+		},
+		Children: map[uint32]*tree.Node{},
+		Amount:   60_000,
+	}
+	desc.Ancestry[0].TreePath = &tree.Tree{
+		Root: &tree.Node{
+			Input: wire.OutPoint{
+				Hash: desc.CommitmentTxID,
+			},
+			Outputs: []*wire.TxOut{
+				{
+					Value: 40_000,
+					PkScript: []byte{
+						0x51,
+					},
+				},
+				{
+					Value: 60_000,
+					PkScript: []byte{
+						0x51,
+						0x20,
+					},
+				},
+			},
+			CoSigners: []*btcec.PublicKey{
+				desc.OperatorKey,
+			},
+			Children: map[uint32]*tree.Node{
+				0: left,
+				1: right,
+			},
+			Amount: 100_000,
+		},
+		BatchOutpoint: wire.OutPoint{
+			Hash: desc.CommitmentTxID,
+		},
+		BatchOutput: &wire.TxOut{
+			Value: 100_000,
+			PkScript: []byte{
+				0x51,
+			},
+		},
+		SweepTapscriptRoot: bytes.Repeat([]byte{0x03}, 32),
+	}
+	desc.Ancestry[0].InputIndices = []uint32{0, 3}
+	desc.Ancestry[0].TreeDepth = 2
+	require.Zero(t, desc.Ancestry[0].CommitmentHeight)
+	require.NoError(t, store.SaveVTXO(t.Context(), desc))
+
+	rowKey := sqlc.ListVTXOAncestryPathsParams{
+		VtxoOutpointHash:  desc.Outpoint.Hash[:],
+		VtxoOutpointIndex: int32(desc.Outpoint.Index),
+	}
+	before, err := baseDB.ListVTXOAncestryPaths(t.Context(), rowKey)
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+
+	rpcPath, err := arkrpc.AncestryPathFromTree(
+		desc.Ancestry[0].TreePath, desc.Ancestry[0].CommitmentTxID,
+		desc.Ancestry[0].InputIndices,
+	)
+	require.NoError(t, err)
+	rpcPath.CommitmentHeight = 321
+	indexed, err := vtxo.AncestryFromRPC([]*arkrpc.AncestryPath{rpcPath})
+	require.NoError(t, err)
+
+	repaired, err := store.BackfillVTXOCommitmentHeights(
+		t.Context(), desc.Outpoint, indexed, 1000,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, repaired)
+
+	stored, err := store.GetVTXO(t.Context(), desc.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, int32(321), stored.Ancestry[0].CommitmentHeight)
+	wantKey, err := AncestryFragmentKey(desc.Ancestry[0])
+	require.NoError(t, err)
+	gotKey, err := AncestryFragmentKey(stored.Ancestry[0])
+	require.NoError(t, err)
+	require.Equal(t, wantKey, gotKey)
+
+	after, err := baseDB.ListVTXOAncestryPaths(t.Context(), rowKey)
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	require.Equal(t, int32(321), after[0].CommitmentHeight)
+	after[0].CommitmentHeight = before[0].CommitmentHeight
+	require.Equal(
+		t, before[0], after[0],
+		"height repair must not rewrite local proof columns",
+	)
+
+	// A later indexed value cannot overwrite the known durable height.
+	indexed[0].CommitmentHeight = 999
+	repaired, err = store.BackfillVTXOCommitmentHeights(
+		t.Context(), desc.Outpoint, indexed, 1000,
+	)
+	require.NoError(t, err)
+	require.Zero(t, repaired)
+
+	stored, err = store.GetVTXO(t.Context(), desc.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, int32(321), stored.Ancestry[0].CommitmentHeight)
+}
+
+// TestBackfillVTXOCommitmentHeightsIsAtomic verifies that an indexed fragment
+// mismatch does not partially alter local ancestry.
+func TestBackfillVTXOCommitmentHeightsIsAtomic(t *testing.T) {
+	t.Parallel()
+
+	store, _, _ := newVTXOStoreForTest(t)
+	desc := createTestVTXODescriptor(
+		t, testRoundIDDB("commitment-height-backfill-atomic"), 42,
+	)
+	require.NoError(t, store.SaveVTXO(t.Context(), desc))
+
+	indexed := make([]vtxo.Ancestry, len(desc.Ancestry))
+	copy(indexed, desc.Ancestry)
+	indexed[0].TreePath = &tree.Tree{
+		Root: &tree.Node{},
+		BatchOutpoint: wire.OutPoint{
+			Hash:  desc.CommitmentTxID,
+			Index: 99,
+		},
+	}
+	indexed[0].CommitmentHeight = 321
+
+	repaired, err := store.BackfillVTXOCommitmentHeights(
+		t.Context(), desc.Outpoint, indexed, 1000,
+	)
+	require.Error(t, err)
+	require.Zero(t, repaired)
+
+	stored, getErr := store.GetVTXO(t.Context(), desc.Outpoint)
+	require.NoError(t, getErr)
+	require.Zero(t, stored.Ancestry[0].CommitmentHeight)
+}
+
+// TestBackfillVTXOCommitmentHeightsEnforcesLocalCeiling verifies that an
+// indexed height cannot replace the safe fallback when it exceeds either the
+// local chain tip or a single-fragment VTXO's known creation height.
+func TestBackfillVTXOCommitmentHeightsEnforcesLocalCeiling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		createdHeight   int32
+		bestHeight      int32
+		indexedHeight   int32
+		wantErr         bool
+		wantRepairCount int
+	}{
+		{
+			name:          "invalid local tip",
+			createdHeight: 500,
+			bestHeight:    0,
+			indexedHeight: 400,
+			wantErr:       true,
+		},
+		{
+			name:          "above local tip",
+			createdHeight: 0,
+			bestHeight:    500,
+			indexedHeight: 501,
+			wantErr:       true,
+		},
+		{
+			name:          "above creation height",
+			createdHeight: 450,
+			bestHeight:    500,
+			indexedHeight: 451,
+			wantErr:       true,
+		},
+		{
+			name:            "at local tip",
+			createdHeight:   0,
+			bestHeight:      500,
+			indexedHeight:   500,
+			wantRepairCount: 1,
+		},
+		{
+			name:            "at creation height",
+			createdHeight:   450,
+			bestHeight:      500,
+			indexedHeight:   450,
+			wantRepairCount: 1,
+		},
+	}
+
+	for i, test := range tests {
+		i := i
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, _, _ := newVTXOStoreForTest(t)
+			desc := createTestVTXODescriptor(
+				t, testRoundIDDB(test.name), 50+i,
+			)
+			desc.CreatedHeight = test.createdHeight
+			require.NoError(t, store.SaveVTXO(t.Context(), desc))
+
+			indexed := make([]vtxo.Ancestry, len(desc.Ancestry))
+			copy(indexed, desc.Ancestry)
+			indexed[0].CommitmentHeight = test.indexedHeight
+
+			repaired, err := store.BackfillVTXOCommitmentHeights(
+				t.Context(), desc.Outpoint, indexed,
+				test.bestHeight,
+			)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.wantRepairCount, repaired)
+
+			stored, err := store.GetVTXO(t.Context(), desc.Outpoint)
+			require.NoError(t, err)
+			if test.wantErr {
+				require.Zero(
+					t, stored.Ancestry[0].CommitmentHeight,
+				)
+
+				return
+			}
+
+			require.Equal(
+				t, test.indexedHeight,
+				stored.Ancestry[0].CommitmentHeight,
+			)
+		})
+	}
+}
+
+// TestBackfillVTXOCommitmentHeightsUsesTipForMultiFragment verifies that one
+// scalar VTXO creation height does not reject a valid height for a different
+// contributing commitment. The local chain tip still bounds every fragment.
+func TestBackfillVTXOCommitmentHeightsUsesTipForMultiFragment(t *testing.T) {
+	t.Parallel()
+
+	store, _, _ := newVTXOStoreForTest(t)
+	desc := createTestVTXODescriptor(
+		t, testRoundIDDB("multi-fragment-height-ceiling"), 70,
+	)
+	other := createTestVTXODescriptor(
+		t, testRoundIDDB("other-multi-fragment-height-ceiling"), 71,
+	)
+	desc.Ancestry = append(desc.Ancestry, other.Ancestry[0])
+	desc.CreatedHeight = 450
+	require.NoError(t, store.SaveVTXO(t.Context(), desc))
+
+	indexed := make([]vtxo.Ancestry, len(desc.Ancestry))
+	copy(indexed, desc.Ancestry)
+	indexed[0].CommitmentHeight = 440
+	indexed[1].CommitmentHeight = 475
+
+	repaired, err := store.BackfillVTXOCommitmentHeights(
+		t.Context(), desc.Outpoint, indexed, 500,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, repaired)
+
+	stored, err := store.GetVTXO(t.Context(), desc.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, int32(440), stored.Ancestry[0].CommitmentHeight)
+	require.Equal(t, int32(475), stored.Ancestry[1].CommitmentHeight)
 }
 
 // testOddParityPubKey returns a deterministic odd-parity public key for

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -26,6 +26,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `Config` — per-actor wiring. Notable: `TargetOutpoint`, `ActorID`,
   `DeliveryStore`, `ProofAssembler`, `VTXOStore`, `TxConfirmRef`,
   `ChainSource`, `Wallet` (`SweepWallet`),
+  `LegacyProofScanFloor` (earliest compatible commitment block for a known
+  operator; zero keeps block 1), `LegacyProofScanOperatorKey` (the matching
+  operator identity; nil or mismatch keeps block 1),
   `MaxSweepFeeRateSatPerVByte`, `FraudCheckpointSafetyMargin int32`
   (overrides the fraud-triggered unroll backstop margin in blocks;
   zero falls back to the default), `RegistryRef`.
@@ -59,6 +62,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `RegistryConfig` — `Store`, `DeliveryStore`, `ProofAssembler`,
   `VTXOStore`, `TxConfirmRef`, `ChainSource`, `Wallet`,
   optional `LedgerSink`, `MaxSweepFeeRateSatPerVByte`,
+  `LegacyProofScanFloor` and `LegacyProofScanOperatorKey` (forwarded to every
+  child),
   `ExitSpendPolicyResolver` (optional; reconstructs the exit spend policy
   from `(ExitPolicyKind, ExitPolicyRef)` after restart; nil means every child
   uses the standard VTXO timeout), and optional `VTXOExitObserver`
@@ -160,38 +165,45 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `safeTxOutPkScript(tx, index)` — bounds-checking helper used at
   every `tx.TxOut[i].PkScript` site; surfaces retryable errors for
   malformed proof artifacts instead of panicking the actor.
-- `ensureProofSpendWatches(ctx, txid, node)` — registers spend
+- `ensureProofSpendWatches(ctx, txid, node, heightHint)` — registers spend
   watches on proof-node outputs consumed by in-proof children.
-  Neutrino can miss direct confirmation under load; a spend of the
-  parent output proves parent confirmation. `proofSpendWatches` map
-  dedups.
+  `ensureNodeConfirmed` computes `heightHint` once with
+  `proofNodeConfHeightHint` and passes the same floor to these backup watches
+  and the direct confirmation watch. Neutrino can miss direct confirmation
+  under load; a spend of the parent output proves parent confirmation.
+  `proofSpendWatches` map dedups.
 - `watchDeferredCheckpoint(ctx, txid, node)` — registers confirmation
   watch for fraud-triggered checkpoints while the actor waits for
   operator confirmation of the proof node.
 - `behavior.proofNodeConfHeightHint(ctx, txid)` — confirmation-watch height
   floor for proof-graph nodes. Primary floor is `commitmentHeightFloor()`:
   `min(Descriptor.Ancestry[i].CommitmentHeight)`, but only when EVERY fragment
-  has a known (>0) height — a single unknown fragment returns 0 and defers to
-  the fallback (a min over only the known fragments would not bound an unknown
-  fragment's ancestor). Nothing in a VTXO's proof graph confirms before its
-  commitment tx, so once all fragments are known this is a tight, provable
-  floor (min, never max — a lower floor only widens the safe rescan window).
-  When no commitment height is known (legacy persisted VTXOs, empty-ancestry
-  round VTXOs, or a server not yet populating `commitment_height`), it falls
-  back to `proofNodeHeightHint(currentHeight)` =
-  `max(1, currentHeight - proofNodeHeightHintLookback)` (10000 blocks) —
-  identical to the pre-commitment-height behaviour. Roots/intermediate
-  ancestors can confirm before the target VTXO's creation height, so the
-  fallback anchors to tip minus a lookback (never `CreatedHeight`), bounding
-  the neutrino historical rescan instead of scanning to genesis
-  (wavelength#884). The fallback path warns when the VTXO's age exceeds the
-  lookback (the floor may then miss an already-confirmed ancestor). One
-  process-local `proofNodeFloorAlertDeduper` is shared by every child of an
-  unroll registry, so targets with the same proof ancestor produce one warning
-  per proof transaction and process lifetime. That warning carries the first
-  affected target's outpoint, age, and creation height. A Debug record retains
-  the same evidence for every target. A restart creates a new deduper and
-  warns again if the condition persists.
+  has a known (>0) height. A single unknown fragment returns 0 because a min
+  over only known fragments would not bound its ancestor. Nothing in a VTXO's
+  proof graph confirms before its commitment tx, so complete heights provide
+  a tight, provable floor. Without complete heights, `CreatedHeight` decides.
+  A single-fragment target created less than one lookback ago uses
+  `proofNodeHeightHint(currentHeight)` =
+  `max(1, currentHeight - proofNodeHeightHintLookback)` (10000 blocks) to
+  bound the neutrino rescan (wavelength#884). A configured operator deployment
+  floor may raise that fallback only when the target descriptor's stored
+  operator key matches `LegacyProofScanOperatorKey`. Every other legacy target
+  uses that matching deployment floor: an age of at least one lookback (that
+  bound can skip an earlier proof ancestor), an unknown `CreatedHeight`
+  (nothing proves the target is recent), or multiple ancestry fragments (one
+  scalar creation height cannot prove every contributing commitment is
+  recent). A missing or mismatched operator key, zero, block 1, or a floor
+  above the current tip safely resolves to block 1. This prevents a current
+  endpoint from imposing its deployment history on VTXOs from an older
+  operator.
+  Direct proof confirmations and their backup proof-output spend watches use
+  the same floor. The fallback scan can be expensive but cannot silently stall
+  the exit. One process-local
+  `proofNodeFloorAlertDeduper` is
+  shared by every child of an unroll registry, so this fallback emits one
+  warning per registry and process lifetime. Each affected target keeps Debug
+  evidence. A restart creates a new deduper and warns again if the condition
+  persists.
 
 ## Relationships
 

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -203,7 +203,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   shared by every child of an unroll registry, so this fallback emits one
   warning per registry and process lifetime. Each affected target keeps Debug
   evidence. A restart creates a new deduper and warns again if the condition
-  persists.
+  persists. Once the daemon is ready, waved attempts a bounded repair from
+  authenticated indexed ancestry. Indexed heights must be no greater than the
+  local chain tip and, for single-fragment ancestry, the VTXO's known creation
+  height. Existing jobs retain the safe fallback; successful repairs apply to
+  later admissions and restarts.
 
 ## Relationships
 

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -26,6 +26,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `Config` — per-actor wiring. Notable: `TargetOutpoint`, `ActorID`,
   `DeliveryStore`, `ProofAssembler`, `VTXOStore`, `TxConfirmRef`,
   `ChainSource`, `Wallet` (`SweepWallet`),
+  `LegacyProofScanFloor` (earliest compatible commitment block for a known
+  operator; zero keeps block 1), `LegacyProofScanOperatorKey` (the matching
+  operator identity; nil or mismatch keeps block 1),
   `MaxSweepFeeRateSatPerVByte`, `FraudCheckpointSafetyMargin int32`
   (overrides the fraud-triggered unroll backstop margin in blocks;
   zero falls back to the default), `RegistryRef`.
@@ -59,6 +62,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `RegistryConfig` — `Store`, `DeliveryStore`, `ProofAssembler`,
   `VTXOStore`, `TxConfirmRef`, `ChainSource`, `Wallet`,
   optional `LedgerSink`, `MaxSweepFeeRateSatPerVByte`,
+  `LegacyProofScanFloor` and `LegacyProofScanOperatorKey` (forwarded to every
+  child),
   `ExitSpendPolicyResolver` (optional; reconstructs the exit spend policy
   from `(ExitPolicyKind, ExitPolicyRef)` after restart; nil means every child
   uses the standard VTXO timeout), and optional `VTXOExitObserver`
@@ -160,38 +165,45 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `safeTxOutPkScript(tx, index)` — bounds-checking helper used at
   every `tx.TxOut[i].PkScript` site; surfaces retryable errors for
   malformed proof artifacts instead of panicking the actor.
-- `ensureProofSpendWatches(ctx, txid, node)` — registers spend
+- `ensureProofSpendWatches(ctx, txid, node, heightHint)` — registers spend
   watches on proof-node outputs consumed by in-proof children.
-  Neutrino can miss direct confirmation under load; a spend of the
-  parent output proves parent confirmation. `proofSpendWatches` map
-  dedups.
+  `ensureNodeConfirmed` computes `heightHint` once with
+  `proofNodeConfHeightHint` and passes the same floor to these backup watches
+  and the direct confirmation watch. Neutrino can miss direct confirmation
+  under load; a spend of the parent output proves parent confirmation.
+  `proofSpendWatches` map dedups.
 - `watchDeferredCheckpoint(ctx, txid, node)` — registers confirmation
   watch for fraud-triggered checkpoints while the actor waits for
   operator confirmation of the proof node.
 - `behavior.proofNodeConfHeightHint(ctx, txid)` — confirmation-watch height
   floor for proof-graph nodes. Primary floor is `commitmentHeightFloor()`:
   `min(Descriptor.Ancestry[i].CommitmentHeight)`, but only when EVERY fragment
-  has a known (>0) height — a single unknown fragment returns 0 and defers to
-  the fallback (a min over only the known fragments would not bound an unknown
-  fragment's ancestor). Nothing in a VTXO's proof graph confirms before its
-  commitment tx, so once all fragments are known this is a tight, provable
-  floor (min, never max — a lower floor only widens the safe rescan window).
-  When no commitment height is known (legacy persisted VTXOs, empty-ancestry
-  round VTXOs, or a server not yet populating `commitment_height`), it falls
-  back to `proofNodeHeightHint(currentHeight)` =
-  `max(1, currentHeight - proofNodeHeightHintLookback)` (10000 blocks) —
-  identical to the pre-commitment-height behaviour. Roots/intermediate
-  ancestors can confirm before the target VTXO's creation height, so the
-  fallback anchors to tip minus a lookback (never `CreatedHeight`), bounding
-  the neutrino historical rescan instead of scanning to genesis
-  (wavelength#884). The fallback path warns when the VTXO's age exceeds the
-  lookback (the floor may then miss an already-confirmed ancestor). One
-  process-local `proofNodeFloorAlertDeduper` is shared by every child of an
-  unroll registry, so targets with the same proof ancestor produce one warning
-  per proof transaction and process lifetime. That warning carries the first
-  affected target's outpoint, age, and creation height. A Debug record retains
-  the same evidence for every target. A restart creates a new deduper and
-  warns again if the condition persists.
+  has a known (>0) height. A single unknown fragment returns 0 because a min
+  over only known fragments would not bound its ancestor. Nothing in a VTXO's
+  proof graph confirms before its commitment tx, so complete heights provide
+  a tight, provable floor. Without complete heights, `CreatedHeight` decides.
+  A single-fragment target created less than one lookback ago uses
+  `proofNodeHeightHint(currentHeight)` =
+  `max(1, currentHeight - proofNodeHeightHintLookback)` (10000 blocks) to
+  bound the neutrino rescan (wavelength#884). A configured operator deployment
+  floor may raise that fallback only when the target descriptor's stored
+  operator key matches `LegacyProofScanOperatorKey`. Every other legacy target
+  uses that matching deployment floor: an age of at least one lookback (that
+  bound can skip an earlier proof ancestor), an unknown `CreatedHeight`
+  (nothing proves the target is recent), or multiple ancestry fragments (one
+  scalar creation height cannot prove every contributing commitment is
+  recent). A missing or mismatched operator key, zero, block 1, or a floor
+  above the current tip safely resolves to block 1. This prevents a current
+  endpoint from imposing its deployment history on VTXOs from an older
+  operator.
+  Direct proof confirmations and their backup proof-output spend watches use
+  the same floor. The fallback scan can be expensive but cannot silently stall
+  the exit. One process-local
+  `proofNodeFloorAlertDeduper` is
+  shared by every child of an unroll registry, so this fallback emits one
+  warning per registry and process lifetime. Each affected target keeps Debug
+  evidence. A restart creates a new deduper and warns again if the condition
+  persists.
 
 ## Relationships
 

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -203,7 +203,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   shared by every child of an unroll registry, so this fallback emits one
   warning per registry and process lifetime. Each affected target keeps Debug
   evidence. A restart creates a new deduper and warns again if the condition
-  persists.
+  persists. Once the daemon is ready, waved attempts a bounded repair from
+  authenticated indexed ancestry. Indexed heights must be no greater than the
+  local chain tip and, for single-fragment ancestry, the VTXO's known creation
+  height. Existing jobs retain the safe fallback; successful repairs apply to
+  later admissions and restarts.
 
 ## Relationships
 

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
@@ -69,6 +70,19 @@ type Config struct {
 	// FSM Environment.
 	FraudCheckpointSafetyMargin int32
 
+	// LegacyProofScanFloor is the earliest block at which the configured
+	// operator could have created a compatible commitment transaction. It
+	// bounds proof scans for legacy descriptors whose exact commitment
+	// height is unavailable. Zero, one, or a value above the current tip
+	// falls back to block 1.
+	LegacyProofScanFloor uint32
+
+	// LegacyProofScanOperatorKey identifies the operator whose deployment
+	// history justifies LegacyProofScanFloor. The fallback floor applies
+	// only when the target descriptor carries this same key. A nil or
+	// mismatched key falls back to block 1.
+	LegacyProofScanOperatorKey *btcec.PublicKey
+
 	// RegistryRef receives terminal notifications from this actor when set.
 	RegistryRef actor.TellOnlyRef[RegistryMsg]
 
@@ -76,8 +90,8 @@ type Config struct {
 	// final sweep has confirmed.
 	LedgerSink fn.Option[ledger.Sink]
 
-	// proofNodeFloorAlerts is shared by every child of one registry so
-	// targets with the same proof ancestor produce one operator alert.
+	// proofNodeFloorAlerts is shared by every child of one registry so all
+	// legacy fallback scans produce one operator alert.
 	proofNodeFloorAlerts *proofNodeFloorAlertDeduper
 }
 
@@ -740,11 +754,12 @@ func safeTxOutPkScript(tx *wire.MsgTx, index uint32) ([]byte, error) {
 
 // proofNodeHeightHintLookback is the number of blocks below the actor's
 // current best height used as the confirmation-watch FALLBACK floor for
-// proof-graph transactions when no commitment height is known. A genesis
-// floor (height 1) forces neutrino's notifier to rescan every block from tip
-// to block 1 (one GetCFilter per block) when the watched tx never confirms,
-// which floods logs and never terminates (wavelength#884). We therefore
-// bound the rescan window to a fixed lookback below the current height.
+// proof-graph transactions when no commitment height is known and a recent
+// single-fragment target proves that bounded scan is safe. A block-1 floor
+// forces neutrino's notifier to rescan every block from tip to block 1 (one
+// GetCFilter per block) when the watched tx never confirms, which is expensive
+// (wavelength#884). Older and less provable legacy targets use the separate
+// operator-bound fallback in proofNodeConfHeightHint.
 //
 // The lookback MUST comfortably exceed the maximum batch lifetime plus the
 // worst-case tree-depth + CSV exit window, because proof roots and
@@ -752,18 +767,16 @@ func safeTxOutPkScript(tx *wire.MsgTx, index uint32) ([]byte, error) {
 // descriptor's CreatedHeight — using the creation height as the floor would
 // miss an ancestor that already confirmed. A generous operator-configured max
 // batch lifetime is on the order of one month (~4320 blocks at 144
-// blocks/day); 10000 blocks (~10 weeks) is a safe multiple that keeps the
-// floor below any ancestor's real confirmation height while still capping the
-// neutrino rescan at a bounded window instead of scanning to genesis.
+// blocks/day); 10000 blocks (~10 weeks) is a safe multiple for a target whose
+// creation height proves it is inside that window.
 //
 // The primary, tight floor is the commitment-tx confirmation height carried
 // per fragment on Descriptor.Ancestry[i].CommitmentHeight: nothing in a
 // VTXO's proof graph can confirm before its commitment tx, so min() across
 // fragments is a provable lower bound for every proof ancestor. When that
-// height is unknown (zero) — legacy persisted VTXOs, empty-ancestry incoming
-// round VTXOs, or a server that does not yet populate the field — we fall
-// back to this bounded lookback, preserving the pre-commitment-height
-// behaviour exactly.
+// height is unknown (zero), behavior.proofNodeConfHeightHint decides whether
+// this bounded lookback is provable or whether the target needs the matching
+// operator deployment floor or block 1.
 const proofNodeHeightHintLookback uint32 = 10000
 
 // removeAbandonedBroadcastTimeout bounds each best-effort wallet RemoveTx RPC
@@ -788,6 +801,25 @@ func proofNodeHeightHint(currentHeight uint32) uint32 {
 	}
 
 	return currentHeight - proofNodeHeightHintLookback
+}
+
+// legacyProofScanFloor returns the configured operator deployment floor when
+// it is usable at the current chain tip and belongs to the operator that
+// created the target. A missing or mismatched key, absent floor, or future
+// floor falls back to block 1. An endpoint migration therefore cannot apply
+// the new operator's deployment history to an older operator's VTXO.
+func (b *behavior) legacyProofScanFloor(currentHeight uint32) uint32 {
+	floor := b.cfg.LegacyProofScanFloor
+	if floor <= 1 || floor > currentHeight {
+		return 1
+	}
+	if b.desc == nil || b.desc.OperatorKey == nil ||
+		b.cfg.LegacyProofScanOperatorKey == nil ||
+		!b.desc.OperatorKey.IsEqual(b.cfg.LegacyProofScanOperatorKey) {
+		return 1
+	}
+
+	return floor
 }
 
 // commitmentHeightFloor returns the tight, provable confirmation-watch floor
@@ -832,9 +864,13 @@ func (b *behavior) commitmentHeightFloor() int32 {
 // VTXO is old enough that the fallback floor may have risen above a proof
 // ancestor's real confirmation height. On the fallback path the lookback keeps
 // the floor below every ancestor only while the VTXO's age (in blocks) stays
-// within proofNodeHeightHintLookback; past that the neutrino historical rescan
-// can start too late, miss the ancestor's confirmation, and silently stall the
-// exit — so we warn rather than fail.
+// within proofNodeHeightHintLookback and its ancestry has one fragment. A
+// multi-fragment descriptor's scalar CreatedHeight cannot prove every
+// contributing commitment is recent. Past either boundary, legacy descriptors
+// fall back to the deployment floor for their matching operator key. A missing
+// or mismatched key, or an absent, invalid, or future floor becomes block 1.
+// The wider scan is expensive but cannot skip an already-confirmed ancestor
+// and silently stall the exit.
 func (b *behavior) proofNodeConfHeightHint(ctx context.Context,
 	txid chainhash.Hash) uint32 {
 
@@ -850,9 +886,11 @@ func (b *behavior) proofNodeConfHeightHint(ctx context.Context,
 		return uint32(floor)
 	}
 
-	// Fallback path: no commitment height known, so bound the rescan with
-	// the fixed lookback and warn if the VTXO is old enough that the floor
-	// may have risen above an ancestor's real confirmation height.
+	// Fallback path: no commitment height is known. A recent target can use
+	// the fixed lookback safely. An older target must scan from the
+	// earliest block where the configured operator could have created a
+	// compatible commitment, because the bounded floor may already be above
+	// an ancestor's real confirmation height.
 	//
 	// currentHeightHint returns 0 only for an uninitialized job (no height
 	// observed yet), and proofNodeHeightHint(0) is the genesis floor (1) —
@@ -863,46 +901,42 @@ func (b *behavior) proofNodeConfHeightHint(ctx context.Context,
 	// practice.
 	currentHeight := b.currentHeightHint()
 	hint := proofNodeHeightHint(currentHeight)
+	legacyFloor := b.legacyProofScanFloor(currentHeight)
+	if legacyFloor > hint {
+		hint = legacyFloor
+	}
 
-	// CreatedHeight is our proxy for the earliest proof-ancestor
-	// confirmation height. Once the VTXO's age reaches the lookback the
-	// floor sits at or above it, so an ancestor that confirmed earlier can
-	// escape the rescan window.
-	if !b.proofNodeFloorWarned && b.desc != nil &&
-		b.desc.CreatedHeight > 0 {
+	// CreatedHeight is our proxy for deciding whether the bounded fallback
+	// is still sound. An unknown creation height cannot prove the target is
+	// recent. Nor can one scalar creation height prove every contributing
+	// commitment in a multi-fragment ancestry is recent. Once the known age
+	// reaches the lookback, use the operator deployment floor. This can
+	// make neutrino replay many compact filters, but a slow exit is
+	// preferable to one that silently misses a confirmed ancestor.
+	createdHeight := int32(0)
+	ancestryFragments := 0
+	if b.desc != nil {
+		createdHeight = b.desc.CreatedHeight
+		ancestryFragments = len(b.desc.Ancestry)
+	}
+	age := int64(-1)
+	if createdHeight > 0 {
+		age = int64(currentHeight) - int64(createdHeight)
+	}
+	if createdHeight <= 0 || ancestryFragments > 1 ||
+		age >= int64(proofNodeHeightHintLookback) {
 
-		age := int64(currentHeight) - int64(b.desc.CreatedHeight)
-		if age >= int64(proofNodeHeightHintLookback) {
-			b.proofNodeFloorWarned = true
-			firstAlert := b.cfg.proofNodeFloorAlerts == nil ||
-				b.cfg.proofNodeFloorAlerts.first(txid)
-			if firstAlert {
-				b.log.WarnS(ctx, "Proof-node confirmation "+
-					"floor may exceed ancestor height; "+
-					"exits could stall",
-					nil,
-					slog.String(
-						"target_outpoint",
-						b.cfg.TargetOutpoint.String(),
-					),
-					slog.String("proof_txid", txid.String()),
-					slog.Int64("vtxo_age_blocks", age),
-					slog.Uint64(
-						"lookback", uint64(
-							proofNodeHeightHintLookback,
-						),
-					),
-					slog.Uint64(
-						"height_hint", uint64(hint),
-					),
-					slog.Int64(
-						"created_height",
-						int64(b.desc.CreatedHeight),
-					),
-				)
-			}
+		if b.proofNodeFloorWarned {
+			return legacyFloor
+		}
 
-			b.log.DebugS(ctx, "Proof-node confirmation floor target",
+		b.proofNodeFloorWarned = true
+		firstAlert := b.cfg.proofNodeFloorAlerts == nil ||
+			b.cfg.proofNodeFloorAlerts.first()
+		if firstAlert {
+			b.log.WarnS(ctx, "Legacy proof commitment height "+
+				"unavailable; using safe fallback floor",
+				nil,
 				slog.String(
 					"target_outpoint",
 					b.cfg.TargetOutpoint.String(),
@@ -910,16 +944,42 @@ func (b *behavior) proofNodeConfHeightHint(ctx context.Context,
 				slog.String("proof_txid", txid.String()),
 				slog.Int64("vtxo_age_blocks", age),
 				slog.Uint64(
-					"lookback",
-					uint64(proofNodeHeightHintLookback),
+					"lookback", uint64(
+						proofNodeHeightHintLookback,
+					),
 				),
-				slog.Uint64("height_hint", uint64(hint)),
+				slog.Uint64(
+					"height_hint", uint64(legacyFloor),
+				),
 				slog.Int64(
-					"created_height",
-					int64(b.desc.CreatedHeight),
+					"created_height", int64(createdHeight),
+				),
+				slog.Int(
+					"ancestry_fragment_count",
+					ancestryFragments,
 				),
 			)
 		}
+
+		b.log.DebugS(ctx, "Legacy proof fallback-scan target",
+			slog.String(
+				"target_outpoint",
+				b.cfg.TargetOutpoint.String(),
+			),
+			slog.String("proof_txid", txid.String()),
+			slog.Int64("vtxo_age_blocks", age),
+			slog.Uint64(
+				"lookback", uint64(proofNodeHeightHintLookback),
+			),
+			slog.Uint64("height_hint", uint64(legacyFloor)),
+			slog.Int64(
+				"created_height",
+				int64(createdHeight),
+			),
+			slog.Int("ancestry_fragment_count", ancestryFragments),
+		)
+
+		return legacyFloor
 	}
 
 	return hint
@@ -953,11 +1013,13 @@ func (b *behavior) ensureNodeConfirmed(ctx context.Context,
 		return fmt.Errorf("proof node %s: %w", txid, err)
 	}
 
-	if err := b.ensureProofSpendWatches(ctx, txid, node); err != nil {
+	heightHint := b.proofNodeConfHeightHint(ctx, txid)
+	if err := b.ensureProofSpendWatches(
+		ctx, txid, node, heightHint,
+	); err != nil {
 		return err
 	}
 
-	heightHint := b.proofNodeConfHeightHint(ctx, txid)
 	resp, err := b.cfg.TxConfirmRef.Ask(ctx, &txconfirm.EnsureConfirmedReq{
 		Tx:                   node.Tx,
 		ConfirmationPkScript: pkScript,
@@ -1580,7 +1642,7 @@ func (b *behavior) spendCallerID() string {
 // confirmation notification under load, but a spend of one of these outputs
 // still proves the parent proof transaction confirmed.
 func (b *behavior) ensureProofSpendWatches(ctx context.Context,
-	txid chainhash.Hash, node *recovery.Node) error {
+	txid chainhash.Hash, node *recovery.Node, heightHint uint32) error {
 
 	if node == nil {
 		return fmt.Errorf("proof node %s missing", txid)
@@ -1595,11 +1657,6 @@ func (b *behavior) ensureProofSpendWatches(ctx context.Context,
 	}
 	if len(outpoints) > 0 && b.proofSpendWatches == nil {
 		b.proofSpendWatches = make(map[wire.OutPoint]struct{})
-	}
-
-	heightHint := uint32(0)
-	if b.desc != nil && b.desc.CreatedHeight > 0 {
-		heightHint = uint32(b.desc.CreatedHeight)
 	}
 
 	for _, outpoint := range outpoints {

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -422,6 +422,7 @@ type fakeChainSourceRef struct {
 	blockRef    actor.TellOnlyRef[chainsource.BlockEpoch]
 	spendRefs   map[wire.OutPoint]spendEventRef
 	spendRegs   []wire.OutPoint
+	spendReqs   map[wire.OutPoint]*spendReq
 	removedTxes []chainhash.Hash
 	confRefs    map[chainhash.Hash]confRef
 	confReqs    map[chainhash.Hash]*confReq
@@ -429,6 +430,9 @@ type fakeChainSourceRef struct {
 
 // spendEventRef is the fake chain-source spend notification actor reference.
 type spendEventRef = actor.TellOnlyRef[chainsource.SpendEvent]
+
+// spendReq aliases the chainsource spend request captured by the fake.
+type spendReq = chainsource.RegisterSpendRequest
 
 // ID returns the fake actor ID.
 func (f *fakeChainSourceRef) ID() string {
@@ -542,6 +546,14 @@ func (f *fakeChainSourceRef) Ask(_ context.Context,
 		}
 		f.spendRefs[outpoint] = msg.NotifyActor.UnwrapOr(nil)
 		f.spendRegs = append(f.spendRegs, outpoint)
+		if f.spendReqs == nil {
+			f.spendReqs = make(map[wire.OutPoint]*spendReq)
+		}
+		reqCopy := *msg
+		outpointCopy := outpoint
+		reqCopy.Outpoint = &outpointCopy
+		reqCopy.PkScript = append([]byte(nil), msg.PkScript...)
+		f.spendReqs[outpoint] = &reqCopy
 		f.mu.Unlock()
 		promise.Complete(
 			fn.Ok[chainsource.ChainSourceResp](
@@ -670,6 +682,21 @@ func (f *fakeChainSourceRef) spendRegistrations() []wire.OutPoint {
 	defer f.mu.Unlock()
 
 	return append([]wire.OutPoint(nil), f.spendRegs...)
+}
+
+// spendRequest returns the registered spend request for outpoint.
+func (f *fakeChainSourceRef) spendRequest(t *testing.T,
+	outpoint wire.OutPoint) *spendReq {
+
+	t.Helper()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	req := f.spendReqs[outpoint]
+	require.NotNil(t, req)
+
+	return req
 }
 
 // removedTxSnapshot returns the txids the actor asked to remove from the wallet
@@ -1653,6 +1680,7 @@ func TestProofNodeHeightHintBoundedBelowTip(t *testing.T) {
 	// A mainnet-scale height comfortably above the lookback so the floor
 	// is (height - lookback), not the genesis clamp.
 	const startHeight uint32 = 850_000
+	desc.CreatedHeight = int32(startHeight - 100)
 
 	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
 		Height:  int32(startHeight),
@@ -1806,7 +1834,14 @@ func TestProofNodeHeightHintUsesCommitmentHeight(t *testing.T) {
 		},
 	}
 
-	unrollActor, _, txconfirmRef, _ := newActorHarness(t, proof, desc)
+	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
+		t, proof, desc,
+	)
+
+	// Exact local ancestry remains authoritative even when it predates the
+	// configured fallback floor.
+	behavior.cfg.LegacyProofScanFloor = 750_000
+	behavior.cfg.LegacyProofScanOperatorKey = desc.OperatorKey
 
 	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
 		Height:  int32(startHeight),
@@ -1821,26 +1856,18 @@ func TestProofNodeHeightHintUsesCommitmentHeight(t *testing.T) {
 	require.NotEqual(t, startHeight-proofNodeHeightHintLookback, hint)
 }
 
-// TestProofNodeHeightHintFallsBackWithoutCommitmentHeight verifies that when
-// no fragment carries a commitment height (legacy/absent server field) the
-// hint falls back to exactly the bounded lookback floor — identical to the
-// pre-commitment-height behaviour.
-func TestProofNodeHeightHintFallsBackWithoutCommitmentHeight(t *testing.T) {
+// TestProofNodeHeightHintFallsBackForRecentVTXO verifies that a recent target
+// with no commitment height can safely use the bounded lookback floor.
+func TestProofNodeHeightHintFallsBackForRecentVTXO(t *testing.T) {
 	proof := buildLinearProof(t)
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
 
-	// Ancestry present but all commitment heights unknown (zero): the floor
-	// must fall back to the lookback, just like today.
-	desc.Ancestry = []vtxo.Ancestry{
-		{
-			CommitmentHeight: 0,
-		},
-		{
-			CommitmentHeight: 0,
-		},
-	}
+	// A single ancestry fragment with an unknown commitment height can use
+	// the recent target's creation height to justify the lookback.
+	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
 
 	const startHeight uint32 = 850_000
+	desc.CreatedHeight = int32(startHeight - 100)
 
 	unrollActor, _, txconfirmRef, _ := newActorHarness(t, proof, desc)
 
@@ -1853,6 +1880,202 @@ func TestProofNodeHeightHintFallsBackWithoutCommitmentHeight(t *testing.T) {
 	hint := txconfirmRef.lastRequest(t).HeightHint
 
 	require.Equal(t, startHeight-proofNodeHeightHintLookback, hint)
+}
+
+// TestProofNodeHeightHintUsesGenesisForOldLegacyVTXO verifies that an old
+// target without a commitment height cannot use a floor that may sit above an
+// already-confirmed proof ancestor.
+func TestProofNodeHeightHintUsesGenesisForOldLegacyVTXO(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 1
+	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
+
+	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
+		t, proof, desc,
+	)
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  850_000,
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(t, uint32(1), txconfirmRef.lastRequest(t).HeightHint)
+	chainRef, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	rootOutpoint := wire.OutPoint{
+		Hash:  proof.RootTxids()[0],
+		Index: 0,
+	}
+	require.Equal(
+		t, uint32(1), chainRef.spendRequest(t, rootOutpoint).HeightHint,
+	)
+}
+
+// TestProofNodeHeightHintUsesConfiguredFloorForOldLegacyVTXO verifies that an
+// operator deployment floor bounds the expensive fallback scan without
+// restoring the unsound tip-relative lookback for an old target.
+func TestProofNodeHeightHintUsesConfiguredFloorForOldLegacyVTXO(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 1
+	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
+
+	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
+		t, proof, desc,
+	)
+	const deploymentFloor uint32 = 800_000
+	behavior.cfg.LegacyProofScanFloor = deploymentFloor
+	behavior.cfg.LegacyProofScanOperatorKey = desc.OperatorKey
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  850_000,
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(
+		t, deploymentFloor, txconfirmRef.lastRequest(t).HeightHint,
+	)
+	chainRef, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	rootOutpoint := wire.OutPoint{
+		Hash:  proof.RootTxids()[0],
+		Index: 0,
+	}
+	require.Equal(
+		t, deploymentFloor,
+		chainRef.spendRequest(t, rootOutpoint).HeightHint,
+	)
+}
+
+// TestProofNodeHeightHintUsesConfiguredFloorForRecentLegacyVTXO verifies the
+// configured deployment floor also prevents a recent fallback scan from
+// starting earlier than the operator could have created commitments.
+func TestProofNodeHeightHintUsesConfiguredFloorForRecentLegacyVTXO(
+	t *testing.T) {
+
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 849_900
+	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
+
+	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
+		t, proof, desc,
+	)
+	const deploymentFloor uint32 = 845_000
+	behavior.cfg.LegacyProofScanFloor = deploymentFloor
+	behavior.cfg.LegacyProofScanOperatorKey = desc.OperatorKey
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  850_000,
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(
+		t, deploymentFloor, txconfirmRef.lastRequest(t).HeightHint,
+	)
+}
+
+// TestProofNodeHeightHintRejectsConfiguredFloorForAnotherOperator verifies an
+// endpoint migration cannot apply the current operator's deployment floor to
+// a legacy VTXO created by a different operator.
+func TestProofNodeHeightHintRejectsConfiguredFloorForAnotherOperator(
+	t *testing.T) {
+
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 1
+	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
+
+	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
+		t, proof, desc,
+	)
+	currentOperator, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	behavior.cfg.LegacyProofScanFloor = 800_000
+	behavior.cfg.LegacyProofScanOperatorKey = currentOperator.PubKey()
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  850_000,
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(t, uint32(1), txconfirmRef.lastRequest(t).HeightHint)
+	chainRef, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	rootOutpoint := wire.OutPoint{
+		Hash:  proof.RootTxids()[0],
+		Index: 0,
+	}
+	require.Equal(
+		t, uint32(1), chainRef.spendRequest(t, rootOutpoint).HeightHint,
+	)
+}
+
+// TestProofNodeHeightHintRejectsConfiguredFloorAboveTip verifies stale or
+// mismatched network configuration cannot hand the notifier a future floor.
+func TestProofNodeHeightHintRejectsConfiguredFloorAboveTip(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 1
+	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
+
+	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
+		t, proof, desc,
+	)
+	behavior.cfg.LegacyProofScanFloor = 900_000
+	behavior.cfg.LegacyProofScanOperatorKey = desc.OperatorKey
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  850_000,
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(t, uint32(1), txconfirmRef.lastRequest(t).HeightHint)
+}
+
+// TestProofNodeHeightHintUsesGenesisWhenCreatedHeightUnknown verifies that an
+// absent creation height cannot be treated as evidence that a legacy target is
+// recent enough for the bounded floor.
+func TestProofNodeHeightHintUsesGenesisWhenCreatedHeightUnknown(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 0
+	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
+
+	unrollActor, _, txconfirmRef, _ := newActorHarness(t, proof, desc)
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  850_000,
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(t, uint32(1), txconfirmRef.lastRequest(t).HeightHint)
+}
+
+// TestProofNodeHeightHintUsesGenesisForMultiFragmentLegacyVTXO verifies one
+// recent scalar creation height cannot justify a bounded scan for every
+// commitment in a multi-fragment ancestry.
+func TestProofNodeHeightHintUsesGenesisForMultiFragmentLegacyVTXO(
+	t *testing.T) {
+
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 849_900
+	desc.Ancestry = []vtxo.Ancestry{
+		{
+			CommitmentHeight: 0,
+		},
+		{
+			CommitmentHeight: 849_950,
+		},
+	}
+
+	unrollActor, _, txconfirmRef, _ := newActorHarness(t, proof, desc)
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  850_000,
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(t, uint32(1), txconfirmRef.lastRequest(t).HeightHint)
 }
 
 // TestProofNodeHeightHintWarnsOncePerActor verifies an old VTXO without a
@@ -1884,8 +2107,9 @@ func TestProofNodeHeightHintWarnsOncePerActor(t *testing.T) {
 		t, 1,
 		bytes.Count(
 			buf.Bytes(), []byte(
-				"Proof-node confirmation floor may exceed "+
-					"ancestor height",
+				"Legacy proof commitment height "+
+					"unavailable; using safe fallback "+
+					"floor",
 			),
 		),
 	)

--- a/unroll/proof_floor_alert.go
+++ b/unroll/proof_floor_alert.go
@@ -2,38 +2,34 @@ package unroll
 
 import (
 	"sync"
-
-	"github.com/btcsuite/btcd/chainhash/v2"
 )
 
-// proofNodeFloorAlertDeduper limits the confirmation-floor warning to one
-// alert per proof transaction and process lifetime. Multiple target VTXOs can
-// share the same proof ancestor, so per-target warnings describe one recovery
-// condition and create redundant alert instances.
+// proofNodeFloorAlertDeduper limits the legacy fallback-scan warning to one
+// alert per unroll registry and process lifetime. The alert reports the shared
+// compatibility condition; per-target Debug logs retain the affected
+// outpoints without repeating an operator warning for every proof transaction.
 type proofNodeFloorAlertDeduper struct {
-	mu   sync.Mutex
-	seen map[chainhash.Hash]struct{}
+	mu     sync.Mutex
+	warned bool
 }
 
-// newProofNodeFloorAlertDeduper creates an empty process-local alert set.
+// newProofNodeFloorAlertDeduper creates an unused process-local alert gate.
 func newProofNodeFloorAlertDeduper() *proofNodeFloorAlertDeduper {
-	return &proofNodeFloorAlertDeduper{
-		seen: make(map[chainhash.Hash]struct{}),
-	}
+	return &proofNodeFloorAlertDeduper{}
 }
 
-// first reports whether txid has not produced a warning through this deduper.
-// It records txid before returning so concurrent child actors cannot both
-// claim the first alert.
-func (d *proofNodeFloorAlertDeduper) first(txid chainhash.Hash) bool {
+// first reports whether no child has produced the registry's fallback warning.
+// It records the claim before returning so concurrent children cannot both
+// emit it.
+func (d *proofNodeFloorAlertDeduper) first() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if _, ok := d.seen[txid]; ok {
+	if d.warned {
 		return false
 	}
 
-	d.seen[txid] = struct{}{}
+	d.warned = true
 
 	return true
 }

--- a/unroll/proof_floor_alert_test.go
+++ b/unroll/proof_floor_alert_test.go
@@ -5,23 +5,19 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/stretchr/testify/require"
 )
 
-// TestProofNodeFloorAlertDeduper verifies that targets sharing one proof
-// transaction produce one alert while an independent proof still alerts.
+// TestProofNodeFloorAlertDeduper verifies that one registry produces one
+// fallback warning even when many child actors reach it concurrently.
 func TestProofNodeFloorAlertDeduper(t *testing.T) {
 	t.Parallel()
 
 	deduper := newProofNodeFloorAlertDeduper()
-	firstProof := chainhash.Hash{1}
-	secondProof := chainhash.Hash{2}
-
-	require.True(t, deduper.first(firstProof))
-	require.False(t, deduper.first(firstProof))
-	require.True(t, deduper.first(secondProof))
+	require.True(t, deduper.first())
+	require.False(t, deduper.first())
 
 	// Concurrent children must not both claim the first warning.
 	concurrent := newProofNodeFloorAlertDeduper()
@@ -31,7 +27,7 @@ func TestProofNodeFloorAlertDeduper(t *testing.T) {
 		workers.Add(1)
 		go func() {
 			defer workers.Done()
-			if concurrent.first(firstProof) {
+			if concurrent.first() {
 				firstCount.Add(1)
 			}
 		}()
@@ -41,8 +37,12 @@ func TestProofNodeFloorAlertDeduper(t *testing.T) {
 
 	// Exercise the production registry constructor and spawn seam. Two real
 	// children must receive the same registry-lifetime deduper.
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
 	registry := NewUnrollRegistryActor(RegistryConfig{
-		DeliveryStore: newMemCheckpointStore(),
+		DeliveryStore:              newMemCheckpointStore(),
+		LegacyProofScanFloor:       123,
+		LegacyProofScanOperatorKey: operatorPriv.PubKey(),
 	})
 	t.Cleanup(registry.Stop)
 	require.NotNil(t, registry.behavior.proofNodeFloorAlerts)
@@ -69,5 +69,21 @@ func TestProofNodeFloorAlertDeduper(t *testing.T) {
 	require.Same(
 		t, registry.behavior.proofNodeFloorAlerts,
 		secondChild.behavior.cfg.proofNodeFloorAlerts,
+	)
+	require.Equal(
+		t, uint32(123), firstChild.behavior.cfg.LegacyProofScanFloor,
+	)
+	require.Equal(
+		t, uint32(123), secondChild.behavior.cfg.LegacyProofScanFloor,
+	)
+	require.True(
+		t, operatorPriv.PubKey().IsEqual(
+			firstChild.behavior.cfg.LegacyProofScanOperatorKey,
+		),
+	)
+	require.True(
+		t, operatorPriv.PubKey().IsEqual(
+			secondChild.behavior.cfg.LegacyProofScanOperatorKey,
+		),
 	)
 }

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
@@ -164,6 +165,17 @@ type RegistryConfig struct {
 	// into every spawned VTXOUnrollActor and from there into the
 	// FSM Environment.
 	FraudCheckpointSafetyMargin int32
+
+	// LegacyProofScanFloor is the earliest block where the configured
+	// operator could have created a compatible commitment transaction.
+	// It is forwarded to every child unroll actor. Zero preserves the
+	// block-1 fallback.
+	LegacyProofScanFloor uint32
+
+	// LegacyProofScanOperatorKey identifies the operator whose deployment
+	// history justifies LegacyProofScanFloor. It is forwarded to every
+	// child unroll actor. A nil key preserves the block-1 fallback.
+	LegacyProofScanOperatorKey *btcec.PublicKey
 
 	// VTXOExitObserver, when set, receives an ExitOutcomeNotification each
 	// time a child unroll job reaches a terminal phase: a clean failure
@@ -1491,6 +1503,8 @@ func (r *registryBehavior) childConfig(target wire.OutPoint) Config {
 		MaxSweepFeeRateSatPerVByte:  r.cfg.MaxSweepFeeRateSatPerVByte,
 		ExitSpendPolicyResolver:     r.cfg.ExitSpendPolicyResolver,
 		FraudCheckpointSafetyMargin: r.cfg.FraudCheckpointSafetyMargin,
+		LegacyProofScanFloor:        r.cfg.LegacyProofScanFloor,
+		LegacyProofScanOperatorKey:  r.cfg.LegacyProofScanOperatorKey,
 		RegistryRef:                 r.selfRef,
 		proofNodeFloorAlerts:        r.proofNodeFloorAlerts,
 	}

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -107,20 +107,48 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   than inheriting the caller's context, because the ingress puller builds its
   context with no deadline at all.
 - Public network endpoint defaults live in `defaultNetworkEndpoints`
-  (`config.go`). `mainnet`, `testnet3`, and `signet` resolve to the Lightning
-  Labs deployments; `regtest`/`simnet` keep the historical localhost
-  endpoints. The mainnet **REST** hosts are declared but not yet routable —
-  the external NLB and dual-SAN certificates cover only the gRPC names — so
-  they stay dark pending the ingress work tracked in lightning-infra#3749.
+  (`config.go`). `mainnet`, `testnet` (testnet3), `testnet4`, and `signet`
+  resolve to the Lightning Labs deployments; `regtest`/`simnet` keep the
+  historical localhost endpoints, and every other network name resolves to no
+  defaults at all. The mainnet **REST** hosts are declared but not yet
+  routable — the external NLB and dual-SAN certificates cover only the gRPC
+  names — so they stay dark pending the ingress work tracked in
+  lightning-infra#3749.
   Changing a default here changes where an existing user's daemon dials on
-  restart; treat it as a deployment change, not a constant tweak.
+  restart; treat it as a deployment change, not a constant tweak. The same
+  table anchors legacy proof scans at a rounded floor below each canonical
+  operator's first supported deployment. The floor applies only when the
+  VTXO's stored operator key matches the key negotiated from that endpoint.
+  An explicit custom operator or key mismatch keeps block 1 because the
+  relevant deployment history is unknown.
 - All sub-stores share the single `s.clk` clock assigned in `NewServer`; new
   code must not call `clock.NewDefaultClock()` directly, use `s.clk`.
 - Actor startup order in `startWalletDependentActors`: VTXO manager, then
-  round actor, then the unroll subsystem (`initUnrollSubsystem`), then the
-  OOR actor (`initOORActor`). The VTXO manager is constructed with a
+  round actor, the unroll subsystem (`initUnrollSubsystem`), then the OOR actor
+  (`initOORActor`). The VTXO manager is constructed with a
   `vtxo.LazyChainResolver` placeholder that `initUnrollSubsystem` fills in
   later; anything needing that seam must run after `initUnrollSubsystem`.
+- After the daemon is ready,
+  `repairLegacyCommitmentHeights` (`commitment_height_repair.go`) runs under
+  one synchronous, whole-pass maintenance timeout. Both readiness signals are
+  published first, so it cannot delay a readiness boundary. A large legacy set
+  may converge across restarts. The repair covers recoverable plus
+  `VTXOStatusUnilateralExit` descriptors, and returns before building the
+  indexer proof signer or ancestry fetcher when no fragment is missing a
+  height. Each remaining candidate fetches authenticated indexed ancestry and
+  calls `db.BackfillVTXOCommitmentHeights`, which atomically fills only zero
+  heights whose exact local commitment/tree fragment matches. Before fetching,
+  the repair reads the local chain tip once; the store rejects every candidate
+  above that tip and, for single-fragment ancestry, a candidate above the
+  VTXO's known creation height. A per-target failure does not stop later
+  repairs; failures produce one non-fatal Info summary. The unroll registry
+  owns the single process-level warning if an affected target needs the safe
+  fallback scan. Canonical Lightning Labs endpoints use the network's
+  deployment floor only for descriptors whose stored operator key matches the
+  negotiated endpoint key. Custom operators, operator-key mismatches, regtest,
+  simnet, unknown networks, and a configured floor above the current tip use
+  block 1. Existing unroll jobs keep that fallback for this process, while
+  successful repairs apply to later admissions and restarts.
 - `initUnrollSubsystem` boot ordering is policy-preserving.
   `recoverySvc.RestoreNonTerminal` (in-flight vHTLC recovery jobs, each
   carrying its durable exit policy) runs **before** the chain resolver is

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -107,20 +107,48 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   than inheriting the caller's context, because the ingress puller builds its
   context with no deadline at all.
 - Public network endpoint defaults live in `defaultNetworkEndpoints`
-  (`config.go`). `mainnet`, `testnet3`, and `signet` resolve to the Lightning
-  Labs deployments; `regtest`/`simnet` keep the historical localhost
-  endpoints. The mainnet **REST** hosts are declared but not yet routable —
-  the external NLB and dual-SAN certificates cover only the gRPC names — so
-  they stay dark pending the ingress work tracked in lightning-infra#3749.
+  (`config.go`). `mainnet`, `testnet` (testnet3), `testnet4`, and `signet`
+  resolve to the Lightning Labs deployments; `regtest`/`simnet` keep the
+  historical localhost endpoints, and every other network name resolves to no
+  defaults at all. The mainnet **REST** hosts are declared but not yet
+  routable — the external NLB and dual-SAN certificates cover only the gRPC
+  names — so they stay dark pending the ingress work tracked in
+  lightning-infra#3749.
   Changing a default here changes where an existing user's daemon dials on
-  restart; treat it as a deployment change, not a constant tweak.
+  restart; treat it as a deployment change, not a constant tweak. The same
+  table anchors legacy proof scans at a rounded floor below each canonical
+  operator's first supported deployment. The floor applies only when the
+  VTXO's stored operator key matches the key negotiated from that endpoint.
+  An explicit custom operator or key mismatch keeps block 1 because the
+  relevant deployment history is unknown.
 - All sub-stores share the single `s.clk` clock assigned in `NewServer`; new
   code must not call `clock.NewDefaultClock()` directly, use `s.clk`.
 - Actor startup order in `startWalletDependentActors`: VTXO manager, then
-  round actor, then the unroll subsystem (`initUnrollSubsystem`), then the
-  OOR actor (`initOORActor`). The VTXO manager is constructed with a
+  round actor, the unroll subsystem (`initUnrollSubsystem`), then the OOR actor
+  (`initOORActor`). The VTXO manager is constructed with a
   `vtxo.LazyChainResolver` placeholder that `initUnrollSubsystem` fills in
   later; anything needing that seam must run after `initUnrollSubsystem`.
+- After the daemon is ready,
+  `repairLegacyCommitmentHeights` (`commitment_height_repair.go`) runs under
+  one synchronous, whole-pass maintenance timeout. Both readiness signals are
+  published first, so it cannot delay a readiness boundary. A large legacy set
+  may converge across restarts. The repair covers recoverable plus
+  `VTXOStatusUnilateralExit` descriptors, and returns before building the
+  indexer proof signer or ancestry fetcher when no fragment is missing a
+  height. Each remaining candidate fetches authenticated indexed ancestry and
+  calls `db.BackfillVTXOCommitmentHeights`, which atomically fills only zero
+  heights whose exact local commitment/tree fragment matches. Before fetching,
+  the repair reads the local chain tip once; the store rejects every candidate
+  above that tip and, for single-fragment ancestry, a candidate above the
+  VTXO's known creation height. A per-target failure does not stop later
+  repairs; failures produce one non-fatal Info summary. The unroll registry
+  owns the single process-level warning if an affected target needs the safe
+  fallback scan. Canonical Lightning Labs endpoints use the network's
+  deployment floor only for descriptors whose stored operator key matches the
+  negotiated endpoint key. Custom operators, operator-key mismatches, regtest,
+  simnet, unknown networks, and a configured floor above the current tip use
+  block 1. Existing unroll jobs keep that fallback for this process, while
+  successful repairs apply to later admissions and restarts.
 - `initUnrollSubsystem` boot ordering is policy-preserving.
   `recoverySvc.RestoreNonTerminal` (in-flight vHTLC recovery jobs, each
   carrying its durable exit policy) runs **before** the chain resolver is

--- a/waved/commitment_height_repair.go
+++ b/waved/commitment_height_repair.go
@@ -1,0 +1,154 @@
+package waved
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/lightninglabs/wavelength/vtxo"
+)
+
+// legacyCommitmentHeightRepairTimeout bounds the optional post-ready indexer
+// maintenance so a slow or unavailable indexer cannot hold its startup worker
+// indefinitely.
+const legacyCommitmentHeightRepairTimeout = 30 * time.Second
+
+// repairLegacyCommitmentHeights refreshes commitment confirmation heights for
+// active VTXOs written before that field was persisted. It runs as bounded
+// post-ready maintenance. Existing restored exits therefore retain the safe
+// configured fallback floor for the current process, while repaired heights
+// become available to later admissions and restarts.
+//
+// The authenticated indexer supplies only candidate heights. The database
+// repair matches each candidate against the exact local commitment/tree
+// fragment, bounds it by local chain state, and preserves all local proof
+// material. Per-target failures do not stop later repairs; the caller receives
+// one bounded summary and the unroller retains its locally configured safe
+// fallback floor without depending on repair success.
+func (s *Server) repairLegacyCommitmentHeights(ctx context.Context) error {
+	if s.vtxoStore == nil {
+		return fmt.Errorf("vtxo store not initialized")
+	}
+
+	recoverable, err := s.vtxoStore.ListRecoverableVTXOs(ctx)
+	if err != nil {
+		return fmt.Errorf("list recoverable VTXOs: %w", err)
+	}
+	exiting, err := s.vtxoStore.ListVTXOsByStatus(
+		ctx, vtxo.VTXOStatusUnilateralExit,
+	)
+	if err != nil {
+		return fmt.Errorf("list exiting VTXOs: %w", err)
+	}
+
+	targets := make([]*vtxo.Descriptor, 0, len(recoverable)+len(exiting))
+	targets = append(targets, recoverable...)
+	targets = append(targets, exiting...)
+	candidateCount := 0
+	for _, desc := range targets {
+		if hasUnknownCommitmentHeight(desc) {
+			candidateCount++
+		}
+	}
+	if candidateCount == 0 {
+		return nil
+	}
+	if s.chainBackend == nil {
+		return fmt.Errorf("chain backend not initialized")
+	}
+
+	bestHeight, _, err := s.chainBackend.BestBlock(ctx)
+	if err != nil {
+		return fmt.Errorf("get local best height: %w", err)
+	}
+	if bestHeight <= 0 {
+		return fmt.Errorf("invalid local best height %d", bestHeight)
+	}
+
+	signerFactory, err := s.indexerProofSignerFactory()
+	if err != nil {
+		return fmt.Errorf("build indexer proof signer: %w", err)
+	}
+	fetcher, err := incomingAncestryFetcher(s.indexer, signerFactory)
+	if err != nil {
+		return fmt.Errorf("build ancestry fetcher: %w", err)
+	}
+
+	var (
+		repairedTargets   int
+		repairedFragments int
+		failedTargets     int
+		firstErr          error
+	)
+	for _, desc := range targets {
+		if !hasUnknownCommitmentHeight(desc) {
+			continue
+		}
+
+		extras, fetchErr := fetcher(
+			ctx, desc.Outpoint, desc.PkScript, desc.ClientKey,
+		)
+		if fetchErr != nil {
+			failedTargets++
+			if firstErr == nil {
+				firstErr = fmt.Errorf("fetch %s: %w",
+					desc.Outpoint, fetchErr)
+			}
+
+			continue
+		}
+
+		repaired, repairErr := s.vtxoStore.
+			BackfillVTXOCommitmentHeights(
+				ctx, desc.Outpoint, extras.Ancestry, bestHeight,
+			)
+		if repairErr != nil {
+			failedTargets++
+			if firstErr == nil {
+				firstErr = fmt.Errorf("repair %s: %w",
+					desc.Outpoint, repairErr)
+			}
+
+			continue
+		}
+
+		if repaired > 0 {
+			repairedTargets++
+			repairedFragments += repaired
+		}
+	}
+
+	if repairedTargets > 0 {
+		s.log.InfoS(ctx, "Repaired legacy VTXO commitment heights",
+			slog.Int("target_count", repairedTargets),
+			slog.Int("fragment_count", repairedFragments),
+		)
+	}
+
+	if failedTargets > 0 {
+		return fmt.Errorf("%d of %d legacy VTXO commitment-height "+
+			"repairs failed; first failure: %w", failedTargets,
+			candidateCount, firstErr)
+	}
+
+	return nil
+}
+
+// hasUnknownCommitmentHeight reports whether desc has usable local ancestry
+// but at least one fragment still lacks its commitment confirmation height.
+// Empty ancestry is a separate recovery-material defect and cannot be repaired
+// safely by a height-only backfill.
+func hasUnknownCommitmentHeight(desc *vtxo.Descriptor) bool {
+	if desc == nil || len(desc.Ancestry) == 0 {
+		return false
+	}
+
+	for _, ancestry := range desc.Ancestry {
+		if ancestry.CommitmentHeight <= 0 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/waved/commitment_height_repair_test.go
+++ b/waved/commitment_height_repair_test.go
@@ -1,0 +1,68 @@
+package waved
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHasUnknownCommitmentHeight verifies that only usable ancestry with at
+// least one missing height enters the startup repair.
+func TestHasUnknownCommitmentHeight(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		desc *vtxo.Descriptor
+		want bool
+	}{
+		{
+			name: "nil descriptor",
+		},
+		{
+			name: "empty ancestry",
+			desc: &vtxo.Descriptor{},
+		},
+		{
+			name: "all heights known",
+			desc: &vtxo.Descriptor{
+				Ancestry: []vtxo.Ancestry{{
+					CommitmentHeight: 100,
+				}},
+			},
+		},
+		{
+			name: "zero height",
+			desc: &vtxo.Descriptor{
+				Ancestry: []vtxo.Ancestry{
+					{},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "mixed heights",
+			desc: &vtxo.Descriptor{
+				Ancestry: []vtxo.Ancestry{
+					{
+						CommitmentHeight: 100,
+					},
+					{},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(
+				t, test.want,
+				hasUnknownCommitmentHeight(test.desc),
+			)
+		})
+	}
+}

--- a/waved/config.go
+++ b/waved/config.go
@@ -144,6 +144,17 @@ const (
 	defaultSignetSwapServerRESTHost = "signet.swapd-rest." +
 		"lightning.finance"
 
+	// The legacy proof scan floors are rounded well below the first
+	// supported operator deployment on each public network. They are used
+	// only with the canonical Lightning Labs operator endpoint. The extra
+	// margin covers incomplete deployment history and operator database
+	// resets while still avoiding a scan of chain history in which that
+	// operator could not have created VTXOs.
+	defaultMainnetLegacyProofScanFloor uint32 = 950_000
+	testnet3LegacyProofScanFloor       uint32 = 4_940_000
+	testnet4LegacyProofScanFloor       uint32 = 140_000
+	signetLegacyProofScanFloor         uint32 = 300_000
+
 	// DefaultIndexerServerID is the canonical operator identifier used
 	// in signed indexer proofs.
 	DefaultIndexerServerID = "lumosd"
@@ -1569,6 +1580,42 @@ func (c *Config) ArkServerAddress() string {
 	}
 
 	return defaults.ark.forTransport(c.Server.Transport)
+}
+
+// legacyProofScanFloor returns the earliest block where the configured Ark
+// operator could have created a compatible commitment. The deployment-backed
+// floors apply only to the canonical Lightning Labs endpoints. A custom or
+// unknown operator retains block 1 because its deployment history is unknown.
+func (c *Config) legacyProofScanFloor() uint32 {
+	if c == nil || c.Server == nil {
+		return 1
+	}
+
+	defaults, ok := defaultNetworkEndpoints(c.Network)
+	if !ok {
+		return 1
+	}
+	canonical := defaults.ark.forTransport(c.Server.Transport)
+	if canonical == "" || c.ArkServerAddress() != canonical {
+		return 1
+	}
+
+	switch c.Network {
+	case "mainnet":
+		return defaultMainnetLegacyProofScanFloor
+
+	case "testnet":
+		return testnet3LegacyProofScanFloor
+
+	case "testnet4":
+		return testnet4LegacyProofScanFloor
+
+	case "signet":
+		return signetLegacyProofScanFloor
+
+	default:
+		return 1
+	}
 }
 
 // SwapServerAddress returns the configured swap server address, or the

--- a/waved/config_network_test.go
+++ b/waved/config_network_test.go
@@ -406,6 +406,113 @@ func TestConfigEndpointDefaultsPreserveOverrides(t *testing.T) {
 	require.Equal(t, "localhost:11030", cfg.SwapServerAddress())
 }
 
+// TestLegacyProofScanFloor verifies deployment-backed floors apply only to
+// the canonical operator for each public network. Custom operators retain the
+// block-1 fallback because their earliest compatible commitment is unknown.
+func TestLegacyProofScanFloor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		network   string
+		transport string
+		host      string
+		want      uint32
+	}{
+		{
+			name:      "mainnet grpc",
+			network:   "mainnet",
+			transport: RPCTransportGRPC,
+			want:      defaultMainnetLegacyProofScanFloor,
+		},
+		{
+			name:      "mainnet rest",
+			network:   "mainnet",
+			transport: RPCTransportREST,
+			want:      defaultMainnetLegacyProofScanFloor,
+		},
+		{
+			name:      "testnet3 grpc",
+			network:   "testnet",
+			transport: RPCTransportGRPC,
+			want:      testnet3LegacyProofScanFloor,
+		},
+		{
+			name:      "testnet3 rest",
+			network:   "testnet",
+			transport: RPCTransportREST,
+			want:      testnet3LegacyProofScanFloor,
+		},
+		{
+			name:      "testnet4 grpc",
+			network:   "testnet4",
+			transport: RPCTransportGRPC,
+			want:      testnet4LegacyProofScanFloor,
+		},
+		{
+			name:      "testnet4 rest",
+			network:   "testnet4",
+			transport: RPCTransportREST,
+			want:      testnet4LegacyProofScanFloor,
+		},
+		{
+			name:      "signet grpc",
+			network:   "signet",
+			transport: RPCTransportGRPC,
+			want:      signetLegacyProofScanFloor,
+		},
+		{
+			name:      "signet rest",
+			network:   "signet",
+			transport: RPCTransportREST,
+			want:      signetLegacyProofScanFloor,
+		},
+		{
+			name:    "custom public operator",
+			network: "testnet",
+			host:    "ark.example.com:443",
+			want:    1,
+		},
+		{
+			name:    "explicit canonical operator",
+			network: "signet",
+			host:    defaultSignetServerGRPCHost,
+			want:    signetLegacyProofScanFloor,
+		},
+		{
+			name:    "regtest",
+			network: "regtest",
+			want:    1,
+		},
+		{
+			name:    "simnet",
+			network: "simnet",
+			want:    1,
+		},
+		{
+			name:    "unknown network",
+			network: "unknown",
+			want:    1,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := DefaultConfig()
+			cfg.Network = tc.network
+			cfg.Server.Transport = tc.transport
+			cfg.Server.Host = tc.host
+
+			require.Equal(t, tc.want, cfg.legacyProofScanFloor())
+		})
+	}
+
+	require.Equal(t, uint32(1), (*Config)(nil).legacyProofScanFloor())
+}
+
 // TestNetworkToChainParams verifies network strings map to their exact btcd
 // chain parameters.
 func TestNetworkToChainParams(t *testing.T) {

--- a/waved/server.go
+++ b/waved/server.go
@@ -1708,6 +1708,25 @@ func (s *Server) startWalletReadyServices(ctx context.Context,
 
 	s.markDaemonReady()
 
+	// Repair legacy confirmation floors as bounded post-ready maintenance.
+	// This call is synchronous, but both wallet-services and daemon
+	// readiness were published above, so the indexer cannot delay a
+	// readiness boundary. One 30-second context bounds the whole pass, not
+	// each target; a large legacy set may therefore converge across
+	// restarts. Restored jobs keep the configured safe fallback floor for
+	// this process, while successful backfills are durable for later
+	// admissions and restarts.
+	repairCtx, repairCancel := context.WithTimeout(
+		ctx, legacyCommitmentHeightRepairTimeout,
+	)
+	repairErr := s.repairLegacyCommitmentHeights(repairCtx)
+	repairCancel()
+	if repairErr != nil && ctx.Err() == nil {
+		s.log.InfoS(ctx, "Legacy VTXO commitment-height repair "+
+			"incomplete; old exits will use the safe fallback floor",
+			slog.String("error", repairErr.Error()))
+	}
+
 	return nil
 }
 
@@ -5846,6 +5865,13 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 		ArtifactStore: oorStore,
 	}
 	s.proofAssembler = proofAssembler
+	legacyProofScanFloor := s.cfg.legacyProofScanFloor()
+	var legacyProofScanOperatorKey *btcec.PublicKey
+	if legacyProofScanFloor > 1 {
+		if terms := s.loadOperatorTerms(); terms != nil {
+			legacyProofScanOperatorKey = terms.PubKey
+		}
+	}
 
 	// Adapt the VTXO manager ref into a tell-only exit observer so the
 	// unroll registry can report each job's terminal outcome back to the
@@ -5877,7 +5903,9 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 			Jobs:     recoveryStore,
 			Preimage: preimages,
 		},
-		VTXOExitObserver: exitObserver,
+		VTXOExitObserver:           exitObserver,
+		LegacyProofScanFloor:       legacyProofScanFloor,
+		LegacyProofScanOperatorKey: legacyProofScanOperatorKey,
 	})
 	s.unrollRegistry = registry
 	s.unrollRegistryRef = fn.Some(registry.Ref())


### PR DESCRIPTION
## Problem

Unilateral exit recovery reconstructs a VTXO's local proof graph. It watches
each proof ancestor for confirmation and each backup proof output for a spend.
The chain notifier needs a starting height for both watches.

Current rows store a commitment height for every ancestry fragment. The minimum
of those heights is an exact lower bound: no proof ancestor can confirm before
the commitment that created its branch.

Legacy rows can have a zero commitment height. The old fallback scanned only
the latest 10,000 blocks. That is safe for a recent single-fragment VTXO whose
creation height proves the commitment is inside the window. It is not safe for
an old, undated, or multi-fragment VTXO. An ancestor may already have confirmed
below the scan floor, so the notifier can miss it and leave the exit stalled.

## Fix

The confirmation-watch floor now follows these rules:

1. Complete ancestry uses the exact minimum commitment height.
2. Recent single-fragment legacy ancestry uses the later of the 10,000-block
   lookback and the configured operator floor.
3. Old, undated, or multi-fragment legacy ancestry uses the configured operator
   floor.

The default operator floors for the canonical Lightning Labs endpoints are
rounded conservatively below the earliest supported deployment boundary on
each network:

| Network | Legacy proof scan floor |
| --- | ---: |
| Bitcoin mainnet | 950,000 |
| Bitcoin testnet3 | 4,940,000 |
| Bitcoin testnet4 | 140,000 |
| Bitcoin signet | 300,000 |

The margin accounts for incomplete deployment history and database resets. It
is intentionally more conservative than using current database minima alone.
This keeps the floor below any supported legacy commitment while avoiding a
scan of chain history in which the canonical operator could not have created
VTXOs.

These floors apply only when Waved uses the canonical endpoint for that
network and transport and the VTXO's stored operator key matches the key
negotiated from that endpoint. Custom operator endpoints, operator-key
mismatches, regtest, simnet, unknown networks, absent values, invalid values,
and values above the current tip use block 1. This keeps the fallback safe when
the VTXO came from another operator or the relevant deployment history is
unknown.

The same floor is computed once and passed to both direct proof-node
confirmation watches and backup proof-output spend watches. One process-owned
unroll registry emits one operator warning for legacy fallback scans. Per-target
details remain available at debug level.

## Authenticated height repair

Waved also runs one bounded, 30-second repair pass after both readiness signals
have been published. It considers active legacy VTXOs with missing commitment
heights. A fully populated database returns before querying the local chain or
constructing an indexer request.

The existing authenticated indexer proof-of-control flow supplies candidate
ancestry. A candidate is accepted only when it matches the exact local
commitment transaction and serialized tree path. Waved reads the local chain
tip before contacting the indexer. The database rejects heights above that tip;
for single-fragment ancestry, it also rejects heights above the known VTXO
creation height.

The database validates the complete target before writing. It then updates only
zero `commitment_height` fields inside one target transaction. It never
overwrites a known height or rewrites a commitment transaction, tree, depth,
input index, or other local proof material.

Missing, duplicate, mismatched, heightless, out-of-bounds, or concurrently
changed fragments fail closed and roll back the target. Local-chain,
authenticated-indexer, timeout, and repair failures are non-fatal. The locally
configured safe fallback remains active without depending on repair success.
Successful repairs give later admissions and restarts an exact floor.

## Unchanged

- No database migration or RPC change.
- No change to current VTXOs with complete commitment heights.
- No indexer availability dependency for unilateral-exit correctness.
- Repaired heights remain subject to the existing authenticated-indexer trust
  model, plus the local ceilings described above.
- No replacement of local ancestry or proof transactions.
- No unroll state-machine or database redesign.

## Verification

- Regression tests for exact, recent, old, unknown-height, multi-fragment,
  configured, invalid, and above-tip floors.
- Direct confirmation and backup-spend hint tests.
- Canonical-endpoint and custom-endpoint tests for every supported network and
  transport, plus matching- and migrated-operator-key tests.
- Warning-deduplication and per-target debug-evidence tests.
- Exact-match backfill, local-ceiling, target-atomicity, concurrent-change, and
  local-proof-preservation tests.
- Independent database and RPC/indexer ancestry decoding with a non-trivial
  two-child tree.
- Full unit, coverage, SQLite, PostgreSQL, swap-runtime, race, and system-test
  suites.
- Lint, formatting, schema, SQLC, migration, module-tidy, sample-config,
  commit-message, documentation, and agent-document checks.
- P durable-mailbox model and Go bridge conformance.
- Supported-platform cross-compilation in CI.

## Rollout and rollback

The change is compatible with existing databases and needs no migration. On
the first start, restored legacy exits use the endpoint- and operator-specific
safe fallback while the post-ready repair runs. Later admissions and restarts
use repaired exact heights when local validation succeeds.

Rollback needs no schema downgrade. Repaired heights remain valid data. A
rollback can restore the missed-ancestor risk for any active legacy rows that
still lack exact heights, so it should keep the safe fallback or first confirm
that those rows were repaired.
