### PR TITLE
txconfirm: propagate state query errors

### DIFF
--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -40,12 +40,16 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   coordination.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — public Ask API:
   register interest in a txid with `TargetConfs`, `ConfirmationPkScript`,
-  and a subscriber.
+  and a subscriber. An Ask error means the subscriber was not retained:
+  no later notification arrives and the caller must re-send
+  `EnsureConfirmedReq` to attach.
 - `CancelInterestReq` / `CancelInterestResp` — drop a subscriber; the
   last subscriber's cancel tears down tracking.
 - `BumpNowReq` / `BumpNowResp` — operator "bump this stuck tx now" Ask:
   forces an immediate CPFP bump at a supplied fee rate (clamped to the
-  broadcaster's max) instead of waiting for the next interval.
+  broadcaster's max) instead of waiting for the next interval. An entry
+  holding an unapplied terminal transition answers `Bumped: false` instead
+  of broadcasting again.
 - `TxConfirmed` / `TxFailed` — terminal `Notification` types delivered
   to each subscriber.
 - `NewServiceKey` / `LookupRef` — actor-system service-key helpers
@@ -79,7 +83,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   `waved` (wiring/registration).
 - **Sends → `chainsource`** (Ask): `BestHeightRequest`,
   `SubscribeBlocksRequest`, `RegisterConfRequest`,
-  `UnregisterConfRequest`, `BroadcastTxRequest`,
+  `UnsubscribeBlocksRequest`, `UnregisterConfRequest`, `BroadcastTxRequest`,
   `SubmitPackageRequest`, `TestMempoolAcceptRequest`,
   `FeeEstimateRequest`.
 - **Sends → `Wallet`** (direct): `ListUnspent`, `NewWalletPkScript`,
@@ -109,6 +113,32 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   must agree on `TargetConfs` and `ConfirmationPkScript`; mismatches
   return `ErrEnsureParamsMismatch` rather than silently reusing the
   existing watch.
+- **Setup errors stay retryable.** Block-subscription and confirmation-watch
+  errors unwind the incomplete tracker and return an Ask error before any
+  broadcast. Cleanup uses a detached, one-second context because the failed
+  request may already be cancelled. If confirmation registration is
+  ambiguous, cleanup unregisters the deterministic watch; an existing shared
+  block subscription stays active.
+- **An Ask error never promises a notification.** State-read and broadcast
+  errors return through the Ask after removing that request's subscriber.
+  The caller must retry `EnsureConfirmedReq` to attach again. After an
+  ambiguous broadcast result, the detached tracker keeps its confirmation
+  watch until confirmation arrives or the next actor tick reconciles its
+  pending terminal transition. An immediate retry returns another Ask error
+  rather than attaching to that pending transition.
+- **Reported state is proven, never guessed.** Response paths use the state
+  established by a successful FSM transition. They never substitute
+  `TxStateFailed` when a state query fails, and they do not perform a second
+  query after a successful submission merely to build the response.
+- **Failed terminal transitions are retried before broadcast.** A background
+  path retains the terminal reason when its FSM transition fails. Block and
+  fee-input retry paths apply that transition before attempting another
+  broadcast. Confirmation or other forward progress clears the stale reason;
+  only a transaction still in `Broadcasting` may be failed by the retry.
+- **The per-txid FSM outlives the creating Ask.** `newTrackedTx` starts the
+  state machine without the caller's cancellation or database transaction.
+  Explicit setup cleanup, terminal eviction, cancellation, and actor shutdown
+  stop it.
 - **TRUC version gate**: `CPFPBroadcaster.Submit` rejects parents whose
   `Tx.Version != arktx.TxVersion` (v3). Pattern-based anchor detection
   on non-v3 parents is structurally unsafe.

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -40,12 +40,16 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   coordination.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — public Ask API:
   register interest in a txid with `TargetConfs`, `ConfirmationPkScript`,
-  and a subscriber.
+  and a subscriber. An Ask error means the subscriber was not retained:
+  no later notification arrives and the caller must re-send
+  `EnsureConfirmedReq` to attach.
 - `CancelInterestReq` / `CancelInterestResp` — drop a subscriber; the
   last subscriber's cancel tears down tracking.
 - `BumpNowReq` / `BumpNowResp` — operator "bump this stuck tx now" Ask:
   forces an immediate CPFP bump at a supplied fee rate (clamped to the
-  broadcaster's max) instead of waiting for the next interval.
+  broadcaster's max) instead of waiting for the next interval. An entry
+  holding an unapplied terminal transition answers `Bumped: false` instead
+  of broadcasting again.
 - `TxConfirmed` / `TxFailed` — terminal `Notification` types delivered
   to each subscriber.
 - `NewServiceKey` / `LookupRef` — actor-system service-key helpers
@@ -79,7 +83,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   `waved` (wiring/registration).
 - **Sends → `chainsource`** (Ask): `BestHeightRequest`,
   `SubscribeBlocksRequest`, `RegisterConfRequest`,
-  `UnregisterConfRequest`, `BroadcastTxRequest`,
+  `UnsubscribeBlocksRequest`, `UnregisterConfRequest`, `BroadcastTxRequest`,
   `SubmitPackageRequest`, `TestMempoolAcceptRequest`,
   `FeeEstimateRequest`.
 - **Sends → `Wallet`** (direct): `ListUnspent`, `NewWalletPkScript`,
@@ -109,6 +113,32 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   must agree on `TargetConfs` and `ConfirmationPkScript`; mismatches
   return `ErrEnsureParamsMismatch` rather than silently reusing the
   existing watch.
+- **Setup errors stay retryable.** Block-subscription and confirmation-watch
+  errors unwind the incomplete tracker and return an Ask error before any
+  broadcast. Cleanup uses a detached, one-second context because the failed
+  request may already be cancelled. If confirmation registration is
+  ambiguous, cleanup unregisters the deterministic watch; an existing shared
+  block subscription stays active.
+- **An Ask error never promises a notification.** State-read and broadcast
+  errors return through the Ask after removing that request's subscriber.
+  The caller must retry `EnsureConfirmedReq` to attach again. After an
+  ambiguous broadcast result, the detached tracker keeps its confirmation
+  watch until confirmation arrives or the next actor tick reconciles its
+  pending terminal transition. An immediate retry returns another Ask error
+  rather than attaching to that pending transition.
+- **Reported state is proven, never guessed.** Response paths use the state
+  established by a successful FSM transition. They never substitute
+  `TxStateFailed` when a state query fails, and they do not perform a second
+  query after a successful submission merely to build the response.
+- **Failed terminal transitions are retried before broadcast.** A background
+  path retains the terminal reason when its FSM transition fails. Block and
+  fee-input retry paths apply that transition before attempting another
+  broadcast. Confirmation or other forward progress clears the stale reason;
+  only a transaction still in `Broadcasting` may be failed by the retry.
+- **The per-txid FSM outlives the creating Ask.** `newTrackedTx` starts the
+  state machine without the caller's cancellation or database transaction.
+  Explicit setup cleanup, terminal eviction, cancellation, and actor shutdown
+  stop it.
 - **TRUC version gate**: `CPFPBroadcaster.Submit` rejects parents whose
   `Tx.Version != arktx.TxVersion` (v3). Pattern-based anchor detection
   on non-v3 parents is structurally unsafe.

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -1223,6 +1223,12 @@ func (a *TxBroadcasterActor) handleConfirmationObserved(ctx context.Context,
 		return
 	}
 
+	// Chain confirmation supersedes an earlier ambiguous broadcast
+	// failure even if persisting the confirmation transition fails. Leaving
+	// the reason latched would let the next block move a mined transaction
+	// into Failed while its FSM still reports Broadcasting.
+	entry.pendingFailureReason = ""
+
 	if err := a.advanceTrackedTxFSM(ctx, entry, &trackedTxConfirmed{
 		BlockHeight: msg.blockHeight,
 		BlockHash:   msg.blockHash,
@@ -1233,8 +1239,6 @@ func (a *TxBroadcasterActor) handleConfirmationObserved(ctx context.Context,
 
 		return
 	}
-	entry.pendingFailureReason = ""
-
 	a.notifyConfirmed(
 		ctx, entry, msg.blockHeight, msg.blockHash, msg.numConfs,
 	)

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -253,6 +253,13 @@ type trackedTx struct {
 	// means "no override pending".
 	pendingTargetFeeRate int64
 
+	// pendingFailureReason retains a terminal failure whose FSM transition
+	// could not be applied. Background retry paths
+	// attempt the transition again before any further broadcast, so a
+	// transient actor context failure cannot turn a structural rejection
+	// into endless relay attempts.
+	pendingFailureReason string
+
 	// sealed is set true the moment terminal delivery (TxFinalized /
 	// TxFailed) begins for this entry. Reversible deliveries
 	// (TxReorged / re-TxConfirmed) run on detached fire-and-forget
@@ -618,7 +625,7 @@ func (a *TxBroadcasterActor) handleEnsure(ctx context.Context,
 				Ref:              req.Subscriber,
 				pendingConfirmed: true,
 			},
-		), nil
+		)
 	}
 
 	if err := a.ensureBestHeight(ctx); err != nil {
@@ -673,9 +680,17 @@ func (a *TxBroadcasterActor) handleEnsure(ctx context.Context,
 	}
 
 	_, err = a.broadcastTrackedTx(ctx, entry, TxStateBroadcasting)
-	a.recordInitialBroadcastOutcome(ctx, entry, err)
+	state, err := a.recordInitialBroadcastOutcome(ctx, entry, err)
+	if err != nil {
+		// An Ask error never promises future notifications. Keep the
+		// tracker for reconciliation when broadcast acceptance is
+		// ambiguous, but require this caller to retry before attaching.
+		delete(entry.subscribers, req.Subscriber.ID())
 
-	return a.ensureResp(entry, true), nil
+		return nil, err
+	}
+
+	return a.ensureRespForState(entry, state, true), nil
 }
 
 // cleanupFailedBlockSubscription removes a block subscription actor whose
@@ -752,14 +767,18 @@ func (a *TxBroadcasterActor) discardIncompleteTrackedTx(ctx context.Context,
 //   - any other error on a non-anchor parent: a plain direct broadcast with no
 //     CPFP retry machinery. There is nothing to fee-bump and no fund-risk
 //     retry contract, so fail it terminally as before.
+//
+// The returned state is the outcome proven by a successful FSM transition.
+// This lets callers report the outcome without a second query, even if
+// terminal notification delivery already evicted the entry.
 func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
-	entry *trackedTx, err error) {
+	entry *trackedTx, err error) (TxState, error) {
 
 	a.maybeEnsureFeeInputSupply(ctx, err)
 
 	switch {
 	case err == nil:
-		return
+		return TxStateAwaitingConfirmation, nil
 
 	case errors.Is(err, ErrParentAlreadyBroadcast):
 		// A live parent exists on another path, so the conf watch can
@@ -769,7 +788,7 @@ func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
 			"txid", entry.data.Txid, slog.Any("err", err),
 		)
 
-		_ = a.advanceTrackedTxFSM(
+		err := a.advanceTrackedTxFSM(
 			ctx, entry, &trackedTxBroadcastAccepted{
 				Progress: trackedTxProgress{
 					LastBroadcastHeight: fn.Some(
@@ -779,26 +798,34 @@ func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
 			},
 		)
 
+		return TxStateAwaitingConfirmation, err
+
 	case isPermanentBroadcastError(err):
 		// The tx is structurally unacceptable (e.g. a non-TRUC parent);
 		// no amount of retrying will land it, so fail terminally.
-		a.failTrackedTx(
+		err := a.failTrackedTx(
 			ctx, entry, fmt.Sprintf("broadcast: %v", err),
 		)
+
+		return TxStateFailed, err
 
 	case findAnchorOutput(entry.data.Tx) >= 0:
 		// An anchor (CPFP) parent reached no mempool. The failure is
 		// plausibly transient and this is the fund-risk path, so stay
 		// in Broadcasting, re-attempt next interval, and escalate
 		// rather than give up.
-		a.recordBroadcastFailure(ctx, entry, err)
+		err := a.recordBroadcastFailure(ctx, entry, err)
+
+		return TxStateBroadcasting, err
 
 	default:
 		// A non-anchor direct broadcast failed and has no CPFP retry
 		// contract; fail terminally.
-		a.failTrackedTx(
+		err := a.failTrackedTx(
 			ctx, entry, fmt.Sprintf("broadcast: %v", err),
 		)
+
+		return TxStateFailed, err
 	}
 }
 
@@ -822,14 +849,11 @@ func isPermanentBroadcastError(err error) bool {
 // txs) must keep retrying until it lands, so the escalation is informational
 // rather than a give-up.
 func (a *TxBroadcasterActor) recordBroadcastFailure(ctx context.Context,
-	entry *trackedTx, cause error) {
+	entry *trackedTx, cause error) error {
 
 	currentState, stateErr := entry.currentFSMState()
 	if stateErr != nil {
-		a.log.WarnS(ctx, "Failed to read tracked tx state",
-			stateErr, "txid", entry.data.Txid)
-
-		return
+		return fmt.Errorf("read tracked tx state: %w", stateErr)
 	}
 
 	failures := trackedTxBroadcastFailures(currentState) + 1
@@ -845,7 +869,7 @@ func (a *TxBroadcasterActor) recordBroadcastFailure(ctx context.Context,
 		slog.Any("cause", cause),
 	)
 
-	_ = a.advanceTrackedTxFSM(
+	err := a.advanceTrackedTxFSM(
 		ctx, entry, &trackedTxBroadcastFailed{
 			Progress: trackedTxProgress{
 				LastBroadcastHeight: fn.Some(a.bestHeight),
@@ -853,6 +877,9 @@ func (a *TxBroadcasterActor) recordBroadcastFailure(ctx context.Context,
 			},
 		},
 	)
+	if err != nil {
+		return err
+	}
 
 	// Escalate once the failure count reaches the threshold. escalateLog
 	// edge-triggers on the first crossing and then emits at most one
@@ -871,6 +898,8 @@ func (a *TxBroadcasterActor) recordBroadcastFailure(ctx context.Context,
 			)
 		})
 	}
+
+	return nil
 }
 
 // handleCancel removes one subscriber from one tracked txid.
@@ -958,6 +987,20 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 			Txid:   req.Txid,
 			Bumped: false,
 			Reason: "transaction not tracked",
+		}, nil
+	}
+
+	if entry.pendingFailureReason != "" {
+		state, err := entry.currentTxState()
+		if err != nil {
+			return nil, err
+		}
+
+		return &BumpNowResp{
+			Txid:   req.Txid,
+			State:  state,
+			Bumped: false,
+			Reason: "transaction has a pending terminal transition",
 		}, nil
 	}
 
@@ -1051,9 +1094,12 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 		// (with the escalation counter ticking) or fails terminally on
 		// structural errors, identical to an interval retry.
 		if nextState == TxStateBroadcasting {
-			a.recordInitialBroadcastOutcome(ctx, entry, bumpErr)
-
-			bumpedState, _ := entry.currentTxState()
+			bumpedState, err := a.recordInitialBroadcastOutcome(
+				ctx, entry, bumpErr,
+			)
+			if err != nil {
+				return nil, err
+			}
 
 			return &BumpNowResp{
 				Txid:   req.Txid,
@@ -1074,7 +1120,7 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 		a.log.WarnS(ctx, "Forced fee bump failed", bumpErr,
 			"txid", entry.data.Txid)
 
-		_ = a.advanceTrackedTxFSM(
+		if err := a.advanceTrackedTxFSM(
 			ctx, entry, &trackedTxBroadcastAccepted{
 				Progress: trackedTxProgress{
 					LastBroadcastHeight: fn.Some(
@@ -1082,19 +1128,17 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 					),
 				},
 			},
-		)
-
-		bumpedState, _ := entry.currentTxState()
+		); err != nil {
+			return nil, err
+		}
 
 		return &BumpNowResp{
 			Txid:   req.Txid,
-			State:  bumpedState,
+			State:  TxStateAwaitingConfirmation,
 			Bumped: false,
 			Reason: fmt.Sprintf("fee bump failed: %v", bumpErr),
 		}, nil
 	}
-
-	bumpedState, _ := entry.currentTxState()
 
 	// A submission that produced no CPFP child did not actually bump
 	// anything: the ephemeral path's hail-mary fallback re-broadcasts the
@@ -1104,7 +1148,7 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 	if result.ChildTxid == nil {
 		return &BumpNowResp{
 			Txid:   req.Txid,
-			State:  bumpedState,
+			State:  TxStateAwaitingConfirmation,
 			Bumped: false,
 			Reason: "cpfp child unavailable; parent re-broadcast " +
 				"directly without a fee bump",
@@ -1116,7 +1160,7 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 	// exceeded the broadcaster's ceiling and was reduced.
 	return &BumpNowResp{
 		Txid:      req.Txid,
-		State:     bumpedState,
+		State:     TxStateAwaitingConfirmation,
 		Bumped:    true,
 		ChildTxid: copyHash(result.ChildTxid),
 
@@ -1169,6 +1213,8 @@ func (a *TxBroadcasterActor) handleConfirmationObserved(ctx context.Context,
 	// a reorg), but we tolerate it by re-delivering TxConfirmed rather
 	// than failing the FSM.
 	if state == TxStateConfirmed {
+		entry.pendingFailureReason = ""
+
 		a.notifyConfirmed(
 			ctx, entry, msg.blockHeight, msg.blockHash,
 			msg.numConfs,
@@ -1187,6 +1233,7 @@ func (a *TxBroadcasterActor) handleConfirmationObserved(ctx context.Context,
 
 		return
 	}
+	entry.pendingFailureReason = ""
 
 	a.notifyConfirmed(
 		ctx, entry, msg.blockHeight, msg.blockHash, msg.numConfs,
@@ -1367,6 +1414,10 @@ func (a *TxBroadcasterActor) handleBlockObserved(ctx context.Context,
 	}
 
 	for _, entry := range a.tracked {
+		if a.retryPendingFailure(ctx, entry) {
+			continue
+		}
+
 		state, err := entry.currentTxState()
 		if err != nil {
 			a.log.WarnS(ctx, "Failed to read tracked tx state",
@@ -1394,7 +1445,14 @@ func (a *TxBroadcasterActor) handleBlockObserved(ctx context.Context,
 			_, err := a.broadcastTrackedTx(
 				ctx, entry, TxStateBroadcasting,
 			)
-			a.recordInitialBroadcastOutcome(ctx, entry, err)
+			_, outcomeErr := a.recordInitialBroadcastOutcome(
+				ctx, entry, err,
+			)
+			if outcomeErr != nil {
+				a.log.WarnS(ctx, "Failed to record broadcast "+
+					"outcome",
+					outcomeErr, "txid", entry.data.Txid)
+			}
 
 		// A tx already in a mempool is fee-bumped.
 		case a.shouldFeeBump(entry):
@@ -1456,22 +1514,23 @@ func (a *TxBroadcasterActor) handleBlockObserved(ctx context.Context,
 
 // attachExistingSubscriber attaches a new subscriber to an already-tracked
 // txid or immediately replays a terminal result.
-func (a *TxBroadcasterActor) attachExistingSubscriber(
-	ctx context.Context, entry *trackedTx,
-	subscriber trackedSubscriber,
-) *EnsureConfirmedResp {
+func (a *TxBroadcasterActor) attachExistingSubscriber(ctx context.Context,
+	entry *trackedTx, subscriber trackedSubscriber) (*EnsureConfirmedResp,
+	error) {
 
 	state, err := entry.currentFSMState()
 	if err != nil {
-		a.notifyOneFailed(
-			ctx, subscriber.Ref, entry.data.Txid,
-			fmt.Sprintf("tracked tx state: %v", err),
-		)
+		return nil, fmt.Errorf("read tracked tx state: %w", err)
+	}
 
-		return &EnsureConfirmedResp{
-			Txid:  entry.data.Txid,
-			State: TxStateFailed,
-		}
+	// A previous Ask can leave a terminal transition queued when its
+	// context expires after an ambiguous broadcast result. Do not attach a
+	// new subscriber that would receive that stale request's TxFailed on
+	// the next actor tick. The caller can retry after the actor reconciles
+	// or a confirmation supersedes the pending transition.
+	if entry.pendingFailureReason != "" {
+		return nil, fmt.Errorf("transaction %v has a pending terminal "+
+			"transition", entry.data.Txid)
 	}
 
 	subID := subscriber.Ref.ID()
@@ -1537,17 +1596,15 @@ func (a *TxBroadcasterActor) attachExistingSubscriber(
 		entry.subscribers[subID] = subscriber
 	}
 
-	return a.ensureResp(entry, false)
+	return a.ensureRespForState(
+		entry, txStateFromTrackedState(state), false,
+	), nil
 }
 
-// ensureResp constructs one EnsureConfirmedResp from the current entry state.
-func (a *TxBroadcasterActor) ensureResp(entry *trackedTx,
+// ensureRespForState constructs an EnsureConfirmedResp when the actor has
+// already proven the state through a successful transition.
+func (a *TxBroadcasterActor) ensureRespForState(entry *trackedTx, state TxState,
 	created bool) *EnsureConfirmedResp {
-
-	state, err := entry.currentTxState()
-	if err != nil {
-		state = TxStateFailed
-	}
 
 	return &EnsureConfirmedResp{
 		Txid:    entry.data.Txid,
@@ -1586,7 +1643,12 @@ func (a *TxBroadcasterActor) newTrackedTx(ctx context.Context,
 		ParentFee:   req.ParentFee,
 	}
 	fsm := newTrackedTxStateMachine(fsmLog, data)
-	fsm.Start(ctx)
+
+	// The per-transaction FSM is actor-owned. Cancellation, terminal
+	// eviction, and actor shutdown stop it explicitly. It must not inherit
+	// the Ask caller's deadline or database transaction after admission.
+	fsmCtx := actor.WithoutTx(context.WithoutCancel(ctx))
+	fsm.Start(fsmCtx)
 
 	return &trackedTx{
 		data: data,
@@ -1951,8 +2013,11 @@ func (a *TxBroadcasterActor) broadcastIntervalElapsed(entry *trackedTx,
 // failTrackedTx moves one tracked txid into terminal failure and notifies all
 // current subscribers. The entry is retained if any terminal notification
 // cannot be delivered, so a later actor tick can retry the failed delivery.
+// It returns only after the FSM proves the terminal transition.
 func (a *TxBroadcasterActor) failTrackedTx(ctx context.Context,
-	entry *trackedTx, reason string) {
+	entry *trackedTx, reason string) error {
+
+	entry.pendingFailureReason = reason
 
 	if err := a.advanceTrackedTxFSM(ctx, entry, &trackedTxFailed{
 		Reason: reason,
@@ -1960,10 +2025,53 @@ func (a *TxBroadcasterActor) failTrackedTx(ctx context.Context,
 
 		a.log.WarnS(ctx, "Failed to move tracked tx into terminal state",
 			err, "txid", entry.data.Txid)
+
+		return fmt.Errorf("move tracked tx into terminal state: %w",
+			err)
 	}
+	entry.pendingFailureReason = ""
+
 	if a.notifyFailed(ctx, entry, reason) {
 		a.evictTerminal(ctx, entry)
 	}
+
+	return nil
+}
+
+// retryPendingFailure re-attempts a terminal transition that a background
+// path could not apply. It returns true whenever a failure is pending so the
+// caller never broadcasts the structurally invalid transaction again first.
+func (a *TxBroadcasterActor) retryPendingFailure(ctx context.Context,
+	entry *trackedTx) bool {
+
+	reason := entry.pendingFailureReason
+	if reason == "" {
+		return false
+	}
+
+	state, err := entry.currentTxState()
+	if err != nil {
+		a.log.WarnS(ctx, "Failed to read pending-failure tx state",
+			err, "txid", entry.data.Txid)
+
+		return true
+	}
+
+	// Confirmation or any other forward progress supersedes an earlier
+	// ambiguous broadcast failure. Only a still-Broadcasting entry may be
+	// moved into Failed by this deferred transition.
+	if state != TxStateBroadcasting {
+		entry.pendingFailureReason = ""
+
+		return false
+	}
+
+	if err := a.failTrackedTx(ctx, entry, reason); err != nil {
+		a.log.WarnS(ctx, "Failed to retry tracked tx terminal state",
+			err, "txid", entry.data.Txid)
+	}
+
+	return true
 }
 
 // evictTerminal releases all resources held for one tracked tx that has

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -1564,6 +1564,19 @@ func TestEnsureBroadcastErrorDetachesBeforeConfirmation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, TxStateConfirmed, state)
 	require.Empty(t, entry.pendingFailureReason)
+
+	retryResp, retryErr = behavior.handleEnsure(
+		t.Context(), &EnsureConfirmedReq{
+			Tx:         tx,
+			Subscriber: retrySub,
+		},
+	)
+	require.NoError(t, retryErr)
+	require.Equal(t, TxStateConfirmed, retryResp.State)
+	require.False(t, retryResp.Created)
+	require.IsType(t, &TxConfirmed{}, mustAwaitNotification(t, retrySub))
+	require.Contains(t, entry.subscribers, retrySub.ID())
+
 	behavior.handleBlockObserved(t.Context(), &blockEpochObservedMsg{
 		height: 102,
 	})

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/baselib/protofsm"
 	"github.com/lightninglabs/wavelength/chainbackends"
 	"github.com/lightninglabs/wavelength/chainsource"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
@@ -1264,12 +1265,13 @@ func TestLateFinalizedSubscriberRetrySkipsConfirmed(t *testing.T) {
 
 	behavior := NewTxBroadcasterActor(Config{})
 	sub := newRetryNotifyRef("late-finalized", 1)
-	resp := behavior.attachExistingSubscriber(
+	resp, err := behavior.attachExistingSubscriber(
 		t.Context(), entry, trackedSubscriber{
 			Ref:              sub,
 			pendingConfirmed: true,
 		},
 	)
+	require.NoError(t, err)
 	require.Equal(t, TxStateFinalized, resp.State)
 	require.Equal(t, 1, sub.attemptsCount())
 	require.Len(t, entry.subscribers, 1)
@@ -1286,6 +1288,288 @@ func TestLateFinalizedSubscriberRetrySkipsConfirmed(t *testing.T) {
 
 	unexpected, ok := sub.awaitMessage(100 * time.Millisecond)
 	require.False(t, ok, "unexpected extra notification: %T", unexpected)
+}
+
+// TestEnsureConfirmedPropagatesStateQueryError verifies that an unavailable
+// FSM state cannot be reported or delivered as a proven transaction failure.
+// The caller can retry the returned error without driving its own state
+// machine into a false terminal state.
+func TestEnsureConfirmedPropagatesStateQueryError(t *testing.T) {
+	chain := newFakeChainSourceRef(100)
+	ref, behavior := newTestActor(t, Config{
+		ChainSource: chain,
+	})
+
+	tx := makeTestTx(false)
+	subA := actor.NewChannelTellOnlyRef[Notification]("sub-a", 4)
+	subB := actor.NewChannelTellOnlyRef[Notification]("sub-b", 4)
+	resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: subA,
+	})
+	require.Equal(t, TxStateAwaitingConfirmation, resp.State)
+
+	entry := behavior.tracked[tx.TxHash()]
+	require.NotNil(t, entry)
+	entry.fsm.Stop()
+
+	ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
+	defer cancel()
+
+	_, err := ref.Ref().Ask(ctx, &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: subB,
+	}).Await(ctx).Unpack()
+	require.ErrorIs(t, err, protofsm.ErrStateMachineShutdown)
+	require.NotContains(t, entry.subscribers, subB.ID())
+	mustHaveNoNotification(t, subB)
+}
+
+// TestFailTrackedTxPropagatesTransitionError verifies that a failed terminal
+// transition returns an error without sending a false TxFailed notification.
+func TestFailTrackedTxPropagatesTransitionError(t *testing.T) {
+	tx := makeTestTx(false)
+	entry := newTrackedTxForState(t, &trackedTxStateAwaitingConfirmation{
+		trackedTxData: trackedTxData{
+			Tx:   tx,
+			Txid: tx.TxHash(),
+		},
+	})
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub", 1)
+	entry.subscribers[sub.ID()] = trackedSubscriber{
+		Ref: sub,
+	}
+	entry.fsm.Stop()
+
+	behavior := NewTxBroadcasterActor(Config{})
+	err := behavior.failTrackedTx(t.Context(), entry, "broadcast failed")
+	require.ErrorIs(t, err, protofsm.ErrStateMachineShutdown)
+	require.Contains(t, entry.subscribers, sub.ID())
+	mustHaveNoNotification(t, sub)
+}
+
+// TestEnsureCanceledSetupCleanupAllowsRetry verifies that cleanup does not
+// inherit cancellation from a failed setup request. The incomplete entry is
+// removed, and a retry creates a working tracker instead of attaching to an
+// orphan.
+func TestEnsureCanceledSetupCleanupAllowsRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub", 4)
+	tx := makeTestTx(false)
+	var subscribeCalls int
+
+	chain := &staticChainSourceRef{
+		handler: func(_ context.Context,
+			msg chainsource.ChainSourceMsg) (
+			chainsource.ChainSourceResp, error) {
+
+			switch req := msg.(type) {
+			case *chainsource.BestHeightRequest:
+				return &chainsource.BestHeightResponse{
+					Height: 100,
+				}, nil
+
+			case *chainsource.SubscribeBlocksRequest:
+				subscribeCalls++
+				if subscribeCalls == 1 {
+					cancel()
+
+					return nil, fmt.Errorf("subscribe " +
+						"failed")
+				}
+
+				resp := &chainsource.SubscribeBlocksResponse{}
+
+				return resp, nil
+
+			case *chainsource.RegisterConfRequest:
+				return &chainsource.RegisterConfResponse{}, nil
+
+			case *chainsource.BroadcastTxRequest:
+				return &chainsource.BroadcastTxResponse{
+					Txid: req.Tx.TxHash(),
+				}, nil
+
+			default:
+				return nil, fmt.Errorf("unexpected request %T",
+					msg)
+			}
+		},
+	}
+	behavior := NewTxBroadcasterActor(Config{
+		ChainSource: chain,
+	})
+	behavior.SetSelfRef(actor.NewChannelTellOnlyRef[Msg]("self", 4))
+
+	resp, err := behavior.handleEnsure(ctx, &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+	require.ErrorContains(t, err, "subscribe blocks: subscribe failed")
+	require.Nil(t, resp)
+	require.NotContains(t, behavior.tracked, tx.TxHash())
+	mustHaveNoNotification(t, sub)
+
+	resp, err = behavior.handleEnsure(t.Context(), &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Created)
+	require.Equal(t, TxStateAwaitingConfirmation, resp.State)
+	require.Equal(t, 2, subscribeCalls)
+
+	entry := behavior.tracked[tx.TxHash()]
+	require.NotNil(t, entry)
+	entry.fsm.Stop()
+}
+
+// TestPendingFailureRetriesBeforeBroadcast verifies that a canceled background
+// transition is retried on the next tick without broadcasting a structurally
+// invalid transaction again. Subscribers are notified only after that retry
+// proves the terminal state.
+func TestPendingFailureRetriesBeforeBroadcast(t *testing.T) {
+	chain := newFakeChainSourceRef(100)
+	behavior := NewTxBroadcasterActor(Config{
+		ChainSource: chain,
+	})
+	tx := makeTestTx(false)
+	entry := newTrackedTxForState(t, &trackedTxStateBroadcasting{
+		trackedTxData: trackedTxData{
+			Tx:   tx,
+			Txid: tx.TxHash(),
+		},
+	})
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub", 1)
+	entry.subscribers[sub.ID()] = trackedSubscriber{
+		Ref: sub,
+	}
+	behavior.tracked[tx.TxHash()] = entry
+
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err := behavior.failTrackedTx(
+		canceledCtx, entry, "structural broadcast failure",
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(
+		t, "structural broadcast failure", entry.pendingFailureReason,
+	)
+	mustHaveNoNotification(t, sub)
+
+	bumpResp, err := behavior.handleBumpNow(t.Context(), &BumpNowReq{
+		Txid: tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.False(t, bumpResp.Bumped)
+	require.Equal(t, TxStateBroadcasting, bumpResp.State)
+	require.Contains(t, bumpResp.Reason, "pending terminal transition")
+	require.Zero(t, chain.broadcastCallCount())
+	mustHaveNoNotification(t, sub)
+
+	behavior.handleBlockObserved(t.Context(), &blockEpochObservedMsg{
+		height: 101,
+	})
+
+	failed := mustAwaitNotification(t, sub)
+	failedMsg, ok := failed.(*TxFailed)
+	require.True(t, ok)
+	require.Equal(
+		t, "structural broadcast failure", failedMsg.Reason,
+	)
+	require.NotContains(t, behavior.tracked, tx.TxHash())
+	require.Zero(t, chain.broadcastCallCount())
+}
+
+// TestEnsureBroadcastErrorDetachesBeforeConfirmation verifies that an
+// ambiguous broadcast error keeps the tracker but does not retain the caller's
+// subscriber after returning an Ask error. A later confirmation supersedes the
+// pending failure and cannot be followed by a false TxFailed notification.
+func TestEnsureBroadcastErrorDetachesBeforeConfirmation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub", 4)
+	tx := makeTestTx(false)
+	chain := &staticChainSourceRef{
+		handler: func(_ context.Context,
+			msg chainsource.ChainSourceMsg) (
+			chainsource.ChainSourceResp, error) {
+
+			switch req := msg.(type) {
+			case *chainsource.BestHeightRequest:
+				return &chainsource.BestHeightResponse{
+					Height: 100,
+				}, nil
+
+			case *chainsource.SubscribeBlocksRequest:
+				resp := &chainsource.SubscribeBlocksResponse{}
+
+				return resp, nil
+
+			case *chainsource.RegisterConfRequest:
+				return &chainsource.RegisterConfResponse{}, nil
+
+			case *chainsource.BroadcastTxRequest:
+				cancel()
+
+				return nil, context.Canceled
+
+			default:
+				return nil, fmt.Errorf("unexpected request %T",
+					req)
+			}
+		},
+	}
+	behavior := NewTxBroadcasterActor(Config{
+		ChainSource: chain,
+	})
+	behavior.SetSelfRef(actor.NewChannelTellOnlyRef[Msg]("self", 4))
+
+	resp, err := behavior.handleEnsure(ctx, &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, resp)
+
+	entry := behavior.tracked[tx.TxHash()]
+	require.NotNil(t, entry)
+	require.NotContains(t, entry.subscribers, sub.ID())
+	require.NotEmpty(t, entry.pendingFailureReason)
+	mustHaveNoNotification(t, sub)
+
+	// A durable caller can retry immediately after the Ask error. It must
+	// not attach to the stale pending transition and receive TxFailed for a
+	// broadcast whose acceptance is unknown.
+	retrySub := actor.NewChannelTellOnlyRef[Notification]("retry-sub", 4)
+	retryResp, retryErr := behavior.handleEnsure(
+		t.Context(), &EnsureConfirmedReq{
+			Tx:         tx,
+			Subscriber: retrySub,
+		},
+	)
+	require.ErrorContains(t, retryErr, "pending terminal transition")
+	require.Nil(t, retryResp)
+	require.NotContains(t, entry.subscribers, retrySub.ID())
+	mustHaveNoNotification(t, retrySub)
+
+	behavior.handleConfirmationObserved(
+		t.Context(), &confirmationObservedMsg{
+			txid:        tx.TxHash(),
+			blockHeight: 101,
+			numConfs:    1,
+		},
+	)
+
+	state, err := entry.currentTxState()
+	require.NoError(t, err)
+	require.Equal(t, TxStateConfirmed, state)
+	require.Empty(t, entry.pendingFailureReason)
+	behavior.handleBlockObserved(t.Context(), &blockEpochObservedMsg{
+		height: 102,
+	})
+	mustHaveNoNotification(t, sub)
+	mustHaveNoNotification(t, retrySub)
+	entry.fsm.Stop()
 }
 
 // TestTerminalNotificationsDoNotInheritCallerContext verifies that terminal

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -1585,6 +1585,51 @@ func TestEnsureBroadcastErrorDetachesBeforeConfirmation(t *testing.T) {
 	entry.fsm.Stop()
 }
 
+// TestConfirmationClearsPendingFailureBeforeTransition verifies that chain
+// confirmation remains authoritative when persisting its FSM transition
+// fails. A later block must not apply the stale broadcast failure to a mined
+// transaction.
+func TestConfirmationClearsPendingFailureBeforeTransition(t *testing.T) {
+	tx := makeTestTx(false)
+	entry := newTrackedTxForState(t, &trackedTxStateBroadcasting{
+		trackedTxData: trackedTxData{
+			Tx:   tx,
+			Txid: tx.TxHash(),
+		},
+	})
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub", 1)
+	entry.subscribers[sub.ID()] = trackedSubscriber{
+		Ref: sub,
+	}
+	entry.pendingFailureReason = "ambiguous broadcast failure"
+
+	behavior := NewTxBroadcasterActor(Config{})
+	behavior.tracked[tx.TxHash()] = entry
+
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	behavior.handleConfirmationObserved(
+		canceledCtx, &confirmationObservedMsg{
+			txid:        tx.TxHash(),
+			blockHeight: 101,
+			numConfs:    1,
+		},
+	)
+
+	state, err := entry.currentTxState()
+	require.NoError(t, err)
+	require.Equal(t, TxStateBroadcasting, state)
+	require.Empty(t, entry.pendingFailureReason)
+	mustHaveNoNotification(t, sub)
+
+	behavior.handleBlockObserved(t.Context(), &blockEpochObservedMsg{
+		height: 102,
+	})
+	require.Contains(t, behavior.tracked, tx.TxHash())
+	mustHaveNoNotification(t, sub)
+	entry.fsm.Stop()
+}
+
 // TestTerminalNotificationsDoNotInheritCallerContext verifies that terminal
 // delivery is independent of the txconfirm actor's transaction and cancellation
 // context.

--- a/txconfirm/fee_input_actor.go
+++ b/txconfirm/fee_input_actor.go
@@ -302,13 +302,23 @@ func (a *TxBroadcasterActor) handleFanoutConfirmed(ctx context.Context,
 // this is the point where it can finally build its CPFP child and land.
 func (a *TxBroadcasterActor) retryBroadcastingParents(ctx context.Context) {
 	for _, entry := range a.tracked {
+		if a.retryPendingFailure(ctx, entry) {
+			continue
+		}
+
 		state, err := entry.currentTxState()
 		if err != nil || state != TxStateBroadcasting {
 			continue
 		}
 
 		_, err = a.broadcastTrackedTx(ctx, entry, TxStateBroadcasting)
-		a.recordInitialBroadcastOutcome(ctx, entry, err)
+		_, outcomeErr := a.recordInitialBroadcastOutcome(
+			ctx, entry, err,
+		)
+		if outcomeErr != nil {
+			a.log.WarnS(ctx, "Failed to record broadcast outcome",
+				outcomeErr, "txid", entry.data.Txid)
+		}
 	}
 }
 

--- a/txconfirm/messages.go
+++ b/txconfirm/messages.go
@@ -13,6 +13,7 @@ import (
 type Msg interface {
 	actor.Message
 
+	// txConfirmMsgSealed restricts actor requests to this package.
 	txConfirmMsgSealed()
 }
 
@@ -20,6 +21,7 @@ type Msg interface {
 type Resp interface {
 	actor.Message
 
+	// txConfirmRespSealed restricts actor responses to this package.
 	txConfirmRespSealed()
 }
 
@@ -28,6 +30,8 @@ type Resp interface {
 type Notification interface {
 	actor.Message
 
+	// txConfirmNotificationSealed restricts lifecycle events to this
+	// package.
 	txConfirmNotificationSealed()
 }
 
@@ -107,7 +111,10 @@ func (s TxState) String() string {
 //
 // Deduplication is keyed by txid. If the same txid is already being tracked,
 // the actor attaches the supplied subscriber to the existing tracking state
-// instead of starting a second confirmation workflow.
+// instead of starting a second confirmation workflow. If the Ask returns an
+// error, the subscriber is not retained and receives no later notifications;
+// the caller must retry EnsureConfirmedReq to attach again. An immediate retry
+// can return another error while the actor reconciles an ambiguous broadcast.
 type EnsureConfirmedReq struct {
 	actor.BaseMessage
 


### PR DESCRIPTION
Depends on #1243. Merge #1243 first, then this PR.

## The problem

`txconfirm` lets a second caller attach to transaction tracking that is already in progress. The actor queries the tracked transaction's finite-state machine (FSM) so it can return the current state and replay a terminal result when one exists.

If that state query timed out or the FSM was shutting down, the actor replaced the error with `TxStateFailed`. It also sent the new subscriber a `TxFailed` notification. For example, a transaction could still be broadcasting while a temporary query failure made a caller treat it as terminally failed.

## The fix

State-query errors now leave the subscriber untouched and return through the actor Ask. The per-transaction FSM is owned by the actor after admission, so it no longer shuts down with the original Ask context. Any Ensure error detaches that request's subscriber; the caller must retry to subscribe again.

Failed state transitions propagate through synchronous callers. Background paths retain an unapplied terminal reason and retry that transition before another broadcast. Confirmation or other forward progress clears a stale reason and remains authoritative.

Known terminal failures remain distinct. `TxStateFailed` is returned only after the tracked FSM completes its failure transition, even if successful notification delivery immediately evicts the tracking entry. Successful submissions reuse the state proven by that transition, so response construction does not need a second state query.

This branch is stacked on #1243. Its pre-broadcast subscription setup errors remain request errors. Their bounded cleanup runs before this PR's later state-query and broadcast-error handling.

The paired `txconfirm/CLAUDE.md` and `txconfirm/AGENTS.md` guides now document setup cleanup, Ask-error subscription semantics, deferred terminal transitions, and actor-owned FSM lifetime.

## Safety rule

An unavailable state is not evidence of transaction failure. `TxStateFailed` is returned only after the FSM records a terminal failure.

## What does not change

- Real terminal broadcast failures still notify subscribers and return `TxStateFailed`.
- Successful, pending, confirmed, and finalized responses keep their existing states.
- Public messages, storage, and wire protocols do not change.
- #1243's setup errors remain retryable and never broadcast or emit `TxFailed`.

## Tests

- A repeated ensure against an unavailable FSM returns `ErrStateMachineShutdown`.
- The failed query does not attach the new subscriber or send `TxFailed`.
- A failed terminal transition returns its error without sending `TxFailed` or removing the subscriber.
- Cleanup after a cancelled setup request removes the incomplete tracker, and retry creates working tracking.
- A deferred terminal transition is retried before another broadcast and notifies subscribers only after the state is proven.
- An ambiguous broadcast error detaches the subscriber while retaining the tracker for reconciliation.
- A confirmation that arrives during deferred failure recovery wins and cannot be followed by `TxFailed`.
- Successful forced fee bumps preserve their child transaction ID and fee details without a post-submit state query.
- #1243's block-subscription and confirmation-watch failure regressions pass on the combined branch.
- The full `txconfirm` unit and race suites pass.
- Build, vet, formatting, module tidiness, documentation checks, Go-doc audit, commit-message lint, and changed-code lint pass.

## Compatibility and rollout

Merge #1243 first. This PR is based on its stable signed branch so GitHub reviews and CI exercise the final combined `txconfirm` behavior. After #1243 merges, retarget this PR to `main` without changing its logical commit.

The change affects only internal actor error and context-lifetime semantics. A state-query failure now returns an Ask error where callers previously received a fabricated terminal state. A failed Ensure no longer promises a later subscriber notification, so callers retry the request to subscribe again. No public message, migration, or coordinated deployment is required.

Fixes #1095.
