### PR TITLE
docs: nightly doc-gardening sweep 2026-09-01

### DIFF
--- a/chainbackends/AGENTS.md
+++ b/chainbackends/AGENTS.md
@@ -67,6 +67,18 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
 - `LndClientChainNotifier` enforces a 15-second timeout on registration to
   prevent hanging under LND block load.
 - Log messages use canonical txid strings (not reversed byte slices).
+- **A `Canceled` status is only shutdown noise when the owning context is also
+  done.** Round completion stops each VTXO's block subscription, and a block
+  already in flight can race that cancellation, so `GetBlockHash` or the
+  notifier error channel returns `Canceled` while the forwarder exits normally
+  — paging an operator per terminated VTXO is pure noise.
+  `isBlockEpochShutdownError(ctx, err)` demotes these to debug, but it returns
+  false whenever `ctx.Err() == nil`. Do not simplify it to a bare
+  `errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled`
+  check: a `Canceled` arriving from a *live* subscription means the backend
+  dropped it independently, which is actionable and must stay at warning. Every
+  other notifier or block-hash failure remains a warning regardless of context
+  state.
 
 ## Deep Docs
 

--- a/chainbackends/CLAUDE.md
+++ b/chainbackends/CLAUDE.md
@@ -67,6 +67,18 @@ estimation, and optional v3 package relay via a pluggable `PackageSubmitter`.
 - `LndClientChainNotifier` enforces a 15-second timeout on registration to
   prevent hanging under LND block load.
 - Log messages use canonical txid strings (not reversed byte slices).
+- **A `Canceled` status is only shutdown noise when the owning context is also
+  done.** Round completion stops each VTXO's block subscription, and a block
+  already in flight can race that cancellation, so `GetBlockHash` or the
+  notifier error channel returns `Canceled` while the forwarder exits normally
+  — paging an operator per terminated VTXO is pure noise.
+  `isBlockEpochShutdownError(ctx, err)` demotes these to debug, but it returns
+  false whenever `ctx.Err() == nil`. Do not simplify it to a bare
+  `errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled`
+  check: a `Canceled` arriving from a *live* subscription means the backend
+  dropped it independently, which is actionable and must stay at warning. Every
+  other notifier or block-hash failure remains a warning regardless of context
+  state.
 
 ## Deep Docs
 

--- a/chainfees/AGENTS.md
+++ b/chainfees/AGENTS.md
@@ -38,6 +38,17 @@ on-chain transactions from wallet and daemon chain backends.
   estimate yet" (see `WalletKitEstimator.cachedRate`).
 - `MempoolSpaceEstimator` rejects non-HTTPS URLs except for loopback hosts, to
   avoid tampering with fee data in transit.
+- **Log severity in `MinEstimator` tracks whether an operator must act.** A
+  single provider failing is logged at info: the estimator queries several
+  providers precisely so it can continue past one, and a later provider can
+  still supply the selected rate, so this is degraded input diversity rather
+  than an incident. The all-providers-failed fallback stays a warning. A
+  provider whose rate had to be clamped up to `chainfee.FeePerKwFloor` also
+  stays a **warning**, even though clamping already made the returned rate
+  relay-valid: clamping repairs the value but not the selection, so the clamped
+  provider becomes the minimum candidate and can pin the aggregate estimator at
+  the relay floor indefinitely. Persistent fee underpayment needs a human, so
+  do not demote that one along with the others.
 
 ## Deep Docs
 

--- a/chainfees/CLAUDE.md
+++ b/chainfees/CLAUDE.md
@@ -38,6 +38,17 @@ on-chain transactions from wallet and daemon chain backends.
   estimate yet" (see `WalletKitEstimator.cachedRate`).
 - `MempoolSpaceEstimator` rejects non-HTTPS URLs except for loopback hosts, to
   avoid tampering with fee data in transit.
+- **Log severity in `MinEstimator` tracks whether an operator must act.** A
+  single provider failing is logged at info: the estimator queries several
+  providers precisely so it can continue past one, and a later provider can
+  still supply the selected rate, so this is degraded input diversity rather
+  than an incident. The all-providers-failed fallback stays a warning. A
+  provider whose rate had to be clamped up to `chainfee.FeePerKwFloor` also
+  stays a **warning**, even though clamping already made the returned rate
+  relay-valid: clamping repairs the value but not the selection, so the clamped
+  provider becomes the minimum candidate and can pin the aggregate estimator at
+  the relay floor indefinitely. Persistent fee underpayment needs a human, so
+  do not demote that one along with the others.
 
 ## Deep Docs
 

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -169,6 +169,30 @@ state transitions and validation rules live under [Invariants](#invariants).
   signatures.
 - Primary FSM handles interactive phases (through `InputSigSent`); a
   dedicated FSM per round handles confirmation monitoring.
+- **Arm timeouts before fallible outbox effects.** `processOutbox` stops at the
+  first external effect that errors, so anything ordered after a fallible
+  effect may never run. `forfeitCollectionOutbox` therefore emits the
+  status-reconciliation `StartTimeoutReq` *before* both
+  `SubmitVTXOForfeitSigsToServer` and `RegisterConfirmationRequest`: a
+  transient submit failure would otherwise skip the timeout after the forfeit
+  signatures had already left the client, stranding the reserved inputs with no
+  reconciliation path. The stale forfeit-collection `CancelTimeoutReq` still
+  goes first — the two timers use distinct phase keys, so cancelling one does
+  not disturb the other. The remaining sequence (VTXO forfeit signatures →
+  optional boarding signatures → chain registration) is built by straight
+  appends rather than an insertion index, because the index's meaning shifted
+  depending on whether the optional timeout message was present.
+- **Exactly one commitment confirmation watch per round.** The FSM outbox owns
+  steady-state registration: it emits `RegisterConfirmationRequest` after the
+  durable `InputSigSent` checkpoint commits, using the validated batch-output
+  script and the operator's `MinConfirmations`. Checkpoint handling in
+  `processOutbox` only installs the `commitmentTxIndex` routing entry — it must
+  not register again. Registering in both places created two notifier
+  subscriptions for the same transaction under different caller IDs; both
+  delivered the confirmation, the first completed the round, and the second
+  then reported the transaction as no longer indexed. Restart recovery still
+  re-registers active rounds from durable state in `Start`, so crash recovery
+  is unaffected.
 - The round actor does **not** mark VTXOs as `PendingForfeit` — the
   wallet/manager admits VTXOs before sending `RegisterIntentMsg`.
 - A round that settles in the terminal `ClientFailedState` (admission

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -169,6 +169,30 @@ state transitions and validation rules live under [Invariants](#invariants).
   signatures.
 - Primary FSM handles interactive phases (through `InputSigSent`); a
   dedicated FSM per round handles confirmation monitoring.
+- **Arm timeouts before fallible outbox effects.** `processOutbox` stops at the
+  first external effect that errors, so anything ordered after a fallible
+  effect may never run. `forfeitCollectionOutbox` therefore emits the
+  status-reconciliation `StartTimeoutReq` *before* both
+  `SubmitVTXOForfeitSigsToServer` and `RegisterConfirmationRequest`: a
+  transient submit failure would otherwise skip the timeout after the forfeit
+  signatures had already left the client, stranding the reserved inputs with no
+  reconciliation path. The stale forfeit-collection `CancelTimeoutReq` still
+  goes first — the two timers use distinct phase keys, so cancelling one does
+  not disturb the other. The remaining sequence (VTXO forfeit signatures →
+  optional boarding signatures → chain registration) is built by straight
+  appends rather than an insertion index, because the index's meaning shifted
+  depending on whether the optional timeout message was present.
+- **Exactly one commitment confirmation watch per round.** The FSM outbox owns
+  steady-state registration: it emits `RegisterConfirmationRequest` after the
+  durable `InputSigSent` checkpoint commits, using the validated batch-output
+  script and the operator's `MinConfirmations`. Checkpoint handling in
+  `processOutbox` only installs the `commitmentTxIndex` routing entry — it must
+  not register again. Registering in both places created two notifier
+  subscriptions for the same transaction under different caller IDs; both
+  delivered the confirmation, the first completed the round, and the second
+  then reported the transaction as no longer indexed. Restart recovery still
+  re-registers active rounds from durable state in `Start`, so crash recovery
+  is unaffected.
 - The round actor does **not** mark VTXOs as `PendingForfeit` — the
   wallet/manager admits VTXOs before sending `RegisterIntentMsg`.
 - A round that settles in the terminal `ClientFailedState` (admission

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -103,6 +103,18 @@ background ingress polling with event routing.
   only when the caller leaves `RPCOptions.IdempotencyKey` empty, which is
   correct for a single-shot call and defeats deduplication for a retry.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
+- **A mailbox outage warns once per episode, not once per retry.** `pullPhase`
+  carries a dedicated `pullFailCount` alongside the shared backoff `failCount`:
+  the first failure of an episode logs `WarnS` so the dependency outage still
+  pages, and every subsequent failure logs `DebugS` with a
+  `consecutive_failures` field. A successful pull resets the counter to zero,
+  so a later outage warns again. The counter is pull-specific on purpose —
+  sharing the backoff counter would let unrelated backoff activity suppress the
+  first warning of a genuine outage. Without this, one rollout produced ~8
+  alerts in ~20 seconds per client, all carrying the same cause and cursor.
+  Shutdown errors (`isIngressShutdownErr`) and permanent version errors
+  (`checkPermanentStatus`) are classified before this counter and exit the loop
+  instead.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.
 - `DurableUnaryQuery` implementations must produce stable identity bytes in `BuildBody` so that `MsgID` and `IdempotencyKey` are deterministic across restarts (auto-derived via `mailboxconn.StableEventMsgID` / `StableEventIdempotencyKey` when the caller leaves them empty).
 - `ServerConnectionActor` runs a background heartbeat goroutine (`DefaultHeartbeatInterval` = 30s) to keep the mailbox session alive.

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -103,6 +103,18 @@ background ingress polling with event routing.
   only when the caller leaves `RPCOptions.IdempotencyKey` empty, which is
   correct for a single-shot call and defeats deduplication for a retry.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
+- **A mailbox outage warns once per episode, not once per retry.** `pullPhase`
+  carries a dedicated `pullFailCount` alongside the shared backoff `failCount`:
+  the first failure of an episode logs `WarnS` so the dependency outage still
+  pages, and every subsequent failure logs `DebugS` with a
+  `consecutive_failures` field. A successful pull resets the counter to zero,
+  so a later outage warns again. The counter is pull-specific on purpose —
+  sharing the backoff counter would let unrelated backoff activity suppress the
+  first warning of a genuine outage. Without this, one rollout produced ~8
+  alerts in ~20 seconds per client, all carrying the same cause and cursor.
+  Shutdown errors (`isIngressShutdownErr`) and permanent version errors
+  (`checkPermanentStatus`) are classified before this counter and exit the loop
+  instead.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.
 - `DurableUnaryQuery` implementations must produce stable identity bytes in `BuildBody` so that `MsgID` and `IdempotencyKey` are deterministic across restarts (auto-derived via `mailboxconn.StableEventMsgID` / `StableEventIdempotencyKey` when the caller leaves them empty).
 - `ServerConnectionActor` runs a background heartbeat goroutine (`DefaultHeartbeatInterval` = 30s) to keep the mailbox session alive.

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -177,6 +177,17 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   keeps `pendingConfirmed` set for the next tick. The same split applies on
   the deferred `handleTerminalNotifyResult` path, where a post-timeout stop
   is logged at debug and cancelled rather than warned.
+- **`ErrParentAlreadyBroadcast` is a race outcome, not a failure.** An initial
+  package attempt can lose to an existing broadcast path once the parent
+  reaches a mempool; the duplicate child is rejected, but the parent stays
+  under its confirmation watch, so the entry still advances to
+  `AwaitingConfirmation` and no operator action is possible. Both
+  `recordInitialBroadcastOutcome` and the later fee-bump path log this sentinel
+  at debug — keep the two consistent if either is touched. Log severity here is
+  deliberately **not** pinned by a unit test: the initial-package test asserts
+  the state transition (already-broadcast parent → `AwaitingConfirmation`,
+  still watched), because a test that only asserts the absence of a warning
+  still passes if the diagnostic is deleted outright.
 - **Attach never inserts a dead subscriber**: `attachExistingSubscriber` only
   writes the subscriber into `entry.subscribers` on `Delivered` or `Pending`.
   On `SubscriberStopped` there is no tracked interest to unwind, because it

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -177,6 +177,17 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   keeps `pendingConfirmed` set for the next tick. The same split applies on
   the deferred `handleTerminalNotifyResult` path, where a post-timeout stop
   is logged at debug and cancelled rather than warned.
+- **`ErrParentAlreadyBroadcast` is a race outcome, not a failure.** An initial
+  package attempt can lose to an existing broadcast path once the parent
+  reaches a mempool; the duplicate child is rejected, but the parent stays
+  under its confirmation watch, so the entry still advances to
+  `AwaitingConfirmation` and no operator action is possible. Both
+  `recordInitialBroadcastOutcome` and the later fee-bump path log this sentinel
+  at debug — keep the two consistent if either is touched. Log severity here is
+  deliberately **not** pinned by a unit test: the initial-package test asserts
+  the state transition (already-broadcast parent → `AwaitingConfirmation`,
+  still watched), because a test that only asserts the absence of a warning
+  still passes if the diagnostic is deleted outright.
 - **Attach never inserts a dead subscriber**: `attachExistingSubscriber` only
   writes the subscriber into `entry.subscribers` on `Delivered` or `Pending`.
   On `SubscriberStopped` there is no tracked interest to unwind, because it

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -28,9 +28,9 @@ when the local wallet owns the receive script.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, `FetchOperatorKey`,
-  `ForfeitParticipantSigner`, `TerminalVTXOObserver`, `ExitOutcomeResolver`,
-  and `ReservationStore`. Confirmed exit-cost accounting is emitted by unroll
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, `CriticalExitAssessor`,
+  `FetchOperatorKey`, `ForfeitParticipantSigner`, `TerminalVTXOObserver`,
+  `ExitOutcomeResolver`, and `ReservationStore`. Confirmed exit-cost accounting is emitted by unroll
   after final sweep confirmation. `ForfeitVTXOActorAskTimeout`
   (default 5 s) bounds forfeit and refresh child asks so a blocked child actor
   cannot monopolize the manager until the outer RPC deadline. Zero uses the
@@ -96,11 +96,22 @@ when the local wallet owns the receive script.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
 - `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory preview** before each auto-refresh emission to estimate the per-input operator fee for UX surfaces. Under the seal-time fee handshake (#270) the server is the binding fee authority — the quoter's return value is no longer attached to the wire intent. Nil quoter (legacy and test paths) yields `OperatorFee=0` on the harness-local `RefreshVTXORequest`, which has no effect on the round protocol.
+- `CriticalExitAssessor` — Function type
+  `func(ctx, *Descriptor) (CriticalExitAssessment, error)`. Optional hook on
+  `ManagerConfig`, propagated to every spawned `VTXOActor`. Answers whether the
+  backing wallet can actually fund and execute the unilateral exit package at
+  the current fee rate, *before* a critical-expiry VTXO commits to that path.
+  `waved` wires it to `rpcServer.assessAutomaticCriticalExit`, the same
+  feasibility model the manual exit RPC uses, so automatic and manual exit
+  decisions cannot drift.
+- `CriticalExitAssessment` — `{Feasible bool, Reason string}`. `Reason` is a
+  short, stable diagnostic recorded in the "Automatic expiry decision" log when
+  `Feasible` is false; it is a log field, not a wire value.
 
 ## Relationships
 
 - **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/types` (`Ancestry`), `lib/arkscript` (taproot construction and policy helpers in `IncomingVTXOHandler`), `lib/actormsg` (admission and custom-forfeit message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs), `coinselect` (largest-first VTXO selection), `metrics` (optional `OORTransferReceivedMsg` sink), `ledger` (`Sink` type for compatibility with manager wiring), `unroll` (via `ExitOutcomeResolver` callback wired by `waved`).
-- **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `waved` (wiring, owned-script adapters, incoming event route, and `CheckForfeitAdmission` for the leave filter and exit-plan advisory), `sdk/swaps` (forfeit sign-request conversion).
+- **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `waved` (wiring, owned-script adapters, incoming event route, `CheckForfeitAdmission` for the leave filter and exit-plan advisory, and `assessAutomaticCriticalExit` supplying `CriticalExitAssessor`), `sdk/swaps` (forfeit sign-request conversion).
 - **Sends**:
   - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`
   - → `db` (via outbox): `VTXOStatusUpdate`
@@ -162,6 +173,30 @@ when the local wallet owns the receive script.
 - When the cached boundary fires, auto-refresh fetches fresh operator terms
   before reserving the VTXO. A later still-safe boundary leaves the VTXO live;
   a disabled or unsafe-late window preserves the ordinary paid refresh path.
+- **Critical expiry means "the unilateral time budget is now active", not
+  "exit now".** `ExpiryStatusCritical` used to escalate a `LiveState` or
+  `PendingForfeitState` VTXO straight to `UnilateralExitState`. It no longer
+  does unconditionally: `VTXOActor.preflightCriticalExit` intercepts the
+  `BlockEpochEvent` and consults `CriticalExitAssessor` first. An explicitly
+  infeasible verdict (the wallet cannot fund the exit package at the current
+  fee rate) is rewritten into the actor-local `criticalRefreshEvent`, which
+  starts cooperative refresh in `LiveState` and keeps `PendingForfeitState`
+  waiting on its in-flight round. Entering an exit the wallet cannot pay for
+  would abandon a still-available cooperative round for a recovery that cannot
+  make progress. `waverpc`'s `VTXO_EXPIRY_STATUS_CRITICAL` comment carries the
+  same weakened meaning; do not re-document it as an exit trigger.
+- **The viability preflight fails open, and re-runs every block.** A nil
+  `CriticalExitAssessor`, an assessor error, and a feasible verdict all leave
+  the `BlockEpochEvent` untouched, preserving the direct unilateral-exit
+  transition — an unavailable assessment must never suppress the safety path
+  (the error case logs at `Warn` precisely because it degrades a safety
+  decision). Because the check is redone on each block rather than latched into
+  a state, funding the wallet restores the unilateral path with no extra state
+  transition, and a permanently unfundable VTXO keeps retrying cooperative
+  refresh instead of spinning on an exit that cannot land.
+- `criticalRefreshEvent` is **actor-local** and deliberately unexported: it is
+  synthesized by the actor's own preflight, never sent across a package
+  boundary. External block notifications remain `BlockEpochEvent`.
 - Once ForfeitedState is reached, the old VTXO is unspendable; the new VTXO is available only after round confirmation.
 - SpendingState is persisted as VTXOStatusSpending and survives restarts.
 - OOR completion transitions VTXOs to SpentState through the VTXO actor FSM, not by direct store writes.

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -28,9 +28,9 @@ when the local wallet owns the receive script.
 - `ManagerConfig` — Configuration holding Store, Wallet, ChainSource,
   ActorSystem, ChainParams, ExpiryConfig, RoundActor ref, ChainResolver ref,
   optional `Log`, optional `LedgerSink fn.Option[ledger.Sink]`,
-  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, `FetchOperatorKey`,
-  `ForfeitParticipantSigner`, `TerminalVTXOObserver`, `ExitOutcomeResolver`,
-  and `ReservationStore`. Confirmed exit-cost accounting is emitted by unroll
+  `ForfeitVTXOActorAskTimeout`, `RefreshFeeQuoter`, `CriticalExitAssessor`,
+  `FetchOperatorKey`, `ForfeitParticipantSigner`, `TerminalVTXOObserver`,
+  `ExitOutcomeResolver`, and `ReservationStore`. Confirmed exit-cost accounting is emitted by unroll
   after final sweep confirmation. `ForfeitVTXOActorAskTimeout`
   (default 5 s) bounds forfeit and refresh child asks so a blocked child actor
   cannot monopolize the manager until the outer RPC deadline. Zero uses the
@@ -96,11 +96,22 @@ when the local wallet owns the receive script.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
 - `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory preview** before each auto-refresh emission to estimate the per-input operator fee for UX surfaces. Under the seal-time fee handshake (#270) the server is the binding fee authority — the quoter's return value is no longer attached to the wire intent. Nil quoter (legacy and test paths) yields `OperatorFee=0` on the harness-local `RefreshVTXORequest`, which has no effect on the round protocol.
+- `CriticalExitAssessor` — Function type
+  `func(ctx, *Descriptor) (CriticalExitAssessment, error)`. Optional hook on
+  `ManagerConfig`, propagated to every spawned `VTXOActor`. Answers whether the
+  backing wallet can actually fund and execute the unilateral exit package at
+  the current fee rate, *before* a critical-expiry VTXO commits to that path.
+  `waved` wires it to `rpcServer.assessAutomaticCriticalExit`, the same
+  feasibility model the manual exit RPC uses, so automatic and manual exit
+  decisions cannot drift.
+- `CriticalExitAssessment` — `{Feasible bool, Reason string}`. `Reason` is a
+  short, stable diagnostic recorded in the "Automatic expiry decision" log when
+  `Feasible` is false; it is a log field, not a wire value.
 
 ## Relationships
 
 - **Depends on**: `baselib/protofsm` (FSM engine), `baselib/actor` (actor system), `lib/types` (`Ancestry`), `lib/arkscript` (taproot construction and policy helpers in `IncomingVTXOHandler`), `lib/actormsg` (admission and custom-forfeit message types), `arkrpc` (`IncomingVTXOEvent`), `chainsource` (block epochs), `coinselect` (largest-first VTXO selection), `metrics` (optional `OORTransferReceivedMsg` sink), `ledger` (`Sink` type for compatibility with manager wiring), `unroll` (via `ExitOutcomeResolver` callback wired by `waved`).
-- **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `waved` (wiring, owned-script adapters, incoming event route, and `CheckForfeitAdmission` for the leave filter and exit-plan advisory), `sdk/swaps` (forfeit sign-request conversion).
+- **Depended on by**: `round` (triggers forfeit requests), `oor` (incoming VTXOs), `wallet` (admission gating), `db` (persistence), `waved` (wiring, owned-script adapters, incoming event route, `CheckForfeitAdmission` for the leave filter and exit-plan advisory, and `assessAutomaticCriticalExit` supplying `CriticalExitAssessor`), `sdk/swaps` (forfeit sign-request conversion).
 - **Sends**:
   - → `round` (via manager relay): `RelayToRoundMsg` wrapping `ForfeitSignatureSubmission`
   - → `db` (via outbox): `VTXOStatusUpdate`
@@ -162,6 +173,30 @@ when the local wallet owns the receive script.
 - When the cached boundary fires, auto-refresh fetches fresh operator terms
   before reserving the VTXO. A later still-safe boundary leaves the VTXO live;
   a disabled or unsafe-late window preserves the ordinary paid refresh path.
+- **Critical expiry means "the unilateral time budget is now active", not
+  "exit now".** `ExpiryStatusCritical` used to escalate a `LiveState` or
+  `PendingForfeitState` VTXO straight to `UnilateralExitState`. It no longer
+  does unconditionally: `VTXOActor.preflightCriticalExit` intercepts the
+  `BlockEpochEvent` and consults `CriticalExitAssessor` first. An explicitly
+  infeasible verdict (the wallet cannot fund the exit package at the current
+  fee rate) is rewritten into the actor-local `criticalRefreshEvent`, which
+  starts cooperative refresh in `LiveState` and keeps `PendingForfeitState`
+  waiting on its in-flight round. Entering an exit the wallet cannot pay for
+  would abandon a still-available cooperative round for a recovery that cannot
+  make progress. `waverpc`'s `VTXO_EXPIRY_STATUS_CRITICAL` comment carries the
+  same weakened meaning; do not re-document it as an exit trigger.
+- **The viability preflight fails open, and re-runs every block.** A nil
+  `CriticalExitAssessor`, an assessor error, and a feasible verdict all leave
+  the `BlockEpochEvent` untouched, preserving the direct unilateral-exit
+  transition — an unavailable assessment must never suppress the safety path
+  (the error case logs at `Warn` precisely because it degrades a safety
+  decision). Because the check is redone on each block rather than latched into
+  a state, funding the wallet restores the unilateral path with no extra state
+  transition, and a permanently unfundable VTXO keeps retrying cooperative
+  refresh instead of spinning on an exit that cannot land.
+- `criticalRefreshEvent` is **actor-local** and deliberately unexported: it is
+  synthesized by the actor's own preflight, never sent across a package
+  boundary. External block notifications remain `BlockEpochEvent`.
 - Once ForfeitedState is reached, the old VTXO is unspendable; the new VTXO is available only after round confirmation.
 - SpendingState is persisted as VTXOStatusSpending and survives restarts.
 - OOR completion transitions VTXOs to SpentState through the VTXO actor FSM, not by direct store writes.


### PR DESCRIPTION
Automated nightly documentation sweep via `.claude/skills/doc-gardening`.

Workflow run: https://github.com/lightninglabs/wavelength/actions

This sweep documents behavioral changes merged since the last sweep that did
not carry their own per-package docs:

- **`vtxo`** — `CriticalExitAssessor` / `CriticalExitAssessment`, and the new
  meaning of `ExpiryStatusCritical` (viability preflight before unilateral
  exit, fails open, re-runs every block).
- **`round`** — arm the reconciliation timeout before fallible outbox effects;
  exactly one commitment confirmation watch per round.
- **`serverconn`** — mailbox pull failures warn once per outage episode.
- **`chainbackends`** — a `Canceled` status is only shutdown noise when the
  owning context is also done.
- **`chainfees`** — provider-failure vs. clamped-rate log severity contract.
- **`txconfirm`** — `ErrParentAlreadyBroadcast` is a race outcome, not a
  failure.

Please review the updated `CLAUDE.md` / `AGENTS.md` diffs. No new packages or
`docs/` files were added, so `ARCHITECTURE.md` and `docs/index.md` are
unchanged. `make doc-check` passes.

Note for maintainers: the baseline query in the nightly workflow selects the
last merge commit whose message matches `^docs: nightly doc-gardening sweep`.
The 2026-08-24 and 2026-08-27 sweep merges have empty commit bodies, so they do
not match, and this run's baseline fell back to 2026-08-21. The wider window is
harmless here, but the query will keep skipping body-less merges.
