### PR TITLE
types: decode client-supplied TxProof with DecodeP2P

### DIFF
--- a/lib/types/proof_codec.go
+++ b/lib/types/proof_codec.go
@@ -299,8 +299,16 @@ func DeserializeTxProof(data []byte) (*proof.TxProof, error) {
 		return nil, fmt.Errorf("create TLV stream: %w", err)
 	}
 
+	// The proof arrives from an untrusted peer (a client's boarding
+	// request carries it to the operator), so decode it through the
+	// P2P path. Only DecodeP2P enforces the per-record size cap; the
+	// plain Decode is meant for locally persisted data and hands a
+	// declared record length straight to an allocation, which lets a
+	// ten byte payload panic or exhaust memory. A boarding proof
+	// carries a single transaction, so the 65535 byte record cap is
+	// not a practical limit.
 	reader := bytes.NewReader(data)
-	if err := stream.Decode(reader); err != nil {
+	if err := stream.DecodeP2P(reader); err != nil {
 		return nil, fmt.Errorf("decode TxProof: %w", err)
 	}
 

--- a/lib/types/proof_codec_test.go
+++ b/lib/types/proof_codec_test.go
@@ -1,0 +1,127 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// testTxProof builds a small but structurally complete TxProof so the
+// codec tests can round-trip a realistic value and seed the fuzzer with
+// one.
+func testTxProof(t testing.TB) *proof.TxProof {
+	t.Helper()
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{0x01},
+			Index: 1,
+		},
+	})
+	tx.AddTxOut(&wire.TxOut{
+		Value:    100_000,
+		PkScript: []byte{0x51, 0x20, 0x03, 0x04},
+	})
+
+	merkleProof, err := proof.NewTxMerkleProof([]*wire.MsgTx{tx}, 0)
+	require.NoError(t, err)
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return &proof.TxProof{
+		MsgTx: *tx,
+		BlockHeader: wire.BlockHeader{
+			Version:   4,
+			Bits:      0x1d00ffff,
+			Timestamp: time.Unix(1_700_000_000, 0),
+		},
+		BlockHeight: 500,
+		MerkleProof: *merkleProof,
+		ClaimedOutPoint: wire.OutPoint{
+			Hash:  tx.TxHash(),
+			Index: 0,
+		},
+		InternalKey: *priv.PubKey(),
+		MerkleRoot: []byte{
+			0xaa,
+			0xbb,
+			0xcc,
+			0xdd,
+		},
+	}
+}
+
+// oversizedTxProofRecord is a ten byte TLV payload that declares a
+// merkle_root record of 0x3030303030303030 bytes. Found by fuzzing the
+// operator's boarding request parser: the trusted-storage Decode path
+// hands that length straight to an allocation.
+var oversizedTxProofRecord = []byte("\x06\xff00000000")
+
+// TestTxProofCodecRoundTrip verifies that a serialized TxProof decodes
+// back to the same value.
+func TestTxProofCodecRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := testTxProof(t)
+
+	raw, err := SerializeTxProof(original)
+	require.NoError(t, err)
+
+	decoded, err := DeserializeTxProof(raw)
+	require.NoError(t, err)
+	require.NotNil(t, decoded)
+
+	require.Equal(t, original.MsgTx.TxHash(), decoded.MsgTx.TxHash())
+	require.Equal(
+		t, original.BlockHeader.BlockHash(),
+		decoded.BlockHeader.BlockHash(),
+	)
+	require.Equal(t, original.BlockHeight, decoded.BlockHeight)
+	require.Equal(t, original.MerkleProof, decoded.MerkleProof)
+	require.Equal(t, original.ClaimedOutPoint, decoded.ClaimedOutPoint)
+	require.True(t, original.InternalKey.IsEqual(&decoded.InternalKey))
+	require.Equal(t, original.MerkleRoot, decoded.MerkleRoot)
+}
+
+// TestDeserializeTxProofRejectsOversizedRecord pins the fix for a
+// client-reachable panic: a record that declares a length far beyond
+// the payload must come back as ErrRecordTooLarge rather than reaching
+// the allocator.
+func TestDeserializeTxProofRejectsOversizedRecord(t *testing.T) {
+	t.Parallel()
+
+	_, err := DeserializeTxProof(oversizedTxProofRecord)
+	require.ErrorIs(t, err, tlv.ErrRecordTooLarge)
+}
+
+// FuzzDeserializeTxProof feeds arbitrary bytes to the TxProof decoder,
+// which the operator runs on every boarding request before any other
+// work. The only assertion is that it never panics, and that anything
+// it accepts can be serialized again.
+func FuzzDeserializeTxProof(f *testing.F) {
+	seed, err := SerializeTxProof(testTxProof(f))
+	require.NoError(f, err)
+
+	f.Add(seed)
+	f.Add(oversizedTxProofRecord)
+	f.Add([]byte{})
+	f.Add([]byte{0x00})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		p, err := DeserializeTxProof(data)
+		if err != nil {
+			return
+		}
+
+		_, err = SerializeTxProof(p)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
### Motivation

`types.DeserializeTxProof` runs on the operator for every boarding
request a client submits, before any actor or wallet work (lumos
`rounds.JoinRoundRequestFromProto` -> `boardingRequestFromProto`). It
decoded the client's bytes with `tlv.Stream.Decode`, which is lnd's
trusted-storage path. Only `DecodeP2P` enforces the 65535 byte
`MaxRecordSize`, so a declared record length went straight to
`make([]byte, l)` in `tlv.DVarBytes`.

Fuzzing the lumos round request parser (lightninglabs/lumos#600) found
a ten byte payload, `"\x06\xff00000000"`, that declares a `merkle_root`
record of `0x3030303030303030` bytes and panics with `makeslice: len out
of range`. A smaller declared length would instead attempt a
multi-gigabyte allocation. Any registered client could take the
operator down with one envelope, and capping the input size on the
server does not help because the length is declared, not carried.

### Fix

Switch the decoder to `DecodeP2P`. A boarding proof carries a single
transaction, so the 64 KiB per-record cap is not a practical limit, and
the merkle proof record already bounds its node count via
`MerkleProofMaxNodes`.

The other `Stream.Decode` call sites in this module (`credit`, `unroll`,
`db/tree_codec`) all decode locally persisted data and are left alone.

### Testing

- `TestTxProofCodecRoundTrip`: serialize/deserialize a full proof.
- `TestDeserializeTxProofRejectsOversizedRecord`: the reproducer now
  returns `tlv.ErrRecordTooLarge`.
- `FuzzDeserializeTxProof`: native fuzz target over the decoder, seeded
  with a valid proof and the reproducer; 30s clean.
- `make lint-changed-local` 0 issues, `sg scan` clean.

Follow-up on the lumos side: bump the submodule pin once this lands and
add the reproducer to the `FuzzBoardingRequestFromProtoFields` seed
corpus.
