### PR TITLE
tree: Enforce VTXO value conservation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,11 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 8. Use early returns; do not nest error handling.
 9. Do not batch actor messages without backpressure.
 10. Comments explain WHY and HOW, not WHAT.
+11. **Keep private context out of this public repository.** Never expose a
+    private-repository name, URL, issue or pull request number, or internal
+    context in code, comments, tests, documentation, commit messages, branch
+    names, pull request titles, descriptions, comments, reviews, release notes,
+    or other metadata. Use standalone public wording.
 
 ## Review Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,11 @@ Body wrapped at 72 characters. Explain WHY, not just WHAT.
 8. Use early returns; do not nest error handling.
 9. Do not batch actor messages without backpressure.
 10. Comments explain WHY and HOW, not WHAT.
+11. **Keep private context out of this public repository.** Never expose a
+    private-repository name, URL, issue or pull request number, or internal
+    context in code, comments, tests, documentation, commit messages, branch
+    names, pull request titles, descriptions, comments, reviews, release notes,
+    or other metadata. Use standalone public wording.
 
 ## Review Skills
 

--- a/lib/tree/AGENTS.md
+++ b/lib/tree/AGENTS.md
@@ -8,7 +8,7 @@ descriptors through branch nodes to the batch output.
 
 ## Key Types
 
-- `Tree` — Complete VTXO or connector tree: root outpoint, root output, node hierarchy, and traversal helpers. Built via `BuildVTXOTree` or `BuildConnectorTree`.
+- `Tree` — Complete VTXO or connector tree: root outpoint, root output, node hierarchy, and traversal helpers. `Verify` checks structure plus value flow; `ValidateValueConservation` exposes the funding check separately for callers that have already bound `BatchOutput` to an authoritative prevout. Built via `BuildVTXOTree` or `BuildConnectorTree`.
 - `Node` — Single tree node representing a transaction in the tree (branch or leaf).
 - `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay.
 - `VTXODescriptor` — Interface for VTXO metadata needed by tree construction (amount, cosigners, owner key).
@@ -32,6 +32,16 @@ descriptors through branch nodes to the batch output.
 - Cosigner keys must be deduplicated (`UniqueCosigners`) before computing the final MuSig2 key.
 - Tree materialization is deterministic given the same leaf descriptors and operator key.
 - `ValidateVTXODescriptors` / `ValidateConnectorDescriptor` must pass before tree construction.
+- `Tree.Verify` requires a non-nil `BatchOutput`, checks that every reachable
+  node spends its declared parent output, enforces monetary bounds, and
+  requires each node to preserve the parent's exact value. Tree transactions
+  pay zero fee for v3 ephemeral-anchor relay. Callers accepting an untrusted
+  tree must bind `BatchOutput` to the authoritative commitment output before
+  calling `Verify` or `ValidateValueConservation`. Extracted client paths retain
+  every node output but prune unrelated child nodes, so value validation sums
+  all outputs and recurses only into retained children. The traversal rejects
+  cycles and nodes shared by multiple parents. `Node.Verify` checks only
+  parent-child outpoint topology and is not a trust-boundary validator.
 - **Cache-aliasing invariant**: a `*Tree` is effectively immutable once published from
   a builder or resolver. Multiple downstream consumers may share the same `*Tree`
   pointer through caches and ancestry-fragment slices. Silently mutating a shared

--- a/lib/tree/CLAUDE.md
+++ b/lib/tree/CLAUDE.md
@@ -8,7 +8,7 @@ descriptors through branch nodes to the batch output.
 
 ## Key Types
 
-- `Tree` — Complete VTXO or connector tree: root outpoint, root output, node hierarchy, and traversal helpers. Built via `BuildVTXOTree` or `BuildConnectorTree`.
+- `Tree` — Complete VTXO or connector tree: root outpoint, root output, node hierarchy, and traversal helpers. `Verify` checks structure plus value flow; `ValidateValueConservation` exposes the funding check separately for callers that have already bound `BatchOutput` to an authoritative prevout. Built via `BuildVTXOTree` or `BuildConnectorTree`.
 - `Node` — Single tree node representing a transaction in the tree (branch or leaf).
 - `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay.
 - `VTXODescriptor` — Interface for VTXO metadata needed by tree construction (amount, cosigners, owner key).
@@ -32,6 +32,16 @@ descriptors through branch nodes to the batch output.
 - Cosigner keys must be deduplicated (`UniqueCosigners`) before computing the final MuSig2 key.
 - Tree materialization is deterministic given the same leaf descriptors and operator key.
 - `ValidateVTXODescriptors` / `ValidateConnectorDescriptor` must pass before tree construction.
+- `Tree.Verify` requires a non-nil `BatchOutput`, checks that every reachable
+  node spends its declared parent output, enforces monetary bounds, and
+  requires each node to preserve the parent's exact value. Tree transactions
+  pay zero fee for v3 ephemeral-anchor relay. Callers accepting an untrusted
+  tree must bind `BatchOutput` to the authoritative commitment output before
+  calling `Verify` or `ValidateValueConservation`. Extracted client paths retain
+  every node output but prune unrelated child nodes, so value validation sums
+  all outputs and recurses only into retained children. The traversal rejects
+  cycles and nodes shared by multiple parents. `Node.Verify` checks only
+  parent-child outpoint topology and is not a trust-boundary validator.
 - **Cache-aliasing invariant**: a `*Tree` is effectively immutable once published from
   a builder or resolver. Multiple downstream consumers may share the same `*Tree`
   pointer through caches and ancestry-fragment slices. Silently mutating a shared

--- a/lib/tree/node.go
+++ b/lib/tree/node.go
@@ -724,7 +724,9 @@ func (n *Node) GetNonAnchorOutpoint() (*wire.OutPoint, error) {
 	return nil, fmt.Errorf("no non-anchor output found in leaf node")
 }
 
-// Verify recursively verifies that the node structure is consistent.
+// Verify recursively verifies only parent-child outpoint topology. It does not
+// validate values or bind the root to a funding output. Callers validating an
+// untrusted complete tree must use Tree.Verify.
 func (n *Node) Verify() error {
 	// Get this node's txid.
 	txHash, err := n.TXID()

--- a/lib/tree/tree.go
+++ b/lib/tree/tree.go
@@ -167,17 +167,31 @@ func (t *Tree) ExtractPathForIndices(leafIndices ...int) (*Tree, error) {
 	}, nil
 }
 
-// Verify recursively verifies that the tree structure is consistent.
-// It checks that each child's input correctly references the parent's
-// transaction at the expected output index.
+// Verify recursively verifies that the tree structure and values are
+// consistent. BatchOutput must be non-nil and contain the output spent by the
+// root. Callers accepting an untrusted tree must first bind BatchOutput to the
+// authoritative commitment transaction output. Each tree transaction must
+// spend its declared parent output and preserve that output's exact value.
 func (t *Tree) Verify() error {
-	// Verify root spends batch outpoint.
+	if t == nil {
+		return fmt.Errorf("tree is nil")
+	}
+	if t.Root == nil {
+		return fmt.Errorf("tree root is nil")
+	}
+
+	// Keep the established Tree.Verify error contract while the standalone
+	// value validator repeats this check for trust-boundary callers.
 	if t.Root.Input != t.BatchOutpoint {
 		return fmt.Errorf("root input does not match batch outpoint")
 	}
 
-	// Verify tree structure.
-	return t.Root.Verify()
+	// Reject hostile value flow while walking the structure.
+	if err := t.ValidateValueConservation(); err != nil {
+		return fmt.Errorf("value conservation failed: %w", err)
+	}
+
+	return nil
 }
 
 // VerifyVTXOPath verifies that the tree contains a valid path to a VTXO for

--- a/lib/tree/value.go
+++ b/lib/tree/value.go
@@ -1,0 +1,150 @@
+package tree
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+// ValidateValueConservation verifies the monetary and funding relationships
+// for every reachable transaction in the tree. BatchOutput is the root
+// transaction's spent output; callers at a trust boundary must first bind it
+// to the authoritative commitment transaction output.
+//
+// Tree transactions use v3 ephemeral-anchor relay, so each node must preserve
+// the exact value of the parent output it spends and pay no fee itself. Every
+// output is included in the total, including outputs whose child was pruned
+// from an extracted client path. Each reachable node's input must also name
+// the parent output whose value funds it.
+func (t *Tree) ValidateValueConservation() error {
+	if t == nil {
+		return fmt.Errorf("tree is nil")
+	}
+	if t.Root == nil {
+		return fmt.Errorf("tree root is nil")
+	}
+	if t.BatchOutput == nil {
+		return fmt.Errorf("batch output is nil")
+	}
+
+	if err := validateSatoshiValue(
+		"batch output", t.BatchOutput.Value,
+	); err != nil {
+		return err
+	}
+
+	if err := validateNodeValueConservation(
+		t.Root, t.BatchOutpoint, t.BatchOutput.Value,
+		make(map[*Node]bool),
+	); err != nil {
+		return fmt.Errorf("root: %w", err)
+	}
+
+	return nil
+}
+
+// validateNodeValueConservation verifies a node's output values against the
+// value of the parent output it spends, then recursively verifies each
+// reachable child against its parent output. visitState is false for nodes on
+// the active recursion stack and true for nodes already verified, allowing the
+// traversal to reject cycles and nodes referenced by multiple parents.
+func validateNodeValueConservation(node *Node, expectedInput wire.OutPoint,
+	inputValue int64, visitState map[*Node]bool) error {
+
+	if node == nil {
+		return fmt.Errorf("node is nil")
+	}
+	if verified, ok := visitState[node]; ok {
+		if !verified {
+			return fmt.Errorf("tree contains a cycle")
+		}
+
+		return fmt.Errorf("node is reachable from multiple parents")
+	}
+	visitState[node] = false
+
+	if node.Input != expectedInput {
+		return fmt.Errorf("input %s does not match funding outpoint %s",
+			node.Input, expectedInput)
+	}
+
+	if len(node.Outputs) == 0 {
+		return fmt.Errorf("transaction has no outputs")
+	}
+
+	var totalOutputValue int64
+	for i, output := range node.Outputs {
+		if output == nil {
+			return fmt.Errorf("output %d is nil", i)
+		}
+		if err := validateSatoshiValue(
+			fmt.Sprintf("output %d", i), output.Value,
+		); err != nil {
+			return err
+		}
+
+		if totalOutputValue > int64(btcutil.MaxSatoshi)-output.Value {
+			return fmt.Errorf("total output value exceeds "+
+				"maximum %d", int64(btcutil.MaxSatoshi))
+		}
+		totalOutputValue += output.Value
+	}
+
+	if totalOutputValue > inputValue {
+		return fmt.Errorf("output value %d exceeds input value %d",
+			totalOutputValue, inputValue)
+	}
+	if totalOutputValue < inputValue {
+		return fmt.Errorf("output value %d does not equal input "+
+			"value %d", totalOutputValue, inputValue)
+	}
+
+	txid, err := node.TXID()
+	if err != nil {
+		return fmt.Errorf("derive transaction ID: %w", err)
+	}
+
+	for _, outputIndex := range sortedChildIndices(node.Children) {
+		if uint64(outputIndex) >= uint64(len(node.Outputs)) {
+			return fmt.Errorf("child references non-existent "+
+				"output index %d", outputIndex)
+		}
+
+		child := node.Children[outputIndex]
+		if child == nil {
+			return fmt.Errorf("child at output index %d is nil",
+				outputIndex)
+		}
+
+		expectedChildInput := wire.OutPoint{
+			Hash:  txid,
+			Index: outputIndex,
+		}
+		if err := validateNodeValueConservation(
+			child, expectedChildInput,
+			node.Outputs[outputIndex].Value, visitState,
+		); err != nil {
+			return fmt.Errorf("child at output index %d: %w",
+				outputIndex, err)
+		}
+	}
+
+	visitState[node] = true
+
+	return nil
+}
+
+// validateSatoshiValue verifies that a transaction value is in Bitcoin's
+// consensus monetary range.
+func validateSatoshiValue(name string, value int64) error {
+	if value < 0 {
+		return fmt.Errorf("%s has negative value %d", name, value)
+	}
+	if value > int64(btcutil.MaxSatoshi) {
+		return fmt.Errorf("%s value %d exceeds maximum %d", name, value,
+			int64(btcutil.MaxSatoshi))
+	}
+
+	return nil
+}

--- a/lib/tree/value_test.go
+++ b/lib/tree/value_test.go
@@ -1,0 +1,317 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// valueTestTree builds a minimal tree whose root spends batchValue and creates
+// the supplied output values. Scripts and anchors are irrelevant to value
+// conservation, so the fixture keeps them intentionally small.
+func valueTestTree(batchValue int64, outputValues ...int64) *Tree {
+	batchOutpoint := wire.OutPoint{
+		Hash: chainhash.HashH([]byte("value-test-batch")),
+	}
+	outputs := make([]*wire.TxOut, len(outputValues))
+	for i, value := range outputValues {
+		outputs[i] = wire.NewTxOut(value, []byte{0x51})
+	}
+
+	return &Tree{
+		Root: &Node{
+			Input:    batchOutpoint,
+			Outputs:  outputs,
+			Children: make(map[uint32]*Node),
+		},
+		BatchOutpoint: batchOutpoint,
+		BatchOutput: wire.NewTxOut(
+			batchValue, []byte{0x51},
+		),
+	}
+}
+
+// TestValidateValueConservation exercises the tree's zero-fee value rule and
+// funding relationships at the root and at interior edges.
+func TestValidateValueConservation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid zero-fee root", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 600, 400)
+		require.NoError(t, tree.ValidateValueConservation())
+	})
+
+	t.Run("non-zero fee", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 999)
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(
+			t, err.Error(),
+			"output value 999 does not equal input value 1000",
+		)
+	})
+
+	t.Run("root input mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 1000)
+		tree.Root.Input.Index++
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "funding outpoint")
+	})
+
+	t.Run("root outputs exceed batch output", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 1000, 1)
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(
+			t, err.Error(),
+			"output value 1001 exceeds input",
+		)
+
+		err = tree.Verify()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "value conservation failed")
+	})
+
+	t.Run("interior outputs exceed parent output", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 400, 600)
+		child := &Node{
+			Outputs: []*wire.TxOut{
+				wire.NewTxOut(401, []byte{0x51}),
+			},
+			Children: make(map[uint32]*Node),
+		}
+		txid, err := tree.Root.TXID()
+		require.NoError(t, err)
+		child.Input = wire.OutPoint{
+			Hash:  txid,
+			Index: 0,
+		}
+		tree.Root.Children[0] = child
+
+		err = tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "child at output index 0")
+		require.Contains(
+			t, err.Error(),
+			"output value 401 exceeds input",
+		)
+	})
+
+	t.Run("negative batch output", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(-1, 0)
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(
+			t, err.Error(),
+			"batch output has negative value",
+		)
+	})
+
+	t.Run("batch output exceeds money supply", func(t *testing.T) {
+		t.Parallel()
+
+		maxSatoshi := int64(btcutil.MaxSatoshi)
+		tree := valueTestTree(maxSatoshi+1, maxSatoshi)
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "batch output value")
+		require.Contains(t, err.Error(), "exceeds maximum")
+	})
+
+	t.Run("negative node output", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, -1)
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "output 0 has negative value")
+	})
+
+	t.Run("individual output exceeds money supply", func(t *testing.T) {
+		t.Parallel()
+
+		maxSatoshi := int64(btcutil.MaxSatoshi)
+		tree := valueTestTree(maxSatoshi, maxSatoshi+1)
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum")
+	})
+
+	t.Run("output total exceeds money supply", func(t *testing.T) {
+		t.Parallel()
+
+		maxSatoshi := int64(btcutil.MaxSatoshi)
+		tree := valueTestTree(maxSatoshi, maxSatoshi, 1)
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(
+			t, err.Error(),
+			"total output value exceeds maximum",
+		)
+	})
+
+	t.Run("nil output", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 1000)
+		tree.Root.Outputs[0] = nil
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "output 0 is nil")
+	})
+
+	t.Run("no outputs", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000)
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "transaction has no outputs")
+	})
+
+	t.Run("child output index out of range", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 1000)
+		tree.Root.Children[1] = &Node{}
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(
+			t, err.Error(),
+			"child references non-existent output index 1",
+		)
+	})
+
+	t.Run("nil child", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 1000)
+		tree.Root.Children[0] = nil
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(
+			t, err.Error(),
+			"child at output index 0 is nil",
+		)
+	})
+
+	t.Run("child input index mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 1000)
+		txid, err := tree.Root.TXID()
+		require.NoError(t, err)
+		tree.Root.Children[0] = &Node{
+			Input: wire.OutPoint{
+				Hash:  txid,
+				Index: 1,
+			},
+			Outputs: []*wire.TxOut{
+				wire.NewTxOut(1000, []byte{0x51}),
+			},
+			Children: make(map[uint32]*Node),
+		}
+
+		err = tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "funding outpoint")
+	})
+
+	t.Run("cycle", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 1000)
+		tree.Root.Children[0] = tree.Root
+		err := tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tree contains a cycle")
+	})
+
+	t.Run("multiple parents", func(t *testing.T) {
+		t.Parallel()
+
+		tree := valueTestTree(1000, 500, 500)
+		txid, err := tree.Root.TXID()
+		require.NoError(t, err)
+		child := &Node{
+			Input: wire.OutPoint{
+				Hash: txid,
+			},
+			Outputs: []*wire.TxOut{
+				wire.NewTxOut(500, []byte{0x51}),
+			},
+			Children: make(map[uint32]*Node),
+		}
+		tree.Root.Children[0] = child
+		tree.Root.Children[1] = child
+
+		err = tree.ValidateValueConservation()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "multiple parents")
+	})
+}
+
+// TestValidateValueConservationExtractedPath verifies that both extraction
+// APIs retain every parent output while omitting unrelated child nodes, so
+// conservation can total all outputs while recursing through reachable
+// children only.
+func TestValidateValueConservationExtractedPath(t *testing.T) {
+	t.Parallel()
+
+	_, operatorKey := createTestKey(t)
+	_, clientKey := createTestKey(t)
+	_, otherKey := createTestKey(t)
+
+	leaves := []LeafDescriptor{{
+		PkScript:    []byte("client"),
+		Amount:      1000,
+		CoSignerKey: clientKey,
+	}, {
+		PkScript:    []byte("other"),
+		Amount:      2000,
+		CoSignerKey: otherKey,
+	}}
+	tree, err := NewTree(
+		wire.OutPoint{
+			Hash: chainhash.HashH([]byte("batch")),
+		},
+		wire.NewTxOut(
+			3000, []byte("batch"),
+		),
+		leaves,
+		operatorKey,
+		make([]byte, 32),
+		2,
+	)
+	require.NoError(t, err)
+
+	path, err := tree.ExtractPathForCoSigners(clientKey)
+	require.NoError(t, err)
+	require.NotNil(t, path)
+	require.Len(t, path.Root.Outputs, 3)
+	require.Len(t, path.Root.Children, 1)
+	require.NoError(t, path.ValidateValueConservation())
+
+	indexPath, err := tree.ExtractPathForIndices(0)
+	require.NoError(t, err)
+	require.NotNil(t, indexPath)
+	require.Len(t, indexPath.Root.Outputs, 3)
+	require.Len(t, indexPath.Root.Children, 1)
+	require.NoError(t, indexPath.ValidateValueConservation())
+}

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -280,6 +280,14 @@ state transitions and validation rules live under [Invariants](#invariants).
 - Each client sub-tree in the commitment tree must contain exactly one
   non-anchor leaf; `buildOwnedClientVTXOs` fails the transition
   otherwise.
+- **VTXO-tree value conservation is checked at commitment admission.**
+  `validateVTXOTreeBinding` first byte-binds the server tree's `BatchOutput`
+  to the real commitment output, then verifies that the root spends its
+  declared `BatchOutpoint` and every reachable node spends the expected parent
+  output while preserving its exact value. The zero-fee rule is required for
+  v3 ephemeral-anchor relay. The later quote-authoritative leaf check closes
+  the value chain from the committed root to the client's accepted amount
+  before nonces, signatures, or persistence.
 - **Seal-time fee handshake (#270)**: the server is the amount
   authority. When `QuoteReceivedState.Quote` is non-nil, it threads
   through `RoundJoinedState` → `CommitmentTxReceivedState`, which

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -280,6 +280,14 @@ state transitions and validation rules live under [Invariants](#invariants).
 - Each client sub-tree in the commitment tree must contain exactly one
   non-anchor leaf; `buildOwnedClientVTXOs` fails the transition
   otherwise.
+- **VTXO-tree value conservation is checked at commitment admission.**
+  `validateVTXOTreeBinding` first byte-binds the server tree's `BatchOutput`
+  to the real commitment output, then verifies that the root spends its
+  declared `BatchOutpoint` and every reachable node spends the expected parent
+  output while preserving its exact value. The zero-fee rule is required for
+  v3 ephemeral-anchor relay. The later quote-authoritative leaf check closes
+  the value chain from the committed root to the client's accepted amount
+  before nonces, signatures, or persistence.
 - **Seal-time fee handshake (#270)**: the server is the amount
   authority. When `QuoteReceivedState.Quote` is non-nil, it threads
   through `RoundJoinedState` → `CommitmentTxReceivedState`, which

--- a/round/connector_validation_test.go
+++ b/round/connector_validation_test.go
@@ -1,6 +1,7 @@
 package round
 
 import (
+	"math"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -331,5 +332,71 @@ func TestValidateConnectorAncestryRejects(t *testing.T) {
 				},
 			),
 		)
+	})
+
+	t.Run("underfunded connector root", func(t *testing.T) {
+		t.Parallel()
+
+		commitmentTx, infos := newConnectorFixture(
+			t, operatorKey, 5, 2, 0,
+		)
+		commitmentTx.TxOut[0].Value--
+
+		err := validateConnectorAncestry(
+			commitmentTx, operatorKey, mappingFrom(infos[2]),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "root output value")
+	})
+
+	t.Run("overfunded connector root", func(t *testing.T) {
+		t.Parallel()
+
+		commitmentTx, infos := newConnectorFixture(
+			t, operatorKey, 5, 2, 0,
+		)
+		commitmentTx.TxOut[0].Value++
+
+		err := validateConnectorAncestry(
+			commitmentTx, operatorKey, mappingFrom(infos[2]),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "root output value")
+	})
+
+	t.Run("connector funding multiplication overflows", func(t *testing.T) {
+		t.Parallel()
+
+		commitmentTx, infos := newConnectorFixture(
+			t, operatorKey, 5, 2, 0,
+		)
+		bad := mutate(infos[2], func(info *ConnectorLeafInfo) {
+			info.ConnectorAmount = math.MaxInt64
+		})
+
+		err := validateConnectorAncestry(
+			commitmentTx, operatorKey, mappingFrom(bad),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "overflow int64")
+	})
+
+	t.Run("connector amount exceeds money supply", func(t *testing.T) {
+		t.Parallel()
+
+		commitmentTx, infos := newConnectorFixture(
+			t, operatorKey, 1, 2, 0,
+		)
+		oversized := int64(btcutil.MaxSatoshi) + 1
+		commitmentTx.TxOut[0].Value = oversized
+		bad := mutate(infos[0], func(info *ConnectorLeafInfo) {
+			info.ConnectorAmount = oversized
+		})
+
+		err := validateConnectorAncestry(
+			commitmentTx, operatorKey, mappingFrom(bad),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum")
 	})
 }

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -2363,13 +2363,12 @@ func (s *CommitmentTxReceivedState) processEvent(ctx context.Context,
 			)
 		}
 
-		// Before trusting any tree's contents, prove that each
-		// operator-supplied VTXO tree is rooted in this round's
-		// commitment tx. The per-VTXO ValidatePath check below only
-		// proves internal self-consistency; without this binding a
-		// self-consistent tree rooted at the wrong commitment output
-		// would be co-signed, after which the client's new VTXOs are
-		// unrecoverable (wavelength#680).
+		// Before trusting any tree's contents, bind each operator-
+		// supplied VTXO tree to this round's real commitment output and
+		// prove every reachable transaction is funded. The per-VTXO
+		// ValidatePath check below binds each funded leaf to its
+		// accepted quote, but cannot establish that the server-supplied
+		// root value is the value actually committed on chain.
 		if err := validateVTXOTreeBinding(
 			s.CommitmentTx.UnsignedTx, s.VTXOTreePaths,
 		); err != nil {
@@ -4149,7 +4148,8 @@ func connectorLeafOutput(leaf *tree.Node) (*wire.TxOut, error) {
 // For each (outputIdx, tree) pair it asserts that the tree's BatchOutpoint
 // names this commitment tx, that outputIdx agrees with BatchOutpoint.Index,
 // that the index is in range, that the committed output byte-matches the
-// tree's BatchOutput, and that the committed script equals the taproot script
+// tree's BatchOutput, that every reachable transaction is funded by the
+// output it spends, and that the committed script equals the taproot script
 // recomputed from the tree root's cosigner set and sweep tapscript root (so a
 // substituted-but-self-consistent script is rejected).
 func validateVTXOTreeBinding(commitmentTx *wire.MsgTx,
@@ -4178,9 +4178,10 @@ func validateVTXOTreeBinding(commitmentTx *wire.MsgTx,
 }
 
 // verifyVTXOTreeRoot checks that a single VTXO tree's root spends the
-// commitment output named by outputIdx and that the committed output matches
-// both the tree's claimed BatchOutput and the taproot script recomputed from
-// the tree's declared cosigner set and sweep tapscript root.
+// commitment output named by outputIdx, that each reachable node conserves
+// value from that committed output, and that the committed output matches both
+// the tree's claimed BatchOutput and the taproot script recomputed from the
+// tree's declared cosigner set and sweep tapscript root.
 func verifyVTXOTreeRoot(commitmentTx *wire.MsgTx, commitmentTxID chainhash.Hash,
 	outputIdx int, vtxoTree *tree.Tree) error {
 
@@ -4261,6 +4262,14 @@ func verifyVTXOTreeRoot(commitmentTx *wire.MsgTx, commitmentTxID chainhash.Hash,
 	if !bytes.Equal(rootScript, committed.PkScript) {
 		return fmt.Errorf("committed output script does not match " +
 			"script recomputed from tree cosigners and sweep root")
+	}
+
+	// BatchOutput is operator-supplied, so validate values only after the
+	// byte comparison above has bound it to the real commitment output. The
+	// subsequent per-client ValidatePath call binds the funded path's leaf
+	// to the amount accepted in the client's quote.
+	if err := vtxoTree.ValidateValueConservation(); err != nil {
+		return fmt.Errorf("value conservation failed: %w", err)
 	}
 
 	return nil

--- a/round/vtxo_tree_binding_test.go
+++ b/round/vtxo_tree_binding_test.go
@@ -4,12 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/lib/tree"
 	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,6 +76,19 @@ func TestValidateVTXOTreeBindingRejects(t *testing.T) {
 			vtxtTree.BatchOutpoint.Hash = chainhash.Hash{
 				0xff,
 			}
+
+			return map[int]*tree.Tree{
+				0: vtxtTree,
+			}
+		},
+	}, {
+		// The tree metadata names the real commitment output, but the
+		// root transaction itself spends a different outpoint.
+		name: "root input disagrees with batch outpoint",
+		corrupt: func(t *testing.T, _ *wire.MsgTx, vtxtTree *tree.Tree,
+			_ *boardingTestHarness) map[int]*tree.Tree {
+
+			vtxtTree.Root.Input.Index++
 
 			return map[int]*tree.Tree{
 				0: vtxtTree,
@@ -190,6 +205,66 @@ func TestValidateVTXOTreeBindingRejects(t *testing.T) {
 			)
 		})
 	}
+}
+
+// relinkVTXOTree updates every reachable child input after a test mutates a
+// parent's outputs. This preserves structural validity so conservation, rather
+// than a stale txid link, is the reason the hostile fixture is rejected.
+func relinkVTXOTree(t *testing.T, node *tree.Node) {
+	t.Helper()
+
+	txid, err := node.TXID()
+	require.NoError(t, err)
+	for outputIdx, child := range node.Children {
+		child.Input = wire.OutPoint{
+			Hash:  txid,
+			Index: outputIdx,
+		}
+		relinkVTXOTree(t, child)
+	}
+}
+
+// TestValidateVTXOTreeBindingRejectsUnderfundedInterior proves that a child
+// cannot create more value than its parent output. The root remains exactly
+// conserved and all txid links are repaired, matching the report's case where
+// structure-only validation succeeds but an interior transaction is invalid.
+func TestValidateVTXOTreeBindingRejectsUnderfundedInterior(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	vtxtTree, _ := h.newTestVTXOTree(4)
+	commitment := h.bindTreeToCommitment(
+		[]BoardingIntent{
+			h.newTestBoardingIntent(),
+			h.newTestBoardingIntent(),
+			h.newTestBoardingIntent(),
+			h.newTestBoardingIntent(),
+		},
+		vtxtTree,
+	)
+
+	require.Len(t, vtxtTree.Root.Outputs, 3)
+	require.Len(t, vtxtTree.Root.Children, 2)
+	require.False(t, vtxtTree.Root.Children[0].IsLeaf())
+
+	// Move one satoshi from the first child allocation to the second. The
+	// root still spends exactly its batch output, but the non-leaf child at
+	// index 0 now tries to create 100,000 sats from a 99,999-sat parent
+	// output.
+	vtxtTree.Root.Outputs[0].Value--
+	vtxtTree.Root.Outputs[1].Value++
+	relinkVTXOTree(t, vtxtTree.Root)
+
+	// The old topology-only verifier accepts the hostile tree. The round
+	// trust boundary must additionally reject its value flow.
+	require.NoError(t, vtxtTree.Root.Verify())
+	err := validateVTXOTreeBinding(
+		commitment.UnsignedTx, map[int]*tree.Tree{
+			0: vtxtTree,
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "value conservation")
 }
 
 // TestConfirmationWatchScriptUsesBatchOutput builds a multi-output round whose
@@ -356,4 +431,122 @@ func TestCommitmentTxReceivedRejectsUnboundTree(t *testing.T) {
 
 	// The round must NOT have advanced toward signing.
 	require.NotContains(t, failedState.Reason, "validation failed")
+}
+
+// TestCommitmentTxReceivedRejectsCommitmentSiphon reproduces the source-
+// analyzed attack where the operator lowers both copies of the batch output
+// and diverts the missing value to a hidden commitment-tx change output. The
+// client's leaf still matches its accepted quote, so only end-to-end value
+// conservation binds that quote back to the real commitment output.
+func TestCommitmentTxReceivedRejectsCommitmentSiphon(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+	vtxoReq := h.newTestVTXORequestForIntent(intent)
+	vtxoReq.IsChange = true
+
+	// Use the quote-authoritative residual rather than the intent target so
+	// the fixture exercises the production root-to-quote trust chain.
+	quotedAmount := int64(vtxoReq.Amount) - 1500
+	require.NotEqual(t, int64(vtxoReq.Amount), quotedAmount)
+	vtxoReqForTree := vtxoReq
+	vtxoReqForTree.Amount = btcutil.Amount(quotedAmount)
+	vtxtTree := h.newTestVTXOTreeForIntents(
+		[]types.VTXORequest{vtxoReqForTree},
+	)
+
+	const siphonedValue = int64(1000)
+	changeScript, err := txscript.PayToTaprootScript(h.operatorPubKey)
+	require.NoError(t, err)
+	commitment := h.bindTreeToCommitment(
+		[]BoardingIntent{intent}, vtxtTree, &wire.TxOut{
+			Value:    siphonedValue,
+			PkScript: changeScript,
+		},
+	)
+
+	batchOutput := commitment.UnsignedTx.TxOut[0]
+	batchOutput.Value -= siphonedValue
+	require.NoError(
+		t, psbt.VerifyInputOutputLen(commitment, true, true),
+	)
+
+	// Keep the tree's server-supplied BatchOutput equal to the lowered
+	// commitment output and re-root it at the changed commitment txid. The
+	// pre-fix binding compares these two hostile values and accepts them.
+	vtxtTree.BatchOutput = wire.NewTxOut(
+		batchOutput.Value,
+		append(
+			[]byte(nil), batchOutput.PkScript...,
+		),
+	)
+	vtxtTree.BatchOutpoint.Hash = commitment.UnsignedTx.TxHash()
+	vtxtTree.Root.Input = vtxtTree.BatchOutpoint
+
+	roundID := testRoundIDTr("round-commitment-siphon")
+	state := &CommitmentTxReceivedState{
+		RoundID:      roundID,
+		CommitmentTx: commitment,
+		TxID:         commitment.UnsignedTx.TxHash(),
+		SweepDelay:   1008,
+		VTXOTreePaths: map[int]*tree.Tree{
+			0: vtxtTree,
+		},
+		Intents: Intents{
+			Boarding: []BoardingIntent{
+				intent,
+			},
+			VTXOs: []types.VTXORequest{
+				vtxoReq,
+			},
+		},
+		ClientTrees: make(map[SignerKey]*tree.Tree),
+		Quote: &ClientQuote{
+			OperatorFeeSat: 1500,
+			VTXOQuotes: []VTXOQuoteEntry{{
+				AmountSat: quotedAmount,
+				PkScript:  vtxoReq.PkScript,
+				RecipientKey: vtxoReq.SigningKey.PubKey.
+					SerializeCompressed(),
+			}},
+		},
+	}
+	h.withState(state)
+
+	event := &CommitmentTxBuilt{
+		RoundID: roundID,
+		Tx:      commitment,
+		VTXOTreePaths: map[int]*tree.Tree{
+			0: vtxtTree,
+		},
+	}
+
+	transition, err := h.sendEvent(event)
+	require.NoError(t, err)
+	require.NotNil(t, transition)
+	transition.NewEvents.WhenSome(func(emitted ClientEmittedEvent) {
+		require.Empty(t, emitted.InternalEvent)
+	})
+	for _, msg := range h.outboxMessages {
+		_, submitsNonces := msg.(*SubmitNoncesRequest)
+		require.False(t, submitsNonces)
+	}
+	h.wallet.AssertNotCalled(
+		t, "MuSig2CreateSession", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	)
+	h.wallet.AssertNotCalled(
+		t, "SignOutputRaw", mock.Anything, mock.Anything,
+	)
+	h.roundStore.AssertNotCalled(
+		t, "CommitState", mock.Anything, mock.Anything, mock.Anything,
+	)
+	h.vtxoStore.AssertNotCalled(
+		t, "SaveVTXOs", mock.Anything, mock.Anything,
+	)
+
+	failedState := assertStateType[*ClientFailedState](h)
+	require.Contains(t, failedState.Reason, "binding")
+	require.Contains(t, failedState.Error.Error(), "value conservation")
 }


### PR DESCRIPTION
## What changed

- validate every reachable tree node against the exact parent output it spends
- require zero-fee value conservation for v3 ephemeral-anchor tree transactions
- bind round validation to the actual batch output in the commitment transaction before accepting an untrusted tree
- apply the same amount and overflow checks to reconstructed connector trees
- reject malformed, cyclic, shared, mis-rooted, or mis-funded trees before nonce generation, signing, or persistence
- cover both cosigner-based and index-based extracted paths
- keep private-repository context out of public code and collaboration metadata

## Safety

The validator uses transaction output values rather than node metadata. It rejects negative values, values above `MaxSatoshi`, checked-sum overflow, non-zero transaction fees, and any root or child input that does not name its declared funding output.

`Tree.Verify` documents its required `BatchOutput` trust binding. `Node.Verify` is explicitly topology-only and directs untrusted complete-tree callers to `Tree.Verify`.

## Validation

- `make fmt-changed`
- `make lint-changed-local`: 0 issues
- `make unit pkg=lib/tree timeout=5m`
- `make unit pkg=round timeout=5m`
- `make doc-check`
- `./.github/scripts/check-agent-docs-sync.sh`
- `make commitmsg-lint range=origin/main..HEAD`
- `git diff --check origin/main...HEAD`
