### PR TITLE
vtxo+round: scope forfeit releases to the reserving round, keep dead rounds dead

### DIFF
--- a/lib/actormsg/vtxo_admission.go
+++ b/lib/actormsg/vtxo_admission.go
@@ -162,6 +162,15 @@ type ReleaseForfeitRequest struct {
 
 	// Outpoints identifies the VTXOs to release from forfeit.
 	Outpoints []wire.OutPoint
+
+	// RoundID names the round releasing its reservation, in the string
+	// form the forfeit request stamped on the VTXO. A VTXO that already
+	// signed its forfeit for a round refuses a release from any other
+	// round, so a stale release from a round that failed earlier cannot
+	// return a coin the current round is forfeiting to the spendable set.
+	// Empty when the producer has no round ID yet: pre-admission
+	// failures, registration rollbacks, and manager-internal rollbacks.
+	RoundID string
 }
 
 // VTXOManagerMsg implements VTXOManagerMsg marker interface.

--- a/round/actor.go
+++ b/round/actor.go
@@ -2824,6 +2824,7 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 			if err := a.cfg.VTXOManager.Tell(
 				ctx, &actormsg.ReleaseForfeitRequest{
 					Outpoints: m.Outpoints,
+					RoundID:   m.RoundID,
 				},
 			); err != nil {
 

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -920,6 +920,12 @@ type ReleaseForfeitReservation struct {
 
 	// Outpoints identifies the VTXOs to release from pending-forfeit.
 	Outpoints []wire.OutPoint
+
+	// RoundID is the failed round releasing its reservation, empty when
+	// the round failed before the operator assigned it an ID. A VTXO
+	// that already signed its forfeit for a round only honors a release
+	// from that round (see vtxo.ErrForfeitReleaseRoundMismatch).
+	RoundID string
 }
 
 func (m *ReleaseForfeitReservation) clientOutMsgSealed() {}

--- a/round/status_reconcile_test.go
+++ b/round/status_reconcile_test.go
@@ -186,6 +186,10 @@ func TestDeadStatusFailsAndReleases(t *testing.T) {
 	require.True(t, ok, "no ReleaseForfeitReservation emitted")
 	require.Equal(t, []wire.OutPoint{op}, release.Outpoints)
 
+	// The release names the dead round so a VTXO that has since signed
+	// its forfeit for a newer round refuses it.
+	require.Equal(t, roundID.String(), release.RoundID)
+
 	cancel, ok := findOutbox[*CancelTimeoutReq](outbox)
 	require.True(t, ok, "no CancelTimeoutReq emitted")
 	require.Equal(t, TimeoutPhaseStatusReconcile, cancel.Phase)

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -129,7 +129,7 @@ func releaseForfeitsOnFailure(transition *ClientStateTransition, err error,
 	roundID fn.Option[RoundID],
 	forfeits []types.ForfeitRequest) (*ClientStateTransition, error) {
 
-	rollback := rollbackOutbox(forfeits)
+	rollback := rollbackOutbox(roundID, forfeits)
 
 	// A raw inner error has no transition for the FSM to land on;
 	// synthesize a failure transition so the release below has somewhere to
@@ -230,14 +230,20 @@ func forfeitOutpoints(forfeits []types.ForfeitRequest) []wire.OutPoint {
 }
 
 // rollbackOutbox builds local rollback messages for a round that failed before
-// connector-bound forfeit signatures were sent.
-func rollbackOutbox(forfeits []types.ForfeitRequest) []ClientOutMsg {
+// connector-bound forfeit signatures were sent. The release carries the
+// failed round's ID (when the operator assigned one) so a VTXO that has
+// already signed its forfeit for a different, newer round refuses it.
+func rollbackOutbox(roundID fn.Option[RoundID],
+	forfeits []types.ForfeitRequest) []ClientOutMsg {
+
 	standard, custom := forfeitRollbackOutpoints(forfeits)
+	roundIDStr := fn.MapOptionZ(roundID, RoundID.String)
 
 	outbox := make([]ClientOutMsg, 0, 2)
 	if len(standard) > 0 {
 		outbox = append(outbox, &ReleaseForfeitReservation{
 			Outpoints: standard,
+			RoundID:   roundIDStr,
 		})
 	}
 	if len(custom) > 0 {
@@ -283,7 +289,7 @@ func failureOutbox(reason string, err error, recoverable bool,
 			OriginalError: err,
 		},
 	}
-	outbox = append(outbox, rollbackOutbox(forfeits)...)
+	outbox = append(outbox, rollbackOutbox(roundID, forfeits)...)
 
 	return outbox
 }
@@ -1870,18 +1876,10 @@ func (s *QuoteReceivedState) processEvent(ctx context.Context,
 			QuoteID: evt.QuoteID,
 			Reason:  evt.Reason,
 		}
-		outbox := []ClientOutMsg{reject}
-		standard, custom := forfeitRollbackOutpoints(s.Intents.Forfeits)
-		if len(standard) > 0 {
-			outbox = append(outbox, &ReleaseForfeitReservation{
-				Outpoints: standard,
-			})
-		}
-		if len(custom) > 0 {
-			outbox = append(outbox, &DropCustomForfeitReservation{
-				Outpoints: custom,
-			})
-		}
+		rollback := rollbackOutbox(
+			fn.Some(s.RoundID), s.Intents.Forfeits,
+		)
+		outbox := append([]ClientOutMsg{reject}, rollback...)
 
 		return &ClientStateTransition{
 			NextState: &ClientFailedState{

--- a/round/vtxo_messages.go
+++ b/round/vtxo_messages.go
@@ -161,12 +161,19 @@ func (e *SpendCompletedEvent) MessageType() string {
 	return "SpendCompletedEvent"
 }
 
-// ForfeitReleasedEvent releases a VTXO whose cooperative round did not cross
-// the signature-handoff checkpoint. It is accepted from PendingForfeitState,
-// and from ForfeitingState only when the manager has durable proof that no
-// round checkpoint exists.
+// ForfeitReleasedEvent releases a VTXO whose cooperative round failed. It is
+// accepted unconditionally from PendingForfeitState, where no round has
+// claimed the reservation yet, and from ForfeitingState only when RoundID
+// names the round the VTXO signed its forfeit for: once a forfeit signature is
+// out, only the round holding it can hand the coin back.
 type ForfeitReleasedEvent struct {
 	actor.BaseMessage
+
+	// RoundID is the round releasing the reservation, in the same string
+	// form ForfeitRequestToVTXO stamped on the VTXO. Empty when the
+	// producer has no round ID yet: pre-admission failures, registration
+	// rollbacks, and manager-internal rollbacks.
+	RoundID string
 }
 
 // VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.

--- a/vtxo/admission_errors.go
+++ b/vtxo/admission_errors.go
@@ -17,6 +17,14 @@ var (
 	// to a second one until that round resolves.
 	ErrForfeitInFlight = errors.New("vtxo is already committed to a round")
 
+	// ErrForfeitReleaseRoundMismatch means a forfeit release named a
+	// round other than the one this VTXO signed its forfeit for. The
+	// release is stale (its round failed and let go of the coin before
+	// the current round claimed it) and is refused so it cannot return a
+	// coin the current round is forfeiting to the spendable set.
+	ErrForfeitReleaseRoundMismatch = errors.New("forfeit release names a " +
+		"round that does not hold the reservation")
+
 	// ErrExitInFlight means the VTXO has been handed to the chain
 	// resolver for a unilateral exit, so it is no longer available for
 	// any cooperative operation.

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -2586,7 +2586,9 @@ func (m *Manager) releasePreCheckpointForfeits(ctx context.Context) {
 		}
 
 		result := m.askForfeitVTXOActor(
-			ctx, ref, &ForfeitReleasedEvent{},
+			ctx, ref, &ForfeitReleasedEvent{
+				RoundID: desc.ForfeitRoundID,
+			},
 		)
 		if _, err := result.Unpack(); err != nil {
 			m.logger(ctx).WarnS(
@@ -2882,7 +2884,9 @@ func (m *Manager) handleReleaseForfeit(ctx context.Context,
 		}
 
 		result := m.askForfeitVTXOActor(
-			ctx, ref, &ForfeitReleasedEvent{},
+			ctx, ref, &ForfeitReleasedEvent{
+				RoundID: req.RoundID,
+			},
 		)
 		if _, err := result.Unpack(); err != nil {
 			m.logger(ctx).WarnS(ctx, "Forfeit release failed",

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -1210,6 +1210,18 @@ func (s *ForfeitingState) ProcessEvent(ctx context.Context, event VTXOEvent,
 		}, nil
 
 	case *ForfeitReleasedEvent:
+		// Only the round this VTXO signed its forfeit for may release
+		// it. A release naming any other round is stale (that round
+		// failed and let go of the coin before the round recorded here
+		// claimed it), and honoring it would return a coin the
+		// operator is about to consume to LiveState.
+		if evt.RoundID != s.NewRoundID {
+			return nil, fmt.Errorf("%w (outpoint %s, reserved by "+
+				"round %q, release from round %q)",
+				ErrForfeitReleaseRoundMismatch, s.VTXO.Outpoint,
+				s.NewRoundID, evt.RoundID)
+		}
+
 		// A pre-signing round failure released this VTXO. We can land
 		// here, not just in PendingForfeitState, when the round fails
 		// during ForfeitSignaturesCollecting after this VTXO already

--- a/vtxo/transitions_test.go
+++ b/vtxo/transitions_test.go
@@ -1670,7 +1670,9 @@ func TestForfeitReleasedFromForfeiting(t *testing.T) {
 		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusLive,
 	).Return(nil)
 
-	_, err := h.sendEvent(&round.ForfeitReleasedEvent{})
+	_, err := h.sendEvent(&round.ForfeitReleasedEvent{
+		RoundID: "round-123",
+	})
 	require.NoError(t, err)
 
 	state := assertState[*LiveState](h)
@@ -1678,6 +1680,44 @@ func TestForfeitReleasedFromForfeiting(t *testing.T) {
 
 	su := assertOutboxContains[*VTXOStatusUpdate](h)
 	require.Equal(t, VTXOStatusLive, su.NewStatus)
+}
+
+// TestForfeitReleasedFromForfeitingOtherRoundRefused pins the round scope of
+// a forfeit release: once a VTXO has signed its forfeit for a round, only that
+// round may hand the coin back. A release naming another round is stale (that
+// round failed and let go of the coin before the current round claimed it) and
+// must be refused, or a dead round resurrected on restart could return a coin
+// the operator is about to consume to the spendable set. The refusal is a
+// typed error and the VTXO stays in ForfeitingState.
+func TestForfeitReleasedFromForfeitingOtherRoundRefused(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	h.withState(&ForfeitingState{
+		VTXO:       vtxo,
+		NewRoundID: "round-123",
+	})
+
+	for _, stale := range []string{"round-122", "round-124", ""} {
+		_, err := h.sendEvent(&round.ForfeitReleasedEvent{
+			RoundID: stale,
+		})
+		require.ErrorIs(t, err, ErrForfeitReleaseRoundMismatch)
+	}
+
+	// The refusals left the reservation intact: the owning round's own
+	// release still lands and returns the coin to LiveState.
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusLive,
+	).Return(nil)
+
+	_, err := h.sendEvent(&round.ForfeitReleasedEvent{
+		RoundID: "round-123",
+	})
+	require.NoError(t, err)
+	assertState[*LiveState](h)
 }
 
 // TestSpendingStateResumeStaysInSpending verifies that SpendingState stays in


### PR DESCRIPTION
The lumos DST nightly has failed on four consecutive nights (2026-08-27
through 2026-08-30) with the same signature, `consumed VTXO ... not
forfeited on the client`: a coin the operator had marked forfeited was
still Live in the wallet's VTXO manager. Every failure replays
deterministically from its logged recipe, and the minimal shape is three
ops: materialize, strand a refresh, then refresh the same coin again with
the client crashing after its second durable write.

What happens is a stale release from a resurrected round:

1. The first refresh strands (forfeit signature dropped). The client
   probes the operator, is told the round is dead, fails it, and
   releases the forfeit reservation. The round's row stays in
   `input_sig_sent`, because nothing ever updates it on failure.
2. A second refresh re-reserves the coin and signs its forfeit. The
   client crashes.
3. On restart, `ListActiveRounds` reloads the dead round alongside the
   live one. The dead round re-arms its reconcile timer, probes, is told
   "dead" again, and emits a second `ReleaseForfeitReservation`.
4. The release names only outpoints, so the VTXO actor honours it from
   `ForfeitingState` and returns the coin to Live. The second round's
   commitment then confirms and the operator forfeits the coin, but the
   client-side transition out of Forfeiting never runs.

Two commits, each closing one half:

`vtxo: Scope forfeit release to the reserving round` stamps the failing
round's ID on every release (round actor rollbacks, manager, and the
startup sweep, which already looks the round up) and makes
`ForfeitingState` refuse a release from any other round with a typed
`ErrForfeitReleaseRoundMismatch`. `PendingForfeitState` is unchanged: no
round has claimed the coin there. This makes the bad state unreachable
regardless of how the stale release is produced.

`round: Mark dead rounds failed so restart does not resurrect them` adds
`RoundStore.FailRound` (flips the row to the `failed` status the schema
already defines) and calls it from the `RoundFailedNotification`
handler. The dead-verdict path in `InputSigSentState` now emits that
notification, which it never did before, so it also starts counting in
the failed-round metric. Without this, every restart re-probes every
dead round forever and would still hand back a coin a newer round had
only reserved but not yet signed for.

Verification: unit tests for the transition refusal, the dead-verdict
outbox, and the store; `lint-changed-local` clean. In lumos, with the
submodule on this branch, all five nightly recipes pinned as seed-corpus
entries pass, the full `systest/dst` package passes, and a 300-check soak
of `TestRoundWorkloadProperty` is green. The lumos PR that pins those
seeds and bumps the submodule follows.