### PR TITLE
db: Demote canceled transaction body warnings

### DIFF
--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -239,6 +239,15 @@ func NewTransactionExecutor[Querier any](db BatchedQuerier,
 	}
 }
 
+// isExpectedTxShutdownErr reports transaction errors caused by explicit
+// cancellation or database teardown. It inspects the transaction error rather
+// than the context so an unrelated failure that coincides with cancellation
+// remains visible. A deadline is not shutdown: it can indicate a slow backend
+// and must remain visible at warning level.
+func isExpectedTxShutdownErr(dbErr error) bool {
+	return errors.Is(dbErr, context.Canceled) || isDBClosedError(dbErr)
+}
+
 // ExecTx is a wrapper for txBody to abstract the creation and commit of a db
 // transaction. The db transaction is embedded in a `*Queries` that txBody
 // needs to use when executing each one of the queries that need to be applied
@@ -285,14 +294,14 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 			}
 
 			// During shutdown the underlying *sql.DB is closed
-			// before every actor's lease/poll loop has wound
-			// down, which produces a flood of "sql: database is
-			// closed" warnings at the tail of every itest. Treat
-			// that case as expected and demote to debug; real
-			// production failures (corrupt DB, disk full, …)
-			// still surface as WARN because the ctx is not
-			// cancelled in that path.
-			if ctx.Err() != nil || isDBClosedError(dbErr) {
+			// before every actor's lease/poll loop has wound down,
+			// which produces a flood of "sql: database is closed"
+			// warnings at the tail of every itest. Treat that case
+			// as expected and demote to debug; real production
+			// failures (corrupt DB, disk full, …) still surface as
+			// WARN because their error is not caused by
+			// cancellation or teardown.
+			if isExpectedTxShutdownErr(dbErr) {
 				t.log.DebugS(ctx, "Transaction begin failed "+
 					"during shutdown", "err", dbErr)
 
@@ -322,6 +331,17 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 				continue
 			}
 
+			// Explicit cancellation interrupts the body before
+			// commit. The transaction rolls back and the caller
+			// owns recovery, so the failure is lifecycle noise
+			// rather than an operational warning.
+			if isExpectedTxShutdownErr(dbErr) {
+				t.log.DebugS(ctx, "Transaction body failed "+
+					"during shutdown", "err", dbErr)
+
+				return dbErr
+			}
+
 			// A missing row is a normal negative lookup for several
 			// stores, for example when wallet UTXOs are checked
 			// against known boarding addresses. Let callers decide
@@ -347,6 +367,17 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 				waitBeforeRetry(i)
 
 				continue
+			}
+
+			if isExpectedTxShutdownErr(dbErr) {
+				// Unlike begin or body cancellation, reaching
+				// commit means the body completed work that is
+				// now discarded. Keep that event greppable
+				// without alerting during expected shutdown.
+				t.log.InfoS(ctx, "Transaction commit failed "+
+					"during shutdown", "err", dbErr)
+
+				return dbErr
 			}
 
 			t.log.WarnS(ctx, "Transaction commit failed", dbErr)

--- a/db/interfaces_test.go
+++ b/db/interfaces_test.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btclog/v2"
@@ -10,6 +12,55 @@ import (
 	"github.com/lightninglabs/wavelength/db/sqlc"
 	"github.com/stretchr/testify/require"
 )
+
+// TestExpectedTxShutdownErr verifies that shutdown classification follows the
+// transaction error rather than an independently canceled caller context.
+func TestExpectedTxShutdownErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "canceled",
+			err:      context.Canceled,
+			expected: true,
+		},
+		{
+			name:     "wrapped canceled",
+			err:      fmt.Errorf("query: %w", context.Canceled),
+			expected: true,
+		},
+		{
+			name:     "closed connection",
+			err:      sql.ErrConnDone,
+			expected: true,
+		},
+		{
+			name:     "deadline",
+			err:      context.DeadlineExceeded,
+			expected: false,
+		},
+		{
+			name:     "unrelated database error",
+			err:      errors.New("disk full"),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, test.expected,
+				isExpectedTxShutdownErr(test.err),
+			)
+		})
+	}
+}
 
 // TestTransactionExecutorUsesContextTx verifies that ExecTx participates in an
 // existing actor transaction when present in context.


### PR DESCRIPTION
## Summary

- demote transaction begin and body failures caused by explicit cancellation
- keep canceled commit failures visible at info without alerting
- keep warning logs for deadline expiry and other database failures
- centralize the existing closed-database shutdown classification
- test cancellation, closed-store, deadline, and unrelated-error classification

## Problem

When a durable actor reaches a terminal state, it cancels its context and stops its mailbox lease loop. An idle `PeekNextMessage` query can still be inside a read transaction at that instant. The query returns `context canceled`, the transaction rolls back, and the lease loop exits normally.

The lease loop already classifies this as expected shutdown and logs it at debug. The generic transaction wrapper currently emits `Transaction body failed` at warning level first, which triggers the log alert even though no operation failed and no mailbox message was lost. The same cancellation can race after the body and before commit, so all three transaction failure boundaries use one shutdown classifier. A canceled commit stays at info because the body completed work that was discarded.

This was observed 12 times across the Lumos environments over 30 days. Every inspected staging occurrence was immediately followed by `Lease loop exiting on shutdown` and `Durable actor terminated`.

## Safety

This changes logging only. The transaction still returns the same error and follows the same rollback path. The classifier inspects the transaction error itself, not merely the state of its context. Therefore an unrelated disk, WAL, backend, deadline, or other commit error remains a warning even if cancellation happens concurrently. Only an actual `context.Canceled` error or known closed-database teardown avoids warning level. `context.DeadlineExceeded` remains a warning because it can signal an overloaded or slow database.

## Validation

- `make fmt-changed`
- `make unit pkg=./db`
- `go test -race -tags='dev nolog' ./db`
- `make lint-changed-local`
- `make commitmsg-lint range='origin/main..HEAD'`
