### PR TITLE
credit: keep receives pending until server terminal state

### DIFF
--- a/credit/config.go
+++ b/credit/config.go
@@ -262,11 +262,10 @@ type OpActorConfig struct {
 	// polls while awaiting a server or chain signal.
 	PollInterval time.Duration
 
-	// MaxAwaitingPolls caps how many reconciliation polls an awaiting state
-	// may take before the operation terminal-fails, a backstop against an
-	// operation parking forever when the server never reports a terminal
-	// state. Zero means unlimited: rely on the server-reported terminal
-	// states (expired/failed/released) to bound the wait.
+	// MaxAwaitingPolls caps how many reconciliation polls a pay top-up,
+	// credit-only pay, or redemption may take before the operation
+	// terminal-fails. Credit receives are excluded because the server-owned
+	// invoice lifecycle is their terminal authority. Zero means unlimited.
 	MaxAwaitingPolls uint32
 
 	// AutoRedeemEnabled turns on the receive-driven auto-redeem: a settled
@@ -319,9 +318,10 @@ type RegistryConfig struct {
 	// PollInterval is the backoff between reconciliation polls in children.
 	PollInterval time.Duration
 
-	// MaxAwaitingPolls caps reconciliation polls in an awaiting child state
-	// before it terminal-fails. Zero relies on server-reported terminal
-	// states to bound the wait.
+	// MaxAwaitingPolls caps reconciliation polls for pay top-ups,
+	// credit-only pays, and redemptions before they terminal-fail. Credit
+	// receives rely only on server-reported terminal states. Zero means
+	// unlimited.
 	MaxAwaitingPolls uint32
 
 	// AdmitTimeout bounds the synchronous server work an admission performs

--- a/credit/op_actor.go
+++ b/credit/op_actor.go
@@ -161,9 +161,10 @@ type opBehavior struct {
 	// a terminal row keeps the marker the wallet projector reads.
 	creditOnly bool
 
-	// awaitPolls counts reconciliation polls taken in the current awaiting
-	// state, checked against cfg.MaxAwaitingPolls. Reset to zero whenever
-	// the FSM advances into a different state.
+	// awaitPolls counts reconciliation polls taken in a capped awaiting
+	// state, checked against cfg.MaxAwaitingPolls. Receive settlement does
+	// not use this cap because the server owns the invoice lifecycle. Reset
+	// to zero whenever the FSM advances into a different state.
 	awaitPolls uint32
 
 	// acctKey caches the wallet identity pubkey that keys the credit

--- a/credit/op_actor_test.go
+++ b/credit/op_actor_test.go
@@ -25,12 +25,14 @@ type fakeExec struct {
 	commitCalls int
 }
 
+// Read executes a fake actor read transaction inline.
 func (e *fakeExec) Read(ctx context.Context,
 	fn func(context.Context, creditTx) error) error {
 
 	return fn(ctx, creditTx{})
 }
 
+// Stage executes a fake actor stage transaction or returns its one-shot error.
 func (e *fakeExec) Stage(ctx context.Context,
 	fn func(context.Context, creditTx) error) error {
 
@@ -45,6 +47,8 @@ func (e *fakeExec) Stage(ctx context.Context,
 	return fn(ctx, creditTx{})
 }
 
+// Commit executes a fake actor commit transaction or returns its one-shot
+// error.
 func (e *fakeExec) Commit(ctx context.Context,
 	fn func(context.Context, creditTx) error) error {
 
@@ -69,10 +73,12 @@ type fakeStore struct {
 	getErr error
 }
 
+// newFakeStore creates an empty in-memory credit operation store.
 func newFakeStore() *fakeStore {
 	return &fakeStore{ops: make(map[string]db.CreditOperationRecord)}
 }
 
+// GetOperation returns a defensive copy of one fake operation.
 func (s *fakeStore) GetOperation(_ context.Context, opID string) (
 	*db.CreditOperationRecord, error) {
 
@@ -92,6 +98,7 @@ func (s *fakeStore) GetOperation(_ context.Context, opID string) (
 	return &out, nil
 }
 
+// UpsertOperation inserts or replaces one fake operation.
 func (s *fakeStore) UpsertOperation(_ context.Context,
 	rec db.CreditOperationRecord) error {
 
@@ -103,6 +110,7 @@ func (s *fakeStore) UpsertOperation(_ context.Context,
 	return nil
 }
 
+// LookupActiveOperationByKey returns the non-failed operation for an op key.
 func (s *fakeStore) LookupActiveOperationByKey(_ context.Context, key string) (
 	*db.CreditOperationRecord, error) {
 
@@ -120,6 +128,7 @@ func (s *fakeStore) LookupActiveOperationByKey(_ context.Context, key string) (
 	return nil, db.ErrCreditOperationNotFound
 }
 
+// ListNonTerminal returns every fake operation that remains in flight.
 func (s *fakeStore) ListNonTerminal(_ context.Context) (
 	[]db.CreditOperationRecord, error) {
 
@@ -136,6 +145,7 @@ func (s *fakeStore) ListNonTerminal(_ context.Context) (
 	return out, nil
 }
 
+// ListOperations returns every fake operation, including terminal rows.
 func (s *fakeStore) ListOperations(_ context.Context) (
 	[]db.CreditOperationRecord, error) {
 
@@ -170,8 +180,11 @@ type fakeServer struct {
 	createState ServerCreditState
 	redeemState ServerCreditState
 	receiveHash []byte
+	listCalls   int
+	listErr     error
 }
 
+// newFakeServer creates an empty server ledger with non-terminal defaults.
 func newFakeServer() *fakeServer {
 	return &fakeServer{
 		ops:         make(map[string]*fakeServerOp),
@@ -183,6 +196,7 @@ func newFakeServer() *fakeServer {
 	}
 }
 
+// CreateCredit creates or reuses a fake server funding operation by key.
 func (s *fakeServer) CreateCredit(_ context.Context, _ []byte,
 	idempotencyKey string, source CreditSource, _ uint64, _ string) (
 	*CreateCreditResult, error) {
@@ -217,12 +231,16 @@ func (s *fakeServer) CreateCredit(_ context.Context, _ []byte,
 	return res, nil
 }
 
+// ListCredits returns one snapshot of all fake server operations.
 func (s *fakeServer) ListCredits(_ context.Context, _ []byte) (*CreditSnapshot,
 	error) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
+	s.listCalls++
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
 	snap := &CreditSnapshot{AvailableSat: s.available}
 	for _, op := range s.ops {
 		snap.Operations = append(snap.Operations, ServerCreditOp{
@@ -235,6 +253,7 @@ func (s *fakeServer) ListCredits(_ context.Context, _ []byte) (*CreditSnapshot,
 	return snap, nil
 }
 
+// RedeemCredit creates or reuses a fake server redemption by key.
 func (s *fakeServer) RedeemCredit(_ context.Context, _ []byte,
 	idempotencyKey string, _ uint64, _ []byte) (*RedeemResult, error) {
 
@@ -255,6 +274,7 @@ func (s *fakeServer) RedeemCredit(_ context.Context, _ []byte,
 	return &RedeemResult{OperationID: op.id, State: op.state}, nil
 }
 
+// StartPay records a fake payment attempt and returns its configured error.
 func (s *fakeServer) StartPay(_ context.Context, _ string, _, _ uint64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -286,6 +306,22 @@ func (s *fakeServer) setOpState(key string, state ServerCreditState) {
 	}
 }
 
+// addServerOp adds an operation with an explicit server id to ListCredits.
+func (s *fakeServer) addServerOp(id string, state ServerCreditState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ops["test:"+id] = &fakeServerOp{id: id, state: state}
+}
+
+// listCallCount returns the number of ListCredits snapshots requested.
+func (s *fakeServer) listCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.listCalls
+}
+
 // setPayOp registers a server pay operation bound to a payment hash in the
 // given state, so a credit-only pay can reconcile against it via ListCredits.
 func (s *fakeServer) setPayOp(paymentHash []byte, state ServerCreditState) {
@@ -311,14 +347,17 @@ type fakeDaemon struct {
 	vtxoFloorErr error
 }
 
+// newFakeDaemon creates a fake daemon with no observed redeemed VTXO.
 func newFakeDaemon() *fakeDaemon {
 	return &fakeDaemon{sendOORCalls: make(map[string]int)}
 }
 
+// IdentityPubKey returns the stable fake credit account key.
 func (d *fakeDaemon) IdentityPubKey(context.Context) ([]byte, error) {
 	return []byte("identity-pubkey"), nil
 }
 
+// VTXOFloor returns the configured fake operator floor.
 func (d *fakeDaemon) VTXOFloor(context.Context) (uint64, error) {
 	if d.vtxoFloorErr != nil {
 		return 0, d.vtxoFloorErr
@@ -330,6 +369,7 @@ func (d *fakeDaemon) VTXOFloor(context.Context) (uint64, error) {
 	return 354, nil
 }
 
+// SendOOR records one idempotency-keyed fake transfer.
 func (d *fakeDaemon) SendOOR(_ context.Context, _ []byte, _ uint64,
 	idempotencyKey string) (string, error) {
 
@@ -341,6 +381,7 @@ func (d *fakeDaemon) SendOOR(_ context.Context, _ []byte, _ uint64,
 	return "oor-" + idempotencyKey, nil
 }
 
+// AllocateReceiveScript returns a stable fake redemption destination.
 func (d *fakeDaemon) AllocateReceiveScript(context.Context, string) ([]byte,
 	[]byte, error) {
 
@@ -352,6 +393,7 @@ func (d *fakeDaemon) AllocateReceiveScript(context.Context, string) ([]byte,
 	return []byte("redeem-pubkey"), []byte("redeem-pkscript"), nil
 }
 
+// FindLiveVTXOByPkScript reports the configured fake redemption observation.
 func (d *fakeDaemon) FindLiveVTXOByPkScript(context.Context, []byte) (bool,
 	int64, error) {
 
@@ -427,6 +469,7 @@ func driveTurn(b *opBehavior, ax actor.Exec[creditTx]) error {
 	return err
 }
 
+// payHash returns the stable payment hash shared by credit-pay tests.
 func payHash() [32]byte {
 	var h [32]byte
 	copy(h[:], "payment-hash-for-testing-000000000")
@@ -440,6 +483,7 @@ var errInjected = errInjectedT{}
 
 type errInjectedT struct{}
 
+// Error identifies the injected transaction failure.
 func (errInjectedT) Error() string { return "injected failure" }
 
 // TestDispatchFailsCorruptState asserts that an operation whose persisted state
@@ -630,9 +674,10 @@ func TestCreditPayFailsOnRelease(t *testing.T) {
 	require.NotEmpty(t, b.rec.LastError)
 }
 
-// TestAwaitingPollCapFailsOp asserts the configurable poll cap terminal-fails
-// an operation that the server never resolves, instead of parking forever.
-func TestAwaitingPollCapFailsOp(t *testing.T) {
+// TestReceiveIgnoresPollCap asserts an inbound receive remains pending beyond
+// the outgoing-operation poll cap and can still complete when the server later
+// reports the invoice credited.
+func TestReceiveIgnoresPollCap(t *testing.T) {
 	t.Parallel()
 
 	store := newFakeStore()
@@ -649,13 +694,99 @@ func TestAwaitingPollCapFailsOp(t *testing.T) {
 	drive(t, b, &ResumeCreditOpRequest{OpID: "op1"})
 	require.Equal(t, string(StateAwaitingSettlement), b.rec.State)
 
-	// The server never credits; after the poll cap the op fails rather than
-	// parking forever.
+	// The server never credits during several more polls than the cap. The
+	// client cannot treat that local count as proof the invoice failed.
+	for i := 0; i < 5; i++ {
+		drive(t, b, &ResumeCreditOpRequest{OpID: "op1"})
+		require.Equal(t, string(StateAwaitingSettlement), b.rec.State)
+	}
+
+	// A late authoritative credit still completes the receive.
+	server.markCredited("recv:abc", 42)
+	drive(t, b, &ResumeCreditOpRequest{OpID: "op1"})
+	require.Equal(t, string(StateCompleted), b.rec.State)
+}
+
+// TestReceiveFailsOnServerExpiry asserts an inbound receive fails when the
+// server reports its invoice expired, even though the local poll cap is not an
+// authority for receive termination.
+func TestReceiveFailsOnServerExpiry(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	server, daemon := newFakeServer(), newFakeDaemon()
+	b := testBehavior("op1", store, server, daemon)
+	b.cfg.MaxAwaitingPolls = 1
+
+	admit(t, b, store, &StartCreditReceiveRequest{
+		OpKey:     "recv:abc",
+		AmountSat: 42,
+	})
 	drive(t, b, &ResumeCreditOpRequest{OpID: "op1"})
 	require.Equal(t, string(StateAwaitingSettlement), b.rec.State)
+
+	server.setOpState("recv:abc", ServerStateExpired)
 	drive(t, b, &ResumeCreditOpRequest{OpID: "op1"})
 	require.Equal(t, string(StateFailed), b.rec.State)
-	require.NotEmpty(t, b.rec.LastError)
+	require.Equal(t, "receive funding ended in expired", b.rec.LastError)
+}
+
+// TestOutgoingOperationsHonorPollCap is the negative control for receive's
+// unbounded wait: top-up funding and credit-only payment settlement still fail
+// when their server operations remain unresolved past the configured cap.
+func TestOutgoingOperationsHonorPollCap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		msg  CreditMsg
+		want State
+	}{
+		{
+			name: "top-up",
+			msg: &StartCreditPayRequest{
+				OpKey:        "pay:topup",
+				Invoice:      "lnbc1",
+				PaymentHash:  payHash(),
+				AmountSat:    500,
+				TopupSat:     200,
+				MaxCreditSat: 500,
+			},
+			want: StateTopupAwaitingCredit,
+		},
+		{
+			name: "credit-only pay",
+			msg: &StartCreditPayRequest{
+				OpKey:        "pay:credit-only",
+				Invoice:      "lnbc2",
+				PaymentHash:  payHash(),
+				AmountSat:    500,
+				MaxCreditSat: 500,
+				CreditOnly:   true,
+			},
+			want: StatePayAwaitingSettlement,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newFakeStore()
+			server, daemon := newFakeServer(), newFakeDaemon()
+			b := testBehavior("op1", store, server, daemon)
+			b.cfg.MaxAwaitingPolls = 1
+
+			admit(t, b, store, test.msg)
+			drive(t, b, &ResumeCreditOpRequest{OpID: "op1"})
+			require.Equal(t, string(test.want), b.rec.State)
+
+			drive(t, b, &ResumeCreditOpRequest{OpID: "op1"})
+			require.Equal(t, string(StateFailed), b.rec.State)
+			require.NotEmpty(t, b.rec.LastError)
+		})
+	}
 }
 
 // TestPayNoTopupCompletes asserts a pay with no shortfall jumps straight to

--- a/credit/registry.go
+++ b/credit/registry.go
@@ -584,9 +584,9 @@ func (b *registryBehavior) repairLegacyReceivePollCapFailures(
 		return
 	}
 
-	repairTimeout := b.cfg.AdmitTimeout
+	repairTimeout := b.cfg.ReceiveAdmitTimeout
 	if repairTimeout <= 0 {
-		repairTimeout = DefaultAdmitTimeout
+		repairTimeout = DefaultReceiveAdmitTimeout
 	}
 	repairCtx, cancel := context.WithTimeout(ctx, repairTimeout)
 	defer cancel()
@@ -672,7 +672,12 @@ func (b *registryBehavior) repairLegacyReceivePollCapFailures(
 			)
 			switch {
 			case lookupErr == nil && active.OpID != updated.OpID:
-				continue
+				// Keep failed; the newer row owns the key.
+				// Replace only the known-false verdict.
+				updated = rec
+				updated.LastError = supersededReceiveReason(
+					serverState,
+				)
 
 			case lookupErr != nil && !errors.Is(
 				lookupErr, db.ErrCreditOperationNotFound,
@@ -774,6 +779,13 @@ func repairLegacyReceiveRecord(rec db.CreditOperationRecord,
 	default:
 		return rec, false, nil
 	}
+}
+
+// supersededReceiveReason replaces the known-false legacy poll-cap verdict
+// when a newer local operation already owns the active operation key.
+func supersededReceiveReason(serverState ServerCreditState) string {
+	return fmt.Sprintf("legacy receive superseded while server state is %s",
+		serverState)
 }
 
 // handleList projects the stored operations into compact summaries. A

--- a/credit/registry.go
+++ b/credit/registry.go
@@ -18,7 +18,14 @@ import (
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
-const creditChildStopTimeout = 5 * time.Second
+const (
+	creditChildStopTimeout = 5 * time.Second
+
+	// LegacyReceivePollCapError is the exact terminal error written by
+	// clients that incorrectly applied the outgoing-operation poll cap to
+	// server-owned receive invoices.
+	LegacyReceivePollCapError = "receive credit not settled within poll cap"
+)
 
 // Registry is the credit subsystem coordinator. It is a plain (non-durable)
 // supervisor actor: it admits operations by writing their control-plane row in
@@ -524,6 +531,12 @@ func (b *registryBehavior) ensureChild(ctx context.Context, opID string) (
 
 // restoreNonTerminal respawns and resumes every non-terminal operation.
 func (b *registryBehavior) restoreNonTerminal(ctx context.Context) error {
+	// Repair the false terminal receive state written by older clients
+	// before selecting rows to restore. This is deliberately best-effort:
+	// an unavailable server snapshot cannot prove a different state, so it
+	// must not either rewrite local history or block ordinary boot restore.
+	b.repairLegacyReceivePollCapFailures(ctx)
+
 	rows, err := b.cfg.Store.ListNonTerminal(ctx)
 	if err != nil {
 		return fmt.Errorf("list non-terminal credit ops: %w", err)
@@ -538,6 +551,229 @@ func (b *registryBehavior) restoreNonTerminal(ctx context.Context) error {
 	)
 
 	return nil
+}
+
+// repairLegacyReceivePollCapFailures reconciles receives that an older client
+// falsely terminal-failed after exhausting its local poll budget. All eligible
+// rows share one server snapshot so the repair makes one coherent decision per
+// boot. Missing operations and unavailable evidence leave their rows untouched.
+func (b *registryBehavior) repairLegacyReceivePollCapFailures(
+	ctx context.Context) {
+
+	rows, err := b.cfg.Store.ListOperations(ctx)
+	if err != nil {
+		b.
+			logger(ctx).
+			InfoS(
+				ctx,
+				"Skipping legacy credit receive repair: "+
+					"operations unavailable",
+				slog.String("err", err.Error()),
+			)
+
+		return
+	}
+
+	candidates := make([]db.CreditOperationRecord, 0)
+	for i := range rows {
+		if isLegacyReceivePollCapFailure(rows[i]) {
+			candidates = append(candidates, rows[i])
+		}
+	}
+	if len(candidates) == 0 {
+		return
+	}
+
+	repairTimeout := b.cfg.AdmitTimeout
+	if repairTimeout <= 0 {
+		repairTimeout = DefaultAdmitTimeout
+	}
+	repairCtx, cancel := context.WithTimeout(ctx, repairTimeout)
+	defer cancel()
+
+	accountKey, err := b.cfg.Daemon.IdentityPubKey(repairCtx)
+	if err != nil {
+		b.
+			logger(ctx).
+			InfoS(
+				ctx,
+				"Skipping legacy credit receive repair: "+
+					"identity unavailable",
+				slog.String("err", err.Error()),
+			)
+
+		return
+	}
+
+	snapshot, err := b.cfg.Server.ListCredits(repairCtx, accountKey)
+	if err != nil || snapshot == nil {
+		attrs := []any{
+			slog.Int("candidate_count", len(candidates)),
+		}
+		if err != nil {
+			attrs = append(attrs, slog.String("err", err.Error()))
+		}
+		b.
+			logger(ctx).
+			InfoS(
+				ctx,
+				"Skipping legacy credit receive repair: "+
+					"server snapshot unavailable",
+				attrs...,
+			)
+
+		return
+	}
+
+	serverStates := make(
+		map[string]ServerCreditState, len(snapshot.Operations),
+	)
+	for i := range snapshot.Operations {
+		op := snapshot.Operations[i]
+		serverStates[op.OperationID] = op.State
+	}
+
+	var repaired int
+	store := b.cfg.Store
+	for i := range candidates {
+		rec := candidates[i]
+		serverState, ok := serverStates[rec.ServerOpID]
+		if !ok {
+			continue
+		}
+
+		updated, changed, err := repairLegacyReceiveRecord(
+			rec, serverState,
+		)
+		if err != nil {
+			b.
+				logger(ctx).
+				InfoS(
+					ctx,
+					"Skipping legacy credit receive "+
+						"repair: snapshot invalid",
+					slog.String("op_id", rec.OpID),
+					slog.String("err", err.Error()),
+				)
+
+			continue
+		}
+		if !changed {
+			continue
+		}
+
+		// Pending and completed rows participate in the active op-key
+		// uniqueness constraint. A retry admitted after the legacy
+		// failure owns that key now, so leave the historical row failed
+		// instead of colliding with or displacing the newer operation.
+		if updated.Status != db.CreditOpStatusFailed {
+			active, lookupErr := store.LookupActiveOperationByKey(
+				ctx, updated.OpKey,
+			)
+			switch {
+			case lookupErr == nil && active.OpID != updated.OpID:
+				continue
+
+			case lookupErr != nil && !errors.Is(
+				lookupErr, db.ErrCreditOperationNotFound,
+			):
+
+				b.
+					logger(ctx).
+					InfoS(
+						ctx,
+						"Credit receive repair skipped",
+						slog.String("op_id", rec.OpID),
+						slog.String(
+							"err",
+							lookupErr.Error(),
+						),
+					)
+
+				continue
+			}
+		}
+
+		if err := store.UpsertOperation(
+			ctx, updated,
+		); err != nil {
+
+			b.
+				logger(ctx).
+				InfoS(
+					ctx,
+					"Unable to repair legacy credit "+
+						"receive",
+					slog.String("op_id", rec.OpID),
+					slog.String("err", err.Error()),
+				)
+
+			continue
+		}
+
+		repaired++
+	}
+
+	if repaired > 0 {
+		b.logger(ctx).InfoS(ctx, "Repaired legacy credit receive "+
+			"operations", slog.Int("count", repaired))
+	}
+}
+
+// isLegacyReceivePollCapFailure reports whether a row carries the exact false
+// terminal state written by the old receive poll-cap path. The strict match
+// keeps unrelated failures and operation kinds outside the compatibility fix.
+func isLegacyReceivePollCapFailure(rec db.CreditOperationRecord) bool {
+	return rec.Kind == KindReceive &&
+		rec.State == string(StateFailed) &&
+		rec.Status == db.CreditOpStatusFailed &&
+		rec.ServerOpID != "" &&
+		rec.LastError == LegacyReceivePollCapError
+}
+
+// repairLegacyReceiveRecord maps one legacy false failure to the authoritative
+// server state. A still-payable invoice resumes, a credited invoice completes,
+// and a server terminal failure remains failed with its authoritative reason.
+func repairLegacyReceiveRecord(rec db.CreditOperationRecord,
+	serverState ServerCreditState) (db.CreditOperationRecord, bool, error) {
+
+	switch serverState {
+	case ServerStateCreated, ServerStateAwaitingPayment:
+		snapshot, err := decodeOpSnapshot(rec.SnapshotData)
+		if err != nil {
+			return rec, false, err
+		}
+		snapshot.AwaitPolls = 0
+
+		raw, err := snapshot.encode()
+		if err != nil {
+			return rec, false, err
+		}
+
+		rec.State = string(StateAwaitingSettlement)
+		rec.Status = db.CreditOpStatusPending
+		rec.LastError = ""
+		rec.SnapshotData = raw
+		rec.SnapshotVersion = snapshotVersion
+
+		return rec, true, nil
+
+	case ServerStateCredited:
+		rec.State = string(StateCompleted)
+		rec.Status = db.CreditOpStatusCompleted
+		rec.LastError = ""
+
+		return rec, true, nil
+
+	case ServerStateExpired, ServerStateFailed, ServerStateReleased:
+		rec.LastError = fmt.Sprintf("receive funding ended in %s",
+			serverState)
+
+		return rec, true, nil
+
+	default:
+		return rec, false, nil
+	}
 }
 
 // handleList projects the stored operations into compact summaries. A

--- a/credit/registry_test.go
+++ b/credit/registry_test.go
@@ -47,6 +47,205 @@ func waitForState(t *testing.T, store Store, opID string, want State) {
 	}, 5*time.Second, 20*time.Millisecond)
 }
 
+// legacyFailedReceive builds the exact terminal row written by the old receive
+// poll-cap path, including a persisted exhausted counter that repair must reset
+// before resuming the operation.
+func legacyFailedReceive(t *testing.T, opID, opKey,
+	serverOpID string) db.CreditOperationRecord {
+
+	t.Helper()
+
+	raw, err := (&opSnapshot{AwaitPolls: 121}).encode()
+	require.NoError(t, err)
+
+	return db.CreditOperationRecord{
+		OpID:            opID,
+		OpKey:           opKey,
+		Kind:            KindReceive,
+		State:           string(StateFailed),
+		Status:          db.CreditOpStatusFailed,
+		ServerOpID:      serverOpID,
+		Invoice:         "lnbc-" + opID,
+		AmountSat:       200,
+		LastError:       LegacyReceivePollCapError,
+		SnapshotData:    raw,
+		SnapshotVersion: snapshotVersion,
+	}
+}
+
+// TestRepairLegacyReceivePollCapFailures asserts one server snapshot repairs
+// every eligible legacy row according to server truth while leaving absent and
+// unrelated operations untouched.
+func TestRepairLegacyReceivePollCapFailures(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	server, daemon := newFakeServer(), newFakeDaemon()
+
+	awaiting := legacyFailedReceive(
+		t, "recv-awaiting", "recv:key-awaiting", "srv-awaiting",
+	)
+	credited := legacyFailedReceive(
+		t, "recv-credited", "recv:key-credited", "srv-credited",
+	)
+	expired := legacyFailedReceive(
+		t, "recv-expired", "recv:key-expired", "srv-expired",
+	)
+	missing := legacyFailedReceive(
+		t, "recv-missing", "recv:key-missing", "srv-missing",
+	)
+	unrelated := legacyFailedReceive(
+		t, "recv-unrelated", "recv:key-unrelated", "srv-unrelated",
+	)
+	unrelated.LastError = "some other failure"
+	conflictPending := legacyFailedReceive(
+		t, "recv-conflict-pending", "recv:key-conflict-pending",
+		"srv-conflict-pending",
+	)
+	conflictCompleted := legacyFailedReceive(
+		t, "recv-conflict-completed", "recv:key-conflict-completed",
+		"srv-conflict-completed",
+	)
+
+	for _, rec := range []db.CreditOperationRecord{
+		awaiting, credited, expired, missing, unrelated,
+		conflictPending, conflictCompleted,
+	} {
+		store.ops[rec.OpID] = rec
+	}
+	store.ops["newer-pending"] = db.CreditOperationRecord{
+		OpID:   "newer-pending",
+		OpKey:  conflictPending.OpKey,
+		Kind:   KindReceive,
+		State:  string(StateAwaitingSettlement),
+		Status: db.CreditOpStatusPending,
+	}
+	store.ops["newer-completed"] = db.CreditOperationRecord{
+		OpID:   "newer-completed",
+		OpKey:  conflictCompleted.OpKey,
+		Kind:   KindReceive,
+		State:  string(StateCompleted),
+		Status: db.CreditOpStatusCompleted,
+	}
+	server.addServerOp("srv-awaiting", ServerStateAwaitingPayment)
+	server.addServerOp("srv-credited", ServerStateCredited)
+	server.addServerOp("srv-expired", ServerStateExpired)
+	server.addServerOp("srv-unrelated", ServerStateCredited)
+	server.addServerOp(
+		"srv-conflict-pending", ServerStateAwaitingPayment,
+	)
+	server.addServerOp("srv-conflict-completed", ServerStateCredited)
+
+	behavior := &registryBehavior{
+		cfg: RegistryConfig{
+			Store:  store,
+			Server: server,
+			Daemon: daemon,
+		},
+		log:    btclog.Disabled,
+		active: make(map[string]*OpActor),
+	}
+	behavior.repairLegacyReceivePollCapFailures(t.Context())
+
+	require.Equal(t, 1, server.listCallCount())
+
+	got, err := store.GetOperation(t.Context(), awaiting.OpID)
+	require.NoError(t, err)
+	require.Equal(t, string(StateAwaitingSettlement), got.State)
+	require.Equal(t, db.CreditOpStatusPending, got.Status)
+	require.Empty(t, got.LastError)
+	snapshot, err := decodeOpSnapshot(got.SnapshotData)
+	require.NoError(t, err)
+	require.Zero(t, snapshot.AwaitPolls)
+
+	got, err = store.GetOperation(t.Context(), credited.OpID)
+	require.NoError(t, err)
+	require.Equal(t, string(StateCompleted), got.State)
+	require.Equal(t, db.CreditOpStatusCompleted, got.Status)
+	require.Empty(t, got.LastError)
+
+	got, err = store.GetOperation(t.Context(), expired.OpID)
+	require.NoError(t, err)
+	require.Equal(t, string(StateFailed), got.State)
+	require.Equal(t, db.CreditOpStatusFailed, got.Status)
+	require.Equal(t, "receive funding ended in expired", got.LastError)
+
+	got, err = store.GetOperation(t.Context(), missing.OpID)
+	require.NoError(t, err)
+	require.Equal(t, missing, *got)
+
+	got, err = store.GetOperation(t.Context(), unrelated.OpID)
+	require.NoError(t, err)
+	require.Equal(t, unrelated, *got)
+
+	got, err = store.GetOperation(t.Context(), conflictPending.OpID)
+	require.NoError(t, err)
+	require.Equal(t, conflictPending, *got)
+
+	got, err = store.GetOperation(t.Context(), conflictCompleted.OpID)
+	require.NoError(t, err)
+	require.Equal(t, conflictCompleted, *got)
+}
+
+// TestRepairLegacyReceiveSkipsUnavailableSnapshot asserts boot repair never
+// rewrites local terminal history when the authoritative server view cannot be
+// obtained.
+func TestRepairLegacyReceiveSkipsUnavailableSnapshot(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	server, daemon := newFakeServer(), newFakeDaemon()
+	rec := legacyFailedReceive(t, "recv", "recv:key", "srv-recv")
+	store.ops[rec.OpID] = rec
+	server.listErr = errors.New("server unavailable")
+
+	behavior := &registryBehavior{
+		cfg: RegistryConfig{
+			Store:  store,
+			Server: server,
+			Daemon: daemon,
+		},
+		log:    btclog.Disabled,
+		active: make(map[string]*OpActor),
+	}
+	behavior.repairLegacyReceivePollCapFailures(t.Context())
+
+	got, err := store.GetOperation(t.Context(), rec.OpID)
+	require.NoError(t, err)
+	require.Equal(t, rec, *got)
+	require.Equal(t, 1, server.listCallCount())
+}
+
+// TestRestoreLegacyReceiveResumesSettlement proves the boot path reopens the
+// exact legacy false failure, respawns its durable child, and later completes
+// it from an authoritative credited state.
+func TestRestoreLegacyReceiveResumesSettlement(t *testing.T) {
+	t.Parallel()
+
+	store, delivery := newFakeStore(), newTestDelivery(t)
+	server, daemon := newFakeServer(), newFakeDaemon()
+	rec := legacyFailedReceive(t, "recv", "recv:key", "srv-recv")
+	store.ops[rec.OpID] = rec
+	server.addServerOp("srv-recv", ServerStateAwaitingPayment)
+
+	registry, err := NewRegistry(RegistryConfig{
+		Store:            store,
+		DeliveryStore:    delivery,
+		Server:           server,
+		Daemon:           daemon,
+		PollInterval:     50 * time.Millisecond,
+		MaxAwaitingPolls: 1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(registry.Stop)
+
+	require.NoError(t, registry.RestoreNonTerminal(t.Context()))
+	waitForState(t, store, rec.OpID, StateAwaitingSettlement)
+
+	server.addServerOp("srv-recv", ServerStateCredited)
+	waitForState(t, store, rec.OpID, StateCompleted)
+}
+
 // TestRegistryReceiveAdmitTimeoutFallback verifies that the dedicated receive
 // timeout preserves the legacy AdmitTimeout override while using its shorter
 // default for callers that left both fields unset.
@@ -510,4 +709,5 @@ func findOp(ops []CreditOpSummary, opID string) (CreditOpSummary, bool) {
 // paying state without completing.
 type errContextStub struct{}
 
+// Error identifies the fake transient payment error.
 func (errContextStub) Error() string { return "stubbed transient pay error" }

--- a/credit/registry_test.go
+++ b/credit/registry_test.go
@@ -180,11 +180,21 @@ func TestRepairLegacyReceivePollCapFailures(t *testing.T) {
 
 	got, err = store.GetOperation(t.Context(), conflictPending.OpID)
 	require.NoError(t, err)
-	require.Equal(t, conflictPending, *got)
+	require.Equal(t, string(StateFailed), got.State)
+	require.Equal(t, db.CreditOpStatusFailed, got.Status)
+	require.Equal(
+		t, "legacy receive superseded while server state is "+
+			"awaiting_payment", got.LastError,
+	)
 
 	got, err = store.GetOperation(t.Context(), conflictCompleted.OpID)
 	require.NoError(t, err)
-	require.Equal(t, conflictCompleted, *got)
+	require.Equal(t, string(StateFailed), got.State)
+	require.Equal(t, db.CreditOpStatusFailed, got.Status)
+	require.Equal(
+		t, "legacy receive superseded while server state is credited",
+		got.LastError,
+	)
 }
 
 // TestRepairLegacyReceiveSkipsUnavailableSnapshot asserts boot repair never

--- a/credit/snapshot.go
+++ b/credit/snapshot.go
@@ -39,10 +39,10 @@ type opSnapshot struct {
 	// ops.
 	CreditOnly bool
 
-	// AwaitPolls counts how many reconciliation polls the current awaiting
-	// state has taken, so a configured MaxAwaitingPolls cap can terminal-
-	// fail an operation that the server never resolves. Reset to zero each
-	// time the FSM advances into a new awaiting state.
+	// AwaitPolls counts how many reconciliation polls the current capped
+	// awaiting state has taken. Receive settlement is uncapped because the
+	// server owns the invoice lifecycle. Reset to zero each time the FSM
+	// advances into a new awaiting state.
 	AwaitPolls uint32
 }
 

--- a/credit/transition_table.go
+++ b/credit/transition_table.go
@@ -145,7 +145,7 @@ var CreditTransitions = CreditTransitionTable{
 			}, {
 				Event:       &opDrive{},
 				ToState:     &failedState{},
-				Description: "receive failed or poll cap",
+				Description: "server reports receive failed",
 				IsTerminal:  true,
 			}},
 		},

--- a/credit/transitions.go
+++ b/credit/transitions.go
@@ -263,9 +263,9 @@ func (receiveCreatingState) ProcessEvent(ctx context.Context, _ CreditEvent,
 // and, if the earmark-adjusted available balance now clears the threshold,
 // emits a triggerRedeem so the registry can materialize the credits — folding
 // the auto-redeem decision into the receive state machine instead of a periodic
-// background sweep. The wait is bounded by the server-reported terminal states
-// and the optional poll cap, so an unpaid invoice the server expires fails the
-// operation deterministically.
+// background sweep. The server owns the invoice lifecycle, so only its
+// CREDITED/EXPIRED/FAILED/RELEASED state can terminate the receive. A client
+// poll count cannot prove that a still-payable invoice failed.
 func (awaitingSettlementState) ProcessEvent(ctx context.Context, _ CreditEvent,
 	b *opBehavior) (*CreditTransition, error) {
 
@@ -300,10 +300,6 @@ func (awaitingSettlementState) ProcessEvent(ctx context.Context, _ CreditEvent,
 		}
 
 		return emit(&completedState{}, out...)
-	}
-
-	if b.awaitExhausted() {
-		return b.fail(ctx, "receive credit not settled within poll cap")
 	}
 
 	return emit(&awaitingSettlementState{}, &parkOp{})

--- a/db/activity_store.go
+++ b/db/activity_store.go
@@ -20,6 +20,14 @@ type ActivityStore interface {
 	UpsertActivityEntry(ctx context.Context,
 		arg sqlc.UpsertActivityEntryParams) (int64, error)
 
+	// RepairCreditReceivePollCapActivity reopens only the exact legacy
+	// inbound credit-receive failure.
+	RepairCreditReceivePollCapActivity(ctx context.Context,
+		arg sqlc.RepairCreditReceivePollCapActivityParams) (
+		int64,
+		error,
+	)
+
 	// AppendActivityEvent records one immutable activity transition.
 	AppendActivityEvent(ctx context.Context,
 		arg sqlc.AppendActivityEventParams) (int64, error)
@@ -154,6 +162,63 @@ type ActivityProjection struct {
 type ActivityPersistenceStore struct {
 	db    BatchedActivityStore
 	clock clock.Clock
+}
+
+// RepairCreditReceivePollCap reopens only an inbound receive activity row
+// carrying the exact legacy poll-cap failure. The guarded current-state update
+// and corrective pending event commit atomically, preserving the append-only
+// event history without relaxing ProjectEntry's terminal-to-pending rule.
+func (s *ActivityPersistenceStore) RepairCreditReceivePollCap(
+	ctx context.Context, p ActivityProjection, failedStatus int64,
+	legacyFailureReason string) (int64, error) {
+
+	now := s.clock.Now().Unix()
+	updatedAt := p.UpdatedAtUnix
+	if updatedAt == 0 {
+		updatedAt = now
+	}
+
+	var eventSeq int64
+	err := s.db.ExecTx(ctx, WriteTxOption(), func(q ActivityStore) error {
+		eventSeq = 0
+
+		rows, err := q.RepairCreditReceivePollCapActivity(
+			ctx, sqlc.RepairCreditReceivePollCapActivityParams{
+				PendingStatus:       p.Status,
+				PendingPhase:        p.Phase,
+				PendingPhaseLabel:   p.PhaseLabel,
+				UpdatedAtUnix:       updatedAt,
+				CanonicalID:         p.CanonicalID,
+				ReceiveKind:         p.Kind,
+				FailedStatus:        failedStatus,
+				LegacyFailureReason: legacyFailureReason,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return nil
+		}
+
+		seq, err := q.AppendActivityEvent(
+			ctx, sqlc.AppendActivityEventParams{
+				CanonicalID:   p.CanonicalID,
+				Status:        p.Status,
+				Phase:         p.Phase,
+				EntryJson:     p.EntryJSON,
+				CreatedAtUnix: updatedAt,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		eventSeq = seq
+
+		return nil
+	})
+
+	return eventSeq, err
 }
 
 // NewActivityPersistenceStore creates an activity-log store using the

--- a/db/activity_store_test.go
+++ b/db/activity_store_test.go
@@ -168,6 +168,81 @@ func TestActivityStoreRejectsTerminalRegression(t *testing.T) {
 	require.Len(t, events, 2)
 }
 
+// TestActivityStoreRepairsCreditReceivePollCap verifies the compatibility
+// write is narrower than the ordinary terminal-to-pending rule: only the exact
+// receive failure is reopened, its correction is appended, and other terminal
+// failures remain immutable.
+func TestActivityStoreRepairsCreditReceivePollCap(t *testing.T) {
+	t.Parallel()
+
+	const legacyError = "receive credit not settled within poll cap"
+
+	ctx := t.Context()
+	store := newActivityStoreForTest(t)
+
+	failed := sampleProjection("legacy-receive")
+	failed.Kind = 2
+	failed.Status = 2
+	failed.Phase = 9
+	failed.PhaseLabel = "failed"
+	failed.FailureCode = 1
+	failed.FailureReason = legacyError
+	failed.EntryJSON = `{"id":"legacy-receive","status":"failed"}`
+	_, err := store.ProjectEntry(ctx, failed)
+	require.NoError(t, err)
+
+	pending := failed
+	pending.Status = 1
+	pending.Phase = 4
+	pending.PhaseLabel = "waiting_for_payment"
+	pending.FailureCode = 0
+	pending.FailureReason = ""
+	pending.EntryJSON = `{"id":"legacy-receive","status":"pending"}`
+	pending.UpdatedAtUnix = 200
+
+	ordinarySeq, err := store.ProjectEntry(ctx, pending)
+	require.NoError(t, err)
+	require.Zero(t, ordinarySeq)
+
+	repairSeq, err := store.RepairCreditReceivePollCap(
+		ctx, pending, 2, legacyError,
+	)
+	require.NoError(t, err)
+	require.Positive(t, repairSeq)
+
+	row, err := store.GetEntry(ctx, failed.CanonicalID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, row.Status)
+	require.EqualValues(t, 4, row.Phase)
+	require.Empty(t, row.FailureReason)
+
+	events, err := store.PullEvents(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	require.EqualValues(t, 1, events[1].Status)
+
+	// An authoritative failure with a different reason cannot be reopened
+	// through the compatibility method.
+	other := failed
+	other.CanonicalID = "other-failure"
+	other.FailureReason = "receive funding ended in expired"
+	_, err = store.ProjectEntry(ctx, other)
+	require.NoError(t, err)
+
+	otherPending := pending
+	otherPending.CanonicalID = other.CanonicalID
+	seq, err := store.RepairCreditReceivePollCap(
+		ctx, otherPending, 2, legacyError,
+	)
+	require.NoError(t, err)
+	require.Zero(t, seq)
+
+	row, err = store.GetEntry(ctx, other.CanonicalID)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, row.Status)
+	require.Equal(t, other.FailureReason, row.FailureReason)
+}
+
 // TestActivityStoreRequestOnlyEnrichment verifies immutable request context is
 // allowed to enrich an otherwise unchanged sparse row exactly once.
 func TestActivityStoreRequestOnlyEnrichment(t *testing.T) {

--- a/db/sqlc/activity_log.sql.go
+++ b/db/sqlc/activity_log.sql.go
@@ -302,6 +302,52 @@ func (q *Queries) PullActivityEvents(ctx context.Context, arg PullActivityEvents
 	return items, nil
 }
 
+const RepairCreditReceivePollCapActivity = `-- name: RepairCreditReceivePollCapActivity :execrows
+UPDATE activity_entries SET
+    status          = $1,
+    phase           = $2,
+    phase_label     = $3,
+    failure_code    = 0,
+    failure_reason  = '',
+    updated_at_unix = $4
+WHERE canonical_id = $5
+    AND kind = $6
+    AND status = $7
+    AND failure_reason = $8
+`
+
+type RepairCreditReceivePollCapActivityParams struct {
+	PendingStatus       int64
+	PendingPhase        int64
+	PendingPhaseLabel   string
+	UpdatedAtUnix       int64
+	CanonicalID         string
+	ReceiveKind         int64
+	FailedStatus        int64
+	LegacyFailureReason string
+}
+
+// RepairCreditReceivePollCapActivity narrowly reopens an inbound credit
+// receive that an older client marked terminal after exhausting its local poll
+// budget. The exact kind, failed status, and legacy error guard prevent this
+// compatibility repair from weakening the normal terminal-to-pending rule.
+func (q *Queries) RepairCreditReceivePollCapActivity(ctx context.Context, arg RepairCreditReceivePollCapActivityParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, RepairCreditReceivePollCapActivity,
+		arg.PendingStatus,
+		arg.PendingPhase,
+		arg.PendingPhaseLabel,
+		arg.UpdatedAtUnix,
+		arg.CanonicalID,
+		arg.ReceiveKind,
+		arg.FailedStatus,
+		arg.LegacyFailureReason,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const UpsertActivityEntry = `-- name: UpsertActivityEntry :execrows
 
 INSERT INTO activity_entries (

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -382,6 +382,11 @@ type Querier interface {
 	// event_seq order, the resumable-subscribe replay primitive.
 	PullActivityEvents(ctx context.Context, arg PullActivityEventsParams) ([]ActivityEvent, error)
 	RenewOwnedReceiveScriptRegistration(ctx context.Context, arg RenewOwnedReceiveScriptRegistrationParams) (int64, error)
+	// RepairCreditReceivePollCapActivity narrowly reopens an inbound credit
+	// receive that an older client marked terminal after exhausting its local poll
+	// budget. The exact kind, failed status, and legacy error guard prevent this
+	// compatibility repair from weakening the normal terminal-to-pending rule.
+	RepairCreditReceivePollCapActivity(ctx context.Context, arg RepairCreditReceivePollCapActivityParams) (int64, error)
 	SumBoardingIntentAmountsByStatus(ctx context.Context, status string) (interface{}, error)
 	SumUnspentVTXOAmounts(ctx context.Context) (interface{}, error)
 	UpdateBoardingIntentStatus(ctx context.Context, arg UpdateBoardingIntentStatusParams) error

--- a/db/sqlc/queries/activity_log.sql
+++ b/db/sqlc/queries/activity_log.sql
@@ -45,6 +45,23 @@ ON CONFLICT (canonical_id) DO UPDATE SET
 WHERE activity_entries.status = sqlc.arg(pending_status)
     OR EXCLUDED.status <> sqlc.arg(pending_status);
 
+-- name: RepairCreditReceivePollCapActivity :execrows
+-- RepairCreditReceivePollCapActivity narrowly reopens an inbound credit
+-- receive that an older client marked terminal after exhausting its local poll
+-- budget. The exact kind, failed status, and legacy error guard prevent this
+-- compatibility repair from weakening the normal terminal-to-pending rule.
+UPDATE activity_entries SET
+    status          = sqlc.arg(pending_status),
+    phase           = sqlc.arg(pending_phase),
+    phase_label     = sqlc.arg(pending_phase_label),
+    failure_code    = 0,
+    failure_reason  = '',
+    updated_at_unix = sqlc.arg(updated_at_unix)
+WHERE canonical_id = sqlc.arg(canonical_id)
+    AND kind = sqlc.arg(receive_kind)
+    AND status = sqlc.arg(failed_status)
+    AND failure_reason = sqlc.arg(legacy_failure_reason);
+
 -- name: AppendActivityEvent :one
 -- AppendActivityEvent records one immutable lifecycle-transition row and
 -- returns the event_seq the database assigned (monotonic, not necessarily

--- a/docs/credit_durable_actor_design.md
+++ b/docs/credit_durable_actor_design.md
@@ -299,10 +299,10 @@ quoting → topup_creating → topup_funding → topup_awaiting_credit → payin
   / `FAILED` / `EXPIRED` fails. This closes the window where a credit-only pay was
   reported complete before the Lightning leg settled.
 
-Every awaiting state honors an optional `MaxAwaitingPolls` cap: an operation the
-server never resolves terminal-fails after the cap rather than polling forever.
-Zero (the default) relies on the server-reported terminal states to bound the
-wait.
+The top-up, pay, and redeem awaiting states honor an optional
+`MaxAwaitingPolls` cap: an outgoing operation the server never resolves
+terminal-fails after the cap rather than blocking forever. Zero (the default)
+disables the cap.
 
 ### 5.2 Receive
 
@@ -317,6 +317,19 @@ the caller and survives restart. The spawned child therefore enters at
 `awaiting_settlement`, a poll-driven `ListCredits` for `CREDITED`.
 `receive_creating` remains the resume and fallback path; its `CreateCredit` is
 idempotent by op key.
+
+The receive remains pending until the server reports `CREDITED`, `EXPIRED`,
+`FAILED`, or `RELEASED`. `MaxAwaitingPolls` does not apply: exhausting a local
+poll budget cannot prove that the server-owned invoice is no longer payable.
+At boot, the registry repairs rows written by older versions with the exact
+legacy poll-cap failure. It reads one authoritative account snapshot, restores
+still-payable receives to `awaiting_settlement`, promotes already-credited
+receives to `completed`, and preserves authoritative terminal failures. A
+missing operation or unavailable snapshot leaves the local row unchanged.
+For a still-payable receive, the wallet projector atomically reopens the exact
+legacy `FAILED` activity row to `PENDING` and appends a corrective event. The
+ordinary terminal-to-pending guard remains unchanged for every other activity
+row.
 
 When the receive settles, the same step evaluates the auto-redeem watermark
 (section 6) and, when it clears, emits `triggerRedeem` on the edge to

--- a/docs/credit_system.md
+++ b/docs/credit_system.md
@@ -348,6 +348,14 @@ daemon restarts after an Ark top-up but before the pay starts, it resumes the
 same operation under the same idempotency key, so the top-up is never repeated
 and the value is not lost.
 
+A credit receive stays pending for the lifetime of its server-owned invoice.
+Local polling never marks it failed; only the server's credited or terminal
+operation state resolves it. On upgrade, the daemon reconciles the exact
+poll-cap failure written by older versions against one server snapshot so a
+still-payable or already-credited receive is visible again. A still-payable
+receive's wallet activity row is restored from the exact legacy failure to
+pending without weakening terminal-state handling for other wallet activity.
+
 If the daemon restarts during a credit-assisted receive, the receive session
 reloads the planned `attached_credit_sat` and `vhtlc_amount_sat`. When the HTLC
 event arrives, the FSM validates the funded vHTLC against that plan before it

--- a/swapwallet/credit_projector.go
+++ b/swapwallet/credit_projector.go
@@ -4,6 +4,8 @@ package swapwallet
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -221,7 +223,12 @@ func (r *Runtime) pollCreditOps(projected map[string]credit.State) {
 		// class of bug). The store suppresses no-op re-projections, so
 		// the coarse re-poll of unchanged terminal rows appends no
 		// duplicate events.
-		if _, err := r.projectEmitLocked(r.rootCtx, entry); err != nil {
+		repairLegacyReceive := op.Kind == credit.KindReceive &&
+			!op.State.IsTerminal()
+		if _, err := r.projectCreditEntry(
+			r.rootCtx, entry, repairLegacyReceive,
+		); err != nil {
+
 			continue
 		}
 
@@ -236,6 +243,96 @@ func (r *Runtime) pollCreditOps(projected map[string]credit.State) {
 			r.trackPendingEntryWithoutTimeout(entry)
 		}
 	}
+}
+
+// projectCreditEntry projects one credit operation while preserving the
+// global project-and-emit ordering. A resumed receive gets one narrowly scoped
+// compatibility attempt to reopen an activity row carrying the exact legacy
+// poll-cap failure; all other rows use the ordinary monotonic projector.
+func (r *Runtime) projectCreditEntry(ctx context.Context,
+	entry *wavewalletrpc.WalletEntry, repairLegacyReceive bool) (int64,
+	error) {
+
+	if !repairLegacyReceive || r.deps == nil ||
+		r.deps.ActivityStore == nil {
+		return r.projectEmitLocked(ctx, entry)
+	}
+
+	r.projectMu.Lock()
+	defer r.projectMu.Unlock()
+
+	seq, effective, repaired, err := r.repairLegacyCreditReceiveActivity(
+		ctx, entry,
+	)
+	if err != nil {
+		r.deps.resolveLog().WarnS(
+			ctx,
+			"Legacy credit receive activity repair failed",
+			err,
+		)
+
+		return 0, err
+	}
+	if !repaired {
+		seq, effective, err = r.project(ctx, entry)
+		if err != nil {
+			return 0, err
+		}
+	}
+	if seq > 0 {
+		r.emit(seq, effective)
+	}
+
+	return seq, nil
+}
+
+// repairLegacyCreditReceiveActivity atomically reopens the user-visible
+// activity row only when it is a failed receive carrying the exact legacy
+// local poll-cap error. The store keeps the normal terminal-to-pending guard
+// for every other row and appends the corrective pending event to history.
+func (r *Runtime) repairLegacyCreditReceiveActivity(ctx context.Context,
+	entry *wavewalletrpc.WalletEntry) (int64, *wavewalletrpc.WalletEntry,
+	bool, error) {
+
+	existingRow, err := r.deps.ActivityStore.GetEntry(ctx, entry.GetId())
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return 0, entry, false, nil
+
+	case err != nil:
+		return 0, nil, false, fmt.Errorf("read legacy credit receive "+
+			"activity: %w", err)
+	}
+
+	existing, err := rowToWalletEntry(existingRow)
+	if err != nil {
+		return 0, nil, false, fmt.Errorf("decode legacy credit "+
+			"receive activity: %w", err)
+	}
+	if existing.GetKind() != wavewalletrpc.EntryKind_ENTRY_KIND_RECV ||
+		existing.GetStatus() != wavewalletrpc.
+			EntryStatus_ENTRY_STATUS_FAILED ||
+		existing.GetFailureReason() != credit.LegacyReceivePollCapError {
+		return 0, entry, false, nil
+	}
+
+	effective := mergeActivityContext(existing, entry)
+	projection, err := entryToProjection(effective)
+	if err != nil {
+		return 0, nil, false, fmt.Errorf("encode legacy credit "+
+			"receive activity: %w", err)
+	}
+
+	seq, err := r.deps.ActivityStore.RepairCreditReceivePollCap(
+		ctx, projection,
+		int64(wavewalletrpc.EntryStatus_ENTRY_STATUS_FAILED),
+		credit.LegacyReceivePollCapError,
+	)
+	if err != nil {
+		return 0, nil, false, err
+	}
+
+	return seq, effective, seq > 0, nil
 }
 
 // creditEntryFromSummary projects one credit-operation summary onto a

--- a/swapwallet/credit_projector_test.go
+++ b/swapwallet/credit_projector_test.go
@@ -305,6 +305,107 @@ func TestCreditProjectorTracksPendingForRestart(t *testing.T) {
 	)
 }
 
+// TestCreditProjectorReopensLegacyReceiveActivity proves the upgrade repair is
+// visible to users: a canonical FAILED row carrying the exact old poll-cap
+// error becomes PENDING with a corrective event, retains its invoice context,
+// and can later advance to COMPLETE. The global terminal-to-pending rule stays
+// unchanged for every other activity row.
+func TestCreditProjectorReopensLegacyReceiveActivity(t *testing.T) {
+	t.Parallel()
+
+	history, store := newStoreListFixture(t)
+	runtime := history.runtime
+
+	const opID = "legacy-receive"
+	failed := &wavewalletrpc.WalletEntry{
+		Id:            opID,
+		Kind:          wavewalletrpc.EntryKind_ENTRY_KIND_RECV,
+		Status:        wavewalletrpc.EntryStatus_ENTRY_STATUS_FAILED,
+		AmountSat:     200,
+		Counterparty:  creditCounterparty,
+		Note:          "small receive",
+		FailureReason: credit.LegacyReceivePollCapError,
+		FailureCode: wavewalletrpc.
+			EntryFailureCode_ENTRY_FAILURE_CODE_FAILED.Enum(),
+		Request: &wavewalletrpc.WalletEntryRequest{
+			Request: &wavewalletrpc.
+				WalletEntryRequest_LightningInvoice{
+				LightningInvoice: &wavewalletrpc.
+					LightningInvoiceRequest{
+					Invoice: "lnbc-legacy",
+				},
+			},
+		},
+		Progress: &wavewalletrpc.WalletEntryProgress{
+			Phase: wavewalletrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_FAILED,
+			PhaseLabel: "failed",
+		},
+	}
+	runtime.projectAndEmit(t.Context(), failed)
+
+	op := credit.CreditOpSummary{
+		OpID:      opID,
+		OpKey:     "recv:legacy",
+		Kind:      credit.KindReceive,
+		State:     credit.StateAwaitingSettlement,
+		Pending:   true,
+		AmountSat: 200,
+	}
+	reg := &fakeCreditRegistry{
+		listResp: &credit.ListCreditOpsResponse{
+			Ops: []credit.CreditOpSummary{
+				op,
+			},
+		},
+	}
+	runtime.deps.CreditRegistry = reg
+
+	sub := runtime.subscribe()
+	t.Cleanup(func() { runtime.unsubscribe(sub) })
+	projected := make(map[string]credit.State)
+	runtime.pollCreditOps(projected)
+
+	row, err := store.GetEntry(t.Context(), opID)
+	require.NoError(t, err)
+	require.EqualValues(
+		t, wavewalletrpc.EntryStatus_ENTRY_STATUS_PENDING, row.Status,
+	)
+	require.Empty(t, row.FailureReason)
+	require.Equal(t, "small receive", row.Note)
+	require.Contains(t, row.RequestJson, "lnbc-legacy")
+
+	updates := drainEntries(sub)
+	require.Len(t, updates, 1)
+	require.Equal(
+		t, wavewalletrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		updates[0].GetStatus(),
+	)
+	require.Equal(
+		t, "lnbc-legacy",
+		updates[0].GetRequest().GetLightningInvoice().GetInvoice(),
+	)
+
+	events, err := store.PullEvents(t.Context(), 0, 10)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	require.EqualValues(
+		t, wavewalletrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		events[1].Status,
+	)
+
+	op.State = credit.StateCompleted
+	op.Pending = false
+	reg.listResp.Ops[0] = op
+	runtime.pollCreditOps(projected)
+
+	row, err = store.GetEntry(t.Context(), opID)
+	require.NoError(t, err)
+	require.EqualValues(
+		t, wavewalletrpc.EntryStatus_ENTRY_STATUS_COMPLETE, row.Status,
+	)
+}
+
 // TestCreditProjectorRetriesFailedTerminalProjection verifies a transient
 // activity-store failure does not memoize terminal state or clear pending
 // tracking before the next poll durably records the transition.

--- a/swapwallet/projector_test.go
+++ b/swapwallet/projector_test.go
@@ -53,6 +53,15 @@ func (f *fakeActivityProjector) ProjectEntry(_ context.Context,
 	return int64(len(f.projected)), nil
 }
 
+// RepairCreditReceivePollCap satisfies waved.ActivityStore. The fake has no
+// durable terminal rows, so tests that need the guarded repair use the real
+// activity store.
+func (f *fakeActivityProjector) RepairCreditReceivePollCap(context.Context,
+	db.ActivityProjection, int64, string) (int64, error) {
+
+	return 0, nil
+}
+
 // GetEntry reports no existing row. Tests that need durable merge behavior use
 // a real ActivityPersistenceStore.
 func (f *fakeActivityProjector) GetEntry(context.Context, string) (

--- a/waved/config.go
+++ b/waved/config.go
@@ -755,9 +755,10 @@ type CreditConfig struct {
 	// this value and the live floor; zero uses the live floor alone.
 	AutoRedeemMinSat uint64 `mapstructure:"autoredeemminsat"`
 
-	// MaxAwaitingPolls caps how many reconciliation polls a single
-	// credit-operation awaiting state (top-up funding or credit-pay
-	// settlement) may take before the operation terminal-fails. It is the
+	// MaxAwaitingPolls caps how many reconciliation polls a pay top-up,
+	// credit-only pay, or redemption may take before terminal failure. It
+	// does not cap inbound credit receives because the server-owned invoice
+	// lifecycle is authoritative for those operations. It is the
 	// backstop that stops a credit-backed send from parking forever when
 	// the server never reports a terminal state (wavelength#880). Zero
 	// applies credit.DefaultMaxAwaitingPolls: the fail-fast bound cannot be
@@ -847,6 +848,12 @@ type ActivityStore interface {
 	// change-suppressed (no transition, so nothing to emit).
 	ProjectEntry(ctx context.Context,
 		p db.ActivityProjection) (int64, error)
+
+	// RepairCreditReceivePollCap atomically reopens only a receive row
+	// carrying the exact legacy local poll-cap failure and appends its
+	// corrective pending event. Ordinary terminal rows remain immutable.
+	RepairCreditReceivePollCap(ctx context.Context, p db.ActivityProjection,
+		failedStatus int64, legacyFailureReason string) (int64, error)
 
 	// GetEntry returns the current durable projection for one canonical id.
 	// The live projector uses it to retain immutable request context in a

--- a/waved/credit_registry.go
+++ b/waved/credit_registry.go
@@ -67,9 +67,11 @@ func (s *Server) initCreditRegistry(ctx context.Context) error {
 		CallbackRef:   callbackRef,
 		ActorSystem:   s.actorSystem,
 
-		// Bound the awaiting states so a stuck credit-backed send fails
-		// fast rather than parking forever (wavelength#880); see
-		// MaxAwaitingPollsOrDefault for the zero-coercion rationale.
+		// Bound outgoing credit work so a stuck credit-backed send
+		// fails fast rather than parking forever (wavelength#880).
+		// Inbound receives still follow the server-owned invoice
+		// lifecycle; see MaxAwaitingPollsOrDefault for the
+		// zero-coercion rationale.
 		MaxAwaitingPolls: s.cfg.Swap.Credit.MaxAwaitingPollsOrDefault(),
 		AutoRedeem: credit.AutoRedeemConfig{
 			Enabled:      !s.cfg.Swap.Credit.AutoRedeemDisabled,


### PR DESCRIPTION
## What breaks

A sub-floor Lightning receive uses the credit subsystem. The server owns the invoice and may keep it payable for hours, but waved applied the outgoing-operation poll cap to that receive.

With the default two-second interval and 120-poll cap, waved marked the receive failed after about four minutes even though the server invoice was still non-terminal. A later payment could then settle against a local activity entry already shown as failed.

This is the client-side failure reported in #1224.

## What changes

Credit receives now use the server operation as their only terminal authority:

- `CREDITED` completes the receive.
- `EXPIRED`, `FAILED`, or `RELEASED` fails the receive.
- `CREATED` or `AWAITING_PAYMENT` remains pending without a client poll limit.

`MaxAwaitingPolls` still applies to outgoing credit work:

- pay top-up funding;
- credit-only payment settlement;
- credit redemption.

## Upgrade behavior

Older clients may already have written the exact false terminal error:

`receive credit not settled within poll cap`

At startup, waved now:

1. selects only receive operations with that exact kind, state, status, server operation ID, and error;
2. reads one server-authoritative account snapshot;
3. reopens a still-payable receive at `awaiting_settlement`;
4. completes an already-credited receive;
5. preserves an authoritative server failure;
6. leaves the row unchanged if the server snapshot is unavailable or the operation is absent;
7. skips repair if a newer pending or completed operation owns the same operation key.

For a reopened receive, the wallet activity projector atomically changes only the exact legacy failed receive to pending and appends a corrective event. The normal terminal-to-pending guard remains unchanged for every other activity row. Existing invoice, memo, and creation context are retained.

## Scope

This PR fixes the local poll-cap verdict and upgrade recovery. The service-side credit-invoice routing correction is a separate rollout. Both are required to complete #1224 end to end.

## Validation

- `make unit pkg=./credit timeout=5m`
- `make unit pkg=./db timeout=5m`
- `make unit pkg=./swapwallet tags="swapruntime wavewalletrpc" timeout=5m`
- `make unit pkg=./waved tags="swapruntime wavewalletrpc" timeout=5m`
- `go test -race -tags="dev nolog" ./credit -count=1 -timeout=5m`
- `make lint-changed-local`
- `make schema-check`
- `make sqlc`
- `make tidy-module-check`
- `make fmt-changed-check`
- changed-file Go documentation audit
- `git diff --check`
- commit-message lint
- signed commit verification

Manual live-signet and local swapruntime acceptance both passed. Reports: https://github.com/lightninglabs/wavelength/pull/1228#issuecomment-5498074520 and https://github.com/lightninglabs/wavelength/pull/1228#issuecomment-5498123218.
