### PR TITLE
oor: scope the spend-input release to its reservation

### DIFF
--- a/lib/actormsg/vtxo_admission.go
+++ b/lib/actormsg/vtxo_admission.go
@@ -54,6 +54,13 @@ type SelectedVTXO struct {
 	// Outpoint is the selected VTXO's outpoint.
 	Outpoint wire.OutPoint
 
+	// ReserveEpoch is the manager's monotonic reservation epoch for this
+	// VTXO, echoed back so the spend that carries it into its durable
+	// state can present it on release and have a superseded reservation
+	// refused (see vtxo.Manager.handleReleaseSpend). Zero for reservations
+	// that are not spend reservations (e.g. forfeit inputs).
+	ReserveEpoch uint64
+
 	// Amount is the value of this VTXO in satoshis.
 	Amount btcutil.Amount
 
@@ -81,6 +88,17 @@ type ReleaseSpendRequest struct {
 
 	// Outpoints identifies the VTXOs to release from spend reservation.
 	Outpoints []wire.OutPoint
+
+	// ReserveEpochs optionally names, per outpoint, the reservation epoch
+	// the releasing owner held. When an entry is present, the manager
+	// releases the VTXO only if its current reservation epoch still
+	// matches: a stale release from a session whose reservation was
+	// superseded (released and re-reserved by a newer session, e.g. after
+	// a rolled-back failure redelivered the release) is refused rather
+	// than returning a coin the newer session is spending to the live set.
+	// An absent entry (or a nil map) releases unconditionally, preserving
+	// the behaviour for callers that hold no epoch (e.g. a manual unlock).
+	ReserveEpochs map[wire.OutPoint]uint64
 }
 
 // VTXOManagerMsg implements VTXOManagerMsg marker interface.

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -133,6 +133,7 @@ const (
 	transferInputRequiredSequenceRecordType   tlv.Type = 15
 	transferInputRequiredLockTimeRecordType   tlv.Type = 16
 	transferInputExternalSignaturesRecordType tlv.Type = 17
+	transferInputReserveEpochRecordType       tlv.Type = 18
 )
 
 const (
@@ -1145,6 +1146,7 @@ func encodeTransferInputSnapshot(input *TransferInputSnapshot) ([]byte, error) {
 
 	outpoint := outPointBytes(input.Outpoint)
 	amountSat := uint64(input.AmountSat)
+	reserveEpoch := input.ReserveEpoch
 	clientFamily := uint32(input.ClientKeyFamily)
 	clientIndex := input.ClientKeyIndex
 	clientPubKey := input.ClientPubKey
@@ -1282,6 +1284,15 @@ func encodeTransferInputSnapshot(input *TransferInputSnapshot) ([]byte, error) {
 		)
 	}
 
+	// Type 18: appended last so the encoded stream stays canonical
+	// (ascending record type). Always present; a zero epoch means the
+	// input predates the field or carries no reservation.
+	records = append(
+		records, tlv.MakePrimitiveRecord(
+			transferInputReserveEpochRecordType, &reserveEpoch,
+		),
+	)
+
 	stream, err := tlv.NewStream(records...)
 	if err != nil {
 		return nil, err
@@ -1314,6 +1325,7 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 		externalSigBlob    []byte
 		requiredSequence   uint32
 		requiredLockTime   uint32
+		reserveEpoch       uint64
 	)
 
 	records := []tlv.Record{
@@ -1374,6 +1386,9 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 			transferInputExternalSignaturesRecordType,
 			&externalSigBlob,
 		),
+		tlv.MakePrimitiveRecord(
+			transferInputReserveEpochRecordType, &reserveEpoch,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -1405,6 +1420,7 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 
 	snap := &TransferInputSnapshot{
 		Outpoint:           outpoint,
+		ReserveEpoch:       reserveEpoch,
 		AmountSat:          decodedAmountSat,
 		ClientKeyFamily:    decodedClientFamily,
 		ClientKeyIndex:     clientIndex,

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -35,6 +35,7 @@ func TestStartTransferPayloadTLVRoundTrip(t *testing.T) {
 					},
 					Index: 7,
 				},
+				ReserveEpoch:    42,
 				AmountSat:       1000,
 				ClientKeyFamily: 1,
 				ClientKeyIndex:  9,

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -68,7 +68,7 @@ type SpendCompleter func(ctx context.Context,
 // no return (the server never locked the inputs), so the funds become
 // spendable again without waiting for a restart sweep.
 type SpendReleaser func(ctx context.Context,
-	outpoints []wire.OutPoint) error
+	outpoints []wire.OutPoint, reserveEpochs map[wire.OutPoint]uint64) error
 
 // IncomingVTXONotifier is called after incoming VTXOs are durably
 // materialized, allowing callers to spawn/manage VTXO actors for expiry and

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -306,6 +306,16 @@ type ReleaseInputsRequest struct {
 
 	// Outpoints are the reserved input VTXO outpoints to release.
 	Outpoints []wire.OutPoint
+
+	// ReserveEpochs names, per outpoint, the manager reservation epoch
+	// this session held, so the manager can refuse a stale release whose
+	// reservation was superseded. It is an in-memory side channel:
+	// ToProto does not serialize it because this request is never a
+	// persisted transport message. It is rebuilt from the session's
+	// durable TransferInputs (which carry ReserveEpoch) every time the
+	// FSM re-enters the failure transition, so a release replayed after a
+	// rolled-back commit still carries the epoch it held.
+	ReserveEpochs map[wire.OutPoint]uint64
 }
 
 // outboxType returns a stable identifier for this outbox message.

--- a/oor/session_actor.go
+++ b/oor/session_actor.go
@@ -909,7 +909,10 @@ func (b *sessionBehavior) driveOutboxEvents(ctx context.Context,
 		// redelivery loop. A failed release just leaves the startup
 		// sweep as the backstop it already is.
 		case *ReleaseInputsRequest:
-			if err := b.releaseSpend(ctx, m.Outpoints); err != nil {
+			if err := b.releaseSpend(
+				ctx, m.Outpoints, m.ReserveEpochs,
+			); err != nil {
+
 				b.logger(ctx).WarnS(ctx, "Failed to release "+
 					"reserved inputs after a "+
 					"terminal session failure; "+
@@ -1094,6 +1097,7 @@ func (b *sessionBehavior) commitAck(ctx context.Context,
 		if err := b.cfg.RegistryStore.UpsertSession(
 			txCtx, record,
 		); err != nil {
+
 			// On Postgres the resolveKeyDedup SELECT above can miss
 			// a concurrent same-key winner (the racing children do
 			// not serialize on oor_session_registry the way

--- a/oor/session_actor_flow_test.go
+++ b/oor/session_actor_flow_test.go
@@ -655,7 +655,8 @@ func TestSessionActorReleaseInputsBestEffort(t *testing.T) {
 		cfg: SessionActorConfig{
 			VTXOStore: store,
 			SpendReleaser: func(_ context.Context,
-				ops []wire.OutPoint) error {
+				ops []wire.OutPoint,
+				_ map[wire.OutPoint]uint64) error {
 
 				released = append(released, ops...)
 
@@ -668,7 +669,7 @@ func TestSessionActorReleaseInputsBestEffort(t *testing.T) {
 	require.NoError(
 		t,
 		b.releaseSpend(
-			ctx, []wire.OutPoint{local, foreign},
+			ctx, []wire.OutPoint{local, foreign}, nil,
 		),
 	)
 	require.Equal(t, []wire.OutPoint{local}, released)
@@ -677,7 +678,9 @@ func TestSessionActorReleaseInputsBestEffort(t *testing.T) {
 	// fail the turn. Returning the error here would re-drive the terminal
 	// transition that emitted the release and wedge the session in a
 	// redelivery loop, the exact regression this case guards against.
-	b.cfg.SpendReleaser = func(context.Context, []wire.OutPoint) error {
+	b.cfg.SpendReleaser = func(context.Context, []wire.OutPoint,
+		map[wire.OutPoint]uint64) error {
+
 		return errFilterBroken
 	}
 	release := &ReleaseInputsRequest{

--- a/oor/session_actor_handlers.go
+++ b/oor/session_actor_handlers.go
@@ -325,7 +325,8 @@ func (b *sessionBehavior) completeSpend(ctx context.Context,
 // FSM is already terminal Failed, so the startup sweep remains the backstop
 // for any reservation this path fails to clear.
 func (b *sessionBehavior) releaseSpend(ctx context.Context,
-	outpoints []wire.OutPoint) error {
+	outpoints []wire.OutPoint,
+	reserveEpochs map[wire.OutPoint]uint64) error {
 
 	if len(outpoints) == 0 {
 		return nil
@@ -356,7 +357,7 @@ func (b *sessionBehavior) releaseSpend(ctx context.Context,
 		return fmt.Errorf("no spend releaser configured")
 	}
 
-	return b.cfg.SpendReleaser(ctx, known)
+	return b.cfg.SpendReleaser(ctx, known, reserveEpochs)
 }
 
 // persistOutgoingPackage writes the finalized outgoing package and its input

--- a/oor/transfer_input_snapshot.go
+++ b/oor/transfer_input_snapshot.go
@@ -22,6 +22,11 @@ type TransferInputSnapshot struct {
 	// Outpoint identifies the input VTXO being transferred.
 	Outpoint wire.OutPoint
 
+	// ReserveEpoch is the VTXO manager's reservation epoch for this input,
+	// persisted so a release replayed after a rolled-back failure names
+	// the reservation it held (see TransferInput.ReserveEpoch).
+	ReserveEpoch uint64
+
 	// AmountSat is the input VTXO amount in satoshis.
 	AmountSat int64
 
@@ -100,6 +105,7 @@ func (i *TransferInput) ToSnapshot() (*TransferInputSnapshot, error) {
 
 	snap := &TransferInputSnapshot{
 		Outpoint:           i.VTXO.Outpoint,
+		ReserveEpoch:       i.ReserveEpoch,
 		AmountSat:          int64(i.VTXO.Amount),
 		ClientKeyFamily:    int32(i.VTXO.ClientKey.KeyLocator.Family),
 		ClientKeyIndex:     i.VTXO.ClientKey.KeyLocator.Index,
@@ -216,6 +222,7 @@ func TransferInputFromSnapshot(snap *TransferInputSnapshot) (TransferInput,
 
 	result := TransferInput{
 		VTXO:               desc,
+		ReserveEpoch:       snap.ReserveEpoch,
 		OwnerLeafScript:    snap.OwnerLeafScript,
 		OwnerLeafPolicy:    snap.OwnerLeafPolicy,
 		VTXOPolicyTemplate: snap.VTXOPolicyTemplate,

--- a/oor/transfer_inputs.go
+++ b/oor/transfer_inputs.go
@@ -23,6 +23,18 @@ type TransferInput struct {
 	// VTXO is the descriptor for the input VTXO being transferred.
 	VTXO *vtxo.Descriptor
 
+	// ReserveEpoch is the monotonic epoch the VTXO manager stamped when it
+	// reserved this input for the spend (SelectAndReserveSpendResponse).
+	// It travels with the input into the durable snapshot so a release
+	// driven by a redelivered, rolled-back failure names the reservation
+	// it actually held: if the coin has since been released and
+	// re-reserved by a newer session, the manager refuses the stale
+	// release rather than returning a coin the newer session is spending
+	// to the live set. Zero means "no epoch known"; the manager then
+	// releases unconditionally, preserving the pre-epoch behaviour for
+	// callers (e.g. a manual unlock) that do not carry one.
+	ReserveEpoch uint64
+
 	// VTXOPolicyTemplate is the semantic arkscript policy
 	// encoding for the spent input VTXO. When empty, standard
 	// Ark ownership is derived from the descriptor's

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -551,6 +551,36 @@ func prePONRInputOutpoints(state State) []wire.OutPoint {
 	return outpoints
 }
 
+// prePONRReserveEpochs maps each pre-point-of-no-return input outpoint to the
+// manager reservation epoch it was reserved under, so the release names the
+// reservation it held and a superseded one is refused. Inputs reserved before
+// the epoch existed (a pre-upgrade snapshot) carry epoch zero and are omitted,
+// so the manager releases them unconditionally.
+func prePONRReserveEpochs(state State) map[wire.OutPoint]uint64 {
+	var inputs []TransferInput
+	switch s := state.(type) {
+	case *AwaitingArkSignatures:
+		inputs = s.TransferInputs
+
+	case *AwaitingSubmitAccepted:
+		inputs = s.TransferInputs
+
+	default:
+		return nil
+	}
+
+	epochs := make(map[wire.OutPoint]uint64, len(inputs))
+	for _, input := range inputs {
+		if input.VTXO == nil || input.ReserveEpoch == 0 {
+			continue
+		}
+
+		epochs[input.VTXO.Outpoint] = input.ReserveEpoch
+	}
+
+	return epochs
+}
+
 // handleOutboxError emits retry scheduling for retryable errors while keeping
 // the FSM in the current protocol state. Non-retryable errors drive the
 // session to terminal Failed; when the failure lands before the point of
@@ -566,14 +596,14 @@ func handleOutboxError(env *Environment, current State,
 
 	if !evt.Retryable {
 		newEvents := fn.None[EmittedEvent]()
-		if outpoints := prePONRInputOutpoints(
-			current,
-		); len(outpoints) > 0 {
-
+		outpoints := prePONRInputOutpoints(current)
+		if len(outpoints) > 0 {
+			epochs := prePONRReserveEpochs(current)
 			newEvents = fn.Some(EmittedEvent{
 				Outbox: []OutboxEvent{
 					&ReleaseInputsRequest{
-						Outpoints: outpoints,
+						Outpoints:     outpoints,
+						ReserveEpochs: epochs,
 					},
 				},
 			})

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -277,6 +277,20 @@ func (m *Manager) markReserved(op wire.OutPoint) uint64 {
 	return m.reserveEpoch
 }
 
+// markReservedUnknown records an in-memory reservation with an unknown epoch
+// (0). The startup sweep uses it because the epoch counter restarts at 0, so
+// it cannot reconstruct the epoch a resumed session holds; a zero mark keeps
+// the coin out of admission (isReserved tests presence) without letting the
+// release guard refuse the resumed session's release. Nil-safe for test
+// fixtures that build a Manager literal.
+func (m *Manager) markReservedUnknown(op wire.OutPoint) {
+	if m.reserved == nil {
+		m.reserved = make(map[wire.OutPoint]uint64)
+	}
+
+	m.reserved[op] = 0
+}
+
 // dropReserved clears an in-memory spend reservation, if present. Used by the
 // synchronous, in-turn paths (rollback, release, completion, terminal
 // notification) where no concurrent re-reservation can have intervened.
@@ -1994,8 +2008,12 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 	}
 
 	// Reserve each selected VTXO via its actor. Track successfully
-	// reserved outpoints so we can roll back on partial failure.
+	// reserved outpoints so we can roll back on partial failure, and the
+	// per-outpoint reservation epoch so the response can echo it (the
+	// spend that owns it later presents it on release; see
+	// handleReleaseSpend).
 	var reserved []wire.OutPoint
+	epochs := make(map[wire.OutPoint]uint64)
 	for _, vtxo := range selected {
 		ref, ok := m.actors[vtxo.Outpoint]
 		if !ok {
@@ -2028,6 +2046,7 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 		// at signing/submit and retries through the normal machinery.
 		if p.detached {
 			epoch := m.markReserved(vtxo.Outpoint)
+			epochs[vtxo.Outpoint] = epoch
 			m.detachedReserve(
 				ctx, ref, vtxo.Outpoint, epoch, p.reserveEvent,
 				p.label,
@@ -2069,9 +2088,10 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 	)
 	for _, vtxo := range selected {
 		selectedVTXOs = append(selectedVTXOs, SelectedVTXO{
-			Outpoint: vtxo.Outpoint,
-			Amount:   vtxo.Amount,
-			PkScript: vtxo.PkScript,
+			Outpoint:     vtxo.Outpoint,
+			Amount:       vtxo.Amount,
+			PkScript:     vtxo.PkScript,
+			ReserveEpoch: epochs[vtxo.Outpoint],
 		})
 		totalSelected += vtxo.Amount
 	}
@@ -2414,7 +2434,16 @@ func (m *Manager) sweepOrphanedReservations(ctx context.Context) {
 			continue
 		}
 
-		m.markReserved(op)
+		// Re-mark with an UNKNOWN epoch (0), not a fresh one. The
+		// reservation epoch counter restarts at 0 on boot, so a fresh
+		// mark here would not match the epoch the resumed session
+		// persisted, and its later release would be wrongly refused as
+		// superseded and the coin stranded. Admission only tests
+		// presence (isReserved), and the sweep's Tell carries no
+		// failure hop-back, so nothing needs the real epoch here; the
+		// release guard treats a zero mark as "owner unknown, do not
+		// refuse".
+		m.markReservedUnknown(op)
 
 		if err := ref.Tell(ctx, &SpendReserveEvent{}); err != nil {
 			m.logger(ctx).WarnS(
@@ -2642,6 +2671,41 @@ func (m *Manager) handleReleaseSpend(ctx context.Context,
 		errs     []error
 	)
 	for _, op := range outpoints {
+		// Refuse a release only when a LIVE in-memory reservation names
+		// a DIFFERENT epoch than the one the caller held: that means
+		// this reservation was superseded (released and re-reserved by
+		// a newer owner in the same process), so honouring the stale
+		// release would return a coin the newer owner is spending to
+		// the live set. Everything else releases:
+		//
+		//   - a zero epoch is "unknown" (a pre-upgrade snapshot with no
+		//     epoch record, or a manual unlock), so it releases
+		//     unconditionally, matching the pre-epoch behaviour;
+		//   - no live reservation (!ok) means the manager restarted and
+		//     the in-memory map has not been repopulated for this coin
+		//     (the orphan sweep skips Spending rows), so a legitimate
+		//     resumed session's release must still be honoured rather
+		//     than stranding the coin in Spending forever.
+		if epoch := req.ReserveEpochs[op]; epoch != 0 {
+			if cur, ok := m.reserved[op]; ok && cur != 0 &&
+				cur != epoch {
+
+				m.logger(ctx).InfoS(ctx, "Refusing "+
+					"stale spend release; "+
+					"reservation superseded",
+					slog.String(
+						"outpoint", op.String(),
+					),
+					slog.Uint64(
+						"release_epoch", epoch,
+					),
+					slog.Uint64("current_epoch", cur),
+				)
+
+				continue
+			}
+		}
+
 		ref, ok := m.actors[op]
 		if !ok {
 			errs = append(

--- a/vtxo/manager_reservation_test.go
+++ b/vtxo/manager_reservation_test.go
@@ -203,6 +203,175 @@ func TestReleaseSpendTransitionsToLive(t *testing.T) {
 	require.True(t, ok, "expected LiveState after release")
 }
 
+// TestReleaseSpendRefusesSupersededEpoch pins the ownership guard: a release
+// that names a reservation epoch other than the coin's current one is refused,
+// so a stale release (e.g. a rolled-back OOR failure redelivered after the
+// coin was released and re-reserved by a newer session) cannot return a coin
+// the newer owner is spending to the live set. A matching epoch, and an absent
+// epoch, both release as before.
+func TestReleaseSpendRefusesSupersededEpoch(t *testing.T) {
+	t.Parallel()
+
+	coin := makeDescriptor(t, 50000, 0)
+	mgr, _ := newSpendingManager(
+		t, []*Descriptor{coin}, &mockReservationStore{},
+	)
+
+	// The coin is reserved under epoch 5 (the newer owner).
+	mgr.reserved = map[wire.OutPoint]uint64{coin.Outpoint: 5}
+
+	// A stale release naming epoch 3 is refused: nothing released, the
+	// reservation and the Spending state stand.
+	result := mgr.Receive(t.Context(), &ReleaseSpendRequest{
+		Outpoints: []wire.OutPoint{coin.Outpoint},
+		ReserveEpochs: map[wire.OutPoint]uint64{
+			coin.Outpoint: 3,
+		},
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	rr, ok := resp.(*ReleaseSpendResponse)
+	require.True(t, ok, "expected *ReleaseSpendResponse")
+	require.Equal(t, 0, rr.ReleasedCount)
+	_, ok = actorState(t, mgr, coin.Outpoint).(*SpendingState)
+	require.True(t, ok, "superseded release moved the coin")
+	require.Equal(
+		t, uint64(5), mgr.reserved[coin.Outpoint],
+		"superseded release dropped the current reservation",
+	)
+
+	// The current owner's release (epoch 5) is honoured.
+	result = mgr.Receive(t.Context(), &ReleaseSpendRequest{
+		Outpoints: []wire.OutPoint{coin.Outpoint},
+		ReserveEpochs: map[wire.OutPoint]uint64{
+			coin.Outpoint: 5,
+		},
+	})
+	resp, err = result.Unpack()
+	require.NoError(t, err)
+	rr, ok = resp.(*ReleaseSpendResponse)
+	require.True(t, ok, "expected *ReleaseSpendResponse")
+	require.Equal(t, 1, rr.ReleasedCount)
+	_, ok = actorState(t, mgr, coin.Outpoint).(*LiveState)
+	require.True(t, ok, "matching-epoch release did not free the coin")
+}
+
+// TestReleaseSpendReleasesWhenNoLiveReservation pins the restart-safety of
+// the guard: after a daemon restart the in-memory reserved map is empty for a
+// coin whose durable reservation row and Spending state survived, so a
+// legitimate resumed session's release (naming the epoch it held) must still
+// be honoured rather than refused and stranded. The guard only refuses on a
+// LIVE, differing reservation.
+func TestReleaseSpendReleasesWhenNoLiveReservation(t *testing.T) {
+	t.Parallel()
+
+	coin := makeDescriptor(t, 50000, 0)
+	mgr, _ := newSpendingManager(
+		t, []*Descriptor{coin}, &mockReservationStore{},
+	)
+
+	// No in-memory reservation (empty map), as after a restart.
+	require.Empty(t, mgr.reserved)
+
+	result := mgr.Receive(t.Context(), &ReleaseSpendRequest{
+		Outpoints: []wire.OutPoint{coin.Outpoint},
+		ReserveEpochs: map[wire.OutPoint]uint64{
+			coin.Outpoint: 7,
+		},
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	rr, ok := resp.(*ReleaseSpendResponse)
+	require.True(t, ok, "expected *ReleaseSpendResponse")
+	require.Equal(t, 1, rr.ReleasedCount)
+	_, ok = actorState(t, mgr, coin.Outpoint).(*LiveState)
+	require.True(t, ok, "release with no live reservation was refused")
+}
+
+// TestReleaseSpendReleasesOnZeroEpoch pins the "zero epoch is unknown" rule: a
+// release naming epoch 0 (a pre-upgrade snapshot with no epoch record) is
+// honoured regardless of the coin's current reservation, so an in-flight
+// upgrade cannot strand it.
+func TestReleaseSpendReleasesOnZeroEpoch(t *testing.T) {
+	t.Parallel()
+
+	coin := makeDescriptor(t, 50000, 0)
+	mgr, _ := newSpendingManager(
+		t, []*Descriptor{coin}, &mockReservationStore{},
+	)
+	mgr.reserved = map[wire.OutPoint]uint64{coin.Outpoint: 4}
+
+	result := mgr.Receive(t.Context(), &ReleaseSpendRequest{
+		Outpoints: []wire.OutPoint{coin.Outpoint},
+		ReserveEpochs: map[wire.OutPoint]uint64{
+			coin.Outpoint: 0,
+		},
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	rr, ok := resp.(*ReleaseSpendResponse)
+	require.True(t, ok, "expected *ReleaseSpendResponse")
+	require.Equal(t, 1, rr.ReleasedCount)
+	_, ok = actorState(t, mgr, coin.Outpoint).(*LiveState)
+	require.True(t, ok, "zero-epoch release was refused")
+}
+
+// TestReleaseSpendReleasesAgainstUnknownSweepMark pins the restart-sweep path:
+// after a boot the orphan sweep re-marks a reserved coin with epoch 0 (the
+// counter restarts at 0 and cannot reconstruct the epoch the resumed session
+// holds). A later release from that session, carrying its persisted non-zero
+// epoch, must be honoured rather than refused against the unknown mark.
+func TestReleaseSpendReleasesAgainstUnknownSweepMark(t *testing.T) {
+	t.Parallel()
+
+	coin := makeDescriptor(t, 50000, 0)
+	mgr, _ := newSpendingManager(
+		t, []*Descriptor{coin}, &mockReservationStore{},
+	)
+
+	// The sweep re-marked the coin with an unknown epoch.
+	mgr.markReservedUnknown(coin.Outpoint)
+	require.Equal(t, uint64(0), mgr.reserved[coin.Outpoint])
+
+	result := mgr.Receive(t.Context(), &ReleaseSpendRequest{
+		Outpoints: []wire.OutPoint{coin.Outpoint},
+		ReserveEpochs: map[wire.OutPoint]uint64{
+			coin.Outpoint: 11,
+		},
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	rr, ok := resp.(*ReleaseSpendResponse)
+	require.True(t, ok, "expected *ReleaseSpendResponse")
+	require.Equal(t, 1, rr.ReleasedCount)
+	_, ok = actorState(t, mgr, coin.Outpoint).(*LiveState)
+	require.True(t, ok, "release against an unknown sweep mark was refused")
+}
+
+// TestReleaseSpendWithoutEpochReleasesUnconditionally pins the backward-
+// compatible path: a caller that supplies no epoch (a nil map, e.g. a manual
+// unlock) releases the coin regardless of its current reservation epoch.
+func TestReleaseSpendWithoutEpochReleasesUnconditionally(t *testing.T) {
+	t.Parallel()
+
+	coin := makeDescriptor(t, 50000, 0)
+	mgr, _ := newSpendingManager(
+		t, []*Descriptor{coin}, &mockReservationStore{},
+	)
+	mgr.reserved = map[wire.OutPoint]uint64{coin.Outpoint: 9}
+
+	result := mgr.Receive(t.Context(), &ReleaseSpendRequest{
+		Outpoints: []wire.OutPoint{coin.Outpoint},
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	rr, ok := resp.(*ReleaseSpendResponse)
+	require.True(t, ok, "expected *ReleaseSpendResponse")
+	require.Equal(t, 1, rr.ReleasedCount)
+	_, ok = actorState(t, mgr, coin.Outpoint).(*LiveState)
+	require.True(t, ok, "unconditional release did not free the coin")
+}
+
 // TestCompleteSpendTransitionsToSpent verifies that completing a spend drives
 // the VTXO out of SpendingState to terminal SpentState. As with release, the
 // reservation row deletion is atomic with the status change in the actor, not

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -583,6 +583,11 @@ type SelectedVTXO struct {
 	// Outpoint is the selected VTXO's outpoint.
 	Outpoint wire.OutPoint
 
+	// ReserveEpoch is the manager reservation epoch for this VTXO, carried
+	// so the OOR transfer that spends it can name the reservation on
+	// release (see oor.TransferInput.ReserveEpoch).
+	ReserveEpoch uint64
+
 	// Amount is the value of this VTXO in satoshis.
 	Amount btcutil.Amount
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2689,9 +2689,10 @@ func (a *Ark) handleSelectAndLockVTXOs(ctx context.Context,
 	selected := make([]SelectedVTXO, len(mgrResp.SelectedVTXOs))
 	for i, v := range mgrResp.SelectedVTXOs {
 		selected[i] = SelectedVTXO{
-			Outpoint: v.Outpoint,
-			Amount:   v.Amount,
-			PkScript: v.PkScript,
+			Outpoint:     v.Outpoint,
+			Amount:       v.Amount,
+			PkScript:     v.PkScript,
+			ReserveEpoch: v.ReserveEpoch,
 		}
 	}
 

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -3266,10 +3266,14 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		outpoints := make(
 			[]wire.OutPoint, 0, len(locked.SelectedVTXOs),
 		)
+		reserveEpochs := make(
+			map[wire.OutPoint]uint64, len(locked.SelectedVTXOs),
+		)
 		for _, sv := range locked.SelectedVTXOs {
 			outpoints = append(
 				outpoints, sv.Outpoint,
 			)
+			reserveEpochs[sv.Outpoint] = sv.ReserveEpoch
 		}
 
 		phaseStart = time.Now()
@@ -3283,6 +3287,11 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 			return nil, status.Errorf(codes.Internal, "build "+
 				"transfer inputs: %v", err)
 		}
+
+		// Carry the manager's reservation epoch onto each input so the
+		// release path (on a pre-PONR failure) names the reservation it
+		// held; a superseded one is refused by the manager.
+		applyReserveEpochs(selectedInputs, reserveEpochs)
 	}
 
 	requestOORRecipients := append(

--- a/waved/server.go
+++ b/waved/server.go
@@ -842,13 +842,14 @@ func (s *Server) oorCompleteSpend(ctx context.Context,
 // path: a session that fails terminally before the server co-signs
 // releases its input reservation through the manager so each VTXO actor
 // transitions from SpendingState back to LiveState.
-func (s *Server) oorReleaseSpend(ctx context.Context,
-	outpoints []wire.OutPoint) error {
+func (s *Server) oorReleaseSpend(ctx context.Context, outpoints []wire.OutPoint,
+	reserveEpochs map[wire.OutPoint]uint64) error {
 
 	mgrKey := actormsg.VTXOManagerServiceKey()
 	result := mgrKey.Ref(s.actorSystem).Ask(
 		ctx, &actormsg.ReleaseSpendRequest{
-			Outpoints: outpoints,
+			Outpoints:     outpoints,
+			ReserveEpochs: reserveEpochs,
 		},
 	).Await(ctx)
 

--- a/waved/wallet_ops.go
+++ b/waved/wallet_ops.go
@@ -157,6 +157,21 @@ func BuildTransferInputs(ctx context.Context, store vtxo.VTXOStore,
 	return inputs, nil
 }
 
+// applyReserveEpochs stamps each transfer input with the manager reservation
+// epoch its outpoint was reserved under, so a pre-point-of-no-return release
+// names the reservation it held and the manager can refuse a superseded one.
+func applyReserveEpochs(inputs []oor.TransferInput,
+	epochs map[wire.OutPoint]uint64) {
+
+	for i := range inputs {
+		if inputs[i].VTXO == nil {
+			continue
+		}
+
+		inputs[i].ReserveEpoch = epochs[inputs[i].VTXO.Outpoint]
+	}
+}
+
 // BuildCustomTransferInputs constructs OOR transfer inputs from
 // explicit custom input specifications. This bypasses wallet VTXO
 // selection for non-standard spend paths (e.g., vHTLC claims).


### PR DESCRIPTION
An OOR session that fails before the point of no return releases its
reserved input VTXOs back to LiveState through the VTXO manager. The
release named only outpoints, so a stale release could undo a newer
session's claim on the same coin.

The lumos DST reproduces it with no crash. A send with a sub-minimum
recipient is rejected at submit and fails pre-PONR, releasing its input
inline through the manager; the manager's write commits on its own, and
only then does the session commit its Failed snapshot in its turn
transaction. Fault that snapshot write and the turn rolls back with the
release already applied. The durable mailbox redelivers the rejection, a
second session reserves the same coin in the gap, and the redelivered
turn releases the coin a second time -- now owned by the second session
-- returning it to LiveState while that session is spending it. The coin
ends live in the wallet and consumed on the server.

This is the OOR analogue of the round-side stale forfeit release (#1230),
and it is fixed the same way: scope the release to the reservation it
held. The manager already stamps a monotonic reservation epoch per
outpoint (`dropReservedEpoch` uses it for the async reserve-failure
hop-back). This PR echoes it from `SelectAndReserveSpendResponse`,
carries it onto the transfer input, and persists it in the durable
outgoing snapshot as one additive TLV record (type 18, appended so the
stream stays canonical; a zero epoch on an older snapshot means
"unknown"). On a pre-PONR failure the release names the epoch it held,
and `handleReleaseSpend` refuses a release whose epoch no longer matches
the coin's current reservation. An absent epoch (nil map, e.g. a manual
unlock) releases unconditionally, so pre-epoch callers are unchanged.
Completion is untouched: it is post-PONR, where the reservation cannot
be superseded.

## Verification

- `TestReleaseSpendRefusesSupersededEpoch` and
  `TestReleaseSpendWithoutEpochReleasesUnconditionally` pin the manager
  guard.
- The end-to-end interleaving is pinned by the lumos DST
  `TestOORStaleReleaseAfterRolledBackFailure`, which fails at the
  stale-release assertion against `main` and passes on this branch.
- `oor`, `vtxo`, `wallet`, `waved` unit tests green; `lint-changed-local`
  clean; the full lumos `systest/dst` suite (with the submodule on this
  branch) passes.

The lumos PR that adds the DST harness + reproduction and bumps the
submodule follows.