### PR TITLE
vtxo: reserve lifetime for high-CLTV payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Common knobs:
 | `--server.host`            | network default    | Ark operator address override.           |
 | `--server.transport`       | `grpc`             | Ark operator transport: `grpc` or `rest`. |
 | `--swap.serveraddress`     | network default    | Swap server address override.            |
+| `--maxpaymentcltv`         | `300` with swaps   | Payment CLTV reserved by refresh.        |
 | `--rpc.listenaddr`         | `localhost:10029`  | Daemon gRPC listen address.              |
 
 ---

--- a/cmd/waved/AGENTS.md
+++ b/cmd/waved/AGENTS.md
@@ -22,6 +22,11 @@ hands off to `waved.Main` to run the daemon.
 - `configureBitcoindSubmitter(v, cfg)` — opt-in direct bitcoind
   `submitpackage` wiring for V3 ephemeral-anchor package relay; a no-op
   when `bitcoind.host` is unset.
+- `registerOperatorFeeFlags(f, cfg)` / `registerMaxPaymentCLTVFlag(f, cfg)` /
+  `registerFeeEstimationFlags(...)` — grouped flag registrars called from
+  `newRootCmd`. `registerMaxPaymentCLTVFlag` owns `--maxpaymentcltv`, the
+  automatic-maintenance target for keeping enough VTXO lifetime available for
+  Lightning payments.
 
 ## Relationships
 
@@ -50,3 +55,8 @@ hands off to `waved.Main` to run the daemon.
 - `EagerRoundJoin`'s flag default comes from `waved.DefaultConfig()`,
   which is itself build-tag aware (true under `wavewalletrpc`, false
   otherwise); `--eagerroundjoin` still overrides it either way.
+- `--maxpaymentcltv`'s default is build-tag aware the same way: it reads
+  `cfg.MaxPaymentCLTV`, which `waved.DefaultConfig()` seeds from
+  `defaultMaxPaymentCLTV()` — 300 under `swapruntime`, zero otherwise. The
+  help text therefore differs between builds, and passing `0` explicitly
+  disables the payment reserve in a swap-enabled build.

--- a/cmd/waved/CLAUDE.md
+++ b/cmd/waved/CLAUDE.md
@@ -22,6 +22,11 @@ hands off to `waved.Main` to run the daemon.
 - `configureBitcoindSubmitter(v, cfg)` — opt-in direct bitcoind
   `submitpackage` wiring for V3 ephemeral-anchor package relay; a no-op
   when `bitcoind.host` is unset.
+- `registerOperatorFeeFlags(f, cfg)` / `registerMaxPaymentCLTVFlag(f, cfg)` /
+  `registerFeeEstimationFlags(...)` — grouped flag registrars called from
+  `newRootCmd`. `registerMaxPaymentCLTVFlag` owns `--maxpaymentcltv`, the
+  automatic-maintenance target for keeping enough VTXO lifetime available for
+  Lightning payments.
 
 ## Relationships
 
@@ -50,3 +55,8 @@ hands off to `waved.Main` to run the daemon.
 - `EagerRoundJoin`'s flag default comes from `waved.DefaultConfig()`,
   which is itself build-tag aware (true under `wavewalletrpc`, false
   otherwise); `--eagerroundjoin` still overrides it either way.
+- `--maxpaymentcltv`'s default is build-tag aware the same way: it reads
+  `cfg.MaxPaymentCLTV`, which `waved.DefaultConfig()` seeds from
+  `defaultMaxPaymentCLTV()` — 300 under `swapruntime`, zero otherwise. The
+  help text therefore differs between builds, and passing `0` explicitly
+  disables the payment reserve in a swap-enabled build.

--- a/cmd/waved/main.go
+++ b/cmd/waved/main.go
@@ -26,6 +26,8 @@ type bestEffortWriter struct {
 	w io.Writer
 }
 
+// Write forwards the bytes when a sink is configured and always reports a
+// successful full write so optional log mirroring cannot stop the daemon.
 func (b bestEffortWriter) Write(p []byte) (int, error) {
 	if b.w != nil {
 		_, _ = b.w.Write(p)
@@ -34,6 +36,8 @@ func (b bestEffortWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// main executes the waved command and reports startup or runtime failures to
+// stderr before returning a non-zero process status.
 func main() {
 	root := newRootCmd()
 
@@ -192,6 +196,7 @@ func newRootCmd() *cobra.Command {
 	)
 
 	registerOperatorFeeFlags(f, cfg)
+	registerMaxPaymentCLTVFlag(f, cfg)
 
 	// Bound concurrent MuSig2 work. Zero lets the daemon choose a safe
 	// backend-aware default; one restores serial signing.
@@ -299,6 +304,17 @@ func registerOperatorFeeFlags(f *pflag.FlagSet, cfg *waved.Config) {
 	f.Uint32(
 		"autorefreshfeerateppm", cfg.AutoRefreshFeeRatePPM,
 		autoRefreshFeeRateHelp,
+	)
+}
+
+// registerMaxPaymentCLTVFlag registers the automatic-maintenance target for
+// keeping enough VTXO lifetime available for Lightning payments.
+func registerMaxPaymentCLTVFlag(f *pflag.FlagSet, cfg *waved.Config) {
+	f.Int32(
+		"maxpaymentcltv", cfg.MaxPaymentCLTV, "largest total "+
+			"Lightning payment CLTV that automatic VTXO "+
+			"maintenance reserves; zero disables the payment "+
+			"reserve",
 	)
 }
 

--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -1781,6 +1781,8 @@ func TestVTXOPersistenceStoreMetadataPersistence(t *testing.T) {
 
 	// Create and save a VTXO with full metadata.
 	desc := createTestVTXODescriptor(t, roundID, 42)
+	desc.BatchExpiry = 1_108
+	desc.CreatedHeight = 100
 	err = vtxoStore.SaveVTXO(ctx, desc)
 	require.NoError(t, err)
 
@@ -1801,6 +1803,12 @@ func TestVTXOPersistenceStoreMetadataPersistence(t *testing.T) {
 	require.Equal(
 		t, desc.CreatedHeight, fetched.CreatedHeight,
 		"CreatedHeight should be persisted",
+	)
+	expiryCfg := vtxo.DefaultExpiryConfig()
+	expiryCfg.MaxPaymentCLTV = 800
+	require.False(
+		t, expiryCfg.CanReserveMaxPaymentCLTV(fetched),
+		"the payment reserve guard should survive store recovery",
 	)
 	require.Equal(
 		t, desc.CommitmentTxID, fetched.CommitmentTxID,

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -145,6 +145,7 @@ waved \
 | `--rpc.tlskeypath` | | Custom TLS key for daemon RPC |
 | `--swap.serveraddress` | network default | Swap server address override for swapruntime builds |
 | `--swap.servertransport` | `grpc` | Swap server transport: `grpc` or `rest` |
+| `--maxpaymentcltv` | `300` in swap-enabled builds | Largest total Lightning payment CLTV reserved by automatic VTXO refresh; `0` disables the payment reserve |
 
 Empty Ark and swap addresses resolve from the selected network and transport.
 See [signet.md](signet.md) for the testnet3, testnet4, and signet endpoints and
@@ -538,6 +539,19 @@ default to zero, which leaves only the global cap in force. If an automatic
 quote is rejected while the VTXOs are still safe, the wallet waits six blocks
 before retrying. Critical or expired VTXOs bypass that cooldown so the wallet
 does not trade unilateral-exit safety for fee throttling.
+
+Swap-enabled builds also default `maxpaymentcltv` to 300 blocks. Automatic
+maintenance adds that payment window above each VTXO's dynamic unilateral-exit
+budget and 72-block refresh-retry buffer. For example, a VTXO with a 186-block
+critical threshold refreshes at `186 + 72 + 300 = 558` blocks remaining. Set
+the value to zero to keep only the ordinary exit-safety policy. This is a
+liquidity-readiness target, not an override of send-time expiry validation: a
+payment whose actual route needs more lifetime still fails safely. If a fresh,
+round-direct VTXO cannot provide the configured reserve plus one 72-block
+healthy window, the wallet logs the mismatch and keeps the ordinary refresh
+threshold. Repeated refreshes cannot extend an operator's batch lifetime, so
+they would only spend fees. An OOR descendant keeps the reserve because one
+refresh can replace its inherited partial lifetime with a new full batch.
 
 An interactive real refresh shows the estimate and asks for
 confirmation. On non-interactive stdin (agents, pipelines) the command

--- a/sample-waved.conf
+++ b/sample-waved.conf
@@ -62,6 +62,12 @@
 # zero, only maxoperatorfeesat applies.
 # autorefreshfeerateppm=0
 
+# Largest total Lightning payment CLTV that automatic VTXO maintenance keeps
+# available above the unilateral-exit and refresh-retry budgets. Swap-enabled
+# builds default to 300. The core build shown by this sample defaults to zero,
+# which disables the payment-specific reserve.
+# maxpaymentcltv=0
+
 # Drive cooperative round-joining from the wallet actor itself: every
 # freshly confirmed boarding UTXO auto-runs the Board path inline, and
 # cooperative-leave intents set TriggerRegistration=true. Off keeps the

--- a/sdk/wavewalletdk/AGENTS.md
+++ b/sdk/wavewalletdk/AGENTS.md
@@ -51,8 +51,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/wave
   Options apply **after** the `Config`/`DaemonConfig` merge and after
   `configureSwapRuntime` / `configureWalletRPC`, so they can override
   values seeded by `waved.DefaultConfig` or carried on a caller-owned
-  `DaemonConfig`. First option: `WithEagerRoundJoinDisabled()` forces
-  `daemonCfg.EagerRoundJoin = false`.
+  `DaemonConfig`. Current options: `WithEagerRoundJoinDisabled()` forces
+  `daemonCfg.EagerRoundJoin = false`, and
+  `WithMaxPaymentCLTVDisabled()` forces `daemonCfg.MaxPaymentCLTV = 0`.
+  Both exist because the matching `Config` fields are enable-only.
 - DTOs (wrapper-owned, isolated from proto enums): `Info` / `ServerInfo`
   (including the advisory free-refresh window), `Balance`,
   `CreateWalletResult`, `UnlockWalletResult`, `ReceiveRequest`/`Result`
@@ -160,6 +162,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/wave
   `//nolint:contextcheck` on `Start` guards this).
 - `Start` blocks until either gRPC reports `Ready`, the daemon exits
   early with an error, or the caller's startup `ctx` cancels.
+- `Config.MaxPaymentCLTV` is the embedded/mobile convenience override for the
+  daemon's automatic-refresh payment reserve. Zero preserves a caller-owned
+  daemon value and the swap-enabled 300-block default. To force an explicit
+  zero, pass `wavewalletdk.WithMaxPaymentCLTVDisabled()` to `Start`; the mobile
+  JSON adapter does this when `max_payment_cltv` is present with value zero.
 - A caller-supplied `DaemonConfig` is deep-copied via
   `cloneDaemonConfig` before mutation (`RPC.Listener` is replaced;
   `RPCServiceRegistrars` may be appended). New reference-typed fields

--- a/sdk/wavewalletdk/CLAUDE.md
+++ b/sdk/wavewalletdk/CLAUDE.md
@@ -51,8 +51,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/wave
   Options apply **after** the `Config`/`DaemonConfig` merge and after
   `configureSwapRuntime` / `configureWalletRPC`, so they can override
   values seeded by `waved.DefaultConfig` or carried on a caller-owned
-  `DaemonConfig`. First option: `WithEagerRoundJoinDisabled()` forces
-  `daemonCfg.EagerRoundJoin = false`.
+  `DaemonConfig`. Current options: `WithEagerRoundJoinDisabled()` forces
+  `daemonCfg.EagerRoundJoin = false`, and
+  `WithMaxPaymentCLTVDisabled()` forces `daemonCfg.MaxPaymentCLTV = 0`.
+  Both exist because the matching `Config` fields are enable-only.
 - DTOs (wrapper-owned, isolated from proto enums): `Info` / `ServerInfo`
   (including the advisory free-refresh window), `Balance`,
   `CreateWalletResult`, `UnlockWalletResult`, `ReceiveRequest`/`Result`
@@ -160,6 +162,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/wave
   `//nolint:contextcheck` on `Start` guards this).
 - `Start` blocks until either gRPC reports `Ready`, the daemon exits
   early with an error, or the caller's startup `ctx` cancels.
+- `Config.MaxPaymentCLTV` is the embedded/mobile convenience override for the
+  daemon's automatic-refresh payment reserve. Zero preserves a caller-owned
+  daemon value and the swap-enabled 300-block default. To force an explicit
+  zero, pass `wavewalletdk.WithMaxPaymentCLTVDisabled()` to `Start`; the mobile
+  JSON adapter does this when `max_payment_cltv` is present with value zero.
 - A caller-supplied `DaemonConfig` is deep-copied via
   `cloneDaemonConfig` before mutation (`RPC.Listener` is replaced;
   `RPCServiceRegistrars` may be appended). New reference-typed fields

--- a/sdk/wavewalletdk/embedded.go
+++ b/sdk/wavewalletdk/embedded.go
@@ -45,6 +45,7 @@ func DefaultConfig() Config {
 		SwapServerInsecure:     cfg.Swap.ServerInsecure,
 		SwapDatabaseFileName:   cfg.Swap.DatabaseFileName,
 		MaxOperatorFeeSat:      cfg.MaxOperatorFeeSat,
+		MaxPaymentCLTV:         cfg.MaxPaymentCLTV,
 		AutoRefreshFeeFloorSat: cfg.AutoRefreshFeeFloorSat,
 		AutoRefreshFeeRatePPM:  cfg.AutoRefreshFeeRatePPM,
 		SigningWorkers:         cfg.SigningWorkers,
@@ -58,6 +59,7 @@ func DefaultConfig() Config {
 // would otherwise leave in place.
 type startOptions struct {
 	disableEagerRoundJoin bool
+	disableMaxPaymentCLTV bool
 }
 
 // Option mutates the embedded daemon configuration during Start. Functional
@@ -75,6 +77,15 @@ type Option func(*startOptions)
 func WithEagerRoundJoinDisabled() Option {
 	return func(o *startOptions) {
 		o.disableEagerRoundJoin = true
+	}
+}
+
+// WithMaxPaymentCLTVDisabled forces automatic maintenance to omit the
+// Lightning payment lifetime reserve. It provides an explicit zero for hosts
+// whose plain Config value would otherwise defer to the daemon default.
+func WithMaxPaymentCLTVDisabled() Option {
+	return func(o *startOptions) {
+		o.disableMaxPaymentCLTV = true
 	}
 }
 
@@ -103,6 +114,9 @@ func resolveDaemonConfig(cfg Config, opts ...Option) (*waved.Config, error) {
 
 	if o.disableEagerRoundJoin {
 		daemonCfg.EagerRoundJoin = false
+	}
+	if o.disableMaxPaymentCLTV {
+		daemonCfg.MaxPaymentCLTV = 0
 	}
 
 	return daemonCfg, nil
@@ -267,6 +281,9 @@ func applyConfigOverrides(daemonCfg *waved.Config, cfg Config) {
 	}
 	if cfg.MaxOperatorFeeSat != 0 {
 		daemonCfg.MaxOperatorFeeSat = cfg.MaxOperatorFeeSat
+	}
+	if cfg.MaxPaymentCLTV != 0 {
+		daemonCfg.MaxPaymentCLTV = cfg.MaxPaymentCLTV
 	}
 	if cfg.AutoRefreshFeeFloorSat != 0 {
 		daemonCfg.AutoRefreshFeeFloorSat = cfg.AutoRefreshFeeFloorSat

--- a/sdk/wavewalletdk/embedded_config.go
+++ b/sdk/wavewalletdk/embedded_config.go
@@ -100,6 +100,12 @@ type Config struct {
 	// MaxOperatorFeeSat caps the per-round operator fee the daemon accepts.
 	MaxOperatorFeeSat int64
 
+	// MaxPaymentCLTV is the largest total Lightning payment CLTV that
+	// automatic VTXO maintenance reserves. Zero preserves the daemon
+	// configuration, including the swap-enabled default. Pass
+	// WithMaxPaymentCLTVDisabled to Start to force an explicit zero.
+	MaxPaymentCLTV int32
+
 	// AutoRefreshFeeFloorSat is the optional fixed allowance in the
 	// automatic-maintenance budget curve. Zero disables the floor.
 	AutoRefreshFeeFloorSat int64

--- a/sdk/wavewalletdk/embedded_test.go
+++ b/sdk/wavewalletdk/embedded_test.go
@@ -74,6 +74,33 @@ func TestAutoRefreshFeeOverrides(t *testing.T) {
 	})
 }
 
+// TestMaxPaymentCLTVOverride verifies embedded hosts can change the payment
+// lifetime target while a zero convenience value preserves a caller-owned
+// daemon policy.
+func TestMaxPaymentCLTVOverride(t *testing.T) {
+	t.Parallel()
+
+	t.Run("convenience override", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultConfig()
+		cfg.MaxPaymentCLTV = 400
+		daemonCfg, err := daemonConfig(cfg)
+		require.NoError(t, err)
+		require.Equal(t, int32(400), daemonCfg.MaxPaymentCLTV)
+	})
+
+	t.Run("zero preserves daemon config", func(t *testing.T) {
+		t.Parallel()
+
+		base := waved.DefaultConfig()
+		base.MaxPaymentCLTV = 250
+		daemonCfg, err := daemonConfig(Config{DaemonConfig: base})
+		require.NoError(t, err)
+		require.Equal(t, int32(250), daemonCfg.MaxPaymentCLTV)
+	})
+}
+
 // TestCloneDaemonConfigIsolation verifies that cloneDaemonConfig produces a
 // graph whose reference-typed fields can be mutated independently of the
 // original. This is the actual contract Start relies on when it injects its

--- a/sdk/wavewalletdk/mobile/AGENTS.md
+++ b/sdk/wavewalletdk/mobile/AGENTS.md
@@ -25,8 +25,15 @@ application-facing wallet API.
   stream, replacing the callback interfaces gomobile would otherwise require.
 - `mobileConfig` — unexported flat JSON config decoded by `parseConfig`/
   `applyMobileConfig` into a `wavewalletdk.Config`; validated (non-negative
-  durations/counts, `uint32`-safe recovery window) before merging onto
-  `wavewalletdk.DefaultConfig()`.
+  durations/counts, `uint32`-safe recovery window, `int32`-safe
+  `max_payment_cltv`) before merging onto `wavewalletdk.DefaultConfig()`.
+  Scalars are value-typed except `MaxPaymentCLTV *int64`, whose pointer
+  distinguishes an omitted key from an explicit JSON zero.
+- `mobileStartOptions(cfg)` — unexported bridge from an explicit zero-valued
+  mobile setting to the `wavewalletdk.Option` that overrides an enable-only
+  SDK convenience field. Its result is passed to `wavewalletdk.Start` and
+  `wavewalletdk.StartExternalSeedWalletWithContexts`; today it emits
+  `WithMaxPaymentCLTVDisabled()` and nothing else.
 - `mobileReceiveRequest` — unexported wire DTO carrying the SDK's current
   `AmountSat`/`Memo` fields plus the mobile-only `TimeoutSeconds`. It is
   projected onto `wavewalletdk.ReceiveRequest` after deadline validation.
@@ -84,6 +91,11 @@ application-facing wallet API.
   reach `wavewalletdk.Config`, since a negative `WalletPollIntervalSeconds` in
   particular panics the lwwallet tip poller's ticker in a background
   goroutine after startup.
+- `wavewalletdk.Config` convenience scalars are enable-only: zero defers to
+  the daemon default rather than forcing zero. A mobile zero that must win
+  needs both a pointer field in `mobileConfig` and a case in
+  `mobileStartOptions`. For `max_payment_cltv`, omission keeps the 300-block
+  swap default while explicit `0` disables the payment reserve.
 
 ## Deep Docs
 

--- a/sdk/wavewalletdk/mobile/CLAUDE.md
+++ b/sdk/wavewalletdk/mobile/CLAUDE.md
@@ -25,8 +25,15 @@ application-facing wallet API.
   stream, replacing the callback interfaces gomobile would otherwise require.
 - `mobileConfig` — unexported flat JSON config decoded by `parseConfig`/
   `applyMobileConfig` into a `wavewalletdk.Config`; validated (non-negative
-  durations/counts, `uint32`-safe recovery window) before merging onto
-  `wavewalletdk.DefaultConfig()`.
+  durations/counts, `uint32`-safe recovery window, `int32`-safe
+  `max_payment_cltv`) before merging onto `wavewalletdk.DefaultConfig()`.
+  Scalars are value-typed except `MaxPaymentCLTV *int64`, whose pointer
+  distinguishes an omitted key from an explicit JSON zero.
+- `mobileStartOptions(cfg)` — unexported bridge from an explicit zero-valued
+  mobile setting to the `wavewalletdk.Option` that overrides an enable-only
+  SDK convenience field. Its result is passed to `wavewalletdk.Start` and
+  `wavewalletdk.StartExternalSeedWalletWithContexts`; today it emits
+  `WithMaxPaymentCLTVDisabled()` and nothing else.
 - `mobileReceiveRequest` — unexported wire DTO carrying the SDK's current
   `AmountSat`/`Memo` fields plus the mobile-only `TimeoutSeconds`. It is
   projected onto `wavewalletdk.ReceiveRequest` after deadline validation.
@@ -84,6 +91,11 @@ application-facing wallet API.
   reach `wavewalletdk.Config`, since a negative `WalletPollIntervalSeconds` in
   particular panics the lwwallet tip poller's ticker in a background
   goroutine after startup.
+- `wavewalletdk.Config` convenience scalars are enable-only: zero defers to
+  the daemon default rather than forcing zero. A mobile zero that must win
+  needs both a pointer field in `mobileConfig` and a case in
+  `mobileStartOptions`. For `max_payment_cltv`, omission keeps the 300-block
+  swap default while explicit `0` disables the payment reserve.
 
 ## Deep Docs
 

--- a/sdk/wavewalletdk/mobile/config.go
+++ b/sdk/wavewalletdk/mobile/config.go
@@ -49,12 +49,13 @@ type mobileConfig struct {
 	SwapServerInsecure    bool   `json:"swap_server_insecure"`
 	SwapDatabaseFileName  string `json:"swap_database_file_name"`
 
-	MaxOperatorFeeSat      int64 `json:"max_operator_fee_sat"`
-	AutoRefreshFeeFloorSat int64 `json:"auto_refresh_fee_floor_sat"`
-	AutoRefreshFeeRatePPM  int64 `json:"auto_refresh_fee_rate_ppm"`
-	SigningWorkers         int64 `json:"signing_workers"`
-	EagerRoundJoin         bool  `json:"eager_round_join"`
-	BufferSize             int   `json:"buffer_size"`
+	MaxOperatorFeeSat      int64  `json:"max_operator_fee_sat"`
+	MaxPaymentCLTV         *int64 `json:"max_payment_cltv"`
+	AutoRefreshFeeFloorSat int64  `json:"auto_refresh_fee_floor_sat"`
+	AutoRefreshFeeRatePPM  int64  `json:"auto_refresh_fee_rate_ppm"`
+	SigningWorkers         int64  `json:"signing_workers"`
+	EagerRoundJoin         bool   `json:"eager_round_join"`
+	BufferSize             int    `json:"buffer_size"`
 }
 
 // parseConfig decodes the host JSON config into a wavewalletdk.Config. An empty
@@ -79,6 +80,20 @@ func parseConfig(cfgJSON string) (wavewalletdk.Config, error) {
 	applyMobileConfig(&cfg, mc)
 
 	return cfg, nil
+}
+
+// mobileStartOptions converts explicit zero-valued mobile settings into the
+// functional options needed to override enable-only SDK convenience fields.
+// An omitted max_payment_cltv retains the non-zero swap-enabled default, so a
+// zero Config value here can only come from an explicit JSON zero.
+func mobileStartOptions(cfg wavewalletdk.Config) []wavewalletdk.Option {
+	if cfg.MaxPaymentCLTV != 0 {
+		return nil
+	}
+
+	return []wavewalletdk.Option{
+		wavewalletdk.WithMaxPaymentCLTVDisabled(),
+	}
 }
 
 // validate rejects malformed scalar config before it reaches the daemon. The
@@ -129,6 +144,10 @@ func (mc mobileConfig) validate() error {
 		return fmt.Errorf("buffer_size must not be negative: %d",
 			mc.BufferSize)
 	}
+	if mc.MaxPaymentCLTV != nil && *mc.MaxPaymentCLTV < 0 {
+		return fmt.Errorf("max_payment_cltv must not be negative: %d",
+			*mc.MaxPaymentCLTV)
+	}
 
 	// The recovery window is narrowed to uint32 in applyMobileConfig, so an
 	// absurdly large positive value would silently wrap. Reject it here to
@@ -136,6 +155,10 @@ func (mc mobileConfig) validate() error {
 	if mc.WalletRecoveryWindow > math.MaxUint32 {
 		return fmt.Errorf("wallet_recovery_window exceeds "+
 			"uint32 max: %d", mc.WalletRecoveryWindow)
+	}
+	if mc.MaxPaymentCLTV != nil && *mc.MaxPaymentCLTV > math.MaxInt32 {
+		return fmt.Errorf("max_payment_cltv exceeds int32 max: %d",
+			*mc.MaxPaymentCLTV)
 	}
 	if mc.SigningWorkers > int64(wavewalletdk.MaxSigningWorkers) {
 		return fmt.Errorf("signing_workers exceeds maximum %d: %d",
@@ -228,6 +251,9 @@ func applyMobileConfig(cfg *wavewalletdk.Config, mc mobileConfig) {
 
 	if mc.MaxOperatorFeeSat != 0 {
 		cfg.MaxOperatorFeeSat = mc.MaxOperatorFeeSat
+	}
+	if mc.MaxPaymentCLTV != nil {
+		cfg.MaxPaymentCLTV = int32(*mc.MaxPaymentCLTV)
 	}
 	if mc.AutoRefreshFeeFloorSat != 0 {
 		cfg.AutoRefreshFeeFloorSat = mc.AutoRefreshFeeFloorSat

--- a/sdk/wavewalletdk/mobile/external_seed_wallet.go
+++ b/sdk/wavewalletdk/mobile/external_seed_wallet.go
@@ -62,6 +62,7 @@ func StartExternalSeedWallet(reqJSON []byte) ([]byte, error) {
 		client, openResult, err :=
 			wavewalletdk.StartExternalSeedWalletWithContexts(
 				startCtx, operationCtx, cfg, req,
+				mobileStartOptions(cfg)...,
 			)
 		if err != nil {
 			return nil, fmt.Errorf("start external-seed wallet: %w",

--- a/sdk/wavewalletdk/mobile/mobile.go
+++ b/sdk/wavewalletdk/mobile/mobile.go
@@ -82,7 +82,9 @@ func Start(cfgJSON string) error {
 			return nil, fmt.Errorf("parse config: %w", err)
 		}
 
-		client, err := wavewalletdk.Start(startCtx, cfg)
+		client, err := wavewalletdk.Start(
+			startCtx, cfg, mobileStartOptions(cfg)...,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("start embedded wallet: %w", err)
 		}

--- a/sdk/wavewalletdk/mobile/mobile_test.go
+++ b/sdk/wavewalletdk/mobile/mobile_test.go
@@ -133,6 +133,9 @@ func TestParseConfigEmptyUsesDefaults(t *testing.T) {
 		t.Fatalf("wallet type = %q, want default %q", got.WalletType,
 			want.WalletType)
 	}
+	if opts := mobileStartOptions(got); len(opts) != 0 {
+		t.Fatalf("default config produced %d start options", len(opts))
+	}
 }
 
 // TestParseConfigOverlaysSetFields verifies that only the fields the host set
@@ -147,6 +150,7 @@ func TestParseConfigOverlaysSetFields(t *testing.T) {
 		"wallet_poll_interval_seconds": 5,
 		"wallet_recovery_window": 250,
 		"max_operator_fee_sat": 1000,
+		"max_payment_cltv": 400,
 		"auto_refresh_fee_floor_sat": 750,
 		"auto_refresh_fee_rate_ppm": 25000,
 		"signing_workers": 1,
@@ -179,6 +183,9 @@ func TestParseConfigOverlaysSetFields(t *testing.T) {
 	if got.MaxOperatorFeeSat != 1000 {
 		t.Fatalf("max operator fee = %d", got.MaxOperatorFeeSat)
 	}
+	if got.MaxPaymentCLTV != 400 {
+		t.Fatalf("max payment CLTV = %d", got.MaxPaymentCLTV)
+	}
 	if got.AutoRefreshFeeFloorSat != 750 {
 		t.Fatalf("auto refresh fee floor = %d",
 			got.AutoRefreshFeeFloorSat)
@@ -192,6 +199,24 @@ func TestParseConfigOverlaysSetFields(t *testing.T) {
 	}
 	if got.BufferSize != 4096 {
 		t.Fatalf("buffer size = %d", got.BufferSize)
+	}
+}
+
+// TestParseConfigDisablesMaxPaymentCLTV verifies an explicit JSON zero wins
+// over the swap-enabled default instead of being mistaken for an omitted
+// convenience field.
+func TestParseConfigDisablesMaxPaymentCLTV(t *testing.T) {
+	got, err := parseConfig(`{"max_payment_cltv": 0}`)
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if got.MaxPaymentCLTV != 0 {
+		t.Fatalf("max payment CLTV = %d, want disabled",
+			got.MaxPaymentCLTV)
+	}
+	if opts := mobileStartOptions(got); len(opts) != 1 {
+		t.Fatalf("explicit zero produced %d start options, want 1",
+			len(opts))
 	}
 }
 
@@ -211,6 +236,7 @@ func TestParseConfigRejectsNegativeScalars(t *testing.T) {
 		"poll interval":    `{"wallet_poll_interval_seconds": -1}`,
 		"recovery window":  `{"wallet_recovery_window": -5}`,
 		"max operator fee": `{"max_operator_fee_sat": -1000}`,
+		"max payment CLTV": `{"max_payment_cltv": -1}`,
 		"auto fee floor":   `{"auto_refresh_fee_floor_sat": -1}`,
 		"auto fee rate":    `{"auto_refresh_fee_rate_ppm": -1}`,
 		"signing workers":  `{"signing_workers": -1}`,
@@ -220,6 +246,17 @@ func TestParseConfigRejectsNegativeScalars(t *testing.T) {
 		if _, err := parseConfig(cfgJSON); err == nil {
 			t.Fatalf("%s: expected error for negative value", name)
 		}
+	}
+}
+
+// TestParseConfigRejectsOverflowMaxPaymentCLTV verifies the mobile boundary
+// rejects a value that would wrap when narrowed to the daemon's int32 policy.
+func TestParseConfigRejectsOverflowMaxPaymentCLTV(t *testing.T) {
+	if _, err := parseConfig(
+		`{"max_payment_cltv": 2147483648}`,
+	); err == nil {
+
+		t.Fatal("expected error for max payment CLTV above int32 max")
 	}
 }
 

--- a/sdk/wavewalletdk/options_test.go
+++ b/sdk/wavewalletdk/options_test.go
@@ -98,3 +98,47 @@ func TestResolveDaemonConfigEagerRoundJoin(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveDaemonConfigMaxPaymentCLTV verifies the explicit disable option
+// wins over both the swap-enabled default and a caller-owned daemon policy.
+func TestResolveDaemonConfigMaxPaymentCLTV(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		buildCfg func() Config
+		want     int32
+	}{
+		{
+			name: "option overrides build default",
+			buildCfg: func() Config {
+				return DefaultConfig()
+			},
+			want: 0,
+		},
+		{
+			name: "option overrides caller daemon config",
+			buildCfg: func() Config {
+				daemonCfg := waved.DefaultConfig()
+				daemonCfg.MaxPaymentCLTV = 450
+
+				return Config{
+					DaemonConfig: daemonCfg,
+				}
+			},
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			daemonCfg, err := resolveDaemonConfig(
+				tc.buildCfg(), WithMaxPaymentCLTVDisabled(),
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, daemonCfg.MaxPaymentCLTV)
+		})
+	}
+}

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -166,6 +166,14 @@ when the local wallet owns the receive script.
 - VTXO actor state is the single source of truth for availability.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
+- `ExpiryConfig.MaxPaymentCLTV` reserves a total Lightning CLTV window above
+  the VTXO-specific critical threshold and `MinRefreshBuffer`. Zero disables
+  the payment reserve. The calculation saturates at `math.MaxInt32`, so an
+  extreme direct package configuration cannot wrap and postpone refresh. If
+  a round-direct VTXO's known batch lifetime cannot satisfy the requested
+  reserve plus one healthy retry buffer, the actor logs the mismatch at info
+  level when it starts and uses the base refresh policy. OOR descendants keep
+  the reserve because one refresh can mint a full-lifetime replacement.
 - Auto-refresh delays to an advertised fee-waiver boundary only when the
   boundary remains at least `MinRefreshBuffer` blocks above the dynamic
   critical threshold. An overly late window never weakens unilateral-exit or

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -166,6 +166,14 @@ when the local wallet owns the receive script.
 - VTXO actor state is the single source of truth for availability.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
+- `ExpiryConfig.MaxPaymentCLTV` reserves a total Lightning CLTV window above
+  the VTXO-specific critical threshold and `MinRefreshBuffer`. Zero disables
+  the payment reserve. The calculation saturates at `math.MaxInt32`, so an
+  extreme direct package configuration cannot wrap and postpone refresh. If
+  a round-direct VTXO's known batch lifetime cannot satisfy the requested
+  reserve plus one healthy retry buffer, the actor logs the mismatch at info
+  level when it starts and uses the base refresh policy. OOR descendants keep
+  the reserve because one refresh can mint a full-lifetime replacement.
 - Auto-refresh delays to an advertised fee-waiver boundary only when the
   boundary remains at least `MinRefreshBuffer` blocks above the dynamic
   critical threshold. An overly late window never weakens unilateral-exit or

--- a/vtxo/expiry.go
+++ b/vtxo/expiry.go
@@ -103,6 +103,11 @@ type ExpiryConfig struct {
 	// requires broadcasting and confirming an additional transaction.
 	TreeDepthMultiplier int32
 
+	// MaxPaymentCLTV is the largest total Lightning payment CLTV that
+	// automatic maintenance reserves above the VTXO's unilateral-exit and
+	// cooperative-retry budgets. Zero disables the payment reserve.
+	MaxPaymentCLTV int32
+
 	// FreeRefreshWindow returns the operator-advertised number of blocks
 	// before batch expiry in which refresh fees are waived. A nil callback
 	// or zero window disables subsidy-aware scheduling. The callback lets a
@@ -246,8 +251,12 @@ func (c *ExpiryConfig) CalculateCriticalThreshold(vtxo *Descriptor) int32 {
 // CalculateRefreshThreshold returns the dynamic refresh threshold for a VTXO.
 func (c *ExpiryConfig) CalculateRefreshThreshold(vtxo *Descriptor) int32 {
 	criticalThreshold := c.CalculateCriticalThreshold(vtxo)
+	safetyFloor := c.effectiveRefreshSafetyFloor(
+		vtxo, criticalThreshold,
+	)
 	refreshThreshold := max(
-		c.RefreshThresholdBlocks, criticalThreshold+c.MinRefreshBuffer,
+		c.RefreshThresholdBlocks,
+		safetyFloor,
 	)
 
 	if c.FreeRefreshWindow == nil {
@@ -263,12 +272,89 @@ func (c *ExpiryConfig) CalculateRefreshThreshold(vtxo *Descriptor) int32 {
 	// Never trade away the configured retry buffer merely to chase a fee
 	// waiver. If the operator opens its free window later than the local
 	// safety floor, the wallet refreshes earlier and pays the normal fee.
-	safetyFloor := criticalThreshold + c.MinRefreshBuffer
 	if uint64(windowBlocks) < uint64(safetyFloor) {
 		return refreshThreshold
 	}
 
 	return int32(windowBlocks)
+}
+
+// CanReserveMaxPaymentCLTV reports whether a round-direct VTXO's known batch
+// lifetime can satisfy the configured payment reserve and leave one healthy
+// retry buffer. A missing creation height leaves the lifetime unknown. An OOR
+// descendant also retains the reserve because refreshing it can mint a
+// round-direct replacement with a new full batch lifetime.
+func (c *ExpiryConfig) CanReserveMaxPaymentCLTV(vtxo *Descriptor) bool {
+	if c == nil || vtxo == nil {
+		return true
+	}
+
+	criticalThreshold := c.CalculateCriticalThreshold(vtxo)
+
+	return c.canReserveMaxPaymentCLTV(vtxo, criticalThreshold)
+}
+
+// canReserveMaxPaymentCLTV applies the batch-lifetime guard using an already
+// calculated critical threshold.
+func (c *ExpiryConfig) canReserveMaxPaymentCLTV(vtxo *Descriptor,
+	criticalThreshold int32) bool {
+
+	if c.MaxPaymentCLTV <= 0 ||
+		vtxo.ChainDepth > 0 || vtxo.CreatedHeight <= 0 ||
+		vtxo.BatchExpiry <= vtxo.CreatedHeight {
+		return true
+	}
+
+	requestedFloor := c.refreshSafetyFloor(criticalThreshold)
+	batchLifetime := int64(vtxo.BatchExpiry) - int64(vtxo.CreatedHeight)
+	minimumUsefulLifetime := int64(requestedFloor) +
+		int64(max(c.MinRefreshBuffer, 0))
+
+	// A fresh round-direct VTXO must remain healthy for at least one retry
+	// buffer. Merely fitting the threshold would replace it again within a
+	// few blocks. OOR descendants skip this check above because refreshing
+	// them can mint a round-direct VTXO with a new full batch lifetime.
+	return minimumUsefulLifetime <= batchLifetime
+}
+
+// effectiveRefreshSafetyFloor returns the configured payment reserve when a
+// fresh VTXO can sustain it, and the ordinary exit-and-retry floor otherwise.
+func (c *ExpiryConfig) effectiveRefreshSafetyFloor(vtxo *Descriptor,
+	criticalThreshold int32) int32 {
+
+	if !c.canReserveMaxPaymentCLTV(vtxo, criticalThreshold) {
+		return c.baseRefreshSafetyFloor(criticalThreshold)
+	}
+
+	return c.refreshSafetyFloor(criticalThreshold)
+}
+
+// refreshSafetyFloor returns the earliest safe automatic-refresh boundary for
+// a VTXO with the given critical threshold. It saturates instead of wrapping
+// when a caller supplies an extreme policy value, because overflow would move
+// refresh later and silently discard the configured payment reserve.
+func (c *ExpiryConfig) refreshSafetyFloor(criticalThreshold int32) int32 {
+	maxPaymentCLTV := max(c.MaxPaymentCLTV, 0)
+	floor := int64(criticalThreshold) + int64(c.MinRefreshBuffer) +
+		int64(maxPaymentCLTV)
+	if floor > math.MaxInt32 {
+		return math.MaxInt32
+	}
+
+	return int32(floor)
+}
+
+// baseRefreshSafetyFloor returns the ordinary exit and cooperative-retry
+// boundary without a payment reserve. It is used when the known batch lifetime
+// cannot ever satisfy MaxPaymentCLTV, so refreshing cannot repair the policy
+// mismatch and must not create a paid refresh loop.
+func (c *ExpiryConfig) baseRefreshSafetyFloor(criticalThreshold int32) int32 {
+	floor := int64(criticalThreshold) + int64(c.MinRefreshBuffer)
+	if floor > math.MaxInt32 {
+		return math.MaxInt32
+	}
+
+	return int32(floor)
 }
 
 // ShouldWaitForFreeRefreshWindow reports whether a same-expiry cohort sibling
@@ -289,8 +375,10 @@ func (c *ExpiryConfig) ShouldWaitForFreeRefreshWindow(vtxo *Descriptor,
 		return false
 	}
 
-	safetyFloor := c.CalculateCriticalThreshold(vtxo) +
-		c.MinRefreshBuffer
+	criticalThreshold := c.CalculateCriticalThreshold(vtxo)
+	safetyFloor := c.effectiveRefreshSafetyFloor(
+		vtxo, criticalThreshold,
+	)
 	if uint64(window) < uint64(safetyFloor) {
 		return false
 	}

--- a/vtxo/expiry_test.go
+++ b/vtxo/expiry_test.go
@@ -95,3 +95,120 @@ func TestFreeRefreshWindowBoundary(t *testing.T) {
 		t, ExpiryStatusNeedsRefresh, cfg.CheckExpiry(desc, 880),
 	)
 }
+
+// TestMaxPaymentCLTVThreshold verifies automatic maintenance reserves the
+// configured Lightning payment window in addition to the VTXO-specific exit
+// and retry budgets. A later fee-waiver boundary must not erase that reserve.
+func TestMaxPaymentCLTVThreshold(t *testing.T) {
+	t.Parallel()
+
+	desc := &Descriptor{
+		BatchExpiry:    1_000,
+		RelativeExpiry: 144,
+		Ancestry: []Ancestry{{
+			TreeDepth: 7,
+		}},
+	}
+
+	cfg := DefaultExpiryConfig()
+	require.Equal(t, int32(258), cfg.CalculateRefreshThreshold(desc))
+
+	cfg.MaxPaymentCLTV = 300
+	require.Equal(t, int32(558), cfg.CalculateRefreshThreshold(desc))
+
+	cfg.FreeRefreshWindow = func() uint32 {
+		return 500
+	}
+	require.Equal(t, int32(558), cfg.CalculateRefreshThreshold(desc))
+	require.False(t, cfg.ShouldWaitForFreeRefreshWindow(desc, 400))
+
+	cfg.FreeRefreshWindow = func() uint32 {
+		return 576
+	}
+	require.Equal(t, int32(558), cfg.CalculateRefreshThreshold(desc))
+	require.True(t, cfg.ShouldWaitForFreeRefreshWindow(desc, 400))
+
+	require.Equal(t, ExpiryStatusSafe, cfg.CheckExpiry(desc, 441))
+	require.Equal(
+		t, ExpiryStatusNeedsRefresh, cfg.CheckExpiry(desc, 442),
+	)
+}
+
+// TestMaxPaymentCLTVThresholdSaturates verifies an extreme direct package
+// configuration cannot wrap the refresh threshold negative and postpone
+// maintenance beyond the requested payment reserve.
+func TestMaxPaymentCLTVThresholdSaturates(t *testing.T) {
+	t.Parallel()
+
+	desc := &Descriptor{
+		BatchExpiry:    1_000,
+		RelativeExpiry: 144,
+	}
+	cfg := DefaultExpiryConfig()
+	cfg.MaxPaymentCLTV = math.MaxInt32
+
+	require.Equal(
+		t, int32(math.MaxInt32), cfg.CalculateRefreshThreshold(desc),
+	)
+}
+
+// TestMaxPaymentCLTVRequiresUsefulBatchLifetime verifies a payment reserve
+// must leave a fresh round-direct VTXO healthy for a full retry buffer. A
+// target that merely fits would still create a near-continuous refresh loop.
+func TestMaxPaymentCLTVRequiresUsefulBatchLifetime(t *testing.T) {
+	t.Parallel()
+
+	desc := &Descriptor{
+		BatchExpiry:    1_108,
+		CreatedHeight:  100,
+		RelativeExpiry: 144,
+		Ancestry: []Ancestry{{
+			TreeDepth: 7,
+		}},
+	}
+	cfg := DefaultExpiryConfig()
+
+	// A 937-block threshold leaves only 71 healthy blocks in this
+	// 1,008-block batch, so the ordinary 258-block policy wins.
+	cfg.MaxPaymentCLTV = 679
+	require.False(t, cfg.CanReserveMaxPaymentCLTV(desc))
+	require.Equal(t, int32(258), cfg.CalculateRefreshThreshold(desc))
+
+	// The same base floor governs subsidy-aware waiting. Without the
+	// fallback, the impossible 937-block floor would reject this safe
+	// 300-block operator window.
+	cfg.FreeRefreshWindow = func() uint32 {
+		return 300
+	}
+	require.True(t, cfg.ShouldWaitForFreeRefreshWindow(desc, 700))
+
+	// A 936-block threshold leaves the full 72-block retry buffer and is
+	// therefore useful rather than immediately recurring.
+	cfg.FreeRefreshWindow = nil
+	cfg.MaxPaymentCLTV = 678
+	require.True(t, cfg.CanReserveMaxPaymentCLTV(desc))
+	require.Equal(t, int32(936), cfg.CalculateRefreshThreshold(desc))
+}
+
+// TestMaxPaymentCLTVOORCanRefreshIntoFullLifetime verifies an OOR descendant
+// does not mistake its inherited remaining lifetime for the operator's batch
+// duration. Its first refresh can mint a round-direct replacement whose
+// creation height makes the useful-lifetime guard authoritative.
+func TestMaxPaymentCLTVOORCanRefreshIntoFullLifetime(t *testing.T) {
+	t.Parallel()
+
+	desc := &Descriptor{
+		BatchExpiry:    676,
+		CreatedHeight:  100,
+		RelativeExpiry: 144,
+		ChainDepth:     1,
+		Ancestry: []Ancestry{{
+			TreeDepth: 7,
+		}},
+	}
+	cfg := DefaultExpiryConfig()
+	cfg.MaxPaymentCLTV = 300
+
+	require.True(t, cfg.CanReserveMaxPaymentCLTV(desc))
+	require.Equal(t, int32(564), cfg.CalculateRefreshThreshold(desc))
+}

--- a/vtxo/incoming_handler_test.go
+++ b/vtxo/incoming_handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
@@ -94,6 +95,13 @@ func TestIncomingVTXOHandlerOwnedScript(t *testing.T) {
 	handler := NewIncomingVTXOHandler(IncomingVTXOHandlerConfig{
 		ScriptStore: lookup,
 		VTXOStore:   saver,
+		AncestryFetcher: func(context.Context, wire.OutPoint, []byte,
+			keychain.KeyDescriptor) (IncomingVTXOExtras, error) {
+
+			return IncomingVTXOExtras{
+				CreatedHeight: 799_500,
+			}, nil
+		},
 	})
 
 	var txid chainhash.Hash
@@ -114,7 +122,12 @@ func TestIncomingVTXOHandlerOwnedScript(t *testing.T) {
 	require.Equal(t, int64(50_000), int64(desc.Amount))
 	require.Equal(t, pkScript, desc.PkScript)
 	require.Equal(t, "round-1", desc.RoundID)
+	require.Equal(t, int32(799_500), desc.CreatedHeight)
 	require.Equal(t, VTXOStatusLive, desc.Status)
+
+	expiryCfg := DefaultExpiryConfig()
+	expiryCfg.MaxPaymentCLTV = 300
+	require.False(t, expiryCfg.CanReserveMaxPaymentCLTV(desc))
 }
 
 // TestIncomingVTXOHandlerUnownedScript verifies that a VTXO_CREATED

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -1891,6 +1891,23 @@ func (m *Manager) respawnActorFromStore(ctx context.Context,
 func (m *Manager) spawnVTXOActor(ctx context.Context, vtxo *Descriptor) (
 	VTXOActorRef, error) {
 
+	if !m.cfg.ExpiryConfig.CanReserveMaxPaymentCLTV(vtxo) {
+		logger := m.logger(ctx)
+		logger.InfoS(ctx, "Payment CLTV reserve exceeds useful "+
+			"batch lifetime; using base refresh policy",
+			slog.String("outpoint", vtxo.Outpoint.String()),
+			slog.Int(
+				"max_payment_cltv",
+				int(m.cfg.ExpiryConfig.MaxPaymentCLTV),
+			),
+			slog.Int(
+				"batch_lifetime", int(
+					vtxo.BatchExpiry-vtxo.CreatedHeight,
+				),
+			),
+		)
+	}
+
 	actorID := fmt.Sprintf("vtxo.%s", vtxo.Outpoint.String())
 	serviceKey := VTXOActorServiceKey(vtxo.Outpoint)
 
@@ -3223,6 +3240,8 @@ func (m *Manager) markCustomForfeitSynthetic(op wire.OutPoint, synthetic bool) {
 	m.customForfeitSynthetic[op] = synthetic
 }
 
+// customForfeitInputAlreadyActive reports whether the durable input identity
+// matches an actor that may already own the custom forfeit request.
 func (m *Manager) customForfeitInputAlreadyActive(ctx context.Context,
 	input CustomForfeitInput) (bool, error) {
 
@@ -3293,6 +3312,8 @@ func (m *Manager) customForfeitInputStoredMatch(ctx context.Context,
 	return true, synthetic, nil
 }
 
+// sameTaprootKey reports whether two public keys encode the same x-only
+// Taproot key. Nil keys never match.
 func sameTaprootKey(a, b *btcec.PublicKey) bool {
 	if a == nil || b == nil {
 		return false

--- a/vtxo/manager_test.go
+++ b/vtxo/manager_test.go
@@ -68,6 +68,15 @@ func TestClientVTXOToDescriptorChainDepthZero(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, desc.ChainDepth)
 	require.Equal(t, "round-1", desc.RoundID)
+	require.Equal(t, int32(700), desc.CreatedHeight)
+
+	// Exercise the useful-lifetime guard through the production conversion
+	// path. Round creation supplies the height needed to prove this
+	// 300-block lifetime is too short for the default payment reserve.
+	expiryCfg := DefaultExpiryConfig()
+	expiryCfg.MaxPaymentCLTV = 300
+	require.False(t, expiryCfg.CanReserveMaxPaymentCLTV(desc))
+	require.Equal(t, int32(144), expiryCfg.CalculateRefreshThreshold(desc))
 }
 
 // TestClientVTXOToDescriptorBuildsStandardTapScriptFromPolicyTemplate

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -294,6 +294,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   window boundary only when the local dynamic critical threshold plus retry
   buffer remains intact. When that cached boundary fires, it fetches a fresh
   `GetInfo` snapshot and rechecks the window before reserving the input.
+- `Config.MaxPaymentCLTV` extends that same local safety floor by the largest
+  total Lightning CLTV the wallet wants to keep available. Swap-enabled builds
+  default to 300 blocks; core builds default to zero. An operator waiver may
+  make the earlier refresh free but cannot shorten this payment reserve.
 
 ## Deep Docs
 

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -294,6 +294,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   window boundary only when the local dynamic critical threshold plus retry
   buffer remains intact. When that cached boundary fires, it fetches a fresh
   `GetInfo` snapshot and rechecks the window before reserving the input.
+- `Config.MaxPaymentCLTV` extends that same local safety floor by the largest
+  total Lightning CLTV the wallet wants to keep available. Swap-enabled builds
+  default to 300 blocks; core builds default to zero. An operator waiver may
+  make the earlier refresh free but cannot shorten this payment reserve.
 
 ## Deep Docs
 

--- a/waved/config.go
+++ b/waved/config.go
@@ -214,6 +214,12 @@ const (
 	// config knob.
 	DefaultMaxOperatorFeeSat int64 = 1_000_000
 
+	// DefaultMaxPaymentCLTV is the total Lightning payment CLTV reserved by
+	// automatic maintenance in swap-enabled builds. Three hundred blocks
+	// covers high-CLTV merchant invoices plus ordinary routing deltas while
+	// leaving substantial room inside a one-week Ark batch lifetime.
+	DefaultMaxPaymentCLTV int32 = 300
+
 	// RPCTransportGRPC selects native gRPC for daemon-owned outbound RPCs.
 	RPCTransportGRPC = "grpc"
 
@@ -406,6 +412,12 @@ type Config struct {
 	// automatic maintenance budget curve. Zero disables this component.
 	// When both components are zero, only MaxOperatorFeeSat applies.
 	AutoRefreshFeeRatePPM uint32 `mapstructure:"autorefreshfeerateppm"`
+
+	// MaxPaymentCLTV is the largest total Lightning payment CLTV that
+	// automatic VTXO maintenance keeps available above the dynamic
+	// unilateral-exit and refresh-retry budgets. Zero disables this extra
+	// reserve. Swap-enabled builds default to DefaultMaxPaymentCLTV.
+	MaxPaymentCLTV int32 `mapstructure:"maxpaymentcltv"`
 
 	// OOR configures off-band receive/send actor behavior.
 	OOR *OORConfig `mapstructure:"oor"`
@@ -1211,6 +1223,7 @@ func DefaultConfig() *Config {
 			VHTLCRecovery:   swapRecovery,
 		},
 		MaxOperatorFeeSat: DefaultMaxOperatorFeeSat,
+		MaxPaymentCLTV:    defaultMaxPaymentCLTV(),
 		SigningWorkers:    DefaultSigningWorkers,
 		OOR:               defaultOORConfig(),
 		FeeEstimation: &FeeEstimationConfig{
@@ -1261,6 +1274,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("autorefreshfeefloorsat must not exceed "+
 			"maxoperatorfeesat: floor=%d, max=%d",
 			c.AutoRefreshFeeFloorSat, c.MaxOperatorFeeSat)
+	}
+	if c.MaxPaymentCLTV < 0 {
+		return fmt.Errorf("maxpaymentcltv must be non-negative: got %d",
+			c.MaxPaymentCLTV)
 	}
 
 	if c.SigningWorkers < 0 {

--- a/waved/config_max_payment_cltv_stub_test.go
+++ b/waved/config_max_payment_cltv_stub_test.go
@@ -1,0 +1,17 @@
+//go:build !swapruntime
+
+package waved
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCoreBuildDisablesMaxPaymentCLTV verifies clients without Lightning swap
+// support do not refresh early for a payment capability they cannot use.
+func TestCoreBuildDisablesMaxPaymentCLTV(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, DefaultConfig().MaxPaymentCLTV)
+}

--- a/waved/config_max_payment_cltv_swap_test.go
+++ b/waved/config_max_payment_cltv_swap_test.go
@@ -1,0 +1,19 @@
+//go:build swapruntime
+
+package waved
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSwapRuntimeDefaultsMaxPaymentCLTV verifies payment-capable builds keep
+// enough VTXO lifetime in reserve for high-CLTV Lightning routes.
+func TestSwapRuntimeDefaultsMaxPaymentCLTV(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t, DefaultMaxPaymentCLTV, DefaultConfig().MaxPaymentCLTV,
+	)
+}

--- a/waved/config_max_payment_cltv_test.go
+++ b/waved/config_max_payment_cltv_test.go
@@ -1,0 +1,37 @@
+package waved
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigValidateMaxPaymentCLTV verifies malformed negative reserves fail
+// at startup while zero continues to provide an explicit opt-out.
+func TestConfigValidateMaxPaymentCLTV(t *testing.T) {
+	t.Parallel()
+
+	newConfig := func() *Config {
+		cfg := DefaultConfig()
+		cfg.Network = "regtest"
+		cfg.Server.Host = "127.0.0.1:10010"
+		cfg.Wallet.EsploraURL = "http://127.0.0.1:3000"
+
+		return cfg
+	}
+
+	negative := newConfig()
+	negative.MaxPaymentCLTV = -1
+	require.ErrorContains(
+		t, negative.Validate(),
+		"maxpaymentcltv must be non-negative",
+	)
+
+	disabled := newConfig()
+	disabled.MaxPaymentCLTV = 0
+	require.NoError(t, disabled.Validate())
+
+	enabled := newConfig()
+	enabled.MaxPaymentCLTV = 300
+	require.NoError(t, enabled.Validate())
+}

--- a/waved/config_swapruntime.go
+++ b/waved/config_swapruntime.go
@@ -1,0 +1,10 @@
+//go:build swapruntime
+
+package waved
+
+// defaultMaxPaymentCLTV returns the automatic-maintenance payment reserve for
+// swap-enabled builds. These builds can initiate Lightning payments, so they
+// keep VTXOs fresh enough for a high-CLTV route by default.
+func defaultMaxPaymentCLTV() int32 {
+	return DefaultMaxPaymentCLTV
+}

--- a/waved/config_swapruntime_stub.go
+++ b/waved/config_swapruntime_stub.go
@@ -1,0 +1,10 @@
+//go:build !swapruntime
+
+package waved
+
+// defaultMaxPaymentCLTV disables the payment-specific lifetime reserve in
+// builds that cannot initiate Lightning swaps. Such clients retain the
+// ordinary VTXO exit and cooperative-retry refresh policy.
+func defaultMaxPaymentCLTV() int32 {
+	return 0
+}

--- a/waved/operator_negotiation_test.go
+++ b/waved/operator_negotiation_test.go
@@ -44,6 +44,27 @@ func TestVTXOExpiryConfigUsesLatestTerms(t *testing.T) {
 	require.Equal(t, int32(144), cfg.CalculateRefreshThreshold(desc))
 }
 
+// TestVTXOExpiryConfigReservesMaxPaymentCLTV verifies the daemon carries its
+// configured Lightning payment target into every VTXO actor's dynamic expiry
+// policy without letting the operator's fee waiver shorten the reserve.
+func TestVTXOExpiryConfigReservesMaxPaymentCLTV(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{cfg: &Config{MaxPaymentCLTV: 300}}
+	server.storeOperatorTerms(&types.OperatorTerms{
+		FreeRefreshWindowBlocks: 144,
+	})
+	cfg := server.vtxoExpiryConfig()
+	desc := &vtxo.Descriptor{
+		RelativeExpiry: 144,
+		Ancestry: []vtxo.Ancestry{{
+			TreeDepth: 7,
+		}},
+	}
+
+	require.Equal(t, int32(558), cfg.CalculateRefreshThreshold(desc))
+}
+
 // activeArkPolicy builds an ACTIVE policy for the given version, used to
 // populate the operator's advertised policy list in fake GetInfo responses.
 func activeArkPolicy(version uint32) *arkrpc.ArkVersionPolicy {

--- a/waved/server.go
+++ b/waved/server.go
@@ -456,6 +456,8 @@ func NewServer(cfg *Config) (*Server, error) {
 	}, nil
 }
 
+// subLogger returns the configured subsystem logger, or a disabled logger
+// when logging has not been initialized or the requested tag is unknown.
 func (s *Server) subLogger(tag string) btclog.Logger {
 	if s.loggers == nil {
 		return btclog.Disabled
@@ -766,6 +768,9 @@ func (s *Server) storeOperatorTerms(terms *types.OperatorTerms) {
 // callback resolves the atomic snapshot when each VTXO evaluates a block.
 func (s *Server) vtxoExpiryConfig() *vtxo.ExpiryConfig {
 	cfg := vtxo.DefaultExpiryConfig()
+	if s.cfg != nil {
+		cfg.MaxPaymentCLTV = s.cfg.MaxPaymentCLTV
+	}
 	cfg.FreeRefreshWindow = func() uint32 {
 		terms := s.loadOperatorTerms()
 		if terms == nil {


### PR DESCRIPTION
## Problem

Automatic VTXO maintenance reserves enough lifetime for an orderly exit and a
small retry buffer. It does not reserve the CLTV needed by a Lightning payment.

That creates a gap between the maintenance policy and payment preparation. A
wallet can consider a VTXO healthy, then discover that a longer Lightning route
does not fit before the VTXO's critical expiry point.

For example, with a 1,008-block batch and a seven-level exit tree:

- the critical exit threshold is 186 blocks;
- the existing 72-block refresh buffer moves the refresh threshold to 258;
- a payment may need up to 300 blocks of total CLTV;
- a VTXO with 400 blocks remaining is therefore considered healthy today, even
  though that payment cannot safely complete before the exit threshold.

Funds remain safe because payment-time validation rejects the unsafe route.
The user still gets a failed payment that automatic maintenance could have
prevented.

## Fix

Add `maxpaymentcltv`, the largest total Lightning payment CLTV that automatic
maintenance should reserve. The effective refresh threshold is now:

```text
max(existing threshold, critical threshold + retry buffer + maxpaymentcltv)
```

With the example above and the swap-enabled default of 300 blocks, the wallet
refreshes at 558 blocks instead of 258.

This PR also:

- exposes the setting through the embedded SDK and mobile JSON as
  `max_payment_cltv`;
- keeps the default at zero in builds without swap support;
- lets standalone, Go SDK, and mobile callers explicitly disable the reserve;
- validates negative and overflowing values at the configuration boundary;
- prevents the operator's free-refresh window from shortening this local
  safety target;
- saturates extreme threshold calculations instead of allowing integer
  overflow.

Payment-time validation remains the final authority. This setting is a
maintenance target. It cannot guarantee a payment whose route exceeds the
configured limit, and it cannot refresh a wallet while that wallet is offline.

## Short batch policy

A round-direct VTXO must fit the complete refresh threshold and then remain
healthy for at least one more 72-block retry buffer. Merely fitting the
threshold could otherwise refresh a new VTXO again within a few blocks.

When the operator's batch is too short to provide that useful window, the
wallet logs the mismatch at info level when the VTXO actor starts and uses the
ordinary exit-and-retry threshold. Repeated refreshes cannot extend the
operator's batch duration, so they would only spend fees.

An off-round (OOR) descendant does not use its inherited partial lifetime for
this decision. Its first refresh can mint a round-direct replacement with a
new full batch lifetime. The replacement then applies the normal useful-window
check.

## Compatibility and rollout

There are no RPC, database, or wire-format changes. Existing configuration
files continue to parse.

Swap-enabled clients default to a 300-block reserve and may refresh earlier.
That refresh can carry an operator fee when the operator's free-refresh window
is smaller than the derived threshold. Operators that want these refreshes to
remain free should advertise a sufficiently large window. A 576-block window,
for example, covers the 558-block threshold above with margin when the batch
itself retains enough useful lifetime.

## Tests

The new tests cover:

- the payment reserve winning over both the base threshold and the operator
  free-refresh window;
- a short round-direct batch falling back to the base policy;
- a threshold retaining a complete 72-block healthy window;
- an OOR descendant refreshing toward a full-lifetime replacement;
- disabled and saturated thresholds;
- swap and non-swap build defaults;
- daemon-to-VTXO propagation;
- embedded SDK overrides and the explicit disable option;
- mobile omission, explicit zero, negative values, and overflow.

Validation run:

```text
make fmt-changed
make lint-changed-local
make unit tags='swapruntime wavewalletrpc'
go test -tags='mobile swapruntime wavewalletrpc' ./sdk/wavewalletdk/mobile
make sample-conf-check
make doc-check
make build-wavewalletrpc
make tidy-module
make commitmsg-lint range='origin/main..HEAD'
git diff --check
```
