### PR TITLE
txconfirm: Retry subscription setup failures

### DIFF
--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -44,6 +44,12 @@ const (
 	// cadence from the (block-driven) retry interval so a permanently stuck
 	// tx does not flood the log.
 	broadcastEscalationReminder = 10 * time.Minute
+
+	// setupCleanupTimeout bounds cleanup after a subscription setup error.
+	// Cleanup must outlive the failed Ask context because that context may
+	// already be cancelled. Keep it within the actor's existing one-second
+	// blocking budget so backend failures cannot stall unrelated work.
+	setupCleanupTimeout = time.Second
 )
 
 var (
@@ -626,25 +632,90 @@ func (a *TxBroadcasterActor) handleEnsure(ctx context.Context,
 	a.tracked[txid] = entry
 
 	if err := a.ensureBlockSubscription(ctx); err != nil {
-		a.failTrackedTx(
-			ctx, entry, fmt.Sprintf("subscribe blocks: %v", err),
+		setupErr := fmt.Errorf("subscribe blocks: %w", err)
+		cleanupCtx, cancel := context.WithTimeout(
+			actor.WithoutTx(
+				context.WithoutCancel(ctx),
+			),
+			setupCleanupTimeout,
 		)
+		a.cleanupFailedBlockSubscription(cleanupCtx, entry.data.Txid)
+		a.discardIncompleteTrackedTx(cleanupCtx, entry)
+		cancel()
 
-		return a.ensureResp(entry, true), nil
+		return nil, setupErr
 	}
 
 	if err := a.registerConfWatch(ctx, entry); err != nil {
-		a.failTrackedTx(
-			ctx, entry, fmt.Sprintf("register conf: %v", err),
+		setupErr := fmt.Errorf("register conf: %w", err)
+		cleanupCtx, cancel := context.WithTimeout(
+			actor.WithoutTx(
+				context.WithoutCancel(ctx),
+			),
+			setupCleanupTimeout,
 		)
+		if cleanupErr := a.unregisterConfWatch(
+			cleanupCtx, entry,
+		); cleanupErr != nil {
 
-		return a.ensureResp(entry, true), nil
+			a.log.DebugS(cleanupCtx,
+				"Confirmation watch cleanup failed after setup "+
+					"error",
+				"txid", entry.data.Txid,
+				"caller_id", a.confCallerID(entry.data.Txid),
+				slog.Any("err", cleanupErr),
+			)
+		}
+		a.discardIncompleteTrackedTx(cleanupCtx, entry)
+		cancel()
+
+		return nil, setupErr
 	}
 
 	_, err = a.broadcastTrackedTx(ctx, entry, TxStateBroadcasting)
 	a.recordInitialBroadcastOutcome(ctx, entry, err)
 
 	return a.ensureResp(entry, true), nil
+}
+
+// cleanupFailedBlockSubscription removes a block subscription actor whose
+// setup did not return success. Chainsource creates the actor before asking its
+// backend to subscribe, so an error can leave that actor registered even though
+// txconfirm never marked the shared subscription active.
+func (a *TxBroadcasterActor) cleanupFailedBlockSubscription(ctx context.Context,
+	txid chainhash.Hash) {
+
+	_, err := a.cfg.ChainSource.Ask(
+		ctx, &chainsource.UnsubscribeBlocksRequest{
+			CallerID: a.blockCallerID(),
+		},
+	).Await(ctx).Unpack()
+	if err != nil {
+		a.log.DebugS(
+			ctx, "Block subscription cleanup failed after setup "+
+				"error",
+			"txid", txid,
+			"caller_id", a.blockCallerID(),
+			slog.Any("err", err),
+		)
+	}
+}
+
+// discardIncompleteTrackedTx releases an entry that never finished chain
+// subscription setup. The caller must separately remove any deterministic
+// chainsource subscription actor that the failed setup call may have created.
+func (a *TxBroadcasterActor) discardIncompleteTrackedTx(ctx context.Context,
+	entry *trackedTx) {
+
+	if entry.fsm != nil {
+		entry.fsm.Stop()
+	}
+
+	a.broadcaster.Evict(ctx, entry.data.Txid)
+	a.driveFeeBump(ctx, &feeBumpParentEvicted{
+		parentTxid: entry.data.Txid,
+	})
+	delete(a.tracked, entry.data.Txid)
 }
 
 // recordInitialBroadcastOutcome advances the FSM based on the result of an

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -48,6 +48,8 @@ type fakeChainSourceRef struct {
 
 	broadcastErr error
 	packageErr   error
+	registerErr  error
+	subscribeErr error
 
 	// mempoolAcceptFn lets tests control the outcome of
 	// TestMempoolAcceptRequest. If nil, the fake returns
@@ -436,6 +438,22 @@ func (f *fakeChainSourceRef) unregisterConfCount() int {
 	return len(f.unregisterConfs)
 }
 
+// subscribeBlockCount returns the number of block subscription attempts.
+func (f *fakeChainSourceRef) subscribeBlockCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return len(f.subscribeBlocks)
+}
+
+// unsubscribeBlockCount returns the number of block subscription cleanups.
+func (f *fakeChainSourceRef) unsubscribeBlockCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return len(f.unsubscribeBlocks)
+}
+
 // ID returns the fake actor ID.
 func (f *fakeChainSourceRef) ID() string {
 	return "fake-chainsource"
@@ -526,6 +544,12 @@ func (f *fakeChainSourceRef) handleAsk(_ context.Context,
 				_ = notifyRef.Tell(context.Background(), event)
 			}
 		}
+		if f.registerErr != nil {
+			err := f.registerErr
+			f.registerErr = nil
+
+			return nil, err
+		}
 
 		return &chainsource.RegisterConfResponse{}, nil
 
@@ -543,6 +567,12 @@ func (f *fakeChainSourceRef) handleAsk(_ context.Context,
 	case *chainsource.SubscribeBlocksRequest:
 		f.subscribeBlocks = append(f.subscribeBlocks, req)
 		f.blockNotify = req.NotifyActor.UnwrapOr(nil)
+		if f.subscribeErr != nil {
+			err := f.subscribeErr
+			f.subscribeErr = nil
+
+			return nil, err
+		}
 
 		return &chainsource.SubscribeBlocksResponse{}, nil
 
@@ -1032,6 +1062,116 @@ func TestEnsureConfirmedDedupesTwoSubscribers(t *testing.T) {
 	mustEventually(t, func() bool {
 		return chain.unregisterConfCount() == 1
 	})
+}
+
+// TestEnsureConfirmedRetriesSetupFailures verifies that temporary chain
+// subscription errors remain request errors. The first attempt must not
+// broadcast or report TxFailed, and a retry must create fresh tracking,
+// register observation, broadcast once, and confirm normally.
+func TestEnsureConfirmedRetriesSetupFailures(t *testing.T) {
+	tests := []struct {
+		name              string
+		errorPrefix       string
+		subscribeErr      error
+		registerErr       error
+		firstSubscribes   int
+		firstUnsubscribes int
+		firstRegisters    int
+		firstUnregisters  int
+		retrySubscribes   int
+		retryRegisters    int
+	}{
+		{
+			name:              "subscribe blocks",
+			errorPrefix:       "subscribe blocks",
+			subscribeErr:      fmt.Errorf("backend unavailable"),
+			firstSubscribes:   1,
+			firstUnsubscribes: 1,
+			retrySubscribes:   2,
+			retryRegisters:    1,
+		},
+		{
+			name:             "register confirmation",
+			errorPrefix:      "register conf",
+			registerErr:      fmt.Errorf("backend unavailable"),
+			firstSubscribes:  1,
+			firstRegisters:   1,
+			firstUnregisters: 1,
+			retrySubscribes:  1,
+			retryRegisters:   2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			chain := newFakeChainSourceRef(100)
+			chain.subscribeErr = test.subscribeErr
+			chain.registerErr = test.registerErr
+			ref, behavior := newTestActor(t, Config{
+				ChainSource: chain,
+			})
+
+			tx := makeTestTx(false)
+			txid := tx.TxHash()
+			sub := actor.NewChannelTellOnlyRef[Notification](
+				"sub-setup-retry", 4,
+			)
+			ctx, cancel := context.WithTimeout(
+				t.Context(), testTimeout,
+			)
+			_, err := ref.Ref().Ask(ctx, &EnsureConfirmedReq{
+				Tx:         tx,
+				Subscriber: sub,
+			}).Await(ctx).Unpack()
+			cancel()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.errorPrefix)
+			require.Equal(t, 0, chain.broadcastCallCount())
+			mustHaveNoNotification(t, sub)
+			require.Empty(t, behavior.tracked)
+			require.Empty(t, behavior.broadcaster.parentStates)
+			require.Equal(
+				t, test.firstSubscribes,
+				chain.subscribeBlockCount(),
+			)
+			require.Equal(
+				t, test.firstUnsubscribes,
+				chain.unsubscribeBlockCount(),
+			)
+			require.Equal(
+				t, test.firstRegisters,
+				chain.registerConfCount(),
+			)
+			require.Equal(
+				t, test.firstUnregisters,
+				chain.unregisterConfCount(),
+			)
+
+			resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+				Tx:         tx,
+				Subscriber: sub,
+			})
+			require.True(t, resp.Created)
+			require.Equal(
+				t, TxStateAwaitingConfirmation, resp.State,
+			)
+			require.Equal(t, 1, chain.broadcastCallCount())
+			require.Equal(
+				t, test.retrySubscribes,
+				chain.subscribeBlockCount(),
+			)
+			require.Equal(
+				t, test.retryRegisters,
+				chain.registerConfCount(),
+			)
+
+			chain.emitConfirmation(t, txid, 101)
+			notification := mustAwaitNotification(t, sub)
+			confirmed, ok := notification.(*TxConfirmed)
+			require.True(t, ok)
+			require.Equal(t, txid, confirmed.Txid)
+		})
+	}
 }
 
 // TestLifecycleDeliveryRetriesAfterTellFailure verifies that a transient


### PR DESCRIPTION
## The problem

Before broadcasting a transaction, `txconfirm` registers a shared block subscription and a transaction-specific confirmation watch. A temporary error from either setup call currently produces `TxFailed`, even though no broadcast was attempted.

For example, if the chain backend briefly rejects `SubscribeBlocks`, a proof transaction gets a terminal failure with zero broadcast attempts. The unilateral-exit actor cannot rebuild operator-signed proof transactions, so it treats that false result as terminal and fails the exit.

## The fix

Treat both setup failures as request errors. `txconfirm` now removes the incomplete tracked entry, stops its state machine, releases any transaction-owned broadcaster state, and returns the setup error to the caller. The same transaction can then be retried safely.

Cleanup also removes a deterministic chainsource actor that may have been created before the setup error was returned. The cleanup uses a detached one-second context so a cancelled request cannot strand the partial actor or stall unrelated actor work.

If block subscription succeeds but confirmation registration fails, the shared block subscription stays active. Only the incomplete transaction entry and its confirmation watch are removed.

## Safety rule

A chain-observation setup error is not evidence that a transaction failed. `TxFailed` remains reserved for terminal transaction outcomes after observation setup succeeds.

## What does not change

- Fully initialized entries still deduplicate by transaction ID.
- Existing confirmation, reorganization, finalization, and broadcast-failure behavior is unchanged.
- No protocol, database, or configuration changes are required.

## Tests

`TestEnsureConfirmedRetriesSetupFailures` injects one error into each setup call and proves:

- the first request returns an error, emits no `TxFailed`, and performs no broadcast;
- partial transaction state and deterministic watch actors are removed;
- a confirmation-watch error does not remove the shared block subscription;
- retry creates fresh tracking, registers observation, broadcasts exactly once, and delivers `TxConfirmed`.

Validation:

- `make unit pkg=./txconfirm timeout=5m`
- `make unit-race pkg=./txconfirm timeout=5m`
- `make unit log="stdlog trace" pkg=./txconfirm case=TestEnsureConfirmedRetriesSetupFailures timeout=5m`
- scoped custom lint on `./txconfirm`: 0 issues
- `make tidy-module-check`
- `make fmt-changed-check`
- `go vet ./txconfirm`
- `make build`

## Compatibility and rollout

This changes only the error semantics of pre-broadcast subscription setup. The durable unroll actor persists the error path and reissues in-flight work during restart recovery. Same-process nack redelivery does not currently reissue and remains a separate pre-existing unroll follow-up. No coordinated rollout is required.

Fixes #1184.
