### PR TITLE
rpc: add scoped macaroon baking

### DIFF
--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -14,8 +14,9 @@ default `--help` face:
 1. **Wallet verbs (group "Wallet", implicit, no parent)** — the everyday
    commands that map 1:1 to what a user does day-to-day. All are
    wavewalletrpc-backed.
-2. **Daemon introspection (group "Introspection")** — getinfo, schema, mcp
-   (the built-in `help` command is grouped here too).
+2. **Daemon introspection (group "Introspection")** — getinfo,
+   bakemacaroon, schema, mcp (the built-in `help` command is grouped here
+   too).
 3. **Advanced subtrees (`ark`, `dev`, `recovery`)** — raw
    waverpc/devrpc commands for power users and operator runbooks.
    Hidden from the default `--help` via cobra `Hidden` (not a build tag),
@@ -52,7 +53,8 @@ unchanged).
 | Command | RPC | Description |
 |---------|-----|-------------|
 | `getinfo` | `waverpc.GetInfo` | Daemon readiness, version, network, wallet state |
-| `schema` | (local) | JSON method registry — single source of truth for CLI commands and MCP tools |
+| `bakemacaroon` | `waverpc.BakeMacaroon` | Provision a scoped credential from known entity/action or exact URI permissions |
+| `schema` | (local) | JSON method registry for curated wallet/ark CLI commands and MCP tools |
 | `mcp` | (local) | MCP server exposing the schema as tools |
 
 ### `ark.*` advanced commands
@@ -109,7 +111,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
 - `snakeToKebabFlags()` — global flag normalizer: help and schemas use
   kebab-case while snake_case remains a silent compatibility alias.
 - `methodRegistry()` / `schemaMethod` / `schemaParam` —
-  machine-readable schema for all CLI commands; shared source of
+  machine-readable schema for curated wallet/ark commands; shared source of
   truth for `schema` and MCP tool definitions. Built from the
   `walletAdmin`/`walletPayment`/`walletQuery`/`arkBase`/`arkVTXO`/
   `arkSend`/`arkObservable` sub-registries. MCP-only methods use

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -14,8 +14,9 @@ default `--help` face:
 1. **Wallet verbs (group "Wallet", implicit, no parent)** — the everyday
    commands that map 1:1 to what a user does day-to-day. All are
    wavewalletrpc-backed.
-2. **Daemon introspection (group "Introspection")** — getinfo, schema, mcp
-   (the built-in `help` command is grouped here too).
+2. **Daemon introspection (group "Introspection")** — getinfo,
+   bakemacaroon, schema, mcp (the built-in `help` command is grouped here
+   too).
 3. **Advanced subtrees (`ark`, `dev`, `recovery`)** — raw
    waverpc/devrpc commands for power users and operator runbooks.
    Hidden from the default `--help` via cobra `Hidden` (not a build tag),
@@ -52,7 +53,8 @@ unchanged).
 | Command | RPC | Description |
 |---------|-----|-------------|
 | `getinfo` | `waverpc.GetInfo` | Daemon readiness, version, network, wallet state |
-| `schema` | (local) | JSON method registry — single source of truth for CLI commands and MCP tools |
+| `bakemacaroon` | `waverpc.BakeMacaroon` | Provision a scoped credential from known entity/action or exact URI permissions |
+| `schema` | (local) | JSON method registry for curated wallet/ark CLI commands and MCP tools |
 | `mcp` | (local) | MCP server exposing the schema as tools |
 
 ### `ark.*` advanced commands
@@ -109,7 +111,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
 - `snakeToKebabFlags()` — global flag normalizer: help and schemas use
   kebab-case while snake_case remains a silent compatibility alias.
 - `methodRegistry()` / `schemaMethod` / `schemaParam` —
-  machine-readable schema for all CLI commands; shared source of
+  machine-readable schema for curated wallet/ark commands; shared source of
   truth for `schema` and MCP tool definitions. Built from the
   `walletAdmin`/`walletPayment`/`walletQuery`/`arkBase`/`arkVTXO`/
   `arkSend`/`arkObservable` sub-registries. MCP-only methods use

--- a/cmd/wavecli/waveclicommands/client.go
+++ b/cmd/wavecli/waveclicommands/client.go
@@ -104,6 +104,10 @@ func getDaemonConn(cmd *cobra.Command) (*grpc.ClientConn, error) {
 // overrides it.
 var getDaemonClient = defaultGetDaemonClient
 
+// getMacaroonClient is package-level indirection for command-wiring tests.
+// Production code uses defaultGetMacaroonClient.
+var getMacaroonClient = defaultGetMacaroonClient
+
 // defaultGetDaemonClient dials the daemon from the command's connection
 // flags.
 func defaultGetDaemonClient(cmd *cobra.Command) (waverpc.DaemonServiceClient,
@@ -115,6 +119,20 @@ func defaultGetDaemonClient(cmd *cobra.Command) (waverpc.DaemonServiceClient,
 	}
 
 	client := waverpc.NewDaemonServiceClient(conn)
+
+	return client, conn, nil
+}
+
+// defaultGetMacaroonClient dials the daemon's local credential service.
+func defaultGetMacaroonClient(cmd *cobra.Command) (
+	waverpc.MacaroonServiceClient, *grpc.ClientConn, error) {
+
+	conn, err := getDaemonConn(cmd)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client := waverpc.NewMacaroonServiceClient(conn)
 
 	return client, conn, nil
 }

--- a/cmd/wavecli/waveclicommands/cmd_macaroon.go
+++ b/cmd/wavecli/waveclicommands/cmd_macaroon.go
@@ -1,0 +1,274 @@
+package waveclicommands
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/macaroons"
+	"github.com/spf13/cobra"
+	"gopkg.in/macaroon.v2"
+)
+
+// bakedMacaroonResult is the command result. A saved macaroon reports only its
+// path so the credential is not also copied into terminal history.
+type bakedMacaroonResult struct {
+	Macaroon string `json:"macaroon,omitempty"`
+	Path     string `json:"path,omitempty"`
+}
+
+// newBakeMacaroonCmd creates the scoped macaroon baking command.
+func newBakeMacaroonCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bakemacaroon <entity:action>...",
+		Short: "Bake a scoped daemon macaroon",
+		Long: "Bakes a daemon macaroon with known entity/action " +
+			"permissions or exact " +
+			"uri:/package.Service/Method scopes. " +
+			"For example: wavecli bakemacaroon " +
+			"uri:/waverpc.DaemonService/GetInfo.",
+		RunE: bakeMacaroon,
+	}
+
+	cmd.Flags().String(
+		"save-to", "", "save the binary macaroon to this path",
+	)
+	cmd.Flags().Uint64(
+		"root-key-id", 0, "numeric macaroon root key ID",
+	)
+	cmd.Flags().Uint64(
+		"valid-for", 0, "validity in seconds (zero means no expiry)",
+	)
+
+	return cmd
+}
+
+// bakeMacaroon validates CLI permission tuples and calls the daemon baker.
+func bakeMacaroon(cmd *cobra.Command, args []string) error {
+	rawJSON, err := cmd.Flags().GetString("request-json")
+	if err != nil {
+		return err
+	}
+	if rawJSON != "" {
+		switch {
+		case len(args) != 0:
+			return invalidArgs(
+				fmt.Errorf("positional permissions cannot " +
+					"be combined with --request-json"),
+			)
+
+		case cmd.Flags().Changed("root-key-id"):
+			return invalidArgs(
+				fmt.Errorf("--root-key-id cannot be " +
+					"combined with --request-json; set " +
+					"rootKeyId in JSON"),
+			)
+		}
+	}
+
+	req := &waverpc.BakeMacaroonRequest{}
+	err = parseRequest(cmd, req, func() error {
+		if len(args) == 0 {
+			return invalidArgs(
+				fmt.Errorf("specify at least one " +
+					"entity:action permission"),
+			)
+		}
+
+		permissions, err := parseMacaroonPermissions(args)
+		if err != nil {
+			return invalidArgs(err)
+		}
+
+		rootKeyID, err := cmd.Flags().GetUint64("root-key-id")
+		if err != nil {
+			return err
+		}
+
+		req.Permissions = permissions
+		req.RootKeyId = rootKeyID
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	outputPath, outputFile, err := openMacaroonOutput(cmd)
+	if err != nil {
+		return err
+	}
+	keepOutput := false
+	if outputFile != nil {
+		defer func() {
+			if keepOutput {
+				return
+			}
+
+			_ = outputFile.Close()
+			_ = os.Remove(outputPath)
+		}()
+	}
+
+	client, conn, err := getMacaroonClient(cmd)
+	if err != nil {
+		return err
+	}
+	if conn != nil {
+		defer func() {
+			_ = conn.Close()
+		}()
+	}
+
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.BakeMacaroon(ctx, req)
+	if err != nil {
+		return fmt.Errorf("BakeMacaroon RPC failed: %w", err)
+	}
+
+	macBytes, macHex, err := constrainBakedMacaroon(
+		cmd, resp.GetMacaroon(),
+	)
+	if err != nil {
+		return err
+	}
+
+	result := bakedMacaroonResult{
+		Macaroon: macHex,
+	}
+	if outputFile != nil {
+		if _, err := outputFile.Write(macBytes); err != nil {
+			return fmt.Errorf("write baked macaroon: %w", err)
+		}
+		if err := outputFile.Close(); err != nil {
+			return fmt.Errorf("close baked macaroon: %w", err)
+		}
+		keepOutput = true
+
+		result.Macaroon = ""
+		result.Path = outputPath
+	}
+
+	return printBakedMacaroonResult(cmd, result)
+}
+
+// openMacaroonOutput reserves a new private output file before an RPC can
+// mint a credential. Exclusive creation prevents accidental replacement of an
+// existing file or symlink.
+func openMacaroonOutput(cmd *cobra.Command) (string, *os.File, error) {
+	savePath, err := cmd.Flags().GetString("save-to")
+	if err != nil {
+		return "", nil, err
+	}
+	if savePath == "" {
+		return "", nil, nil
+	}
+
+	expandedPath, err := expandCLIPath(savePath)
+	if err != nil {
+		return "", nil, err
+	}
+
+	//nolint:gosec // G304: the destination is supplied by the CLI user.
+	file, err := os.OpenFile(
+		expandedPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600,
+	)
+	if err != nil {
+		return "", nil, fmt.Errorf("create baked macaroon: %w", err)
+	}
+
+	return expandedPath, file, nil
+}
+
+// constrainBakedMacaroon validates the daemon response and applies optional
+// client-side restrictions before the credential is displayed or saved.
+func constrainBakedMacaroon(cmd *cobra.Command, macHex string) ([]byte, string,
+	error) {
+
+	macBytes, err := hex.DecodeString(macHex)
+	if err != nil {
+		return nil, "", fmt.Errorf("decode baked macaroon: %w", err)
+	}
+	if len(macBytes) == 0 {
+		return nil, "", fmt.Errorf("daemon returned an empty macaroon")
+	}
+
+	rawMacaroon := &macaroon.Macaroon{}
+	if err := rawMacaroon.UnmarshalBinary(macBytes); err != nil {
+		return nil, "", fmt.Errorf("decode baked macaroon: %w", err)
+	}
+
+	validFor, err := cmd.Flags().GetUint64("valid-for")
+	if err != nil {
+		return nil, "", err
+	}
+	if validFor > math.MaxInt64 {
+		return nil, "", invalidArgs(
+			fmt.Errorf(
+				"--valid-for exceeds %d", int64(math.MaxInt64),
+			),
+		)
+	}
+	if validFor != 0 {
+		rawMacaroon, err = macaroons.AddConstraints(
+			rawMacaroon,
+			macaroons.TimeoutConstraint(
+				int64(validFor),
+			),
+		)
+		if err != nil {
+			return nil, "", fmt.Errorf("constrain baked "+
+				"macaroon: %w", err)
+		}
+
+		macBytes, err = rawMacaroon.MarshalBinary()
+		if err != nil {
+			return nil, "", fmt.Errorf("encode baked macaroon: %w",
+				err)
+		}
+	}
+
+	return macBytes, hex.EncodeToString(macBytes), nil
+}
+
+// parseMacaroonPermissions parses entity:action tuples without splitting URI
+// actions on their path separators.
+func parseMacaroonPermissions(args []string) ([]*waverpc.MacaroonPermission,
+	error) {
+
+	permissions := make([]*waverpc.MacaroonPermission, 0, len(args))
+	for _, arg := range args {
+		entity, action, ok := strings.Cut(arg, ":")
+		if !ok || entity == "" || action == "" {
+			return nil, fmt.Errorf("invalid permission %q: "+
+				"expected entity:action", arg)
+		}
+
+		permissions = append(permissions, &waverpc.MacaroonPermission{
+			Entity: entity,
+			Action: action,
+		})
+	}
+
+	return permissions, nil
+}
+
+// printBakedMacaroonResult writes the stable JSON command result.
+func printBakedMacaroonResult(cmd *cobra.Command,
+	result bakedMacaroonResult) error {
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal macaroon result: %w", err)
+	}
+
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+
+	return err
+}

--- a/cmd/wavecli/waveclicommands/cmd_macaroon_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_macaroon_test.go
@@ -1,0 +1,355 @@
+package waveclicommands
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/macaroons"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon.v2"
+)
+
+type macaroonClientStub struct {
+	bake func(*waverpc.BakeMacaroonRequest) *waverpc.BakeMacaroonResponse
+}
+
+// BakeMacaroon records and serves a test bake request.
+func (s *macaroonClientStub) BakeMacaroon(_ context.Context,
+	req *waverpc.BakeMacaroonRequest, _ ...grpc.CallOption) (
+	*waverpc.BakeMacaroonResponse, error) {
+
+	return s.bake(req), nil
+}
+
+// ListPermissions fulfills the generated client interface for CLI tests.
+func (*macaroonClientStub) ListPermissions(context.Context,
+	*waverpc.ListPermissionsRequest, ...grpc.CallOption) (
+	*waverpc.ListPermissionsResponse, error) {
+
+	return &waverpc.ListPermissionsResponse{}, nil
+}
+
+// TestParseMacaroonPermissions verifies exact URI actions retain their full
+// method path while malformed tuples fail locally.
+func TestParseMacaroonPermissions(t *testing.T) {
+	t.Parallel()
+
+	permissions, err := parseMacaroonPermissions([]string{
+		"info:read", "uri:/waverpc.DaemonService/GetInfo",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []*waverpc.MacaroonPermission{
+		{
+			Entity: "info",
+			Action: "read",
+		},
+		{
+			Entity: "uri",
+			Action: "/waverpc.DaemonService/GetInfo",
+		},
+	}, permissions)
+
+	for _, arg := range []string{"info", ":read", "info:"} {
+		_, err := parseMacaroonPermissions([]string{arg})
+		require.Error(t, err, arg)
+	}
+}
+
+// TestBakeMacaroonCommand verifies the CLI forwards the requested root key
+// and scopes, then emits the returned credential as JSON.
+func TestBakeMacaroonCommand(t *testing.T) {
+	macHex := testMacaroonHex(t)
+	var captured *waverpc.BakeMacaroonRequest
+	stub := &macaroonClientStub{
+		bake: func(
+			req *waverpc.BakeMacaroonRequest,
+		) *waverpc.BakeMacaroonResponse {
+
+			captured = req
+
+			return &waverpc.BakeMacaroonResponse{
+				Macaroon: macHex,
+			}
+		},
+	}
+	useMacaroonClientStub(t, stub)
+
+	root := newRootCmd(false)
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{
+		"bakemacaroon", "--root-key-id", "7", "info:read",
+		"uri:/waverpc.DaemonService/GetInfo",
+	})
+	require.NoError(t, root.Execute())
+
+	require.Equal(t, uint64(7), captured.GetRootKeyId())
+	require.Len(t, captured.GetPermissions(), 2)
+	expected, err := json.Marshal(map[string]string{
+		"macaroon": macHex,
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, string(expected), output.String())
+}
+
+// TestBakeMacaroonCommandJSONInput verifies the raw proto request path works
+// without positional permission arguments.
+func TestBakeMacaroonCommandJSONInput(t *testing.T) {
+	macHex := testMacaroonHex(t)
+	var captured *waverpc.BakeMacaroonRequest
+	stub := &macaroonClientStub{
+		bake: func(
+			req *waverpc.BakeMacaroonRequest,
+		) *waverpc.BakeMacaroonResponse {
+
+			captured = req
+
+			return &waverpc.BakeMacaroonResponse{
+				Macaroon: macHex,
+			}
+		},
+	}
+	useMacaroonClientStub(t, stub)
+
+	root := newRootCmd(false)
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"bakemacaroon", "--request-json",
+		`{"permissions":[{"entity":"info","action":"read"}],` +
+			`"rootKeyId":"7"}`,
+	})
+	require.NoError(t, root.Execute())
+
+	require.Equal(t, uint64(7), captured.GetRootKeyId())
+	require.Equal(t, "info", captured.GetPermissions()[0].GetEntity())
+}
+
+// TestBakeMacaroonCommandRejectsMixedJSONInput verifies bespoke request fields
+// cannot be silently ignored when a raw request is supplied.
+func TestBakeMacaroonCommandRejectsMixedJSONInput(t *testing.T) {
+	rawRequest := `{"permissions":[{"entity":"info","action":"read"}]}`
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "positional permission",
+			args: []string{
+				"bakemacaroon", "info:read", "--request-json",
+				rawRequest,
+			},
+		},
+		{
+			name: "root key flag",
+			args: []string{
+				"bakemacaroon", "--root-key-id", "7",
+				"--request-json", rawRequest,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			called := false
+			stub := &macaroonClientStub{
+				bake: func(
+					*waverpc.BakeMacaroonRequest,
+				) *waverpc.BakeMacaroonResponse {
+
+					called = true
+
+					return &waverpc.BakeMacaroonResponse{}
+				},
+			}
+			useMacaroonClientStub(t, stub)
+
+			root := newRootCmd(false)
+			root.SetArgs(testCase.args)
+			err := root.Execute()
+			require.Error(t, err)
+			require.False(t, called)
+		})
+	}
+}
+
+// TestBakeMacaroonCommandSavesBinary verifies --save-to writes the decoded
+// credential with private permissions and does not repeat it in JSON output.
+func TestBakeMacaroonCommandSavesBinary(t *testing.T) {
+	macHex := testMacaroonHex(t)
+	stub := &macaroonClientStub{
+		bake: func(
+			*waverpc.BakeMacaroonRequest,
+		) *waverpc.BakeMacaroonResponse {
+
+			return &waverpc.BakeMacaroonResponse{
+				Macaroon: macHex,
+			}
+		},
+	}
+	useMacaroonClientStub(t, stub)
+
+	macaroonPath := filepath.Join(t.TempDir(), "payment.macaroon")
+	root := newRootCmd(false)
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{
+		"bakemacaroon", "--save-to", macaroonPath, "info:read",
+	})
+	require.NoError(t, root.Execute())
+
+	contents, err := os.ReadFile(macaroonPath)
+	require.NoError(t, err)
+	expectedContents, err := hex.DecodeString(macHex)
+	require.NoError(t, err)
+	require.Equal(t, expectedContents, contents)
+
+	info, err := os.Stat(macaroonPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	expected, err := json.Marshal(map[string]string{
+		"path": macaroonPath,
+	})
+	require.NoError(t, err)
+	require.JSONEq(
+		t, string(expected), output.String(),
+	)
+}
+
+// TestBakeMacaroonCommandRefusesExistingFile verifies a bad destination is
+// rejected before the daemon mints a new credential.
+func TestBakeMacaroonCommandRefusesExistingFile(t *testing.T) {
+	called := false
+	stub := &macaroonClientStub{
+		bake: func(
+			*waverpc.BakeMacaroonRequest,
+		) *waverpc.BakeMacaroonResponse {
+
+			called = true
+
+			return &waverpc.BakeMacaroonResponse{
+				Macaroon: testMacaroonHex(t),
+			}
+		},
+	}
+	useMacaroonClientStub(t, stub)
+
+	macaroonPath := filepath.Join(t.TempDir(), "payment.macaroon")
+	require.NoError(t, os.WriteFile(macaroonPath, []byte("keep"), 0o644))
+
+	root := newRootCmd(false)
+	root.SetArgs([]string{
+		"bakemacaroon", "--save-to", macaroonPath, "info:read",
+	})
+	err := root.Execute()
+	require.Error(t, err)
+	require.False(t, called)
+
+	contents, readErr := os.ReadFile(macaroonPath)
+	require.NoError(t, readErr)
+	require.Equal(t, []byte("keep"), contents)
+}
+
+// TestBakeMacaroonCommandRemovesEmptyOutput verifies a malformed daemon
+// response does not leave a credential-shaped file behind.
+func TestBakeMacaroonCommandRemovesEmptyOutput(t *testing.T) {
+	stub := &macaroonClientStub{
+		bake: func(
+			*waverpc.BakeMacaroonRequest,
+		) *waverpc.BakeMacaroonResponse {
+
+			return &waverpc.BakeMacaroonResponse{}
+		},
+	}
+	useMacaroonClientStub(t, stub)
+
+	macaroonPath := filepath.Join(t.TempDir(), "payment.macaroon")
+	root := newRootCmd(false)
+	root.SetArgs([]string{
+		"bakemacaroon", "--save-to", macaroonPath, "info:read",
+	})
+	err := root.Execute()
+	require.ErrorContains(t, err, "empty macaroon")
+	require.NoFileExists(t, macaroonPath)
+}
+
+// TestBakeMacaroonCommandAddsExpiry verifies the client can attenuate a
+// daemon-baked credential with a standard time-before caveat.
+func TestBakeMacaroonCommandAddsExpiry(t *testing.T) {
+	stub := &macaroonClientStub{
+		bake: func(
+			*waverpc.BakeMacaroonRequest,
+		) *waverpc.BakeMacaroonResponse {
+
+			return &waverpc.BakeMacaroonResponse{
+				Macaroon: testMacaroonHex(t),
+			}
+		},
+	}
+	useMacaroonClientStub(t, stub)
+
+	root := newRootCmd(false)
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{
+		"bakemacaroon", "--valid-for", "60", "info:read",
+	})
+	require.NoError(t, root.Execute())
+
+	var result bakedMacaroonResult
+	require.NoError(t, json.Unmarshal(output.Bytes(), &result))
+	macBytes, err := hex.DecodeString(result.Macaroon)
+	require.NoError(t, err)
+	rawMacaroon := &macaroon.Macaroon{}
+	require.NoError(t, rawMacaroon.UnmarshalBinary(macBytes))
+	require.Len(t, rawMacaroon.Caveats(), 1)
+	require.True(
+		t,
+		strings.HasPrefix(
+			string(rawMacaroon.Caveats()[0].Id),
+			"time-before ",
+		),
+	)
+}
+
+// testMacaroonHex returns a valid macaroon for command output tests.
+func testMacaroonHex(t *testing.T) string {
+	t.Helper()
+
+	rootKey := bytes.Repeat([]byte{1}, macaroons.RootKeyLen)
+	rawMacaroon, err := macaroons.BakeFromRootKey(
+		rootKey, []bakery.Op{{
+			Entity: "info",
+			Action: "read",
+		}},
+	)
+	require.NoError(t, err)
+
+	macBytes, err := rawMacaroon.MarshalBinary()
+	require.NoError(t, err)
+
+	return hex.EncodeToString(macBytes)
+}
+
+// useMacaroonClientStub installs a test client for one non-parallel test.
+func useMacaroonClientStub(t *testing.T, stub waverpc.MacaroonServiceClient) {
+	t.Helper()
+	previous := getMacaroonClient
+	getMacaroonClient = func(*cobra.Command) (waverpc.MacaroonServiceClient,
+		*grpc.ClientConn, error) {
+
+		return stub, nil, nil
+	}
+	t.Cleanup(func() {
+		getMacaroonClient = previous
+	})
+}

--- a/cmd/wavecli/waveclicommands/root.go
+++ b/cmd/wavecli/waveclicommands/root.go
@@ -143,7 +143,8 @@ func newRootCmd(devMode bool) *cobra.Command {
 
 	// Daemon introspection at root.
 	introspectionCmds := []*cobra.Command{
-		newGetInfoCmd(), newSchemaCmd(), newMCPCmd(),
+		newGetInfoCmd(), newBakeMacaroonCmd(), newSchemaCmd(),
+		newMCPCmd(),
 	}
 	for _, c := range introspectionCmds {
 		c.GroupID = groupIntrospection

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -258,6 +258,39 @@ otherwise `wavecli` looks under `~/.waved/data/mainnet/` and fails with
 wavecli --network=signet --datadir=~/.waved-signet getinfo
 ```
 
+The daemon also writes `readonly.macaroon` beside the admin credential. Use
+the admin macaroon only for administration and provisioning. An admin client
+can create a least-privilege credential with `wavecli bakemacaroon`; the
+command accepts either a known `entity:action` permission or an exact
+`uri:/package.Service/Method` grant. Exact URI grants are useful when one
+method shares a broader write permission with unrelated operations.
+
+For example, this payment credential can inspect balances and activity and
+spend through the two-phase send flow, including a full-balance on-chain send.
+It cannot call Deposit, SweepWallet, Exit, wallet-signing, recovery, or
+administrative RPCs:
+
+```bash
+wavecli bakemacaroon \
+  --save-to ~/.waved/payment.macaroon \
+  --valid-for 3600 \
+  uri:/wavewalletrpc.WalletService/Balance \
+  uri:/wavewalletrpc.WalletService/List \
+  uri:/wavewalletrpc.WalletService/PrepareSend \
+  uri:/wavewalletrpc.WalletService/Send \
+  uri:/wavewalletrpc.WalletInspectionService/InspectActivity
+```
+
+The saved file contains the binary macaroon with mode `0600`. Point the
+integration at it with `--macaroonpath ~/.waved/payment.macaroon`. Omitting
+`--save-to` prints the hex-encoded macaroon as JSON. `BakeMacaroon` requires
+the admin-only `macaroon:generate` permission. A credential carrying that
+permission, or the exact BakeMacaroon URI, can mint any supported permission
+and must also be treated as an admin credential. Root key ID `0` uses the
+same default root key as `admin.macaroon` and `readonly.macaroon`.
+`ListPermissions` exposes the active RPC-to-permission map to authenticated
+clients.
+
 A macaroon cannot ride an unencrypted connection, so `--no-tls` and the
 macaroon are mutually exclusive. There are two working modes:
 
@@ -295,6 +328,7 @@ verbs is unchanged.
 ```
 wavecli
 ├── getinfo                   — daemon status (no wavewalletrpc)
+├── bakemacaroon              — provision a scoped daemon credential
 ├── balance                   — wallet balances (wavewalletrpc)
 ├── create / unlock           — wallet bring-up (wavewalletrpc)
 ├── recv                      — boarding address / Lightning invoice (wavewalletrpc)
@@ -352,6 +386,23 @@ Display daemon status information.
 
 ```bash
 wavecli getinfo
+```
+
+### `bakemacaroon`
+
+Bake a daemon macaroon from one or more known `entity:action` or exact
+`uri:/package.Service/Method` permissions. The caller must authenticate with
+a credential authorized to call `BakeMacaroon`.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--save-to` | string | Write the binary macaroon to this path with mode `0600` |
+| `--root-key-id` | uint64 | Numeric macaroon root key ID (default `0`) |
+| `--valid-for` | uint64 | Add an expiry caveat for this many seconds; `0` does not expire |
+
+```bash
+wavecli bakemacaroon --save-to ./info.macaroon --valid-for 3600 info:read
+wavecli bakemacaroon uri:/waverpc.DaemonService/GetInfo
 ```
 
 ### `balance` (wavewalletrpc) / `dev daemon GetBalance` (no wavewalletrpc)

--- a/sample-waved.conf
+++ b/sample-waved.conf
@@ -174,7 +174,8 @@
 
 # Path to the daemon RPC admin macaroon. Empty auto-generates one in the data
 # dir. A read-only macaroon (readonly.macaroon), scoped to query methods only,
-# is baked alongside it in the same directory.
+# is baked alongside it in the same directory. The admin macaroon can provision
+# additional scoped credentials through BakeMacaroon or wavecli bakemacaroon.
 # rpc.macaroonpath=
 
 # Disable daemon RPC macaroon authentication. Intended for development only.

--- a/systest/scoped_macaroon_test.go
+++ b/systest/scoped_macaroon_test.go
@@ -1,0 +1,248 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	btcwalletrpc "github.com/btcsuite/btcwallet/rpc/walletrpc"
+	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
+	"github.com/lightninglabs/wavelength/waved"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/macaroons"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// scopedMacaroonWalletServer provides successful handlers behind the real
+// waved authentication interceptor. The test is about the daemon's RPC
+// boundary, not the wallet business logic exercised by other systests.
+type scopedMacaroonWalletServer struct {
+	wavewalletrpc.UnimplementedWalletServiceServer
+	wavewalletrpc.UnimplementedWalletInspectionServiceServer
+}
+
+// Balance returns a successful empty response after authorization.
+func (*scopedMacaroonWalletServer) Balance(context.Context,
+	*wavewalletrpc.BalanceRequest) (*wavewalletrpc.BalanceResponse, error) {
+
+	return &wavewalletrpc.BalanceResponse{}, nil
+}
+
+// List returns a successful empty response after authorization.
+func (*scopedMacaroonWalletServer) List(context.Context,
+	*wavewalletrpc.ListRequest) (*wavewalletrpc.ListResponse, error) {
+
+	return &wavewalletrpc.ListResponse{}, nil
+}
+
+// PrepareSend returns a successful empty response after authorization.
+func (*scopedMacaroonWalletServer) PrepareSend(context.Context,
+	*wavewalletrpc.PrepareSendRequest) (*wavewalletrpc.PrepareSendResponse,
+	error) {
+
+	return &wavewalletrpc.PrepareSendResponse{}, nil
+}
+
+// Send returns a successful empty response after authorization.
+func (*scopedMacaroonWalletServer) Send(context.Context,
+	*wavewalletrpc.SendRequest) (*wavewalletrpc.SendResponse, error) {
+
+	return &wavewalletrpc.SendResponse{}, nil
+}
+
+// InspectActivity returns a successful empty response after authorization.
+func (*scopedMacaroonWalletServer) InspectActivity(context.Context,
+	*wavewalletrpc.InspectActivityRequest) (
+	*wavewalletrpc.InspectActivityResponse, error) {
+
+	return &wavewalletrpc.InspectActivityResponse{}, nil
+}
+
+// Deposit returns a successful empty response if authorization lets it run.
+func (*scopedMacaroonWalletServer) Deposit(context.Context,
+	*wavewalletrpc.DepositRequest) (*wavewalletrpc.DepositResponse, error) {
+
+	return &wavewalletrpc.DepositResponse{}, nil
+}
+
+// SweepWallet returns a successful empty response if authorization permits.
+func (*scopedMacaroonWalletServer) SweepWallet(context.Context,
+	*wavewalletrpc.SweepWalletRequest) (*wavewalletrpc.SweepWalletResponse,
+	error) {
+
+	return &wavewalletrpc.SweepWalletResponse{}, nil
+}
+
+// Exit returns a successful empty response if authorization permits.
+func (*scopedMacaroonWalletServer) Exit(context.Context,
+	*wavewalletrpc.ExitRequest) (*wavewalletrpc.ExitResponse, error) {
+
+	return &wavewalletrpc.ExitResponse{}, nil
+}
+
+// TestScopedPaymentMacaroon verifies a credential baked by the running daemon
+// can use only the exact payment workflow methods requested by the caller.
+func TestScopedPaymentMacaroon(t *testing.T) {
+	walletServer := &scopedMacaroonWalletServer{}
+	fixture := newDirectedSendFixture(t, func(cfg *waved.Config) {
+		cfg.RPC.NoTLS = false
+		cfg.RPC.NoMacaroons = false
+		securityDir := filepath.Join(
+			cfg.DataDir, "data", cfg.Network,
+		)
+		cfg.RPC.TLSCertPath = filepath.Join(securityDir, "tls.cert")
+		cfg.RPC.TLSKeyPath = filepath.Join(securityDir, "tls.key")
+		cfg.RPC.MacaroonPath = filepath.Join(
+			securityDir, "admin.macaroon",
+		)
+		cfg.RPCServiceRegistrars = append(
+			cfg.RPCServiceRegistrars,
+			func(_ context.Context, grpcServer *grpc.Server,
+				_ *waved.RPCServer, _ *waved.Config) (func(),
+				error) {
+
+				wavewalletrpc.RegisterWalletServiceServer(
+					grpcServer, walletServer,
+				)
+				registerInspection := wavewalletrpc.
+					RegisterWalletInspectionServiceServer
+				registerInspection(grpcServer, walletServer)
+
+				return nil, nil
+			},
+		)
+	})
+
+	adminClient := waverpc.NewMacaroonServiceClient(fixture.conn)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	permissionResp, err := adminClient.ListPermissions(
+		ctx, &waverpc.ListPermissionsRequest{},
+	)
+	require.NoError(t, err)
+
+	allowedMethods := []string{
+		wavewalletrpc.WalletService_Balance_FullMethodName,
+		wavewalletrpc.WalletService_List_FullMethodName,
+		wavewalletrpc.WalletService_PrepareSend_FullMethodName,
+		wavewalletrpc.WalletService_Send_FullMethodName,
+		wavewalletrpc.
+			WalletInspectionService_InspectActivity_FullMethodName,
+	}
+	permissions := make(
+		[]*waverpc.MacaroonPermission, 0, len(allowedMethods),
+	)
+	for _, fullMethod := range allowedMethods {
+		require.Contains(
+			t, permissionResp.GetMethodPermissions(), fullMethod,
+		)
+		permissions = append(permissions, &waverpc.MacaroonPermission{
+			Entity: macaroons.PermissionEntityCustomURI,
+			Action: fullMethod,
+		})
+	}
+
+	bakeResp, err := adminClient.BakeMacaroon(
+		ctx, &waverpc.BakeMacaroonRequest{
+			Permissions: permissions,
+		},
+	)
+	require.NoError(t, err)
+
+	macBytes, err := hex.DecodeString(bakeResp.GetMacaroon())
+	require.NoError(t, err)
+	macaroonPath := filepath.Join(t.TempDir(), "payment.macaroon")
+	require.NoError(t, os.WriteFile(macaroonPath, macBytes, 0o600))
+
+	paymentConn, err := fixture.dial(macaroonPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, paymentConn.Close())
+	})
+
+	walletClient := wavewalletrpc.NewWalletServiceClient(paymentConn)
+	inspectionClient :=
+		wavewalletrpc.NewWalletInspectionServiceClient(paymentConn)
+
+	_, err = walletClient.Balance(ctx, &wavewalletrpc.BalanceRequest{})
+	require.NoError(t, err)
+	_, err = walletClient.List(ctx, &wavewalletrpc.ListRequest{})
+	require.NoError(t, err)
+	_, err = walletClient.PrepareSend(
+		ctx, &wavewalletrpc.PrepareSendRequest{},
+	)
+	require.NoError(t, err)
+	_, err = walletClient.Send(ctx, &wavewalletrpc.SendRequest{})
+	require.NoError(t, err)
+	_, err = inspectionClient.InspectActivity(
+		ctx, &wavewalletrpc.InspectActivityRequest{},
+	)
+	require.NoError(t, err)
+
+	btcwalletClient := btcwalletrpc.NewWalletServiceClient(paymentConn)
+	daemonClient := waverpc.NewDaemonServiceClient(paymentConn)
+	restrictedMacaroonClient :=
+		waverpc.NewMacaroonServiceClient(paymentConn)
+
+	deniedCalls := map[string]func() error{
+		"deposit": func() error {
+			_, err := walletClient.Deposit(
+				ctx, &wavewalletrpc.DepositRequest{},
+			)
+
+			return err
+		},
+		"sweep wallet": func() error {
+			_, err := walletClient.SweepWallet(
+				ctx, &wavewalletrpc.SweepWalletRequest{},
+			)
+
+			return err
+		},
+		"exit": func() error {
+			_, err := walletClient.Exit(
+				ctx, &wavewalletrpc.ExitRequest{},
+			)
+
+			return err
+		},
+		"wallet signing": func() error {
+			_, err := btcwalletClient.SignTransaction(
+				ctx, &btcwalletrpc.SignTransactionRequest{},
+			)
+
+			return err
+		},
+		"recovery": func() error {
+			_, err := daemonClient.ArmVHTLCRecovery(
+				ctx, &waverpc.ArmVHTLCRecoveryRequest{},
+			)
+
+			return err
+		},
+		"administration": func() error {
+			_, err := restrictedMacaroonClient.BakeMacaroon(
+				ctx, &waverpc.BakeMacaroonRequest{
+					Permissions: permissions,
+				},
+			)
+
+			return err
+		},
+	}
+
+	for name, call := range deniedCalls {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "permission denied")
+		})
+	}
+}

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/lightninglabs/wavelength/round"
 	"github.com/lightninglabs/wavelength/rpc/oorpb"
 	"github.com/lightninglabs/wavelength/rpc/roundpb"
+	"github.com/lightninglabs/wavelength/rpcauth"
 	"github.com/lightninglabs/wavelength/serverconn"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightninglabs/wavelength/waved"
@@ -639,18 +640,63 @@ func (f *directedSendFixture) launch() {
 	f.serverCancel = cancel
 	f.serverErrChan = errChan
 
-	conn, err := grpc.NewClient(
-		f.rpcAddr,
-		grpc.WithTransportCredentials(
-			insecure.NewCredentials(),
-		),
-	)
+	conn, err := f.dial(f.cfg.RPC.MacaroonPath)
 	require.NoError(t, err)
 
 	f.conn = conn
 	f.client = waverpc.NewDaemonServiceClient(conn)
 
 	waitForDaemonReady(t, f.client)
+}
+
+// dial connects to the daemon using the fixture's configured transport and
+// the macaroon at macaroonPath when authentication is enabled.
+func (f *directedSendFixture) dial(macaroonPath string) (*grpc.ClientConn,
+	error) {
+
+	var opts []grpc.DialOption
+	if f.cfg.RPC.NoTLS {
+		opts = append(
+			opts,
+			grpc.WithTransportCredentials(
+				insecure.NewCredentials(),
+			),
+		)
+	} else {
+		waitForFixtureFile(f.t, f.cfg.RPC.TLSCertPath)
+
+		creds, err := rpcauth.ClientTLSCredentials(
+			f.cfg.RPC.TLSCertPath,
+		)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	}
+
+	if !f.cfg.RPC.NoMacaroons {
+		waitForFixtureFile(f.t, macaroonPath)
+
+		macaroonOpt, err := rpcauth.DialOptionFromFile(macaroonPath)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, macaroonOpt)
+	}
+
+	return grpc.NewClient(f.rpcAddr, opts...)
+}
+
+// waitForFixtureFile waits for a daemon credential file to be created during
+// asynchronous startup.
+func waitForFixtureFile(t *testing.T, path string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(path)
+
+		return err == nil
+	}, 15*time.Second, 50*time.Millisecond, "file %s", path)
 }
 
 // shutdown stops the currently running daemon and closes its client connection,

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -17,7 +17,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   mailbox auth signature memo, behind `mailboxAuthSigsMu`), and a single
   `clk` (`clock.Clock`) shared by all sub-stores for deterministic time
   injection.
-- `RPCServer` — implements the gRPC `DaemonService`. Most write RPCs
+- `RPCServer` — implements the local gRPC `DaemonService` and
+  `MacaroonService`. Most write RPCs
   (`Board`, `SendVTXO`, `SendOOR`, `SweepBoardingUTXOs`, `SendOnChain`)
   validate input locally then `Ask` the relevant actor; `GetRound` and
   `ListVTXOs` merge live actor state with persisted SQL rows, while

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -17,7 +17,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   mailbox auth signature memo, behind `mailboxAuthSigsMu`), and a single
   `clk` (`clock.Clock`) shared by all sub-stores for deterministic time
   injection.
-- `RPCServer` — implements the gRPC `DaemonService`. Most write RPCs
+- `RPCServer` — implements the local gRPC `DaemonService` and
+  `MacaroonService`. Most write RPCs
   (`Board`, `SendVTXO`, `SendOOR`, `SweepBoardingUTXOs`, `SendOnChain`)
   validate input locally then `Ask` the relevant actor; `GetRound` and
   `ListVTXOs` merge live actor state with persisted SQL rows, while

--- a/waved/gateway_server.go
+++ b/waved/gateway_server.go
@@ -97,6 +97,15 @@ func (g *gatewayServer) Start(ctx context.Context) error {
 
 		return fmt.Errorf("register daemon gateway handlers: %w", err)
 	}
+	if err := waverpc.RegisterMacaroonServiceHandlerFromEndpoint(
+		registerCtx, mux, endpoint, dialOpts,
+	); err != nil {
+
+		cancelRegister()
+		_ = listener.Close()
+
+		return fmt.Errorf("register macaroon gateway handlers: %w", err)
+	}
 
 	for _, registrar := range g.registrars {
 		if err := registrar(

--- a/waved/rpc_auth.go
+++ b/waved/rpc_auth.go
@@ -54,6 +54,9 @@ const (
 	// entityActivity covers the unified ledger, transaction history, and
 	// activity inspection.
 	entityActivity = "activity"
+
+	// entityMacaroon covers privileged daemon credential creation.
+	entityMacaroon = "macaroon"
 )
 
 // wavedEntities is the full set of logical macaroon entities. The read-only
@@ -70,6 +73,7 @@ var wavedEntities = []string{
 	entityRecovery,
 	entityFees,
 	entityActivity,
+	entityMacaroon,
 }
 
 var wavedRPCPermissions = newWavedRPCPermissions()
@@ -92,6 +96,14 @@ func newWavedRPCPermissions() map[string][]bakery.Op {
 			}}
 		}
 	}
+
+	macaroonService := waverpc.MacaroonService_ServiceDesc.ServiceName
+	grant(
+		macaroonService, entityMacaroon, "generate", "BakeMacaroon",
+	)
+	grant(
+		macaroonService, entityInfo, "read", "ListPermissions",
+	)
 
 	daemon := waverpc.DaemonService_ServiceDesc.ServiceName
 	grant(daemon, entityInfo, "read",
@@ -245,22 +257,27 @@ func wavedReadOnlyPermissions() []bakery.Op {
 	return ops
 }
 
-// registeredRPCPermissions maps every registered gRPC method to the macaroon
-// permission it requires.
+// registeredRPCPermissions maps every known registered gRPC method to the
+// macaroon permission it requires and reports the first unprotected method.
 func registeredRPCPermissions(grpcServer *grpc.Server) (map[string][]bakery.Op,
 	error) {
 
 	info := grpcServer.GetServiceInfo()
 	permissions := make(map[string][]bakery.Op)
+	var permissionErr error
 
 	for serviceName, serviceInfo := range info {
 		for _, method := range serviceInfo.Methods {
 			fullMethod := "/" + serviceName + "/" + method.Name
 			ops, ok := wavedRPCPermissions[fullMethod]
 			if !ok {
-				return nil, fmt.Errorf("no macaroon "+
-					"permission registered for %s",
-					fullMethod)
+				if permissionErr == nil {
+					permissionErr = fmt.Errorf("no "+
+						"macaroon permission "+
+						"registered for %s", fullMethod)
+				}
+
+				continue
 			}
 
 			permissions[fullMethod] = append(
@@ -269,5 +286,5 @@ func registeredRPCPermissions(grpcServer *grpc.Server) (map[string][]bakery.Op,
 		}
 	}
 
-	return permissions, nil
+	return permissions, permissionErr
 }

--- a/waved/rpc_auth_test.go
+++ b/waved/rpc_auth_test.go
@@ -24,6 +24,7 @@ func TestWavedRPCPermissionsMapsReadMethods(t *testing.T) {
 		waverpc.DaemonService_WatchRounds_FullMethodName,
 		waverpc.DaemonService_EstimateFee_FullMethodName,
 		waverpc.DaemonService_GetBalance_FullMethodName,
+		waverpc.MacaroonService_ListPermissions_FullMethodName,
 	} {
 		ops, ok := wavedRPCPermissions[fullMethod]
 		require.True(t, ok, fullMethod)
@@ -64,6 +65,20 @@ func TestWavedRPCPermissionsMapsMutatingMethods(t *testing.T) {
 			fullMethod,
 		)
 	}
+}
+
+// TestWavedRPCPermissionsProtectsMacaroonBaking verifies only the dedicated
+// generate operation authorizes credential creation.
+func TestWavedRPCPermissionsProtectsMacaroonBaking(t *testing.T) {
+	t.Parallel()
+
+	fullMethod := waverpc.MacaroonService_BakeMacaroon_FullMethodName
+	ops, ok := wavedRPCPermissions[fullMethod]
+	require.True(t, ok, fullMethod)
+	require.Equal(t, []bakery.Op{{
+		Entity: entityMacaroon,
+		Action: "generate",
+	}}, ops)
 }
 
 // TestWavedRPCPermissionsCoversBtcwallet verifies btcwallet's public RPC
@@ -212,6 +227,9 @@ func TestWavedRPCPermissionsCoverDaemonServices(t *testing.T) {
 
 	waverpc.RegisterDaemonServiceServer(
 		grpcServer, &waverpc.UnimplementedDaemonServiceServer{},
+	)
+	waverpc.RegisterMacaroonServiceServer(
+		grpcServer, &waverpc.UnimplementedMacaroonServiceServer{},
 	)
 	swapclientrpc.RegisterSwapClientServiceServer(
 		grpcServer,

--- a/waved/rpc_macaroons.go
+++ b/waved/rpc_macaroons.go
@@ -1,0 +1,171 @@
+package waved
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/macaroons"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+)
+
+// macaroonManager validates scoped bake requests against the active daemon
+// permission map and mints them with waved's macaroon root-key store.
+type macaroonManager struct {
+	authService *lndclient.MacaroonService
+	permissions map[string][]bakery.Op
+	knownOps    map[bakery.Op]struct{}
+}
+
+// newMacaroonManager returns a manager over a defensive copy of permissions.
+func newMacaroonManager(authService *lndclient.MacaroonService,
+	permissions map[string][]bakery.Op) *macaroonManager {
+
+	permissionCopy := make(map[string][]bakery.Op, len(permissions))
+	knownOps := make(map[bakery.Op]struct{})
+	for fullMethod, ops := range permissions {
+		permissionCopy[fullMethod] = append([]bakery.Op(nil), ops...)
+		for _, op := range ops {
+			knownOps[op] = struct{}{}
+		}
+	}
+
+	return &macaroonManager{
+		authService: authService,
+		permissions: permissionCopy,
+		knownOps:    knownOps,
+	}
+}
+
+// configureMacaroonManager publishes the active permission map after every
+// optional gRPC service has registered and before the listener starts.
+func (r *RPCServer) configureMacaroonManager(
+	authService *lndclient.MacaroonService,
+	permissions map[string][]bakery.Op) {
+
+	r.macaroonManager = newMacaroonManager(authService, permissions)
+}
+
+// BakeMacaroon creates a new daemon macaroon with a validated permission set.
+func (r *RPCServer) BakeMacaroon(ctx context.Context,
+	req *waverpc.BakeMacaroonRequest) (*waverpc.BakeMacaroonResponse,
+	error) {
+
+	manager := r.macaroonManager
+	if manager == nil || manager.authService == nil {
+		return nil, status.Error(
+			codes.FailedPrecondition,
+			"macaroon authentication is disabled",
+		)
+	}
+
+	ops, err := manager.validatePermissions(req.GetPermissions())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	rootKeyID := []byte(strconv.FormatUint(req.GetRootKeyId(), 10))
+	mac, err := manager.authService.NewMacaroon(
+		ctx, rootKeyID, ops...,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "bake macaroon: %v",
+			err)
+	}
+
+	macBytes, err := mac.M().MarshalBinary()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "marshal "+
+			"macaroon: %v", err)
+	}
+
+	return &waverpc.BakeMacaroonResponse{
+		Macaroon: hex.EncodeToString(macBytes),
+	}, nil
+}
+
+// ListPermissions returns the active RPC method-to-permission map.
+func (r *RPCServer) ListPermissions(_ context.Context,
+	_ *waverpc.ListPermissionsRequest) (*waverpc.ListPermissionsResponse,
+	error) {
+
+	manager := r.macaroonManager
+	if manager == nil {
+		return nil, status.Error(
+			codes.FailedPrecondition,
+			"macaroon permission map is unavailable",
+		)
+	}
+
+	permissions := make(
+		map[string]*waverpc.MacaroonPermissionList,
+		len(manager.permissions),
+	)
+	for fullMethod, ops := range manager.permissions {
+		rpcOps := make([]*waverpc.MacaroonPermission, 0, len(ops))
+		for _, op := range ops {
+			rpcOps = append(rpcOps, &waverpc.MacaroonPermission{
+				Entity: op.Entity,
+				Action: op.Action,
+			})
+		}
+
+		permissions[fullMethod] = &waverpc.MacaroonPermissionList{
+			Permissions: rpcOps,
+		}
+	}
+
+	return &waverpc.ListPermissionsResponse{
+		MethodPermissions: permissions,
+	}, nil
+}
+
+// validatePermissions converts and validates user-facing permission pairs.
+func (m *macaroonManager) validatePermissions(
+	permissions []*waverpc.MacaroonPermission) ([]bakery.Op, error) {
+
+	if len(permissions) == 0 {
+		return nil, fmt.Errorf("permission list cannot be empty")
+	}
+
+	ops := make([]bakery.Op, 0, len(permissions))
+	seen := make(map[bakery.Op]struct{}, len(permissions))
+	for idx, permission := range permissions {
+		if permission == nil {
+			return nil, fmt.Errorf("permission %d is nil", idx)
+		}
+
+		op := bakery.Op{
+			Entity: permission.GetEntity(),
+			Action: permission.GetAction(),
+		}
+		if op.Entity == "" || op.Action == "" {
+			return nil, fmt.Errorf("permission %d requires "+
+				"non-empty entity and action", idx)
+		}
+
+		if op.Entity == macaroons.PermissionEntityCustomURI {
+			if _, ok := m.permissions[op.Action]; !ok {
+				return nil, fmt.Errorf("unknown RPC "+
+					"method URI %q", op.Action)
+			}
+		} else if _, ok := m.knownOps[op]; !ok {
+			return nil, fmt.Errorf("unsupported permission %s:%s",
+				op.Entity, op.Action)
+		}
+
+		if _, ok := seen[op]; ok {
+			continue
+		}
+
+		seen[op] = struct{}{}
+		ops = append(ops, op)
+	}
+
+	return ops, nil
+}

--- a/waved/rpc_macaroons_test.go
+++ b/waved/rpc_macaroons_test.go
@@ -1,0 +1,190 @@
+package waved
+
+import (
+	"context"
+	"encoding/hex"
+	"path/filepath"
+	"testing"
+
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/macaroons"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestBakeMacaroonExactURI verifies an exact URI grant authorizes only the
+// requested method, even when another method has the same entity permission.
+func TestBakeMacaroonExactURI(t *testing.T) {
+	t.Parallel()
+
+	adminPath := filepath.Join(t.TempDir(), "admin.macaroon")
+	authService := newTestMacaroonService(
+		t, adminPath, wavedMacaroonLocation, wavedRPCPermissions,
+	)
+	server := NewRPCServer(nil)
+	server.configureMacaroonManager(authService, wavedRPCPermissions)
+
+	getInfo := waverpc.DaemonService_GetInfo_FullMethodName
+	resp, err := server.BakeMacaroon(
+		context.Background(), &waverpc.BakeMacaroonRequest{
+			Permissions: []*waverpc.MacaroonPermission{{
+				Entity: macaroons.PermissionEntityCustomURI,
+				Action: getInfo,
+			}},
+		},
+	)
+	require.NoError(t, err)
+
+	macBytes, err := hex.DecodeString(resp.GetMacaroon())
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		authService.CheckMacAuth(
+			context.Background(), macBytes,
+			wavedRPCPermissions[getInfo], getInfo,
+		),
+	)
+
+	listPermissions :=
+		waverpc.MacaroonService_ListPermissions_FullMethodName
+	require.Error(
+		t,
+		authService.CheckMacAuth(
+			context.Background(), macBytes,
+			wavedRPCPermissions[listPermissions], listPermissions,
+		),
+	)
+}
+
+// TestBakeMacaroonValidatesPermissions verifies the baker accepts known
+// entity/action pairs and rejects empty or unknown permissions.
+func TestBakeMacaroonValidatesPermissions(t *testing.T) {
+	t.Parallel()
+
+	adminPath := filepath.Join(t.TempDir(), "admin.macaroon")
+	authService := newTestMacaroonService(
+		t, adminPath, wavedMacaroonLocation, wavedRPCPermissions,
+	)
+	server := NewRPCServer(nil)
+	server.configureMacaroonManager(authService, wavedRPCPermissions)
+
+	cases := []struct {
+		name        string
+		permissions []*waverpc.MacaroonPermission
+		wantCode    codes.Code
+	}{
+		{
+			name: "known entity action",
+			permissions: []*waverpc.MacaroonPermission{{
+				Entity: entityInfo,
+				Action: "read",
+			}},
+			wantCode: codes.OK,
+		},
+		{
+			name:     "empty",
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "nil permission",
+			permissions: []*waverpc.MacaroonPermission{
+				nil,
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "unknown entity action",
+			permissions: []*waverpc.MacaroonPermission{{
+				Entity: "unknown",
+				Action: "read",
+			}},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "unknown URI",
+			permissions: []*waverpc.MacaroonPermission{{
+				Entity: macaroons.PermissionEntityCustomURI,
+				Action: "/waverpc.DaemonService/Unknown",
+			}},
+			wantCode: codes.InvalidArgument,
+		},
+	}
+
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp, err := server.BakeMacaroon(
+				context.Background(),
+				&waverpc.BakeMacaroonRequest{
+					Permissions: testCase.permissions,
+				},
+			)
+			require.Equal(t, testCase.wantCode, status.Code(err))
+			if testCase.wantCode == codes.OK {
+				require.NotEmpty(t, resp.GetMacaroon())
+
+				macBytes, err := hex.DecodeString(
+					resp.GetMacaroon(),
+				)
+				require.NoError(t, err)
+				getInfo := waverpc.
+					DaemonService_GetInfo_FullMethodName
+				require.NoError(
+					t,
+					authService.CheckMacAuth(
+						context.Background(), macBytes,
+						wavedRPCPermissions[getInfo],
+						getInfo,
+					),
+				)
+			}
+		})
+	}
+}
+
+// TestListPermissionsReturnsDefensiveMap verifies permission discovery uses
+// the active map and callers cannot mutate the manager through its response.
+func TestListPermissionsReturnsDefensiveMap(t *testing.T) {
+	t.Parallel()
+
+	server := NewRPCServer(nil)
+	server.configureMacaroonManager(nil, wavedRPCPermissions)
+
+	resp, err := server.ListPermissions(
+		context.Background(), &waverpc.ListPermissionsRequest{},
+	)
+	require.NoError(t, err)
+
+	getInfo := waverpc.DaemonService_GetInfo_FullMethodName
+	require.Equal(t, []*waverpc.MacaroonPermission{{
+		Entity: entityInfo,
+		Action: "read",
+	}}, resp.GetMethodPermissions()[getInfo].GetPermissions())
+
+	delete(resp.GetMethodPermissions(), getInfo)
+	again, err := server.ListPermissions(
+		context.Background(), &waverpc.ListPermissionsRequest{},
+	)
+	require.NoError(t, err)
+	require.Contains(t, again.GetMethodPermissions(), getInfo)
+}
+
+// TestBakeMacaroonRequiresAuthentication verifies credential creation fails
+// closed when the daemon was started without macaroon authentication.
+func TestBakeMacaroonRequiresAuthentication(t *testing.T) {
+	t.Parallel()
+
+	server := NewRPCServer(nil)
+	_, err := server.BakeMacaroon(
+		context.Background(), &waverpc.BakeMacaroonRequest{
+			Permissions: []*waverpc.MacaroonPermission{{
+				Entity: entityInfo,
+				Action: "read",
+			}},
+		},
+	)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}

--- a/waved/rpc_security_test.go
+++ b/waved/rpc_security_test.go
@@ -47,6 +47,16 @@ func TestBakeReadOnlyMacaroon(t *testing.T) {
 		),
 	)
 
+	// Credential creation is not a read operation and must remain reserved
+	// for the admin macaroon.
+	bakeMacaroon := waverpc.MacaroonService_BakeMacaroon_FullMethodName
+	require.Error(
+		t, authService.CheckMacAuth(
+			ctx, macBytes, wavedRPCPermissions[bakeMacaroon],
+			bakeMacaroon,
+		),
+	)
+
 	// Baking again is a no-op that leaves the existing file untouched, so a
 	// previously distributed copy stays valid.
 	require.NoError(t, bakeReadOnlyMacaroon(ctx, authService, adminPath))

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -81,11 +81,17 @@ const (
 	maxOORRecipients = 256
 )
 
-// RPCServer implements the daemon's gRPC DaemonService interface.
+// RPCServer implements the daemon's local gRPC daemon and macaroon services.
 type RPCServer struct {
 	waverpc.UnimplementedDaemonServiceServer
+	waverpc.UnimplementedMacaroonServiceServer
 
 	server *Server
+
+	// macaroonManager owns local macaroon baking and reports the active RPC
+	// permission map. It is configured after all optional gRPC services are
+	// registered, before the listener starts serving requests.
+	macaroonManager *macaroonManager
 
 	// customInputLocksMu guards customInputLocks. Together they form
 	// a lightweight in-memory mutex on custom OOR input outpoints
@@ -125,7 +131,10 @@ type RPCServer struct {
 // NewRPCServer creates a new RPCServer backed by the given Server.
 func NewRPCServer(server *Server) *RPCServer {
 	return &RPCServer{
-		server:             server,
+		server: server,
+		macaroonManager: newMacaroonManager(
+			nil, wavedRPCPermissions,
+		),
 		customInputLocks:   make(map[wire.OutPoint]struct{}),
 		receiveScriptLocks: make(map[string]*receiveScriptLock),
 	}

--- a/waved/server.go
+++ b/waved/server.go
@@ -1451,6 +1451,9 @@ func (s *Server) runInner(ctx context.Context, shutdownFn func()) error {
 	waverpc.RegisterDaemonServiceServer(
 		s.grpcServer, s.rpcServer,
 	)
+	waverpc.RegisterMacaroonServiceServer(
+		s.grpcServer, s.rpcServer,
+	)
 	if cleanup := registerBtcwalletRPC(s.grpcServer, s); cleanup != nil {
 		defer cleanup()
 	}
@@ -1474,13 +1477,16 @@ func (s *Server) runInner(ctx context.Context, shutdownFn func()) error {
 			defer cleanup()
 		}
 	}
-	if authService != nil {
-		if _, err := registeredRPCPermissions(
-			s.grpcServer,
-		); err != nil {
-			return err
-		}
+	activePermissions, err := registeredRPCPermissions(s.grpcServer)
+	// Preserve the no-auth development mode's support for custom services
+	// without daemon-defined permissions. When authentication is enabled,
+	// every registered method must remain covered and startup fails closed.
+	if err != nil && authService != nil {
+		return err
 	}
+	s.rpcServer.configureMacaroonManager(
+		authService, activePermissions,
+	)
 
 	// Register the DaemonService for mailbox RPC access. The
 	// ServeMux handles incoming KIND_REQUEST envelopes routed

--- a/waverpc/AGENTS.md
+++ b/waverpc/AGENTS.md
@@ -16,6 +16,9 @@ helper file (`errors.go`) for structured wallet-lifecycle errors.
   server interfaces for the daemon API.
 - `DaemonServiceMailboxClient` / `DaemonServiceMailboxServer` — Generated
   mailbox-RPC client/server stubs (via `protoc-gen-mailboxrpc`).
+- `MacaroonServiceClient` / `MacaroonServiceServer` — Local authenticated
+  credential provisioning and active-permission discovery. The daemon does
+  not register this service on its operator mailbox transport.
 - `WalletNotReadyError(msg)` / `WalletNotReadyStateError(msg, state)` — Build a
   structured `FailedPrecondition` gRPC error carrying a stable `ErrorInfo`
   reason (`WalletNotReadyReason`) and optional `wallet_state` metadata.

--- a/waverpc/CLAUDE.md
+++ b/waverpc/CLAUDE.md
@@ -16,6 +16,9 @@ helper file (`errors.go`) for structured wallet-lifecycle errors.
   server interfaces for the daemon API.
 - `DaemonServiceMailboxClient` / `DaemonServiceMailboxServer` — Generated
   mailbox-RPC client/server stubs (via `protoc-gen-mailboxrpc`).
+- `MacaroonServiceClient` / `MacaroonServiceServer` — Local authenticated
+  credential provisioning and active-permission discovery. The daemon does
+  not register this service on its operator mailbox transport.
 - `WalletNotReadyError(msg)` / `WalletNotReadyStateError(msg, state)` — Build a
   structured `FailedPrecondition` gRPC error carrying a stable `ErrorInfo`
   reason (`WalletNotReadyReason`) and optional `wallet_state` metadata.

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -10439,6 +10439,288 @@ func (x *SignCreditAccountAuthorizationResponse) GetSignature() []byte {
 	return nil
 }
 
+// MacaroonPermission is one entity/action operation granted by a macaroon.
+// The special entity "uri" uses a full registered RPC method URI as action.
+type MacaroonPermission struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// entity is the logical permission domain, or "uri" for one exact RPC.
+	Entity string `protobuf:"bytes,1,opt,name=entity,proto3" json:"entity,omitempty"`
+	// action is the operation within the entity, or the full RPC method URI.
+	Action        string `protobuf:"bytes,2,opt,name=action,proto3" json:"action,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MacaroonPermission) Reset() {
+	*x = MacaroonPermission{}
+	mi := &file_daemon_proto_msgTypes[123]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MacaroonPermission) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MacaroonPermission) ProtoMessage() {}
+
+func (x *MacaroonPermission) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[123]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MacaroonPermission.ProtoReflect.Descriptor instead.
+func (*MacaroonPermission) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{123}
+}
+
+func (x *MacaroonPermission) GetEntity() string {
+	if x != nil {
+		return x.Entity
+	}
+	return ""
+}
+
+func (x *MacaroonPermission) GetAction() string {
+	if x != nil {
+		return x.Action
+	}
+	return ""
+}
+
+type BakeMacaroonRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// permissions is the non-empty set of operations to grant.
+	Permissions []*MacaroonPermission `protobuf:"bytes,1,rep,name=permissions,proto3" json:"permissions,omitempty"`
+	// root_key_id selects the numeric macaroon root key. Zero uses the
+	// daemon's default root key.
+	RootKeyId     uint64 `protobuf:"varint,2,opt,name=root_key_id,json=rootKeyId,proto3" json:"root_key_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BakeMacaroonRequest) Reset() {
+	*x = BakeMacaroonRequest{}
+	mi := &file_daemon_proto_msgTypes[124]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BakeMacaroonRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BakeMacaroonRequest) ProtoMessage() {}
+
+func (x *BakeMacaroonRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[124]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BakeMacaroonRequest.ProtoReflect.Descriptor instead.
+func (*BakeMacaroonRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{124}
+}
+
+func (x *BakeMacaroonRequest) GetPermissions() []*MacaroonPermission {
+	if x != nil {
+		return x.Permissions
+	}
+	return nil
+}
+
+func (x *BakeMacaroonRequest) GetRootKeyId() uint64 {
+	if x != nil {
+		return x.RootKeyId
+	}
+	return 0
+}
+
+type BakeMacaroonResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// macaroon is the hex-encoded binary serialization of the new macaroon.
+	Macaroon      string `protobuf:"bytes,1,opt,name=macaroon,proto3" json:"macaroon,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BakeMacaroonResponse) Reset() {
+	*x = BakeMacaroonResponse{}
+	mi := &file_daemon_proto_msgTypes[125]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BakeMacaroonResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BakeMacaroonResponse) ProtoMessage() {}
+
+func (x *BakeMacaroonResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[125]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BakeMacaroonResponse.ProtoReflect.Descriptor instead.
+func (*BakeMacaroonResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{125}
+}
+
+func (x *BakeMacaroonResponse) GetMacaroon() string {
+	if x != nil {
+		return x.Macaroon
+	}
+	return ""
+}
+
+type MacaroonPermissionList struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Permissions   []*MacaroonPermission  `protobuf:"bytes,1,rep,name=permissions,proto3" json:"permissions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MacaroonPermissionList) Reset() {
+	*x = MacaroonPermissionList{}
+	mi := &file_daemon_proto_msgTypes[126]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MacaroonPermissionList) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MacaroonPermissionList) ProtoMessage() {}
+
+func (x *MacaroonPermissionList) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[126]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MacaroonPermissionList.ProtoReflect.Descriptor instead.
+func (*MacaroonPermissionList) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{126}
+}
+
+func (x *MacaroonPermissionList) GetPermissions() []*MacaroonPermission {
+	if x != nil {
+		return x.Permissions
+	}
+	return nil
+}
+
+type ListPermissionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListPermissionsRequest) Reset() {
+	*x = ListPermissionsRequest{}
+	mi := &file_daemon_proto_msgTypes[127]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPermissionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPermissionsRequest) ProtoMessage() {}
+
+func (x *ListPermissionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[127]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPermissionsRequest.ProtoReflect.Descriptor instead.
+func (*ListPermissionsRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{127}
+}
+
+type ListPermissionsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// method_permissions maps full RPC method URIs to their required
+	// entity/action operations.
+	MethodPermissions map[string]*MacaroonPermissionList `protobuf:"bytes,1,rep,name=method_permissions,json=methodPermissions,proto3" json:"method_permissions,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ListPermissionsResponse) Reset() {
+	*x = ListPermissionsResponse{}
+	mi := &file_daemon_proto_msgTypes[128]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPermissionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPermissionsResponse) ProtoMessage() {}
+
+func (x *ListPermissionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[128]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPermissionsResponse.ProtoReflect.Descriptor instead.
+func (*ListPermissionsResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{128}
+}
+
+func (x *ListPermissionsResponse) GetMethodPermissions() map[string]*MacaroonPermissionList {
+	if x != nil {
+		return x.MethodPermissions
+	}
+	return nil
+}
+
 var File_daemon_proto protoreflect.FileDescriptor
 
 const file_daemon_proto_rawDesc = "" +
@@ -11153,7 +11435,23 @@ const file_daemon_proto_rawDesc = "" +
 	"\x05nonce\x18\x03 \x01(\fR\x05nonce\x12%\n" +
 	"\x0eaccount_pubkey\x18\x04 \x01(\fR\raccountPubkey\"F\n" +
 	"&SignCreditAccountAuthorizationResponse\x12\x1c\n" +
-	"\tsignature\x18\x01 \x01(\fR\tsignature*\x8d\x01\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature\"D\n" +
+	"\x12MacaroonPermission\x12\x16\n" +
+	"\x06entity\x18\x01 \x01(\tR\x06entity\x12\x16\n" +
+	"\x06action\x18\x02 \x01(\tR\x06action\"t\n" +
+	"\x13BakeMacaroonRequest\x12=\n" +
+	"\vpermissions\x18\x01 \x03(\v2\x1b.waverpc.MacaroonPermissionR\vpermissions\x12\x1e\n" +
+	"\vroot_key_id\x18\x02 \x01(\x04R\trootKeyId\"2\n" +
+	"\x14BakeMacaroonResponse\x12\x1a\n" +
+	"\bmacaroon\x18\x01 \x01(\tR\bmacaroon\"W\n" +
+	"\x16MacaroonPermissionList\x12=\n" +
+	"\vpermissions\x18\x01 \x03(\v2\x1b.waverpc.MacaroonPermissionR\vpermissions\"\x18\n" +
+	"\x16ListPermissionsRequest\"\xe8\x01\n" +
+	"\x17ListPermissionsResponse\x12f\n" +
+	"\x12method_permissions\x18\x01 \x03(\v27.waverpc.ListPermissionsResponse.MethodPermissionsEntryR\x11methodPermissions\x1ae\n" +
+	"\x16MethodPermissionsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x125\n" +
+	"\x05value\x18\x02 \x01(\v2\x1f.waverpc.MacaroonPermissionListR\x05value:\x028\x01*\x8d\x01\n" +
 	"\vWalletState\x12\x1c\n" +
 	"\x18WALLET_STATE_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11WALLET_STATE_NONE\x10\x01\x12\x17\n" +
@@ -11297,7 +11595,10 @@ const file_daemon_proto_rawDesc = "" +
 	"\x16GetVHTLCRecoveryStatus\x12&.waverpc.GetVHTLCRecoveryStatusRequest\x1a'.waverpc.GetVHTLCRecoveryStatusResponse\x12`\n" +
 	"\x13ListVHTLCRecoveries\x12#.waverpc.ListVHTLCRecoveriesRequest\x1a$.waverpc.ListVHTLCRecoveriesResponse\x12]\n" +
 	"\x12SignOutSwapHtlcAck\x12\".waverpc.SignOutSwapHtlcAckRequest\x1a#.waverpc.SignOutSwapHtlcAckResponse\x12\x81\x01\n" +
-	"\x1eSignCreditAccountAuthorization\x12..waverpc.SignCreditAccountAuthorizationRequest\x1a/.waverpc.SignCreditAccountAuthorizationResponseB-Z+github.com/lightninglabs/wavelength/waverpcb\x06proto3"
+	"\x1eSignCreditAccountAuthorization\x12..waverpc.SignCreditAccountAuthorizationRequest\x1a/.waverpc.SignCreditAccountAuthorizationResponse2\xb4\x01\n" +
+	"\x0fMacaroonService\x12K\n" +
+	"\fBakeMacaroon\x12\x1c.waverpc.BakeMacaroonRequest\x1a\x1d.waverpc.BakeMacaroonResponse\x12T\n" +
+	"\x0fListPermissions\x12\x1f.waverpc.ListPermissionsRequest\x1a .waverpc.ListPermissionsResponseB-Z+github.com/lightninglabs/wavelength/waverpcb\x06proto3"
 
 var (
 	file_daemon_proto_rawDescOnce sync.Once
@@ -11312,7 +11613,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 124)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 131)
 var file_daemon_proto_goTypes = []any{
 	(WalletState)(0),                                               // 0: waverpc.WalletState
 	(VTXOStatus)(0),                                                // 1: waverpc.VTXOStatus
@@ -11448,7 +11749,14 @@ var file_daemon_proto_goTypes = []any{
 	(*SignOutSwapHtlcAckResponse)(nil),                             // 131: waverpc.SignOutSwapHtlcAckResponse
 	(*SignCreditAccountAuthorizationRequest)(nil),                  // 132: waverpc.SignCreditAccountAuthorizationRequest
 	(*SignCreditAccountAuthorizationResponse)(nil),                 // 133: waverpc.SignCreditAccountAuthorizationResponse
-	nil, // 134: waverpc.LeaveVTXOsRequest.DestinationsEntry
+	(*MacaroonPermission)(nil),                                     // 134: waverpc.MacaroonPermission
+	(*BakeMacaroonRequest)(nil),                                    // 135: waverpc.BakeMacaroonRequest
+	(*BakeMacaroonResponse)(nil),                                   // 136: waverpc.BakeMacaroonResponse
+	(*MacaroonPermissionList)(nil),                                 // 137: waverpc.MacaroonPermissionList
+	(*ListPermissionsRequest)(nil),                                 // 138: waverpc.ListPermissionsRequest
+	(*ListPermissionsResponse)(nil),                                // 139: waverpc.ListPermissionsResponse
+	nil,                                                            // 140: waverpc.LeaveVTXOsRequest.DestinationsEntry
+	nil,                                                            // 141: waverpc.ListPermissionsResponse.MethodPermissionsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,   // 0: waverpc.GetInfoResponse.wallet_state:type_name -> waverpc.WalletState
@@ -11485,7 +11793,7 @@ var file_daemon_proto_depIdxs = []int32{
 	72,  // 31: waverpc.SubmitForfeitParticipantSignaturesRequest.signatures:type_name -> waverpc.ForfeitParticipantSignature
 	60,  // 32: waverpc.LeaveVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
 	75,  // 33: waverpc.LeaveVTXOsRequest.default_destination:type_name -> waverpc.LeaveDestination
-	134, // 34: waverpc.LeaveVTXOsRequest.destinations:type_name -> waverpc.LeaveVTXOsRequest.DestinationsEntry
+	140, // 34: waverpc.LeaveVTXOsRequest.destinations:type_name -> waverpc.LeaveVTXOsRequest.DestinationsEntry
 	75,  // 35: waverpc.SendOnChainRequest.destination:type_name -> waverpc.LeaveDestination
 	85,  // 36: waverpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> waverpc.BoardingSweepOutput
 	88,  // 37: waverpc.BoardingSweep.inputs:type_name -> waverpc.BoardingSweepInput
@@ -11519,106 +11827,114 @@ var file_daemon_proto_depIdxs = []int32{
 	9,   // 65: waverpc.VHTLCRecoveryStatus.action:type_name -> waverpc.VHTLCRecoveryAction
 	10,  // 66: waverpc.VHTLCRecoveryStatus.state:type_name -> waverpc.VHTLCRecoveryState
 	7,   // 67: waverpc.VHTLCRecoveryStatus.unroll_status:type_name -> waverpc.UnrollJobStatus
-	75,  // 68: waverpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> waverpc.LeaveDestination
-	11,  // 69: waverpc.DaemonService.GetInfo:input_type -> waverpc.GetInfoRequest
-	14,  // 70: waverpc.DaemonService.GenSeed:input_type -> waverpc.GenSeedRequest
-	16,  // 71: waverpc.DaemonService.InitWallet:input_type -> waverpc.InitWalletRequest
-	18,  // 72: waverpc.DaemonService.UnlockWallet:input_type -> waverpc.UnlockWalletRequest
-	20,  // 73: waverpc.DaemonService.GetBalance:input_type -> waverpc.GetBalanceRequest
-	25,  // 74: waverpc.DaemonService.ListVTXOs:input_type -> waverpc.ListVTXOsRequest
-	27,  // 75: waverpc.DaemonService.NewAddress:input_type -> waverpc.NewAddressRequest
-	29,  // 76: waverpc.DaemonService.NewReceiveScript:input_type -> waverpc.NewReceiveScriptRequest
-	31,  // 77: waverpc.DaemonService.ReceiveAuthKey:input_type -> waverpc.ReceiveAuthKeyRequest
-	33,  // 78: waverpc.DaemonService.SignReceiveAuthMessage:input_type -> waverpc.SignReceiveAuthMessageRequest
-	35,  // 79: waverpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> waverpc.SignReceiveAuthMessageCompactRequest
-	37,  // 80: waverpc.DaemonService.ReceiveAuthECDH:input_type -> waverpc.ReceiveAuthECDHRequest
-	39,  // 81: waverpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> waverpc.GetIndexedVTXOByPkScriptRequest
-	41,  // 82: waverpc.DaemonService.GetVTXOExpiryInfo:input_type -> waverpc.GetVTXOExpiryInfoRequest
-	43,  // 83: waverpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> waverpc.GetIndexedOORSessionByTxidRequest
-	46,  // 84: waverpc.DaemonService.SendVTXO:input_type -> waverpc.SendVTXORequest
-	48,  // 85: waverpc.DaemonService.SendOOR:input_type -> waverpc.SendOORRequest
-	52,  // 86: waverpc.DaemonService.PrepareOOR:input_type -> waverpc.PrepareOORRequest
-	55,  // 87: waverpc.DaemonService.SignOORCustomInput:input_type -> waverpc.SignOORCustomInputRequest
-	57,  // 88: waverpc.DaemonService.SignVTXOForfeit:input_type -> waverpc.SignVTXOForfeitRequest
-	61,  // 89: waverpc.DaemonService.RefreshVTXOs:input_type -> waverpc.RefreshVTXOsRequest
-	67,  // 90: waverpc.DaemonService.RefreshCustomVTXOs:input_type -> waverpc.RefreshCustomVTXOsRequest
-	70,  // 91: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:input_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsRequest
-	73,  // 92: waverpc.DaemonService.SubmitForfeitParticipantSignatures:input_type -> waverpc.SubmitForfeitParticipantSignaturesRequest
-	76,  // 93: waverpc.DaemonService.LeaveVTXOs:input_type -> waverpc.LeaveVTXOsRequest
-	78,  // 94: waverpc.DaemonService.SendOnChain:input_type -> waverpc.SendOnChainRequest
-	80,  // 95: waverpc.DaemonService.Board:input_type -> waverpc.BoardRequest
-	82,  // 96: waverpc.DaemonService.JoinNextRound:input_type -> waverpc.JoinNextRoundRequest
-	84,  // 97: waverpc.DaemonService.SweepBoardingUTXOs:input_type -> waverpc.SweepBoardingUTXOsRequest
-	87,  // 98: waverpc.DaemonService.ListBoardingSweeps:input_type -> waverpc.ListBoardingSweepsRequest
-	93,  // 99: waverpc.DaemonService.ListRounds:input_type -> waverpc.ListRoundsRequest
-	94,  // 100: waverpc.DaemonService.GetRound:input_type -> waverpc.GetRoundRequest
-	97,  // 101: waverpc.DaemonService.WatchRounds:input_type -> waverpc.WatchRoundsRequest
-	100, // 102: waverpc.DaemonService.ListOORSessions:input_type -> waverpc.ListOORSessionsRequest
-	102, // 103: waverpc.DaemonService.GetOORSession:input_type -> waverpc.GetOORSessionRequest
-	104, // 104: waverpc.DaemonService.EstimateFee:input_type -> waverpc.EstimateFeeRequest
-	106, // 105: waverpc.DaemonService.GetFeeHistory:input_type -> waverpc.GetFeeHistoryRequest
-	109, // 106: waverpc.DaemonService.ListTransactions:input_type -> waverpc.ListTransactionsRequest
-	112, // 107: waverpc.DaemonService.Unroll:input_type -> waverpc.UnrollRequest
-	114, // 108: waverpc.DaemonService.GetUnrollStatus:input_type -> waverpc.GetUnrollStatusRequest
-	119, // 109: waverpc.DaemonService.ArmVHTLCRecovery:input_type -> waverpc.ArmVHTLCRecoveryRequest
-	121, // 110: waverpc.DaemonService.EscalateVHTLCRecovery:input_type -> waverpc.EscalateVHTLCRecoveryRequest
-	123, // 111: waverpc.DaemonService.CancelVHTLCRecovery:input_type -> waverpc.CancelVHTLCRecoveryRequest
-	125, // 112: waverpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> waverpc.GetVHTLCRecoveryStatusRequest
-	127, // 113: waverpc.DaemonService.ListVHTLCRecoveries:input_type -> waverpc.ListVHTLCRecoveriesRequest
-	130, // 114: waverpc.DaemonService.SignOutSwapHtlcAck:input_type -> waverpc.SignOutSwapHtlcAckRequest
-	132, // 115: waverpc.DaemonService.SignCreditAccountAuthorization:input_type -> waverpc.SignCreditAccountAuthorizationRequest
-	12,  // 116: waverpc.DaemonService.GetInfo:output_type -> waverpc.GetInfoResponse
-	15,  // 117: waverpc.DaemonService.GenSeed:output_type -> waverpc.GenSeedResponse
-	17,  // 118: waverpc.DaemonService.InitWallet:output_type -> waverpc.InitWalletResponse
-	19,  // 119: waverpc.DaemonService.UnlockWallet:output_type -> waverpc.UnlockWalletResponse
-	21,  // 120: waverpc.DaemonService.GetBalance:output_type -> waverpc.GetBalanceResponse
-	26,  // 121: waverpc.DaemonService.ListVTXOs:output_type -> waverpc.ListVTXOsResponse
-	28,  // 122: waverpc.DaemonService.NewAddress:output_type -> waverpc.NewAddressResponse
-	30,  // 123: waverpc.DaemonService.NewReceiveScript:output_type -> waverpc.NewReceiveScriptResponse
-	32,  // 124: waverpc.DaemonService.ReceiveAuthKey:output_type -> waverpc.ReceiveAuthKeyResponse
-	34,  // 125: waverpc.DaemonService.SignReceiveAuthMessage:output_type -> waverpc.SignReceiveAuthMessageResponse
-	36,  // 126: waverpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> waverpc.SignReceiveAuthMessageCompactResponse
-	38,  // 127: waverpc.DaemonService.ReceiveAuthECDH:output_type -> waverpc.ReceiveAuthECDHResponse
-	40,  // 128: waverpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> waverpc.GetIndexedVTXOByPkScriptResponse
-	42,  // 129: waverpc.DaemonService.GetVTXOExpiryInfo:output_type -> waverpc.GetVTXOExpiryInfoResponse
-	44,  // 130: waverpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> waverpc.GetIndexedOORSessionByTxidResponse
-	47,  // 131: waverpc.DaemonService.SendVTXO:output_type -> waverpc.SendVTXOResponse
-	51,  // 132: waverpc.DaemonService.SendOOR:output_type -> waverpc.SendOORResponse
-	54,  // 133: waverpc.DaemonService.PrepareOOR:output_type -> waverpc.PrepareOORResponse
-	56,  // 134: waverpc.DaemonService.SignOORCustomInput:output_type -> waverpc.SignOORCustomInputResponse
-	58,  // 135: waverpc.DaemonService.SignVTXOForfeit:output_type -> waverpc.SignVTXOForfeitResponse
-	62,  // 136: waverpc.DaemonService.RefreshVTXOs:output_type -> waverpc.RefreshVTXOsResponse
-	68,  // 137: waverpc.DaemonService.RefreshCustomVTXOs:output_type -> waverpc.RefreshCustomVTXOsResponse
-	71,  // 138: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
-	74,  // 139: waverpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> waverpc.SubmitForfeitParticipantSignaturesResponse
-	77,  // 140: waverpc.DaemonService.LeaveVTXOs:output_type -> waverpc.LeaveVTXOsResponse
-	79,  // 141: waverpc.DaemonService.SendOnChain:output_type -> waverpc.SendOnChainResponse
-	81,  // 142: waverpc.DaemonService.Board:output_type -> waverpc.BoardResponse
-	83,  // 143: waverpc.DaemonService.JoinNextRound:output_type -> waverpc.JoinNextRoundResponse
-	86,  // 144: waverpc.DaemonService.SweepBoardingUTXOs:output_type -> waverpc.SweepBoardingUTXOsResponse
-	90,  // 145: waverpc.DaemonService.ListBoardingSweeps:output_type -> waverpc.ListBoardingSweepsResponse
-	96,  // 146: waverpc.DaemonService.ListRounds:output_type -> waverpc.ListRoundsResponse
-	95,  // 147: waverpc.DaemonService.GetRound:output_type -> waverpc.GetRoundResponse
-	98,  // 148: waverpc.DaemonService.WatchRounds:output_type -> waverpc.WatchRoundsResponse
-	101, // 149: waverpc.DaemonService.ListOORSessions:output_type -> waverpc.ListOORSessionsResponse
-	103, // 150: waverpc.DaemonService.GetOORSession:output_type -> waverpc.GetOORSessionResponse
-	105, // 151: waverpc.DaemonService.EstimateFee:output_type -> waverpc.EstimateFeeResponse
-	108, // 152: waverpc.DaemonService.GetFeeHistory:output_type -> waverpc.GetFeeHistoryResponse
-	111, // 153: waverpc.DaemonService.ListTransactions:output_type -> waverpc.ListTransactionsResponse
-	113, // 154: waverpc.DaemonService.Unroll:output_type -> waverpc.UnrollResponse
-	118, // 155: waverpc.DaemonService.GetUnrollStatus:output_type -> waverpc.GetUnrollStatusResponse
-	120, // 156: waverpc.DaemonService.ArmVHTLCRecovery:output_type -> waverpc.ArmVHTLCRecoveryResponse
-	122, // 157: waverpc.DaemonService.EscalateVHTLCRecovery:output_type -> waverpc.EscalateVHTLCRecoveryResponse
-	124, // 158: waverpc.DaemonService.CancelVHTLCRecovery:output_type -> waverpc.CancelVHTLCRecoveryResponse
-	126, // 159: waverpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> waverpc.GetVHTLCRecoveryStatusResponse
-	128, // 160: waverpc.DaemonService.ListVHTLCRecoveries:output_type -> waverpc.ListVHTLCRecoveriesResponse
-	131, // 161: waverpc.DaemonService.SignOutSwapHtlcAck:output_type -> waverpc.SignOutSwapHtlcAckResponse
-	133, // 162: waverpc.DaemonService.SignCreditAccountAuthorization:output_type -> waverpc.SignCreditAccountAuthorizationResponse
-	116, // [116:163] is the sub-list for method output_type
-	69,  // [69:116] is the sub-list for method input_type
-	69,  // [69:69] is the sub-list for extension type_name
-	69,  // [69:69] is the sub-list for extension extendee
-	0,   // [0:69] is the sub-list for field type_name
+	134, // 68: waverpc.BakeMacaroonRequest.permissions:type_name -> waverpc.MacaroonPermission
+	134, // 69: waverpc.MacaroonPermissionList.permissions:type_name -> waverpc.MacaroonPermission
+	141, // 70: waverpc.ListPermissionsResponse.method_permissions:type_name -> waverpc.ListPermissionsResponse.MethodPermissionsEntry
+	75,  // 71: waverpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> waverpc.LeaveDestination
+	137, // 72: waverpc.ListPermissionsResponse.MethodPermissionsEntry.value:type_name -> waverpc.MacaroonPermissionList
+	11,  // 73: waverpc.DaemonService.GetInfo:input_type -> waverpc.GetInfoRequest
+	14,  // 74: waverpc.DaemonService.GenSeed:input_type -> waverpc.GenSeedRequest
+	16,  // 75: waverpc.DaemonService.InitWallet:input_type -> waverpc.InitWalletRequest
+	18,  // 76: waverpc.DaemonService.UnlockWallet:input_type -> waverpc.UnlockWalletRequest
+	20,  // 77: waverpc.DaemonService.GetBalance:input_type -> waverpc.GetBalanceRequest
+	25,  // 78: waverpc.DaemonService.ListVTXOs:input_type -> waverpc.ListVTXOsRequest
+	27,  // 79: waverpc.DaemonService.NewAddress:input_type -> waverpc.NewAddressRequest
+	29,  // 80: waverpc.DaemonService.NewReceiveScript:input_type -> waverpc.NewReceiveScriptRequest
+	31,  // 81: waverpc.DaemonService.ReceiveAuthKey:input_type -> waverpc.ReceiveAuthKeyRequest
+	33,  // 82: waverpc.DaemonService.SignReceiveAuthMessage:input_type -> waverpc.SignReceiveAuthMessageRequest
+	35,  // 83: waverpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> waverpc.SignReceiveAuthMessageCompactRequest
+	37,  // 84: waverpc.DaemonService.ReceiveAuthECDH:input_type -> waverpc.ReceiveAuthECDHRequest
+	39,  // 85: waverpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> waverpc.GetIndexedVTXOByPkScriptRequest
+	41,  // 86: waverpc.DaemonService.GetVTXOExpiryInfo:input_type -> waverpc.GetVTXOExpiryInfoRequest
+	43,  // 87: waverpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> waverpc.GetIndexedOORSessionByTxidRequest
+	46,  // 88: waverpc.DaemonService.SendVTXO:input_type -> waverpc.SendVTXORequest
+	48,  // 89: waverpc.DaemonService.SendOOR:input_type -> waverpc.SendOORRequest
+	52,  // 90: waverpc.DaemonService.PrepareOOR:input_type -> waverpc.PrepareOORRequest
+	55,  // 91: waverpc.DaemonService.SignOORCustomInput:input_type -> waverpc.SignOORCustomInputRequest
+	57,  // 92: waverpc.DaemonService.SignVTXOForfeit:input_type -> waverpc.SignVTXOForfeitRequest
+	61,  // 93: waverpc.DaemonService.RefreshVTXOs:input_type -> waverpc.RefreshVTXOsRequest
+	67,  // 94: waverpc.DaemonService.RefreshCustomVTXOs:input_type -> waverpc.RefreshCustomVTXOsRequest
+	70,  // 95: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:input_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsRequest
+	73,  // 96: waverpc.DaemonService.SubmitForfeitParticipantSignatures:input_type -> waverpc.SubmitForfeitParticipantSignaturesRequest
+	76,  // 97: waverpc.DaemonService.LeaveVTXOs:input_type -> waverpc.LeaveVTXOsRequest
+	78,  // 98: waverpc.DaemonService.SendOnChain:input_type -> waverpc.SendOnChainRequest
+	80,  // 99: waverpc.DaemonService.Board:input_type -> waverpc.BoardRequest
+	82,  // 100: waverpc.DaemonService.JoinNextRound:input_type -> waverpc.JoinNextRoundRequest
+	84,  // 101: waverpc.DaemonService.SweepBoardingUTXOs:input_type -> waverpc.SweepBoardingUTXOsRequest
+	87,  // 102: waverpc.DaemonService.ListBoardingSweeps:input_type -> waverpc.ListBoardingSweepsRequest
+	93,  // 103: waverpc.DaemonService.ListRounds:input_type -> waverpc.ListRoundsRequest
+	94,  // 104: waverpc.DaemonService.GetRound:input_type -> waverpc.GetRoundRequest
+	97,  // 105: waverpc.DaemonService.WatchRounds:input_type -> waverpc.WatchRoundsRequest
+	100, // 106: waverpc.DaemonService.ListOORSessions:input_type -> waverpc.ListOORSessionsRequest
+	102, // 107: waverpc.DaemonService.GetOORSession:input_type -> waverpc.GetOORSessionRequest
+	104, // 108: waverpc.DaemonService.EstimateFee:input_type -> waverpc.EstimateFeeRequest
+	106, // 109: waverpc.DaemonService.GetFeeHistory:input_type -> waverpc.GetFeeHistoryRequest
+	109, // 110: waverpc.DaemonService.ListTransactions:input_type -> waverpc.ListTransactionsRequest
+	112, // 111: waverpc.DaemonService.Unroll:input_type -> waverpc.UnrollRequest
+	114, // 112: waverpc.DaemonService.GetUnrollStatus:input_type -> waverpc.GetUnrollStatusRequest
+	119, // 113: waverpc.DaemonService.ArmVHTLCRecovery:input_type -> waverpc.ArmVHTLCRecoveryRequest
+	121, // 114: waverpc.DaemonService.EscalateVHTLCRecovery:input_type -> waverpc.EscalateVHTLCRecoveryRequest
+	123, // 115: waverpc.DaemonService.CancelVHTLCRecovery:input_type -> waverpc.CancelVHTLCRecoveryRequest
+	125, // 116: waverpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> waverpc.GetVHTLCRecoveryStatusRequest
+	127, // 117: waverpc.DaemonService.ListVHTLCRecoveries:input_type -> waverpc.ListVHTLCRecoveriesRequest
+	130, // 118: waverpc.DaemonService.SignOutSwapHtlcAck:input_type -> waverpc.SignOutSwapHtlcAckRequest
+	132, // 119: waverpc.DaemonService.SignCreditAccountAuthorization:input_type -> waverpc.SignCreditAccountAuthorizationRequest
+	135, // 120: waverpc.MacaroonService.BakeMacaroon:input_type -> waverpc.BakeMacaroonRequest
+	138, // 121: waverpc.MacaroonService.ListPermissions:input_type -> waverpc.ListPermissionsRequest
+	12,  // 122: waverpc.DaemonService.GetInfo:output_type -> waverpc.GetInfoResponse
+	15,  // 123: waverpc.DaemonService.GenSeed:output_type -> waverpc.GenSeedResponse
+	17,  // 124: waverpc.DaemonService.InitWallet:output_type -> waverpc.InitWalletResponse
+	19,  // 125: waverpc.DaemonService.UnlockWallet:output_type -> waverpc.UnlockWalletResponse
+	21,  // 126: waverpc.DaemonService.GetBalance:output_type -> waverpc.GetBalanceResponse
+	26,  // 127: waverpc.DaemonService.ListVTXOs:output_type -> waverpc.ListVTXOsResponse
+	28,  // 128: waverpc.DaemonService.NewAddress:output_type -> waverpc.NewAddressResponse
+	30,  // 129: waverpc.DaemonService.NewReceiveScript:output_type -> waverpc.NewReceiveScriptResponse
+	32,  // 130: waverpc.DaemonService.ReceiveAuthKey:output_type -> waverpc.ReceiveAuthKeyResponse
+	34,  // 131: waverpc.DaemonService.SignReceiveAuthMessage:output_type -> waverpc.SignReceiveAuthMessageResponse
+	36,  // 132: waverpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> waverpc.SignReceiveAuthMessageCompactResponse
+	38,  // 133: waverpc.DaemonService.ReceiveAuthECDH:output_type -> waverpc.ReceiveAuthECDHResponse
+	40,  // 134: waverpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> waverpc.GetIndexedVTXOByPkScriptResponse
+	42,  // 135: waverpc.DaemonService.GetVTXOExpiryInfo:output_type -> waverpc.GetVTXOExpiryInfoResponse
+	44,  // 136: waverpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> waverpc.GetIndexedOORSessionByTxidResponse
+	47,  // 137: waverpc.DaemonService.SendVTXO:output_type -> waverpc.SendVTXOResponse
+	51,  // 138: waverpc.DaemonService.SendOOR:output_type -> waverpc.SendOORResponse
+	54,  // 139: waverpc.DaemonService.PrepareOOR:output_type -> waverpc.PrepareOORResponse
+	56,  // 140: waverpc.DaemonService.SignOORCustomInput:output_type -> waverpc.SignOORCustomInputResponse
+	58,  // 141: waverpc.DaemonService.SignVTXOForfeit:output_type -> waverpc.SignVTXOForfeitResponse
+	62,  // 142: waverpc.DaemonService.RefreshVTXOs:output_type -> waverpc.RefreshVTXOsResponse
+	68,  // 143: waverpc.DaemonService.RefreshCustomVTXOs:output_type -> waverpc.RefreshCustomVTXOsResponse
+	71,  // 144: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
+	74,  // 145: waverpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> waverpc.SubmitForfeitParticipantSignaturesResponse
+	77,  // 146: waverpc.DaemonService.LeaveVTXOs:output_type -> waverpc.LeaveVTXOsResponse
+	79,  // 147: waverpc.DaemonService.SendOnChain:output_type -> waverpc.SendOnChainResponse
+	81,  // 148: waverpc.DaemonService.Board:output_type -> waverpc.BoardResponse
+	83,  // 149: waverpc.DaemonService.JoinNextRound:output_type -> waverpc.JoinNextRoundResponse
+	86,  // 150: waverpc.DaemonService.SweepBoardingUTXOs:output_type -> waverpc.SweepBoardingUTXOsResponse
+	90,  // 151: waverpc.DaemonService.ListBoardingSweeps:output_type -> waverpc.ListBoardingSweepsResponse
+	96,  // 152: waverpc.DaemonService.ListRounds:output_type -> waverpc.ListRoundsResponse
+	95,  // 153: waverpc.DaemonService.GetRound:output_type -> waverpc.GetRoundResponse
+	98,  // 154: waverpc.DaemonService.WatchRounds:output_type -> waverpc.WatchRoundsResponse
+	101, // 155: waverpc.DaemonService.ListOORSessions:output_type -> waverpc.ListOORSessionsResponse
+	103, // 156: waverpc.DaemonService.GetOORSession:output_type -> waverpc.GetOORSessionResponse
+	105, // 157: waverpc.DaemonService.EstimateFee:output_type -> waverpc.EstimateFeeResponse
+	108, // 158: waverpc.DaemonService.GetFeeHistory:output_type -> waverpc.GetFeeHistoryResponse
+	111, // 159: waverpc.DaemonService.ListTransactions:output_type -> waverpc.ListTransactionsResponse
+	113, // 160: waverpc.DaemonService.Unroll:output_type -> waverpc.UnrollResponse
+	118, // 161: waverpc.DaemonService.GetUnrollStatus:output_type -> waverpc.GetUnrollStatusResponse
+	120, // 162: waverpc.DaemonService.ArmVHTLCRecovery:output_type -> waverpc.ArmVHTLCRecoveryResponse
+	122, // 163: waverpc.DaemonService.EscalateVHTLCRecovery:output_type -> waverpc.EscalateVHTLCRecoveryResponse
+	124, // 164: waverpc.DaemonService.CancelVHTLCRecovery:output_type -> waverpc.CancelVHTLCRecoveryResponse
+	126, // 165: waverpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> waverpc.GetVHTLCRecoveryStatusResponse
+	128, // 166: waverpc.DaemonService.ListVHTLCRecoveries:output_type -> waverpc.ListVHTLCRecoveriesResponse
+	131, // 167: waverpc.DaemonService.SignOutSwapHtlcAck:output_type -> waverpc.SignOutSwapHtlcAckResponse
+	133, // 168: waverpc.DaemonService.SignCreditAccountAuthorization:output_type -> waverpc.SignCreditAccountAuthorizationResponse
+	136, // 169: waverpc.MacaroonService.BakeMacaroon:output_type -> waverpc.BakeMacaroonResponse
+	139, // 170: waverpc.MacaroonService.ListPermissions:output_type -> waverpc.ListPermissionsResponse
+	122, // [122:171] is the sub-list for method output_type
+	73,  // [73:122] is the sub-list for method input_type
+	73,  // [73:73] is the sub-list for extension type_name
+	73,  // [73:73] is the sub-list for extension extendee
+	0,   // [0:73] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -11658,9 +11974,9 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   124,
+			NumMessages:   131,
 			NumExtensions: 0,
-			NumServices:   1,
+			NumServices:   2,
 		},
 		GoTypes:           file_daemon_proto_goTypes,
 		DependencyIndexes: file_daemon_proto_depIdxs,

--- a/waverpc/daemon.pb.gw.go
+++ b/waverpc/daemon.pb.gw.go
@@ -1300,6 +1300,54 @@ func local_request_DaemonService_SignCreditAccountAuthorization_0(ctx context.Co
 	return msg, metadata, err
 }
 
+func request_MacaroonService_BakeMacaroon_0(ctx context.Context, marshaler runtime.Marshaler, client MacaroonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq BakeMacaroonRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.BakeMacaroon(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MacaroonService_BakeMacaroon_0(ctx context.Context, marshaler runtime.Marshaler, server MacaroonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq BakeMacaroonRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.BakeMacaroon(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_MacaroonService_ListPermissions_0(ctx context.Context, marshaler runtime.Marshaler, client MacaroonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListPermissionsRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListPermissions(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MacaroonService_ListPermissions_0(ctx context.Context, marshaler runtime.Marshaler, server MacaroonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListPermissionsRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.ListPermissions(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterDaemonServiceHandlerServer registers the http handlers for service DaemonService to "mux".
 // UnaryRPC     :call DaemonServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -2232,6 +2280,56 @@ func RegisterDaemonServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 			return
 		}
 		forward_DaemonService_SignCreditAccountAuthorization_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+
+	return nil
+}
+
+// RegisterMacaroonServiceHandlerServer registers the http handlers for service MacaroonService to "mux".
+// UnaryRPC     :call MacaroonServiceServer directly.
+// StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterMacaroonServiceHandlerFromEndpoint instead.
+// GRPC interceptors will not work for this type of registration. To use interceptors, you must use the "runtime.WithMiddlewares" option in the "runtime.NewServeMux" call.
+func RegisterMacaroonServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux, server MacaroonServiceServer) error {
+	mux.Handle(http.MethodPost, pattern_MacaroonService_BakeMacaroon_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/waverpc.MacaroonService/BakeMacaroon", runtime.WithHTTPPathPattern("/v1/daemon/macaroon"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MacaroonService_BakeMacaroon_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MacaroonService_BakeMacaroon_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_MacaroonService_ListPermissions_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/waverpc.MacaroonService/ListPermissions", runtime.WithHTTPPathPattern("/v1/daemon/macaroon/permissions"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MacaroonService_ListPermissions_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MacaroonService_ListPermissions_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -3173,4 +3271,87 @@ var (
 	forward_DaemonService_ListVHTLCRecoveries_0                            = runtime.ForwardResponseMessage
 	forward_DaemonService_SignOutSwapHtlcAck_0                             = runtime.ForwardResponseMessage
 	forward_DaemonService_SignCreditAccountAuthorization_0                 = runtime.ForwardResponseMessage
+)
+
+// RegisterMacaroonServiceHandlerFromEndpoint is same as RegisterMacaroonServiceHandler but
+// automatically dials to "endpoint" and closes the connection when "ctx" gets done.
+func RegisterMacaroonServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
+	conn, err := grpc.NewClient(endpoint, opts...)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			if cerr := conn.Close(); cerr != nil {
+				grpclog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+			}
+			return
+		}
+		go func() {
+			<-ctx.Done()
+			if cerr := conn.Close(); cerr != nil {
+				grpclog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+			}
+		}()
+	}()
+	return RegisterMacaroonServiceHandler(ctx, mux, conn)
+}
+
+// RegisterMacaroonServiceHandler registers the http handlers for service MacaroonService to "mux".
+// The handlers forward requests to the grpc endpoint over "conn".
+func RegisterMacaroonServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	return RegisterMacaroonServiceHandlerClient(ctx, mux, NewMacaroonServiceClient(conn))
+}
+
+// RegisterMacaroonServiceHandlerClient registers the http handlers for service MacaroonService
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "MacaroonServiceClient".
+// Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "MacaroonServiceClient"
+// doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
+// "MacaroonServiceClient" to call the correct interceptors. This client ignores the HTTP middlewares.
+func RegisterMacaroonServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux, client MacaroonServiceClient) error {
+	mux.Handle(http.MethodPost, pattern_MacaroonService_BakeMacaroon_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/waverpc.MacaroonService/BakeMacaroon", runtime.WithHTTPPathPattern("/v1/daemon/macaroon"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MacaroonService_BakeMacaroon_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MacaroonService_BakeMacaroon_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_MacaroonService_ListPermissions_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/waverpc.MacaroonService/ListPermissions", runtime.WithHTTPPathPattern("/v1/daemon/macaroon/permissions"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MacaroonService_ListPermissions_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MacaroonService_ListPermissions_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	return nil
+}
+
+var (
+	pattern_MacaroonService_BakeMacaroon_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "macaroon"}, ""))
+	pattern_MacaroonService_ListPermissions_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "daemon", "macaroon", "permissions"}, ""))
+)
+
+var (
+	forward_MacaroonService_BakeMacaroon_0    = runtime.ForwardResponseMessage
+	forward_MacaroonService_ListPermissions_0 = runtime.ForwardResponseMessage
 )

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -272,6 +272,21 @@ service DaemonService {
         returns (SignCreditAccountAuthorizationResponse);
 }
 
+// MacaroonService exposes local credential management for the daemon. It is
+// registered on the authenticated local gRPC/REST listener only, not on the
+// operator mailbox transport used by DaemonService.
+service MacaroonService {
+    // BakeMacaroon creates a new daemon macaroon with the requested scoped
+    // permissions. Callers may use known entity/action pairs or the special
+    // uri entity with a full registered RPC method as its action.
+    rpc BakeMacaroon (BakeMacaroonRequest) returns (BakeMacaroonResponse);
+
+    // ListPermissions returns every RPC method registered by this daemon and
+    // the entity/action permissions that authorize it.
+    rpc ListPermissions (ListPermissionsRequest)
+        returns (ListPermissionsResponse);
+}
+
 // WalletState mirrors the daemon's in-process wallet lifecycle enum:
 // callers should test the specific state they need. SYNCING and READY
 // both mean seed material is loaded, while only READY means wallet RPCs
@@ -2878,4 +2893,41 @@ message SignCreditAccountAuthorizationRequest {
 message SignCreditAccountAuthorizationResponse {
     // signature is the 64-byte BIP-340 Schnorr signature.
     bytes signature = 1;
+}
+
+// MacaroonPermission is one entity/action operation granted by a macaroon.
+// The special entity "uri" uses a full registered RPC method URI as action.
+message MacaroonPermission {
+    // entity is the logical permission domain, or "uri" for one exact RPC.
+    string entity = 1;
+
+    // action is the operation within the entity, or the full RPC method URI.
+    string action = 2;
+}
+
+message BakeMacaroonRequest {
+    // permissions is the non-empty set of operations to grant.
+    repeated MacaroonPermission permissions = 1;
+
+    // root_key_id selects the numeric macaroon root key. Zero uses the
+    // daemon's default root key.
+    uint64 root_key_id = 2;
+}
+
+message BakeMacaroonResponse {
+    // macaroon is the hex-encoded binary serialization of the new macaroon.
+    string macaroon = 1;
+}
+
+message MacaroonPermissionList {
+    repeated MacaroonPermission permissions = 1;
+}
+
+message ListPermissionsRequest {
+}
+
+message ListPermissionsResponse {
+    // method_permissions maps full RPC method URIs to their required
+    // entity/action operations.
+    map<string, MacaroonPermissionList> method_permissions = 1;
 }

--- a/waverpc/daemon.yaml
+++ b/waverpc/daemon.yaml
@@ -3,6 +3,11 @@ config_version: 3
 
 http:
   rules:
+    - selector: waverpc.MacaroonService.BakeMacaroon
+      post: /v1/daemon/macaroon
+      body: "*"
+    - selector: waverpc.MacaroonService.ListPermissions
+      get: /v1/daemon/macaroon/permissions
     - selector: waverpc.DaemonService.GetInfo
       post: /v1/daemon/get-info
       body: "*"

--- a/waverpc/daemon_grpc.pb.go
+++ b/waverpc/daemon_grpc.pb.go
@@ -2165,3 +2165,161 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "daemon.proto",
 }
+
+const (
+	MacaroonService_BakeMacaroon_FullMethodName    = "/waverpc.MacaroonService/BakeMacaroon"
+	MacaroonService_ListPermissions_FullMethodName = "/waverpc.MacaroonService/ListPermissions"
+)
+
+// MacaroonServiceClient is the client API for MacaroonService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// MacaroonService exposes local credential management for the daemon. It is
+// registered on the authenticated local gRPC/REST listener only, not on the
+// operator mailbox transport used by DaemonService.
+type MacaroonServiceClient interface {
+	// BakeMacaroon creates a new daemon macaroon with the requested scoped
+	// permissions. Callers may use known entity/action pairs or the special
+	// uri entity with a full registered RPC method as its action.
+	BakeMacaroon(ctx context.Context, in *BakeMacaroonRequest, opts ...grpc.CallOption) (*BakeMacaroonResponse, error)
+	// ListPermissions returns every RPC method registered by this daemon and
+	// the entity/action permissions that authorize it.
+	ListPermissions(ctx context.Context, in *ListPermissionsRequest, opts ...grpc.CallOption) (*ListPermissionsResponse, error)
+}
+
+type macaroonServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewMacaroonServiceClient(cc grpc.ClientConnInterface) MacaroonServiceClient {
+	return &macaroonServiceClient{cc}
+}
+
+func (c *macaroonServiceClient) BakeMacaroon(ctx context.Context, in *BakeMacaroonRequest, opts ...grpc.CallOption) (*BakeMacaroonResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BakeMacaroonResponse)
+	err := c.cc.Invoke(ctx, MacaroonService_BakeMacaroon_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *macaroonServiceClient) ListPermissions(ctx context.Context, in *ListPermissionsRequest, opts ...grpc.CallOption) (*ListPermissionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListPermissionsResponse)
+	err := c.cc.Invoke(ctx, MacaroonService_ListPermissions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// MacaroonServiceServer is the server API for MacaroonService service.
+// All implementations must embed UnimplementedMacaroonServiceServer
+// for forward compatibility.
+//
+// MacaroonService exposes local credential management for the daemon. It is
+// registered on the authenticated local gRPC/REST listener only, not on the
+// operator mailbox transport used by DaemonService.
+type MacaroonServiceServer interface {
+	// BakeMacaroon creates a new daemon macaroon with the requested scoped
+	// permissions. Callers may use known entity/action pairs or the special
+	// uri entity with a full registered RPC method as its action.
+	BakeMacaroon(context.Context, *BakeMacaroonRequest) (*BakeMacaroonResponse, error)
+	// ListPermissions returns every RPC method registered by this daemon and
+	// the entity/action permissions that authorize it.
+	ListPermissions(context.Context, *ListPermissionsRequest) (*ListPermissionsResponse, error)
+	mustEmbedUnimplementedMacaroonServiceServer()
+}
+
+// UnimplementedMacaroonServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedMacaroonServiceServer struct{}
+
+func (UnimplementedMacaroonServiceServer) BakeMacaroon(context.Context, *BakeMacaroonRequest) (*BakeMacaroonResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BakeMacaroon not implemented")
+}
+func (UnimplementedMacaroonServiceServer) ListPermissions(context.Context, *ListPermissionsRequest) (*ListPermissionsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListPermissions not implemented")
+}
+func (UnimplementedMacaroonServiceServer) mustEmbedUnimplementedMacaroonServiceServer() {}
+func (UnimplementedMacaroonServiceServer) testEmbeddedByValue()                         {}
+
+// UnsafeMacaroonServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to MacaroonServiceServer will
+// result in compilation errors.
+type UnsafeMacaroonServiceServer interface {
+	mustEmbedUnimplementedMacaroonServiceServer()
+}
+
+func RegisterMacaroonServiceServer(s grpc.ServiceRegistrar, srv MacaroonServiceServer) {
+	// If the following call pancis, it indicates UnimplementedMacaroonServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&MacaroonService_ServiceDesc, srv)
+}
+
+func _MacaroonService_BakeMacaroon_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BakeMacaroonRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MacaroonServiceServer).BakeMacaroon(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MacaroonService_BakeMacaroon_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MacaroonServiceServer).BakeMacaroon(ctx, req.(*BakeMacaroonRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MacaroonService_ListPermissions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListPermissionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MacaroonServiceServer).ListPermissions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MacaroonService_ListPermissions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MacaroonServiceServer).ListPermissions(ctx, req.(*ListPermissionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// MacaroonService_ServiceDesc is the grpc.ServiceDesc for MacaroonService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var MacaroonService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "waverpc.MacaroonService",
+	HandlerType: (*MacaroonServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "BakeMacaroon",
+			Handler:    _MacaroonService_BakeMacaroon_Handler,
+		},
+		{
+			MethodName: "ListPermissions",
+			Handler:    _MacaroonService_ListPermissions_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "daemon.proto",
+}

--- a/waverpc/daemon_mailboxrpc.pb.go
+++ b/waverpc/daemon_mailboxrpc.pb.go
@@ -1674,3 +1674,94 @@ func (c *DaemonServiceMailboxClient) SignCreditAccountAuthorization(ctx context.
 
 	return resp, nil
 }
+
+// MacaroonServiceMailboxClient is a typed mailbox RPC client for MacaroonService.
+type MacaroonServiceMailboxClient struct {
+	// C is the underlying RPC-over-mailbox runtime client.
+	C rpc.RPCClient
+}
+
+// NewMacaroonServiceMailboxClient creates a typed mailbox client.
+func NewMacaroonServiceMailboxClient(c rpc.RPCClient) *MacaroonServiceMailboxClient {
+	return &MacaroonServiceMailboxClient{
+		C: c,
+	}
+}
+
+// MacaroonServiceMailboxServer is the mailbox server interface for MacaroonService.
+type MacaroonServiceMailboxServer interface {
+	// BakeMacaroon handles BakeMacaroon.
+	BakeMacaroon(ctx context.Context, req *BakeMacaroonRequest) (*BakeMacaroonResponse, error)
+	// ListPermissions handles ListPermissions.
+	ListPermissions(ctx context.Context, req *ListPermissionsRequest) (*ListPermissionsResponse, error)
+}
+
+// RegisterMacaroonServiceMailboxServer registers handlers for MacaroonService.
+func RegisterMacaroonServiceMailboxServer(r rpc.Router, impl MacaroonServiceMailboxServer) {
+	r.Handle("waverpc.MacaroonService", "BakeMacaroon", func() proto.Message {
+		return &BakeMacaroonRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*BakeMacaroonRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.BakeMacaroon(ctx, req)
+	})
+	r.Handle("waverpc.MacaroonService", "ListPermissions", func() proto.Message {
+		return &ListPermissionsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ListPermissionsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ListPermissions(ctx, req)
+	})
+}
+
+// BakeMacaroon calls the BakeMacaroon RPC.
+func (c *MacaroonServiceMailboxClient) BakeMacaroon(ctx context.Context, req *BakeMacaroonRequest, opts ...rpc.RPCOptions) (*BakeMacaroonResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "waverpc.MacaroonService",
+		Method:  "BakeMacaroon",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(BakeMacaroonResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListPermissions calls the ListPermissions RPC.
+func (c *MacaroonServiceMailboxClient) ListPermissions(ctx context.Context, req *ListPermissionsRequest, opts ...rpc.RPCOptions) (*ListPermissionsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "waverpc.MacaroonService",
+		Method:  "ListPermissions",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ListPermissionsResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
Closes #1194.

## Summary

- expose local authenticated `BakeMacaroon` and `ListPermissions` RPCs, with credential creation protected by the admin-only `macaroon:generate` permission
- accept registered entity/action pairs and exact `uri:/package.Service/Method` grants so payment clients can avoid unrelated methods that share a broader write permission
- add `wavecli bakemacaroon`, including secure binary file output, root-key selection, and raw JSON request input