### PR TITLE
docs: nightly doc-gardening sweep 2026-09-02

### DIFF
--- a/credit/AGENTS.md
+++ b/credit/AGENTS.md
@@ -29,6 +29,11 @@ operator VTXO floor, `max(dust_limit, min_vtxo_amount_sat)`.
 - `StartCreditPayRequest` / `StartCreditReceiveRequest` / `RedeemRequest` —
   admission messages for the three operation kinds (`KindPay`, `KindReceive`,
   `KindRedeem`).
+- `LegacyReceivePollCapError` — the exact terminal error string older clients
+  wrote when they wrongly applied the outgoing poll cap to a server-owned
+  receive invoice. It is exported because the boot repair below and
+  `swapwallet`'s activity repair both key off an exact match; treat it as a
+  frozen compatibility constant, never as a reason to write anew.
 
 ## Relationships
 
@@ -55,6 +60,29 @@ operator VTXO floor, `max(dust_limit, min_vtxo_amount_sat)`.
 - Every external call the behavior makes (`CreateCredit`, `SendOOR`,
   `StartPay`, `RedeemCredit`) must stay idempotent by op key or payment hash,
   since a redelivered message or a reload-after-`commitFailed` re-runs it.
+- **The server owns the receive invoice lifecycle.** `MaxAwaitingPolls` caps
+  only pay top-ups, credit-only pays, and redemptions; `awaitingSettlementState`
+  is deliberately uncapped. A local poll count cannot prove that a
+  still-payable invoice failed, so only a server-reported
+  `CREDITED`/`EXPIRED`/`FAILED`/`RELEASED` state may terminate a receive.
+  Re-adding a client-side cap here reintroduces the false terminal failure the
+  repair below exists to undo.
+- **Legacy receive repair is best-effort and strictly scoped.**
+  `repairLegacyReceivePollCapFailures` runs once per boot, ahead of
+  `restoreNonTerminal`, and rewrites a row only when it matches every
+  `isLegacyReceivePollCapFailure` predicate (receive kind, failed state and
+  status, non-empty `ServerOpID`, and `LastError` equal to
+  `LegacyReceivePollCapError`). All eligible rows share one `ListCredits`
+  snapshot so the pass makes one coherent decision per boot. An unavailable
+  store, identity, or server snapshot logs at `Info` and leaves every row
+  untouched — absent evidence cannot prove a different state, so it must
+  neither rewrite local history nor block ordinary boot restore.
+- **Repair never displaces a newer operation.** Pending and completed rows
+  participate in the active op-key uniqueness constraint, so before reviving a
+  row the pass checks `LookupActiveOperationByKey`. If a retry admitted after
+  the legacy failure already owns that key, the historical row stays failed and
+  only its known-false verdict is replaced (`supersededReceiveReason`) rather
+  than colliding with or displacing the live operation.
 - Auto-redeem is receive-triggered, not a periodic sweep. Its boot reconcile
   retries transient failures with exponential backoff for at most four
   minutes, stops immediately on permanent mailbox/Ark version errors, and

--- a/credit/CLAUDE.md
+++ b/credit/CLAUDE.md
@@ -29,6 +29,11 @@ operator VTXO floor, `max(dust_limit, min_vtxo_amount_sat)`.
 - `StartCreditPayRequest` / `StartCreditReceiveRequest` / `RedeemRequest` —
   admission messages for the three operation kinds (`KindPay`, `KindReceive`,
   `KindRedeem`).
+- `LegacyReceivePollCapError` — the exact terminal error string older clients
+  wrote when they wrongly applied the outgoing poll cap to a server-owned
+  receive invoice. It is exported because the boot repair below and
+  `swapwallet`'s activity repair both key off an exact match; treat it as a
+  frozen compatibility constant, never as a reason to write anew.
 
 ## Relationships
 
@@ -55,6 +60,29 @@ operator VTXO floor, `max(dust_limit, min_vtxo_amount_sat)`.
 - Every external call the behavior makes (`CreateCredit`, `SendOOR`,
   `StartPay`, `RedeemCredit`) must stay idempotent by op key or payment hash,
   since a redelivered message or a reload-after-`commitFailed` re-runs it.
+- **The server owns the receive invoice lifecycle.** `MaxAwaitingPolls` caps
+  only pay top-ups, credit-only pays, and redemptions; `awaitingSettlementState`
+  is deliberately uncapped. A local poll count cannot prove that a
+  still-payable invoice failed, so only a server-reported
+  `CREDITED`/`EXPIRED`/`FAILED`/`RELEASED` state may terminate a receive.
+  Re-adding a client-side cap here reintroduces the false terminal failure the
+  repair below exists to undo.
+- **Legacy receive repair is best-effort and strictly scoped.**
+  `repairLegacyReceivePollCapFailures` runs once per boot, ahead of
+  `restoreNonTerminal`, and rewrites a row only when it matches every
+  `isLegacyReceivePollCapFailure` predicate (receive kind, failed state and
+  status, non-empty `ServerOpID`, and `LastError` equal to
+  `LegacyReceivePollCapError`). All eligible rows share one `ListCredits`
+  snapshot so the pass makes one coherent decision per boot. An unavailable
+  store, identity, or server snapshot logs at `Info` and leaves every row
+  untouched — absent evidence cannot prove a different state, so it must
+  neither rewrite local history nor block ordinary boot restore.
+- **Repair never displaces a newer operation.** Pending and completed rows
+  participate in the active op-key uniqueness constraint, so before reviving a
+  row the pass checks `LookupActiveOperationByKey`. If a retry admitted after
+  the legacy failure already owns that key, the historical row stays failed and
+  only its known-false verdict is replaced (`supersededReceiveReason`) rather
+  than colliding with or displacing the live operation.
 - Auto-redeem is receive-triggered, not a periodic sweep. Its boot reconcile
   retries transient failures with exponential backoff for at most four
   minutes, stops immediately on permanent mailbox/Ark version errors, and

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -127,6 +127,22 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   `vtxo.SpendingReservationStore`.
 - `SpendingReservationStore` / `BatchedSpendingReservationStore` — Internal
   sqlc-backed query interfaces for the reservation table.
+- `ActivityPersistenceStore` / `ActivityStore` — canonical activity-log store
+  + its sqlc-backed query interface. `ProjectEntry` is the monotonic
+  projector (it suppresses no-op re-projections and refuses
+  terminal-to-pending regressions); `GetEntry` reads one canonical row;
+  `AppendActivityEvent` extends the immutable event log.
+- `ActivityPersistenceStore.RepairCreditReceivePollCap(ctx, p, failedStatus,
+  legacyFailureReason)` — the single sanctioned exception to that monotonic
+  rule, for the false receive failure older clients wrote under the retired
+  credit poll cap. The guarded current-state update and the corrective
+  pending event commit in one transaction, so the reopen is *appended* to
+  history rather than erasing the failure. The SQL guard is what keeps the
+  exception narrow: the update matches only an inbound receive row whose
+  status and failure reason equal the caller-supplied legacy pair, so
+  `ProjectEntry`'s terminal-to-pending rule is never relaxed for any other
+  row. A zero row count is not an error — it means the row was already
+  repaired or never legacy — and the caller sees `eventSeq == 0`.
 
 ## Relationships
 

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -127,6 +127,22 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   `vtxo.SpendingReservationStore`.
 - `SpendingReservationStore` / `BatchedSpendingReservationStore` — Internal
   sqlc-backed query interfaces for the reservation table.
+- `ActivityPersistenceStore` / `ActivityStore` — canonical activity-log store
+  + its sqlc-backed query interface. `ProjectEntry` is the monotonic
+  projector (it suppresses no-op re-projections and refuses
+  terminal-to-pending regressions); `GetEntry` reads one canonical row;
+  `AppendActivityEvent` extends the immutable event log.
+- `ActivityPersistenceStore.RepairCreditReceivePollCap(ctx, p, failedStatus,
+  legacyFailureReason)` — the single sanctioned exception to that monotonic
+  rule, for the false receive failure older clients wrote under the retired
+  credit poll cap. The guarded current-state update and the corrective
+  pending event commit in one transaction, so the reopen is *appended* to
+  history rather than erasing the failure. The SQL guard is what keeps the
+  exception narrow: the update matches only an inbound receive row whose
+  status and failure reason equal the caller-supplied legacy pair, so
+  `ProjectEntry`'s terminal-to-pending rule is never relaxed for any other
+  row. A zero row count is not an error — it means the row was already
+  repaired or never legacy — and the caller sees `eventSeq == 0`.
 
 ## Relationships
 

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -213,8 +213,8 @@ state transitions and validation rules live under [Invariants](#invariants).
   fallible sends (`SubmitVTXOForfeitSigsToServer`,
   `SubmitForfeitSigRequest`, `RegisterConfirmationRequest`) — a mid-flight
   send error would otherwise commit the state with no clock. The disarm
-  (`CancelTimeoutReq`, via `reconcileDisarmEvents` /
-  `appendReconcileDisarm` in `fsm_timeouts.go`) must **trail** every
+  (`CancelTimeoutReq`, via `appendReconcileDisarm` in `fsm_timeouts.go`)
+  must **trail** every
   delivery on the exit paths — confirmation notifications, the forfeit
   release, and the terminal job drop — since cleanup must never gate
   delivery. A cancel that never lands only leaks a one-shot timer, which

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -213,8 +213,8 @@ state transitions and validation rules live under [Invariants](#invariants).
   fallible sends (`SubmitVTXOForfeitSigsToServer`,
   `SubmitForfeitSigRequest`, `RegisterConfirmationRequest`) — a mid-flight
   send error would otherwise commit the state with no clock. The disarm
-  (`CancelTimeoutReq`, via `reconcileDisarmEvents` /
-  `appendReconcileDisarm` in `fsm_timeouts.go`) must **trail** every
+  (`CancelTimeoutReq`, via `appendReconcileDisarm` in `fsm_timeouts.go`)
+  must **trail** every
   delivery on the exit paths — confirmation notifications, the forfeit
   release, and the terminal job drop — since cleanup must never gate
   delivery. A cancel that never lands only leaks a one-shot timer, which

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -128,6 +128,23 @@ default builds avoid the swap executor's dependency graph.
   **mixed** and the swap monitor loop stays the single terminal authority for
   the shared payment-hash row — the credit projector must never emit for a
   mixed pay.
+- **The legacy credit-receive activity repair is the one sanctioned
+  terminal-row rewrite.** `ProjectEntry`'s monotonic terminal-to-pending guard
+  otherwise makes a FAILED activity row immutable, which would permanently
+  strand a receive that an older client false-failed under the retired poll cap
+  (see `credit`'s server-authority invariant). `projectCreditEntry` grants one
+  narrowly scoped repair attempt, and only for a resumed non-terminal
+  `credit.KindReceive` op: `repairLegacyCreditReceiveActivity` reopens the row
+  only when the stored entry is RECV, FAILED, and carries a
+  `failure_reason` exactly equal to `credit.LegacyReceivePollCapError`. Any
+  other row — including a receive that failed for a real reason — falls through
+  to the ordinary projector untouched.
+- The repair takes `projectMu` itself and calls `project`/`emit` directly
+  rather than reusing `projectEmitLocked`, so the global project-then-emit
+  ordering still holds across both paths. The store's
+  `RepairCreditReceivePollCap` commits the guarded row update and the
+  corrective pending event in one transaction, so history stays append-only —
+  the reopen is recorded as an event, not by erasing the failure.
 - The credit projector polls on a coarse 5s tick
   (`creditProjectInterval`) and only re-emits an operation when its
   `credit.State` changed since the last poll, keyed by `OpID` in an

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -128,6 +128,23 @@ default builds avoid the swap executor's dependency graph.
   **mixed** and the swap monitor loop stays the single terminal authority for
   the shared payment-hash row — the credit projector must never emit for a
   mixed pay.
+- **The legacy credit-receive activity repair is the one sanctioned
+  terminal-row rewrite.** `ProjectEntry`'s monotonic terminal-to-pending guard
+  otherwise makes a FAILED activity row immutable, which would permanently
+  strand a receive that an older client false-failed under the retired poll cap
+  (see `credit`'s server-authority invariant). `projectCreditEntry` grants one
+  narrowly scoped repair attempt, and only for a resumed non-terminal
+  `credit.KindReceive` op: `repairLegacyCreditReceiveActivity` reopens the row
+  only when the stored entry is RECV, FAILED, and carries a
+  `failure_reason` exactly equal to `credit.LegacyReceivePollCapError`. Any
+  other row — including a receive that failed for a real reason — falls through
+  to the ordinary projector untouched.
+- The repair takes `projectMu` itself and calls `project`/`emit` directly
+  rather than reusing `projectEmitLocked`, so the global project-then-emit
+  ordering still holds across both paths. The store's
+  `RepairCreditReceivePollCap` commits the guarded row update and the
+  corrective pending event in one transaction, so history stays append-only —
+  the reopen is recorded as an event, not by erasing the failure.
 - The credit projector polls on a coarse 5s tick
   (`creditProjectInterval`) and only re-emits an operation when its
   `credit.State` changed since the last poll, keyed by `OpID` in an


### PR DESCRIPTION
Nightly documentation-graph sweep: refreshes the per-package doc graph for
everything that landed since the last merged sweep (`b5388ff6`, 2026-09-01).

Workflow run: https://github.com/lightninglabs/wavelength/actions

Please review the updated `CLAUDE.md`/`AGENTS.md` diffs (`credit`, `db`,
`round`, `swapwallet`). `ARCHITECTURE.md` and `docs/index.md` needed no
changes this pass.
