### PR TITLE
serverconn: bound durable RPC sends with a deadline

### DIFF
--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -90,6 +90,12 @@ background ingress polling with event routing.
 - `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Egress is at-least-once: on the Read/Commit path the `Edge.Send` is not atomic with the mailbox ack (it never was, even on the old Classic path), so a crash or a lost lease between a successful send and its Commit redelivers and re-sends. The server absorbs the duplicate via the stable `MsgId`/`IdempotencyKey`. Under `EgressWorkers > 1` a `SendClientEventRequest` carries the inner message's `CorrelationKey`, so same-session events keep per-key FIFO order across the worker pool while distinct sessions send in parallel. `SendUnaryRequest` and `SendRPCRequest` are intentionally **unkeyed** (the `BaseMessage` default), so distinct unary/RPC sends may reorder across workers; that is safe only because each is an independent request/response RPC matched by an explicit correlation ID, not a position in an ordered stream. Any new order-sensitive egress message MUST define a `CorrelationKey`, or it will silently reorder under the pool.
+- Every durable `Edge.Send` uses `sendEnvelope`, which preserves context values,
+  detaches from actor-turn cancellation, and applies the 30-second
+  `defaultSendEventTimeout`. A timeout returns before Commit, so the actor nacks
+  and retries the unchanged envelope with its stable identifiers. This bound
+  prevents black-holed sends from occupying all egress workers. The direct
+  `UnaryFacade` path remains caller-scoped.
 - The mailbox protocol has no cancel envelope kind (`RpcMeta_Kind` is
   REQUEST/RESPONSE/EVENT only), so a unary caller that gives up on its deadline
   cannot recall the request: the operator runs it to completion and the

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -90,6 +90,12 @@ background ingress polling with event routing.
 - `SendClientEventRequest` auto-derives `Service`/`Method` from `Message.ServiceMethod()` when callers leave them empty, preventing silent drops.
 - Idempotency keys are derived from message payload hash; same key on retry enables server deduplication.
 - Egress is at-least-once: on the Read/Commit path the `Edge.Send` is not atomic with the mailbox ack (it never was, even on the old Classic path), so a crash or a lost lease between a successful send and its Commit redelivers and re-sends. The server absorbs the duplicate via the stable `MsgId`/`IdempotencyKey`. Under `EgressWorkers > 1` a `SendClientEventRequest` carries the inner message's `CorrelationKey`, so same-session events keep per-key FIFO order across the worker pool while distinct sessions send in parallel. `SendUnaryRequest` and `SendRPCRequest` are intentionally **unkeyed** (the `BaseMessage` default), so distinct unary/RPC sends may reorder across workers; that is safe only because each is an independent request/response RPC matched by an explicit correlation ID, not a position in an ordered stream. Any new order-sensitive egress message MUST define a `CorrelationKey`, or it will silently reorder under the pool.
+- Every durable `Edge.Send` uses `sendEnvelope`, which preserves context values,
+  detaches from actor-turn cancellation, and applies the 30-second
+  `defaultSendEventTimeout`. A timeout returns before Commit, so the actor nacks
+  and retries the unchanged envelope with its stable identifiers. This bound
+  prevents black-holed sends from occupying all egress workers. The direct
+  `UnaryFacade` path remains caller-scoped.
 - The mailbox protocol has no cancel envelope kind (`RpcMeta_Kind` is
   REQUEST/RESPONSE/EVENT only), so a unary caller that gives up on its deadline
   cannot recall the request: the operator runs it to completion and the

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -660,6 +660,12 @@ type ServerConnectionActor struct {
 	// cfg holds all dependencies and tuning knobs for the connector.
 	cfg ConnectorConfig
 
+	// sendTimeout bounds durable Edge.Send calls after they detach from the
+	// actor turn's cancellation. Production uses defaultSendEventTimeout;
+	// tests shorten it to exercise black-holed sends without waiting 30
+	// seconds.
+	sendTimeout time.Duration
+
 	log btclog.Logger
 
 	// responseRegistry maps correlation IDs to unary RPC waiters and
@@ -719,8 +725,9 @@ func NewServerConnectionActor(
 	)
 
 	return &ServerConnectionActor{
-		cfg: cfg,
-		log: cfg.Log.UnwrapOr(btclog.Disabled),
+		cfg:         cfg,
+		sendTimeout: defaultSendEventTimeout,
+		log:         cfg.Log.UnwrapOr(btclog.Disabled),
 		responseRegistry: mailboxconn.NewResponseRegistry(
 			cfg.ResponseWaiterTTL,
 		),
@@ -798,7 +805,7 @@ func (a *ServerConnectionActor) Receive(ctx context.Context, msg ServerConnMsg,
 }
 
 // handleSendClientEvent converts a client FSM outbox message to a proto
-// message and sends it to the server via the mailbox edge.
+// message and sends it to the server through the bounded durable-send context.
 func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	req *SendClientEventRequest,
 	ax actor.Exec[egressTx]) fn.Result[ServerConnResp] {
@@ -870,17 +877,7 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 		},
 	}
 
-	// Use a detached context for the gRPC call so that parent
-	// cancellation does not abort the outbound send, while
-	// preserving trace/logging context values.
-	sendCtx, sendCancel := context.WithTimeout(
-		context.WithoutCancel(ctx), defaultSendEventTimeout,
-	)
-	defer sendCancel()
-
-	resp, err := a.cfg.Edge.Send(sendCtx, &mailboxpb.SendRequest{
-		Envelope: envelope,
-	})
+	resp, err := a.sendEnvelope(ctx, envelope)
 	if sErr := edgeResponseError(
 		"send client event", resp, err,
 	); sErr != nil {
@@ -1012,8 +1009,9 @@ func (a *ServerConnectionActor) buildDurableUnary(ctx context.Context,
 	}, nil
 }
 
-// sendUnaryEnvelope sends one durable unary request envelope via the mailbox
-// edge using the given routing metadata and stable identifiers.
+// sendUnaryEnvelope sends one durable unary request envelope through the
+// bounded durable-send context using the given routing metadata and stable
+// identifiers.
 func (a *ServerConnectionActor) sendUnaryEnvelope(ctx context.Context,
 	ax actor.Exec[egressTx], body *anypb.Any, service string, method string,
 	correlationID string, msgID string,
@@ -1040,14 +1038,7 @@ func (a *ServerConnectionActor) sendUnaryEnvelope(ctx context.Context,
 		},
 	}
 
-	sendCtx, sendCancel := context.WithTimeout(
-		context.WithoutCancel(ctx), defaultSendEventTimeout,
-	)
-	defer sendCancel()
-
-	resp, err := a.cfg.Edge.Send(sendCtx, &mailboxpb.SendRequest{
-		Envelope: envelope,
-	})
+	resp, err := a.sendEnvelope(ctx, envelope)
 	if sErr := edgeResponseError(
 		"send unary request", resp, err,
 	); sErr != nil {
@@ -1096,8 +1087,9 @@ func eventRoutingMetadata(req *SendClientEventRequest) (string, string) {
 	return service, method
 }
 
-// handleSendRPCRequest sends a pre-built unary RPC envelope via the mailbox
-// edge.
+// handleSendRPCRequest sends a pre-built unary RPC envelope through the bounded
+// durable-send context. A timeout returns an error without committing, so the
+// durable actor nacks and retries the unchanged envelope.
 func (a *ServerConnectionActor) handleSendRPCRequest(ctx context.Context,
 	req *SendRPCRequest,
 	ax actor.Exec[egressTx]) fn.Result[ServerConnResp] {
@@ -1106,9 +1098,7 @@ func (a *ServerConnectionActor) handleSendRPCRequest(ctx context.Context,
 		return fn.Err[ServerConnResp](ce)
 	}
 
-	resp, err := a.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
-		Envelope: req.Envelope,
-	})
+	resp, err := a.sendEnvelope(ctx, req.Envelope)
 	if sErr := edgeResponseError(
 		"send rpc request", resp, err,
 	); sErr != nil {
@@ -1126,6 +1116,24 @@ func (a *ServerConnectionActor) handleSendRPCRequest(ctx context.Context,
 
 	return fn.Ok[ServerConnResp](&SendRPCResponse{
 		Success: true,
+	})
+}
+
+// sendEnvelope owns one durable Edge.Send past cancellation of the actor turn,
+// while bounding it so a black-holed transport cannot occupy an egress worker
+// forever. The detached context preserves trace and logging values. Every
+// durable send path uses this helper so events and both unary envelope forms
+// share one deadline policy.
+func (a *ServerConnectionActor) sendEnvelope(ctx context.Context,
+	envelope *mailboxpb.Envelope) (*mailboxpb.SendResponse, error) {
+
+	sendCtx, sendCancel := context.WithTimeout(
+		context.WithoutCancel(ctx), a.sendTimeout,
+	)
+	defer sendCancel()
+
+	return a.cfg.Edge.Send(sendCtx, &mailboxpb.SendRequest{
+		Envelope: envelope,
 	})
 }
 

--- a/serverconn/send_deadline_test.go
+++ b/serverconn/send_deadline_test.go
@@ -1,0 +1,292 @@
+package serverconn
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// rpcSendAttempt records the stable envelope identity observed by one edge
+// call. Durable retries must preserve both fields.
+type rpcSendAttempt struct {
+	msgID          string
+	idempotencyKey string
+}
+
+// blackHoleRPCSendEdge blocks the first attempt for selected message IDs until
+// the send context ends. Later attempts succeed so tests can prove that a
+// timed-out durable message remains retryable.
+type blackHoleRPCSendEdge struct {
+	mailboxpb.MailboxServiceClient
+
+	mu sync.Mutex
+
+	blockedIDs map[string]struct{}
+	attempts   map[string][]rpcSendAttempt
+	succeeded  map[string]bool
+	started    chan string
+}
+
+// newBlackHoleRPCSendEdge constructs an edge that black-holes the first send
+// for each supplied message ID.
+func newBlackHoleRPCSendEdge(blockedIDs ...string) *blackHoleRPCSendEdge {
+	blocked := make(map[string]struct{}, len(blockedIDs))
+	for _, id := range blockedIDs {
+		blocked[id] = struct{}{}
+	}
+
+	return &blackHoleRPCSendEdge{
+		blockedIDs: blocked,
+		attempts:   make(map[string][]rpcSendAttempt),
+		succeeded:  make(map[string]bool),
+		started:    make(chan string, len(blockedIDs)),
+	}
+}
+
+// Send records the envelope identity, waits for ctx.Done on the first selected
+// attempt, and accepts every other attempt.
+func (e *blackHoleRPCSendEdge) Send(ctx context.Context,
+	in *mailboxpb.SendRequest, _ ...grpc.CallOption) (
+	*mailboxpb.SendResponse, error) {
+
+	envelope := in.GetEnvelope()
+	attempt := rpcSendAttempt{
+		msgID:          envelope.GetMsgId(),
+		idempotencyKey: envelope.GetIdempotencyKey(),
+	}
+
+	e.mu.Lock()
+	e.attempts[attempt.msgID] = append(
+		e.attempts[attempt.msgID], attempt,
+	)
+	attemptNumber := len(e.attempts[attempt.msgID])
+	_, shouldBlock := e.blockedIDs[attempt.msgID]
+	e.mu.Unlock()
+
+	if shouldBlock && attemptNumber == 1 {
+		e.started <- attempt.msgID
+		<-ctx.Done()
+
+		return nil, ctx.Err()
+	}
+
+	e.mu.Lock()
+	e.succeeded[attempt.msgID] = true
+	e.mu.Unlock()
+
+	return &mailboxpb.SendResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+	}, nil
+}
+
+// snapshot returns copies of the observed attempts and successful message IDs.
+func (e *blackHoleRPCSendEdge) snapshot() (map[string][]rpcSendAttempt,
+	map[string]bool) {
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	attempts := make(map[string][]rpcSendAttempt, len(e.attempts))
+	for id, values := range e.attempts {
+		attempts[id] = append([]rpcSendAttempt(nil), values...)
+	}
+
+	succeeded := make(map[string]bool, len(e.succeeded))
+	for id, value := range e.succeeded {
+		succeeded[id] = value
+	}
+
+	return attempts, succeeded
+}
+
+// countingLeaseStore records lease extensions while preserving the in-memory
+// delivery store's normal fencing behavior.
+type countingLeaseStore struct {
+	*memCheckpointStore
+
+	extensions atomic.Int64
+}
+
+// ExtendLease counts successful heartbeats from the in-memory store.
+func (s *countingLeaseStore) ExtendLease(ctx context.Context, id,
+	leaseToken string, extension time.Duration) (int64, error) {
+
+	rows, err := s.memCheckpointStore.ExtendLease(
+		ctx, id, leaseToken, extension,
+	)
+	if err == nil && rows > 0 {
+		s.extensions.Add(1)
+	}
+
+	return rows, err
+}
+
+// TestSendRPCRequestOwnsBoundedSendContext proves a pre-built durable send
+// ignores cancellation of its actor turn but still ends at its own deadline.
+// The black-holed edge waits on ctx.Done, so the test also pins that the
+// timeout reaches the transport call and that a timed-out send is not
+// committed.
+func TestSendRPCRequestOwnsBoundedSendContext(t *testing.T) {
+	const sendTimeout = 50 * time.Millisecond
+
+	var (
+		hasDeadline        bool
+		deadline           time.Time
+		deadlineObservedAt time.Time
+	)
+	edge := &mailboxClientStub{
+		sendFn: func(ctx context.Context, _ *mailboxpb.SendRequest,
+			_ ...grpc.CallOption) (*mailboxpb.SendResponse, error) {
+
+			deadlineObservedAt = time.Now()
+			deadline, hasDeadline = ctx.Deadline()
+			<-ctx.Done()
+
+			return nil, ctx.Err()
+		},
+	}
+
+	connector := newErrorPathActor(edge, newMemCheckpointStore())
+	require.Equal(t, defaultSendEventTimeout, connector.sendTimeout)
+	connector.sendTimeout = sendTimeout
+
+	turnCtx, cancelTurn := context.WithCancel(t.Context())
+	cancelTurn()
+
+	started := time.Now()
+	ax := &fakeEgressExec{}
+	result := connector.Receive(turnCtx, &SendRPCRequest{
+		Envelope: &mailboxpb.Envelope{
+			MsgId:          "bounded-send",
+			IdempotencyKey: "bounded-send-idempotency",
+		},
+	}, ax)
+	elapsed := time.Since(started)
+
+	require.ErrorIs(t, result.Err(), context.DeadlineExceeded)
+	require.True(t, hasDeadline)
+	require.WithinDuration(
+		t, deadlineObservedAt.Add(sendTimeout), deadline,
+		20*time.Millisecond,
+	)
+	require.GreaterOrEqual(t, elapsed, sendTimeout/2)
+	require.Zero(t, ax.commits)
+}
+
+// TestSendRPCRequestDeadlineReleasesWorkerPool fills the four-worker durable
+// egress pool with black-holed pre-built RPC sends. Lease heartbeats stay
+// active while each delivery is blocked. The timeout then nacks the messages,
+// frees workers for a fifth request, and retries every failed envelope with
+// the same message and idempotency identifiers.
+func TestSendRPCRequestDeadlineReleasesWorkerPool(t *testing.T) {
+	const (
+		numWorkers  = 4
+		sendTimeout = 100 * time.Millisecond
+	)
+
+	blockedIDs := []string{
+		"blocked-1",
+		"blocked-2",
+		"blocked-3",
+		"blocked-4",
+	}
+	edge := newBlackHoleRPCSendEdge(blockedIDs...)
+	store := &countingLeaseStore{
+		memCheckpointStore: newMemCheckpointStore(),
+	}
+
+	cfg := newTestConnectorConfig(
+		newInMemoryMailbox(), store.memCheckpointStore,
+	)
+	cfg.Edge = edge
+	cfg.Store = store
+	cfg.Codec = NewServerConnCodec()
+
+	connector := NewServerConnectionActor(cfg)
+	connector.sendTimeout = sendTimeout
+
+	durableCfg := actor.DefaultDurableTxActorConfig[
+		ServerConnMsg, ServerConnResp, egressTx,
+	](
+		DurableActorID(cfg.LocalMailboxID), connector,
+		connector.bindStores, store, cfg.Codec,
+	)
+	durableCfg.NumWorkers = numWorkers
+	durableCfg.PollInterval = 5 * time.Millisecond
+	// Keep the lease comfortably beyond the injected send timeout. The test
+	// observes successful heartbeat extensions without making exact retry
+	// counts depend on sub-100ms scheduler timing under the race detector.
+	durableCfg.LeaseDuration = time.Second
+	durableCfg.HeartbeatInterval = 10 * time.Millisecond
+	durableCfg.TellRetryPolicy = func(error, int) (bool, time.Duration) {
+		return true, 20 * time.Millisecond
+	}
+
+	durable := actor.NewDurableActor(durableCfg).UnwrapOrFail(t)
+	durable.Start()
+	defer durable.Stop()
+
+	for _, id := range blockedIDs {
+		err := durable.TellRef().Tell(t.Context(), &SendRPCRequest{
+			Envelope: &mailboxpb.Envelope{
+				MsgId:          id,
+				IdempotencyKey: id + "-idempotency",
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	started := make(map[string]bool, numWorkers)
+	for len(started) < numWorkers {
+		select {
+		case id := <-edge.started:
+			started[id] = true
+
+		case <-time.After(time.Second):
+			t.Fatal(
+				"four black-holed sends did not occupy the " +
+					"worker pool",
+			)
+		}
+	}
+
+	const probeID = "probe"
+	err := durable.TellRef().Tell(t.Context(), &SendRPCRequest{
+		Envelope: &mailboxpb.Envelope{
+			MsgId:          probeID,
+			IdempotencyKey: probeID + "-idempotency",
+		},
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, succeeded := edge.snapshot()
+
+		return len(succeeded) == numWorkers+1
+	}, 3*time.Second, 10*time.Millisecond)
+
+	attempts, succeeded := edge.snapshot()
+	require.True(t, succeeded[probeID])
+	require.Len(t, attempts[probeID], 1)
+
+	for _, id := range blockedIDs {
+		require.True(t, succeeded[id])
+		require.Len(t, attempts[id], 2)
+		require.Equal(t, attempts[id][0], attempts[id][1])
+		require.Equal(t, id, attempts[id][0].msgID)
+		require.Equal(
+			t, id+"-idempotency", attempts[id][0].idempotencyKey,
+		)
+	}
+
+	require.Positive(t, store.extensions.Load())
+}


### PR DESCRIPTION
## The problem

The durable server connection persists outbound messages, then lets a pool of four workers send them to the operator. A successful send commits the durable message. A failed send leaves it retryable.

`SendRPCRequest` was the one durable send path without a per-call deadline. If an edge accepted the gRPC call but never returned, its worker stayed inside `Edge.Send` while the actor kept renewing the message lease. Four such calls occupied the full default pool and stopped all durable egress until the daemon restarted.

The registered message codec and the runtime's durable reference still accept this pre-built envelope type, including rows persisted for replay.

## The fix

All three durable send paths now call one helper. The helper preserves the actor turn's context values, detaches from its cancellation, and gives `Edge.Send` a 30-second deadline.

If the deadline expires, the handler returns an error before commit. The durable actor nacks the row, releases the worker, and retries after its existing backoff. The retry uses the same stored envelope.

## Safety rule

Every durable edge send either commits after a confirmed success or returns within 30 seconds without acknowledging the message. An ambiguous timeout remains an at-least-once retry with the same message and idempotency identifiers.

## What does not change

- No RPC, envelope, database, or configuration format changes.
- Fast, non-durable unary calls through `UnaryFacade` still use the caller's context.
- Event sends and constructed durable unary sends keep their existing 30-second policy.
- Lease renewal, retry limits, backoff, and remote deduplication remain unchanged.

## Tests

- A test edge waits for `ctx.Done()` and proves a canceled actor turn does not abort the send, the edge receives a deadline, timeout returns `context.DeadlineExceeded`, and the handler does not commit.
- A four-worker test black-holes the first attempt for four pre-built RPC envelopes. It proves leases renew while the calls are blocked, each call times out, a fifth envelope gets a worker, and every timed-out row retries with the same message and idempotency identifiers.
- `make unit pkg=serverconn timeout=5m`
- `go test -race ./serverconn -count=1`
- `go test ./serverconn -run 'TestSendRPCRequest(OwnsBoundedSendContext|DeadlineReleasesWorkerPool)' -count=50`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make tidy-module-check`
- `make commitmsg-lint range='origin/main..HEAD'`

## Compatibility and rollout

This is a local client behavior change with no protocol or storage migration. It can roll out independently.

Fixes #1183.
