### PR TITLE
vtxo: authenticate expiry against batch evidence

### DIFF
--- a/arkrpc/AGENTS.md
+++ b/arkrpc/AGENTS.md
@@ -22,6 +22,9 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   PSBTs that `IncomingOOREvent` intentionally omits.
 - `VTXO` — Phase 2 query response from `ListVTXOsByScripts`. Carries
   authoritative lineage metadata including the structured `TreePath`.
+- `AncestryPath.commitment_sweep_key` / `commitment_sweep_delay` — Additive
+  evidence that lets clients reconstruct the tree sweep leaf and authenticate
+  an absolute expiry against a locally confirmed commitment transaction.
 
 ## Relationships
 

--- a/arkrpc/CLAUDE.md
+++ b/arkrpc/CLAUDE.md
@@ -22,6 +22,9 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   PSBTs that `IncomingOOREvent` intentionally omits.
 - `VTXO` — Phase 2 query response from `ListVTXOsByScripts`. Carries
   authoritative lineage metadata including the structured `TreePath`.
+- `AncestryPath.commitment_sweep_key` / `commitment_sweep_delay` — Additive
+  evidence that lets clients reconstruct the tree sweep leaf and authenticate
+  an absolute expiry against a locally confirmed commitment transaction.
 
 ## Relationships
 

--- a/arkrpc/indexer.pb.go
+++ b/arkrpc/indexer.pb.go
@@ -1498,8 +1498,16 @@ type AncestryPath struct {
 	// tx anchoring this fragment. Zero means unknown (legacy/unconfirmed),
 	// in which case the client falls back to a bounded lookback floor.
 	CommitmentHeight int32 `protobuf:"varint,5,opt,name=commitment_height,json=commitmentHeight,proto3" json:"commitment_height,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// commitment_sweep_delay is the CSV delay committed by this tree's sweep
+	// tapscript root. New indexers must supply a positive value.
+	CommitmentSweepDelay uint32 `protobuf:"varint,6,opt,name=commitment_sweep_delay,json=commitmentSweepDelay,proto3" json:"commitment_sweep_delay,omitempty"`
+	// commitment_sweep_key is the compressed public key committed by this
+	// tree's sweep tapscript root. Together with commitment_sweep_delay it
+	// lets clients authenticate the absolute expiry derived from the
+	// commitment transaction's confirmation height.
+	CommitmentSweepKey []byte `protobuf:"bytes,7,opt,name=commitment_sweep_key,json=commitmentSweepKey,proto3" json:"commitment_sweep_key,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *AncestryPath) Reset() {
@@ -1565,6 +1573,20 @@ func (x *AncestryPath) GetCommitmentHeight() int32 {
 		return x.CommitmentHeight
 	}
 	return 0
+}
+
+func (x *AncestryPath) GetCommitmentSweepDelay() uint32 {
+	if x != nil {
+		return x.CommitmentSweepDelay
+	}
+	return 0
+}
+
+func (x *AncestryPath) GetCommitmentSweepKey() []byte {
+	if x != nil {
+		return x.CommitmentSweepKey
+	}
+	return nil
 }
 
 // ScriptScope selects a pkScript and carries a proof-of-control for that
@@ -1729,8 +1751,12 @@ type VTXO struct {
 	// IncomingVTXOEvent) does not yet carry this field and adopts it as a
 	// fast-follow. Today the only understood value is 1.
 	ConstructionVersion uint32 `protobuf:"varint,20,opt,name=construction_version,json=constructionVersion,proto3" json:"construction_version,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// ancestry_packages connects round-tree leaves to this OOR output.
+	// Packages are finalized and ordered ancestor-first, with the creating
+	// session last. Round-direct VTXOs leave this empty.
+	AncestryPackages []*OORSessionPackage `protobuf:"bytes,21,rep,name=ancestry_packages,json=ancestryPackages,proto3" json:"ancestry_packages,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *VTXO) Reset() {
@@ -1887,6 +1913,13 @@ func (x *VTXO) GetConstructionVersion() uint32 {
 		return x.ConstructionVersion
 	}
 	return 0
+}
+
+func (x *VTXO) GetAncestryPackages() []*OORSessionPackage {
+	if x != nil {
+		return x.AncestryPackages
+	}
+	return nil
 }
 
 type ListVTXOsByScriptsRequest struct {
@@ -2803,20 +2836,22 @@ const file_indexer_proto_rawDesc = "" +
 	"\x05nodes\x18\x01 \x03(\v2\x14.arkrpc.TreePathNodeR\x05nodes\x127\n" +
 	"\x0ebatch_outpoint\x18\x02 \x01(\v2\x10.arkrpc.OutPointR\rbatchOutpoint\x120\n" +
 	"\fbatch_output\x18\x03 \x01(\v2\r.arkrpc.TxOutR\vbatchOutput\x120\n" +
-	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"\xd7\x01\n" +
+	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"\xbf\x02\n" +
 	"\fAncestryPath\x12-\n" +
 	"\ttree_path\x18\x01 \x01(\v2\x10.arkrpc.TreePathR\btreePath\x12'\n" +
 	"\x0fcommitment_txid\x18\x02 \x01(\fR\x0ecommitmentTxid\x12#\n" +
 	"\rinput_indices\x18\x03 \x03(\rR\finputIndices\x12\x1d\n" +
 	"\n" +
 	"tree_depth\x18\x04 \x01(\rR\ttreeDepth\x12+\n" +
-	"\x11commitment_height\x18\x05 \x01(\x05R\x10commitmentHeight\"\xaa\x01\n" +
+	"\x11commitment_height\x18\x05 \x01(\x05R\x10commitmentHeight\x124\n" +
+	"\x16commitment_sweep_delay\x18\x06 \x01(\rR\x14commitmentSweepDelay\x120\n" +
+	"\x14commitment_sweep_key\x18\a \x01(\fR\x12commitmentSweepKey\"\xaa\x01\n" +
 	"\vScriptScope\x12\x1b\n" +
 	"\tpk_script\x18\x01 \x01(\fR\bpkScript\x12F\n" +
 	"\x0ftaproot_schnorr\x18\n" +
 	" \x01(\v2\x1b.arkrpc.TaprootSchnorrProofH\x00R\x0etaprootSchnorr\x12-\n" +
 	"\x06bip322\x18\v \x01(\v2\x13.arkrpc.BIP322ProofH\x00R\x06bip322B\a\n" +
-	"\x05proof\"\xe2\x05\n" +
+	"\x05proof\"\xaa\x06\n" +
 	"\x04VTXO\x12,\n" +
 	"\boutpoint\x18\x01 \x01(\v2\x10.arkrpc.OutPointR\boutpoint\x12\x1b\n" +
 	"\tvalue_sat\x18\x02 \x01(\x04R\bvalueSat\x12\x1b\n" +
@@ -2838,7 +2873,8 @@ const file_indexer_proto_rawDesc = "" +
 	"\rspent_by_txid\x18\x11 \x01(\fR\vspentByTxid\x12;\n" +
 	"\x0eancestry_paths\x18\x12 \x03(\v2\x14.arkrpc.AncestryPathR\rancestryPaths\x12'\n" +
 	"\x0foperator_pubkey\x18\x13 \x01(\fR\x0eoperatorPubkey\x121\n" +
-	"\x14construction_version\x18\x14 \x01(\rR\x13constructionVersion\"\xb1\x01\n" +
+	"\x14construction_version\x18\x14 \x01(\rR\x13constructionVersion\x12F\n" +
+	"\x11ancestry_packages\x18\x15 \x03(\v2\x19.arkrpc.OORSessionPackageR\x10ancestryPackages\"\xb1\x01\n" +
 	"\x19ListVTXOsByScriptsRequest\x12-\n" +
 	"\ascripts\x18\x01 \x03(\v2\x13.arkrpc.ScriptScopeR\ascripts\x127\n" +
 	"\rstatus_filter\x18\x02 \x03(\x0e2\x12.arkrpc.VTXOStatusR\fstatusFilter\x12\x16\n" +
@@ -3006,45 +3042,46 @@ var file_indexer_proto_depIdxs = []int32{
 	17, // 18: arkrpc.VTXO.outpoint:type_name -> arkrpc.OutPoint
 	0,  // 19: arkrpc.VTXO.status:type_name -> arkrpc.VTXOStatus
 	21, // 20: arkrpc.VTXO.ancestry_paths:type_name -> arkrpc.AncestryPath
-	22, // 21: arkrpc.ListVTXOsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
-	0,  // 22: arkrpc.ListVTXOsByScriptsRequest.status_filter:type_name -> arkrpc.VTXOStatus
-	23, // 23: arkrpc.ListVTXOsByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
-	22, // 24: arkrpc.GetOORSessionByTxidRequest.script:type_name -> arkrpc.ScriptScope
-	17, // 25: arkrpc.TreeNode.input:type_name -> arkrpc.OutPoint
-	22, // 26: arkrpc.GetSubtreeByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
-	23, // 27: arkrpc.GetSubtreeByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
-	28, // 28: arkrpc.GetSubtreeByScriptsResponse.nodes:type_name -> arkrpc.TreeNode
-	29, // 29: arkrpc.GetSubtreeByScriptsResponse.edges:type_name -> arkrpc.TreeEdge
-	1,  // 30: arkrpc.VTXOEvent.type:type_name -> arkrpc.VTXOEventType
-	17, // 31: arkrpc.VTXOEvent.outpoint:type_name -> arkrpc.OutPoint
-	0,  // 32: arkrpc.VTXOEvent.status:type_name -> arkrpc.VTXOStatus
-	22, // 33: arkrpc.ListVTXOEventsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
-	32, // 34: arkrpc.ListVTXOEventsByScriptsResponse.events:type_name -> arkrpc.VTXOEvent
-	1,  // 35: arkrpc.IncomingVTXOEvent.type:type_name -> arkrpc.VTXOEventType
-	17, // 36: arkrpc.IncomingVTXOEvent.outpoint:type_name -> arkrpc.OutPoint
-	0,  // 37: arkrpc.IncomingVTXOEvent.status:type_name -> arkrpc.VTXOStatus
-	2,  // 38: arkrpc.IncomingVTXOEvent.origin:type_name -> arkrpc.VTXOOrigin
-	3,  // 39: arkrpc.IndexerService.RegisterReceiveScript:input_type -> arkrpc.RegisterReceiveScriptRequest
-	8,  // 40: arkrpc.IndexerService.ListMyReceiveScripts:input_type -> arkrpc.ListMyReceiveScriptsRequest
-	7,  // 41: arkrpc.IndexerService.UnregisterReceiveScript:input_type -> arkrpc.UnregisterReceiveScriptRequest
-	12, // 42: arkrpc.IndexerService.ListOORRecipientEventsByScript:input_type -> arkrpc.ListOORRecipientEventsByScriptRequest
-	24, // 43: arkrpc.IndexerService.ListVTXOsByScripts:input_type -> arkrpc.ListVTXOsByScriptsRequest
-	26, // 44: arkrpc.IndexerService.GetOORSessionByTxid:input_type -> arkrpc.GetOORSessionByTxidRequest
-	30, // 45: arkrpc.IndexerService.GetSubtreeByScripts:input_type -> arkrpc.GetSubtreeByScriptsRequest
-	33, // 46: arkrpc.IndexerService.ListVTXOEventsByScripts:input_type -> arkrpc.ListVTXOEventsByScriptsRequest
-	6,  // 47: arkrpc.IndexerService.RegisterReceiveScript:output_type -> arkrpc.RegisterReceiveScriptResponse
-	9,  // 48: arkrpc.IndexerService.ListMyReceiveScripts:output_type -> arkrpc.ListMyReceiveScriptsResponse
-	11, // 49: arkrpc.IndexerService.UnregisterReceiveScript:output_type -> arkrpc.UnregisterReceiveScriptResponse
-	13, // 50: arkrpc.IndexerService.ListOORRecipientEventsByScript:output_type -> arkrpc.ListOORRecipientEventsByScriptResponse
-	25, // 51: arkrpc.IndexerService.ListVTXOsByScripts:output_type -> arkrpc.ListVTXOsByScriptsResponse
-	27, // 52: arkrpc.IndexerService.GetOORSessionByTxid:output_type -> arkrpc.GetOORSessionByTxidResponse
-	31, // 53: arkrpc.IndexerService.GetSubtreeByScripts:output_type -> arkrpc.GetSubtreeByScriptsResponse
-	34, // 54: arkrpc.IndexerService.ListVTXOEventsByScripts:output_type -> arkrpc.ListVTXOEventsByScriptsResponse
-	47, // [47:55] is the sub-list for method output_type
-	39, // [39:47] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	15, // 21: arkrpc.VTXO.ancestry_packages:type_name -> arkrpc.OORSessionPackage
+	22, // 22: arkrpc.ListVTXOsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
+	0,  // 23: arkrpc.ListVTXOsByScriptsRequest.status_filter:type_name -> arkrpc.VTXOStatus
+	23, // 24: arkrpc.ListVTXOsByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
+	22, // 25: arkrpc.GetOORSessionByTxidRequest.script:type_name -> arkrpc.ScriptScope
+	17, // 26: arkrpc.TreeNode.input:type_name -> arkrpc.OutPoint
+	22, // 27: arkrpc.GetSubtreeByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
+	23, // 28: arkrpc.GetSubtreeByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
+	28, // 29: arkrpc.GetSubtreeByScriptsResponse.nodes:type_name -> arkrpc.TreeNode
+	29, // 30: arkrpc.GetSubtreeByScriptsResponse.edges:type_name -> arkrpc.TreeEdge
+	1,  // 31: arkrpc.VTXOEvent.type:type_name -> arkrpc.VTXOEventType
+	17, // 32: arkrpc.VTXOEvent.outpoint:type_name -> arkrpc.OutPoint
+	0,  // 33: arkrpc.VTXOEvent.status:type_name -> arkrpc.VTXOStatus
+	22, // 34: arkrpc.ListVTXOEventsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
+	32, // 35: arkrpc.ListVTXOEventsByScriptsResponse.events:type_name -> arkrpc.VTXOEvent
+	1,  // 36: arkrpc.IncomingVTXOEvent.type:type_name -> arkrpc.VTXOEventType
+	17, // 37: arkrpc.IncomingVTXOEvent.outpoint:type_name -> arkrpc.OutPoint
+	0,  // 38: arkrpc.IncomingVTXOEvent.status:type_name -> arkrpc.VTXOStatus
+	2,  // 39: arkrpc.IncomingVTXOEvent.origin:type_name -> arkrpc.VTXOOrigin
+	3,  // 40: arkrpc.IndexerService.RegisterReceiveScript:input_type -> arkrpc.RegisterReceiveScriptRequest
+	8,  // 41: arkrpc.IndexerService.ListMyReceiveScripts:input_type -> arkrpc.ListMyReceiveScriptsRequest
+	7,  // 42: arkrpc.IndexerService.UnregisterReceiveScript:input_type -> arkrpc.UnregisterReceiveScriptRequest
+	12, // 43: arkrpc.IndexerService.ListOORRecipientEventsByScript:input_type -> arkrpc.ListOORRecipientEventsByScriptRequest
+	24, // 44: arkrpc.IndexerService.ListVTXOsByScripts:input_type -> arkrpc.ListVTXOsByScriptsRequest
+	26, // 45: arkrpc.IndexerService.GetOORSessionByTxid:input_type -> arkrpc.GetOORSessionByTxidRequest
+	30, // 46: arkrpc.IndexerService.GetSubtreeByScripts:input_type -> arkrpc.GetSubtreeByScriptsRequest
+	33, // 47: arkrpc.IndexerService.ListVTXOEventsByScripts:input_type -> arkrpc.ListVTXOEventsByScriptsRequest
+	6,  // 48: arkrpc.IndexerService.RegisterReceiveScript:output_type -> arkrpc.RegisterReceiveScriptResponse
+	9,  // 49: arkrpc.IndexerService.ListMyReceiveScripts:output_type -> arkrpc.ListMyReceiveScriptsResponse
+	11, // 50: arkrpc.IndexerService.UnregisterReceiveScript:output_type -> arkrpc.UnregisterReceiveScriptResponse
+	13, // 51: arkrpc.IndexerService.ListOORRecipientEventsByScript:output_type -> arkrpc.ListOORRecipientEventsByScriptResponse
+	25, // 52: arkrpc.IndexerService.ListVTXOsByScripts:output_type -> arkrpc.ListVTXOsByScriptsResponse
+	27, // 53: arkrpc.IndexerService.GetOORSessionByTxid:output_type -> arkrpc.GetOORSessionByTxidResponse
+	31, // 54: arkrpc.IndexerService.GetSubtreeByScripts:output_type -> arkrpc.GetSubtreeByScriptsResponse
+	34, // 55: arkrpc.IndexerService.ListVTXOEventsByScripts:output_type -> arkrpc.ListVTXOEventsByScriptsResponse
+	48, // [48:56] is the sub-list for method output_type
+	40, // [40:48] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_indexer_proto_init() }

--- a/arkrpc/indexer.proto
+++ b/arkrpc/indexer.proto
@@ -317,6 +317,16 @@ message AncestryPath {
     // tx anchoring this fragment. Zero means unknown (legacy/unconfirmed),
     // in which case the client falls back to a bounded lookback floor.
     int32 commitment_height = 5;
+
+    // commitment_sweep_delay is the CSV delay committed by this tree's sweep
+    // tapscript root. New indexers must supply a positive value.
+    uint32 commitment_sweep_delay = 6;
+
+    // commitment_sweep_key is the compressed public key committed by this
+    // tree's sweep tapscript root. Together with commitment_sweep_delay it
+    // lets clients authenticate the absolute expiry derived from the
+    // commitment transaction's confirmation height.
+    bytes commitment_sweep_key = 7;
 }
 
 // ScriptScope selects a pkScript and carries a proof-of-control for that
@@ -456,6 +466,11 @@ message VTXO {
     // IncomingVTXOEvent) does not yet carry this field and adopts it as a
     // fast-follow. Today the only understood value is 1.
     uint32 construction_version = 20;
+
+    // ancestry_packages connects round-tree leaves to this OOR output.
+    // Packages are finalized and ordered ancestor-first, with the creating
+    // session last. Round-direct VTXOs leave this empty.
+    repeated OORSessionPackage ancestry_packages = 21;
 }
 
 message ListVTXOsByScriptsRequest {

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ into specific topics below.
 | [seed_restore_recovery.md](seed_restore_recovery.md) | Restore a self-managed seed and recover Ark state from chain/indexer data |
 | [swap_background_execution.md](swap_background_execution.md) | Optional build-tagged daemon executor for background swap progress and daemon-backed CLI control |
 | [mailbox_architecture.md](mailbox_architecture.md) | Three-layer mailbox system: pb, rpc, conn, serverconn |
+| [mailbox_ingress_safety.md](mailbox_ingress_safety.md) | Durable ingress handoff, quarantine, replay retention, and recovery |
 | [mailbox_durable_actor_layer.md](mailbox_durable_actor_layer.md) | The durable mailbox and durable actor: leases, dedup, transactional outbox, DurableAsk, and the classic vs. Read/Commit (`TxBehavior`/`Exec[S]`) execution paths |
 | [mailbox_transport_serverconn_clientconn.md](mailbox_transport_serverconn_clientconn.md) | The RPC-over-mailbox transport relating this client's `serverconn` to the operator's `clientconn`: envelope, edge API, shared `mailbox/conn` primitives, ack watermark, identity/auth/liveness, and the wire contract |
 | [RPC_MAILBOX_CONTRACT.md](RPC_MAILBOX_CONTRACT.md) | Envelope semantics, at-least-once delivery, ack watermarks |

--- a/internal/expiryfixture/fixture.go
+++ b/internal/expiryfixture/fixture.go
@@ -1,0 +1,233 @@
+// Package expiryfixture builds signed ancestry for acceptance-boundary tests.
+package expiryfixture
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// Round returns a signed round-direct inventory entry and its commitment.
+// The tag makes independent fixtures use distinct, reproducible commitment IDs.
+func Round(t testing.TB, value int64, script []byte, delay uint32, height int32,
+	tag byte) (*arkrpc.VTXO, *wire.MsgTx) {
+
+	t.Helper()
+	_, ownerPub := btcec.PrivKeyFromBytes([]byte{tag, 1})
+	_, operatorPub := btcec.PrivKeyFromBytes([]byte{tag, 2})
+	keys := []*btcec.PublicKey{ownerPub, operatorPub}
+	leaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(operatorPub, delay)
+	require.NoError(t, err)
+	sweep := leaf.TapHash()
+	finalKey, err := tree.ComputeFinalKey(keys, sweep[:])
+	require.NoError(t, err)
+	batchScript, err := txscript.PayToTaprootScript(finalKey)
+	require.NoError(t, err)
+	commitment := wire.NewMsgTx(2)
+	commitment.AddTxIn(
+		&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{
+				Hash: chainhash.Hash{tag},
+			},
+		},
+	)
+	commitment.AddTxOut(&wire.TxOut{Value: value, PkScript: batchScript})
+	commitmentID := commitment.TxHash()
+	anchor := arkscript.AnchorPkScript
+	node := &tree.Node{
+		Input: wire.OutPoint{
+			Hash: commitmentID,
+		},
+		Outputs: []*wire.TxOut{
+			{
+				Value:    value,
+				PkScript: script,
+			},
+			{
+				PkScript: anchor,
+			},
+		},
+		CoSigners: keys,
+		FinalKey:  finalKey,
+	}
+	path := &tree.Tree{
+		Root: node, BatchOutpoint: node.Input,
+		BatchOutput: commitment.TxOut[0], SweepTapscriptRoot: sweep[:],
+	}
+	signNode(t, node, commitment.TxOut[0], sweep[:], tag)
+	require.NoError(t, path.VerifySigned())
+	rpcPath, err := arkrpc.AncestryPathFromTree(path, commitmentID, nil)
+	require.NoError(t, err)
+	rpcPath.CommitmentSweepKey = operatorPub.SerializeCompressed()
+	rpcPath.CommitmentSweepDelay = delay
+	rpcPath.CommitmentHeight = height
+	txid, err := node.TXID()
+	require.NoError(t, err)
+
+	return &arkrpc.VTXO{
+		Outpoint: &arkrpc.OutPoint{
+			Txid: txid[:],
+		},
+		ValueSat: uint64(value), PkScript: script,
+		RoundId: "proof-round", CommitmentTxid: commitmentID[:],
+		AncestryPaths: []*arkrpc.AncestryPath{
+			rpcPath,
+		},
+		CreatedHeight: height,
+		Status:        arkrpc.VTXOStatus_VTXO_STATUS_LIVE,
+	}, commitment
+}
+
+// signNode signs a tree node under the fixture's deterministic cosigner keys.
+func signNode(t testing.TB, node *tree.Node, prev *wire.TxOut, sweep []byte,
+	tag byte) {
+
+	t.Helper()
+	owner, _ := btcec.PrivKeyFromBytes([]byte{tag, 1})
+	operator, _ := btcec.PrivKeyFromBytes([]byte{tag, 2})
+	fetcher := txscript.NewCannedPrevOutputFetcher(
+		prev.PkScript, prev.Value,
+	)
+	digest, err := node.SigHash(fetcher)
+	require.NoError(t, err)
+	var msg [32]byte
+	copy(msg[:], digest)
+	sessions := make([]*musig2.Session, 2)
+	for i, key := range []*btcec.PrivateKey{owner, operator} {
+		ctx, err := musig2.NewContext(
+			key, true, musig2.WithKnownSigners(node.CoSigners),
+			musig2.WithTaprootTweakCtx(sweep),
+		)
+		require.NoError(t, err)
+		sessions[i], err = ctx.NewSession()
+		require.NoError(t, err)
+	}
+	_, err = sessions[0].RegisterPubNonce(sessions[1].PublicNonce())
+	require.NoError(t, err)
+	_, err = sessions[1].RegisterPubNonce(sessions[0].PublicNonce())
+	require.NoError(t, err)
+	_, err = sessions[0].Sign(msg)
+	require.NoError(t, err)
+	part, err := sessions[1].Sign(msg)
+	require.NoError(t, err)
+	_, err = sessions[0].CombineSig(part)
+	require.NoError(t, err)
+	node.Signature = sessions[0].FinalSig()
+}
+
+// Merge builds a signed transaction consuming two round leaves. sameBatch tests
+// distinct rooted paths within one confirmed commitment; otherwise the parents
+// expire at different heights. The returned package is sufficient to test the
+// inventory proof graph without invoking the OOR state machine.
+func Merge(t testing.TB, sameBatch bool) (*arkrpc.VTXO, []*wire.MsgTx) {
+	t.Helper()
+	key, pub := btcec.PrivKeyFromBytes([]byte{99})
+	script, err := txscript.PayToTaprootScript(
+		txscript.ComputeTaprootKeyNoScript(pub),
+	)
+	require.NoError(t, err)
+	first, firstCommit := Round(t, 10000, script, 50, 100, 10)
+	second, secondCommit := Round(t, 10000, script, 20, 120, 11)
+	parents := []*arkrpc.VTXO{first, second}
+	commits := []*wire.MsgTx{firstCommit, secondCommit}
+	if sameBatch {
+		combined := firstCommit.Copy()
+		combined.AddTxOut(secondCommit.TxOut[0])
+		hash := combined.TxHash()
+		for i, parent := range parents {
+			path, err := arkrpc.AncestryPathToTree(
+				parent.AncestryPaths[0],
+			)
+			require.NoError(t, err)
+			path.BatchOutpoint = wire.OutPoint{
+				Hash:  hash,
+				Index: uint32(i),
+			}
+			path.Root.Input = path.BatchOutpoint
+			signNode(
+				t, path.Root, path.BatchOutput,
+				path.SweepTapscriptRoot, byte(10+i),
+			)
+			rpcPath, err := arkrpc.AncestryPathFromTree(
+				path, hash, []uint32{uint32(i)},
+			)
+			require.NoError(t, err)
+			previous := parent.AncestryPaths[0]
+			rpcPath.CommitmentSweepKey = previous.CommitmentSweepKey
+			delay := previous.CommitmentSweepDelay
+			rpcPath.CommitmentSweepDelay = delay
+			rpcPath.CommitmentHeight = 100
+			parent.AncestryPaths = []*arkrpc.AncestryPath{rpcPath}
+			parent.CommitmentTxid = hash[:]
+			leafHash, err := path.Root.TXID()
+			require.NoError(t, err)
+			parent.Outpoint.Txid = leafHash[:]
+		}
+		commits = []*wire.MsgTx{combined}
+	}
+	tx := wire.NewMsgTx(3)
+	prevouts := txscript.NewMultiPrevOutFetcher(nil)
+	for _, parent := range parents {
+		var hash chainhash.Hash
+		copy(hash[:], parent.Outpoint.Txid)
+		op := wire.OutPoint{Hash: hash}
+		tx.AddTxIn(
+			&wire.TxIn{
+				PreviousOutPoint: op,
+				Sequence:         wire.MaxTxInSequenceNum,
+			},
+		)
+		prevouts.AddPrevOut(
+			op, &wire.TxOut{
+				Value:    int64(parent.ValueSat),
+				PkScript: parent.PkScript,
+			},
+		)
+	}
+	tx.AddTxOut(&wire.TxOut{Value: 20000, PkScript: script})
+	tx.AddTxOut(&wire.TxOut{PkScript: arkscript.AnchorPkScript})
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+	hashes := txscript.NewTxSigHashes(tx, prevouts)
+	for i := range tx.TxIn {
+		sig, err := txscript.RawTxInTaprootSignature(
+			tx, hashes, i, 10000, script, nil,
+			txscript.SigHashDefault, key,
+		)
+		require.NoError(t, err)
+		packet.Inputs[i].TaprootKeySpendSig = sig
+	}
+	raw, err := psbtutil.Serialize(packet)
+	require.NoError(t, err)
+	hash := tx.TxHash()
+	result, ok := proto.Clone(first).(*arkrpc.VTXO)
+	require.True(t, ok)
+	result.Outpoint = &arkrpc.OutPoint{Txid: hash[:]}
+	result.ValueSat = 20000
+	result.ChainDepth = 1
+	result.AncestryPaths = append(
+		result.AncestryPaths, second.AncestryPaths...,
+	)
+	for i, path := range result.AncestryPaths {
+		path.InputIndices = []uint32{uint32(i)}
+	}
+	result.AncestryPackages = []*arkrpc.OORSessionPackage{
+		{
+			SessionId: hash[:],
+			ArkPsbt:   raw,
+		},
+	}
+
+	return result, commits
+}

--- a/lib/types/ancestry.go
+++ b/lib/types/ancestry.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/lightninglabs/wavelength/lib/tree"
 )
@@ -51,6 +52,14 @@ type Ancestry struct {
 	// which case callers fall back to a bounded lookback floor rather than
 	// trusting this value.
 	CommitmentHeight int32
+
+	// CommitmentSweepDelay is the positive CSV delay authenticated against
+	// TreePath.SweepTapscriptRoot at the indexer ingress boundary.
+	CommitmentSweepDelay uint32
+
+	// CommitmentSweepKey is the sweep key authenticated together with
+	// CommitmentSweepDelay against TreePath.SweepTapscriptRoot.
+	CommitmentSweepKey *btcec.PublicKey
 }
 
 // MaxAncestryTreeDepth returns the largest TreeDepth across the given

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -57,6 +57,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
 
 ## Invariants
 
+- Indexed VTXOs pass `vtxo.IndexedAncestryFromRPC` before new acceptance.
+  It verifies signed tree/transaction paths to the exact target outpoint,
+  value, and script. OOR inventory includes `ancestry_packages` to connect
+  round leaves to the target. Sweep expiry is then derived separately from
+  locally confirmed batch outputs. A valid unrelated batch cannot authorize
+  a received target. Existing persisted live rows are outside this check.
+
 - Checkpoint collab output is 2-of-2
   (`arkscript.MultiSigCollabTapLeaf(clientKey, operatorKey)`), never
   single-sig; resumed custom-spend inputs are re-verified against the VTXO
@@ -75,6 +82,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
   actor's DB transaction; both phase-1 hint resolution and phase-2
   authoritative metadata lookup go through durable `serverconn` query
   messages and return as fresh events.
+- Incoming batch expiry is authenticated by
+  `AuthenticateIncomingMetadataRequest` before materialization opens its DB
+  transaction. Indexer expiry scalars are discarded. Chain failures retry the
+  outbox; invalid sweep/tree evidence fails terminally. The descriptor's
+  relative expiry comes from its matching standard or custom policy template,
+  not from operator configuration. Custom policies consider only canonical
+  block-mode CSV sequences; CLTV non-final sentinels are not block delays.
 - Snapshots are versioned per direction (`OutgoingSnapshot.Version = 5`,
   `IncomingSnapshot.Version = 1`); restore rejects a zero version. Outgoing
   v5 adds the `FirstRejectUnixNanos` record (bounded transient submit-reject

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -57,6 +57,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
 
 ## Invariants
 
+- Indexed VTXOs pass `vtxo.IndexedAncestryFromRPC` before new acceptance.
+  It verifies signed tree/transaction paths to the exact target outpoint,
+  value, and script. OOR inventory includes `ancestry_packages` to connect
+  round leaves to the target. Sweep expiry is then derived separately from
+  locally confirmed batch outputs. A valid unrelated batch cannot authorize
+  a received target. Existing persisted live rows are outside this check.
+
 - Checkpoint collab output is 2-of-2
   (`arkscript.MultiSigCollabTapLeaf(clientKey, operatorKey)`), never
   single-sig; resumed custom-spend inputs are re-verified against the VTXO
@@ -75,6 +82,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
   actor's DB transaction; both phase-1 hint resolution and phase-2
   authoritative metadata lookup go through durable `serverconn` query
   messages and return as fresh events.
+- Incoming batch expiry is authenticated by
+  `AuthenticateIncomingMetadataRequest` before materialization opens its DB
+  transaction. Indexer expiry scalars are discarded. Chain failures retry the
+  outbox; invalid sweep/tree evidence fails terminally. The descriptor's
+  relative expiry comes from its matching standard or custom policy template,
+  not from operator configuration. Custom policies consider only canonical
+  block-mode CSV sequences; CLTV non-final sentinels are not block delays.
 - Snapshots are versioned per direction (`OutgoingSnapshot.Version = 5`,
   `IncomingSnapshot.Version = 1`); restore rejects a zero version. Outgoing
   v5 adds the `FirstRejectUnixNanos` record (bounded transient submit-reject

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -152,6 +152,7 @@ const (
 	incomingMetadataMatchCreatedHeightRecordType  tlv.Type = 13
 	incomingMetadataMatchAncestryPathsRecordType  tlv.Type = 17
 	incomingMetadataMatchOperatorKeyRecordType    tlv.Type = 19
+	incomingMetadataMatchExpiryAuthRecordType     tlv.Type = 21
 )
 
 type startTransferPayload struct {
@@ -472,6 +473,9 @@ const (
 	ancestryPathCommitmentTxIDRecordType tlv.Type = 3
 	ancestryPathInputIndicesRecordType   tlv.Type = 5
 	ancestryPathTreeDepthRecordType      tlv.Type = 7
+	ancestryPathCommitmentHeightType     tlv.Type = 9
+	ancestryPathSweepDelayRecordType     tlv.Type = 11
+	ancestryPathSweepKeyRecordType       tlv.Type = 13
 )
 
 // encodeAncestryList encodes []vtxo.Ancestry as a length-prefixed blob
@@ -519,6 +523,11 @@ func decodeAncestryListWithLimits(raw []byte,
 
 // encodeAncestryEntry encodes one vtxo.Ancestry into a TLV blob.
 func encodeAncestryEntry(a vtxo.Ancestry) ([]byte, error) {
+	if a.CommitmentHeight < 0 {
+		return nil, fmt.Errorf("ancestry commitment height must not " +
+			"be negative")
+	}
+
 	var treePath []byte
 	if a.TreePath != nil {
 		var err error
@@ -533,6 +542,9 @@ func encodeAncestryEntry(a vtxo.Ancestry) ([]byte, error) {
 	// Serialize input_indices as a length-prefixed list of uint32.
 	indices := encodeUint32List(a.InputIndices)
 	treeDepth := a.TreeDepth
+	commitmentHeight := uint32(a.CommitmentHeight)
+	sweepDelay := a.CommitmentSweepDelay
+	sweepKey := encodeOptionalPubKey(a.CommitmentSweepKey)
 
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(
@@ -546,6 +558,15 @@ func encodeAncestryEntry(a vtxo.Ancestry) ([]byte, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			ancestryPathTreeDepthRecordType, &treeDepth,
+		),
+		tlv.MakePrimitiveRecord(
+			ancestryPathCommitmentHeightType, &commitmentHeight,
+		),
+		tlv.MakePrimitiveRecord(
+			ancestryPathSweepDelayRecordType, &sweepDelay,
+		),
+		tlv.MakePrimitiveRecord(
+			ancestryPathSweepKeyRecordType, &sweepKey,
 		),
 	}
 
@@ -565,10 +586,13 @@ func encodeAncestryEntry(a vtxo.Ancestry) ([]byte, error) {
 // decodeAncestryEntry is the inverse of encodeAncestryEntry.
 func decodeAncestryEntry(raw []byte) (vtxo.Ancestry, error) {
 	var (
-		treePath       []byte
-		commitmentTxID []byte
-		indicesRaw     []byte
-		treeDepth      uint32
+		treePath         []byte
+		commitmentTxID   []byte
+		indicesRaw       []byte
+		treeDepth        uint32
+		commitmentHeight uint32
+		sweepDelay       uint32
+		sweepKey         []byte
 	)
 
 	records := []tlv.Record{
@@ -583,6 +607,15 @@ func decodeAncestryEntry(raw []byte) (vtxo.Ancestry, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			ancestryPathTreeDepthRecordType, &treeDepth,
+		),
+		tlv.MakePrimitiveRecord(
+			ancestryPathCommitmentHeightType, &commitmentHeight,
+		),
+		tlv.MakePrimitiveRecord(
+			ancestryPathSweepDelayRecordType, &sweepDelay,
+		),
+		tlv.MakePrimitiveRecord(
+			ancestryPathSweepKeyRecordType, &sweepKey,
 		),
 	}
 
@@ -618,11 +651,25 @@ func decodeAncestryEntry(raw []byte) (vtxo.Ancestry, error) {
 		}
 	}
 
+	decodedSweepKey, err := decodeOptionalPubKey(
+		sweepKey, "ancestry sweep key",
+	)
+	if err != nil {
+		return vtxo.Ancestry{}, err
+	}
+	if commitmentHeight > math.MaxInt32 {
+		return vtxo.Ancestry{}, fmt.Errorf("ancestry commitment " +
+			"height overflows int32")
+	}
+
 	return vtxo.Ancestry{
-		TreePath:       decodedTreePath,
-		CommitmentTxID: decodedCommitmentTxID,
-		InputIndices:   indices,
-		TreeDepth:      treeDepth,
+		TreePath:             decodedTreePath,
+		CommitmentTxID:       decodedCommitmentTxID,
+		InputIndices:         indices,
+		TreeDepth:            treeDepth,
+		CommitmentHeight:     int32(commitmentHeight),
+		CommitmentSweepDelay: sweepDelay,
+		CommitmentSweepKey:   decodedSweepKey,
 	}, nil
 }
 
@@ -680,6 +727,8 @@ func decodeUint32List(raw []byte) ([]uint32, error) {
 	return out, nil
 }
 
+// encodeIncomingMetadataMatch persists the locally authenticated expiry flag
+// with its ancestry so durable redelivery preserves the acceptance decision.
 func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 	outputIndex := match.OutputIndex
 	roundID := []byte(match.Metadata.RoundID)
@@ -688,6 +737,10 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 	chainDepth := uint32(match.Metadata.ChainDepth)
 	createdHeight := uint32(match.Metadata.CreatedHeight)
 	operatorKey := encodeOptionalPubKey(match.Metadata.OperatorKey)
+	var expiryAuthenticated uint8
+	if match.Metadata.ExpiryAuthenticated {
+		expiryAuthenticated = 1
+	}
 
 	ancestryBytes, err := encodeAncestryList(match.Metadata.Ancestry)
 	if err != nil {
@@ -725,6 +778,10 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 			incomingMetadataMatchOperatorKeyRecordType,
 			&operatorKey,
 		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchExpiryAuthRecordType,
+			&expiryAuthenticated,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -754,6 +811,7 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 		createdHeight  uint32
 		ancestryBytes  []byte
 		operatorKey    []byte
+		expiryAuth     uint8
 	)
 
 	records := []tlv.Record{
@@ -787,6 +845,9 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 			incomingMetadataMatchOperatorKeyRecordType,
 			&operatorKey,
 		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchExpiryAuthRecordType, &expiryAuth,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -802,6 +863,10 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 	if len(commitmentTxID) != chainhash.HashSize {
 		return IncomingMetadataMatch{}, fmt.Errorf("incoming " +
 			"metadata commitment txid must be provided")
+	}
+	if expiryAuth > 1 {
+		return IncomingMetadataMatch{}, fmt.Errorf("incoming " +
+			"metadata expiry authentication flag must be 0 or 1")
 	}
 
 	decodedBatchExpiry, err := uint32ToInt32(
@@ -843,13 +908,14 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 	return IncomingMetadataMatch{
 		OutputIndex: outputIndex,
 		Metadata: IncomingVTXOMetadata{
-			RoundID:        string(roundID),
-			CommitmentTxID: decodedCommitmentTxID,
-			BatchExpiry:    decodedBatchExpiry,
-			ChainDepth:     int(decodedChainDepth),
-			CreatedHeight:  decodedCreatedHeight,
-			OperatorKey:    decodedOperatorKey,
-			Ancestry:       ancestry,
+			RoundID:             string(roundID),
+			CommitmentTxID:      decodedCommitmentTxID,
+			BatchExpiry:         decodedBatchExpiry,
+			ExpiryAuthenticated: expiryAuth == 1,
+			ChainDepth:          int(decodedChainDepth),
+			CreatedHeight:       decodedCreatedHeight,
+			OperatorKey:         decodedOperatorKey,
+			Ancestry:            ancestry,
 		},
 	}, nil
 }
@@ -2323,6 +2389,8 @@ func encodeEventPayload(event Event) ([]byte, error) {
 
 // decodeEventPayloadWithLimits decodes an event payload and applies receive
 // limits to nested list-shaped event fields.
+//
+//nolint:funlen // One TLV switch owns the complete event wire format.
 func decodeEventPayloadWithLimits(raw []byte,
 	limits ReceiveLimits) (Event, error) {
 
@@ -2505,9 +2573,17 @@ func decodeEventPayloadWithLimits(raw []byte,
 		if err != nil {
 			return nil, err
 		}
+		expiryAuthenticated := len(matches) > 0
+		for i := range matches {
+			if !matches[i].Metadata.ExpiryAuthenticated {
+				expiryAuthenticated = false
+				break
+			}
+		}
 
 		return &IncomingMetadataResolvedEvent{
-			Matches: matches,
+			Matches:             matches,
+			ExpiryAuthenticated: expiryAuthenticated,
 		}, nil
 
 	case eventKindIncomingAckSent:

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -510,23 +510,32 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 	commitmentTxID := chainhash.Hash{11, 11, 11}
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
+	sweepKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorPubKey := operatorKey.PubKey()
+	sweepPubKey := sweepKey.PubKey()
+	ancestry := []vtxo.Ancestry{{
+		CommitmentTxID:       commitmentTxID,
+		CommitmentHeight:     42,
+		CommitmentSweepDelay: 1024,
+		CommitmentSweepKey:   sweepPubKey,
+	}}
 
 	msg := &DriveEventRequest{
 		SessionID: sessionID,
 		Event: &IncomingMetadataResolvedEvent{
+			ExpiryAuthenticated: true,
 			Matches: []IncomingMetadataMatch{{
 				OutputIndex: 1,
 				Metadata: IncomingVTXOMetadata{
-					RoundID:        "mixed-lineage",
-					CommitmentTxID: commitmentTxID,
-					BatchExpiry:    144,
-					ChainDepth:     2,
-					CreatedHeight:  42,
-					OperatorKey:    operatorKey.PubKey(),
-					Ancestry: []vtxo.Ancestry{{
-						CommitmentTxID: commitmentTxID,
-						TreeDepth:      0,
-					}},
+					RoundID:             "mixed-lineage",
+					CommitmentTxID:      commitmentTxID,
+					BatchExpiry:         144,
+					ExpiryAuthenticated: true,
+					ChainDepth:          2,
+					CreatedHeight:       42,
+					OperatorKey:         operatorPubKey,
+					Ancestry:            ancestry,
 				},
 			}},
 		},
@@ -542,6 +551,7 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 
 	metadataEvt, ok := decoded.Event.(*IncomingMetadataResolvedEvent)
 	require.True(t, ok)
+	require.True(t, metadataEvt.ExpiryAuthenticated)
 	require.Len(t, metadataEvt.Matches, 1)
 
 	match := metadataEvt.Matches[0]
@@ -549,6 +559,7 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 	require.Equal(t, "mixed-lineage", match.Metadata.RoundID)
 	require.Equal(t, commitmentTxID, match.Metadata.CommitmentTxID)
 	require.EqualValues(t, 144, match.Metadata.BatchExpiry)
+	require.True(t, match.Metadata.ExpiryAuthenticated)
 	require.EqualValues(t, 2, match.Metadata.ChainDepth)
 	require.EqualValues(t, 42, match.Metadata.CreatedHeight)
 	require.True(
@@ -560,6 +571,18 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 	require.Len(t, match.Metadata.Ancestry, 1)
 	require.Equal(
 		t, commitmentTxID, match.Metadata.Ancestry[0].CommitmentTxID,
+	)
+	require.EqualValues(
+		t, 42, match.Metadata.Ancestry[0].CommitmentHeight,
+	)
+	require.EqualValues(
+		t, 1024, match.Metadata.Ancestry[0].CommitmentSweepDelay,
+	)
+	require.True(
+		t,
+		match.Metadata.Ancestry[0].CommitmentSweepKey.IsEqual(
+			sweepKey.PubKey(),
+		),
 	)
 	require.Nil(t, match.Metadata.Ancestry[0].TreePath)
 }

--- a/oor/incoming_metadata_query.go
+++ b/oor/incoming_metadata_query.go
@@ -28,6 +28,10 @@ type IncomingMetadataResolvedEvent struct {
 	// Matches contains metadata keyed by Ark output index for the current
 	// incoming transfer session.
 	Matches []IncomingMetadataMatch
+
+	// ExpiryAuthenticated is set only by the local chain-authentication
+	// outbox effect. Indexer response adapters leave it false.
+	ExpiryAuthenticated bool
 }
 
 // eventSealed marks this as implementing the sealed Event interface.
@@ -159,7 +163,7 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (IncomingVTXOMetadata,
 			"missing commitment txid")
 	}
 
-	ancestry, err := vtxo.AncestryFromRPC(candidate.GetAncestryPaths())
+	ancestry, err := vtxo.IndexedAncestryFromRPC(candidate)
 	if err != nil {
 		return IncomingVTXOMetadata{}, fmt.Errorf("convert ancestry "+
 			"paths: %w", err)
@@ -178,7 +182,7 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (IncomingVTXOMetadata,
 	return IncomingVTXOMetadata{
 		RoundID:        candidate.GetRoundId(),
 		CommitmentTxID: commitmentTxID,
-		BatchExpiry:    candidate.GetBatchExpiryHeight(),
+		BatchExpiry:    0,
 		ChainDepth:     int(candidate.GetChainDepth()),
 		CreatedHeight:  candidate.GetCreatedHeight(),
 		OperatorKey:    operatorKey,

--- a/oor/incoming_metadata_query_test.go
+++ b/oor/incoming_metadata_query_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/internal/expiryfixture"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,15 +43,9 @@ func TestIncomingMetadataFromRPCOperatorKey(t *testing.T) {
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	commitmentTxID := chainhash.Hash{1, 2, 3}
-	meta, err := incomingMetadataFromRPC(&arkrpc.VTXO{
-		RoundId:        "round-keyed",
-		CommitmentTxid: commitmentTxID[:],
-		OperatorPubkey: operatorKey.PubKey().SerializeCompressed(),
-		AncestryPaths: []*arkrpc.AncestryPath{
-			testValidAncestryPath(commitmentTxID),
-		},
-	})
+	candidate, _ := expiryfixture.Round(t, 1000, []byte{0x51}, 50, 100, 1)
+	candidate.OperatorPubkey = operatorKey.PubKey().SerializeCompressed()
+	meta, err := incomingMetadataFromRPC(candidate)
 	require.NoError(t, err)
 	require.NotNil(t, meta.OperatorKey)
 	require.True(t, meta.OperatorKey.IsEqual(operatorKey.PubKey()))
@@ -61,14 +56,8 @@ func TestIncomingMetadataFromRPCOperatorKey(t *testing.T) {
 func TestIncomingMetadataFromRPCLegacyOperatorKey(t *testing.T) {
 	t.Parallel()
 
-	commitmentTxID := chainhash.Hash{4, 5, 6}
-	meta, err := incomingMetadataFromRPC(&arkrpc.VTXO{
-		RoundId:        "round-legacy",
-		CommitmentTxid: commitmentTxID[:],
-		AncestryPaths: []*arkrpc.AncestryPath{
-			testValidAncestryPath(commitmentTxID),
-		},
-	})
+	candidate, _ := expiryfixture.Round(t, 1000, []byte{0x51}, 50, 100, 2)
+	meta, err := incomingMetadataFromRPC(candidate)
 	require.NoError(t, err)
 	require.Nil(t, meta.OperatorKey)
 }
@@ -78,15 +67,9 @@ func TestIncomingMetadataFromRPCLegacyOperatorKey(t *testing.T) {
 func TestIncomingMetadataFromRPCRejectsInvalidOperatorKey(t *testing.T) {
 	t.Parallel()
 
-	commitmentTxID := chainhash.Hash{7, 8, 9}
-	_, err := incomingMetadataFromRPC(&arkrpc.VTXO{
-		RoundId:        "round-invalid-key",
-		CommitmentTxid: commitmentTxID[:],
-		OperatorPubkey: []byte{0x02},
-		AncestryPaths: []*arkrpc.AncestryPath{
-			testValidAncestryPath(commitmentTxID),
-		},
-	})
+	candidate, _ := expiryfixture.Round(t, 1000, []byte{0x51}, 50, 100, 3)
+	candidate.OperatorPubkey = []byte{0x02}
+	_, err := incomingMetadataFromRPC(candidate)
 	require.ErrorContains(t, err, "parse indexer vtxo operator pubkey")
 }
 

--- a/oor/incoming_vtxo.go
+++ b/oor/incoming_vtxo.go
@@ -41,6 +41,12 @@ type IncomingVTXOMetadata struct {
 	// across all contributing rounds).
 	BatchExpiry int32
 
+	// ExpiryAuthenticated records that BatchExpiry was derived from the
+	// locally confirmed commitment transaction and the sweep policy bound
+	// to each ancestry tree. It is transient receive-state, not persisted
+	// VTXO data.
+	ExpiryAuthenticated bool
+
 	// ChainDepth is the number of OOR checkpoint hops between this
 	// VTXO and the last on-chain commitment. This is distinct from
 	// per-Ancestry TreeDepth, which tracks position within a single
@@ -156,7 +162,7 @@ func BuildIncomingVTXODescriptor(ark *psbt.Packet,
 
 	arkTxid := tx.TxHash()
 
-	policyTemplate, tapscript, err := incomingOutputPolicy(
+	policyTemplate, tapscript, relativeExpiry, err := incomingOutputPolicy(
 		out.PkScript, cfg,
 	)
 	if err != nil {
@@ -180,61 +186,65 @@ func BuildIncomingVTXODescriptor(ark *psbt.Packet,
 		RoundID:        cfg.Metadata.RoundID,
 		CommitmentTxID: cfg.Metadata.CommitmentTxID,
 		BatchExpiry:    cfg.Metadata.BatchExpiry,
-		RelativeExpiry: cfg.ExitDelay,
+		RelativeExpiry: relativeExpiry,
 		ChainDepth:     cfg.Metadata.ChainDepth,
 		CreatedHeight:  cfg.Metadata.CreatedHeight,
 		Status:         vtxo.VTXOStatusLive,
 	}, nil
 }
 
+// incomingOutputPolicy authenticates and returns the incoming output policy,
+// optional standard tapscript, and committed relative expiry.
 func incomingOutputPolicy(pkScript []byte, cfg IncomingVTXOConfig) ([]byte,
-	*waddrmgr.Tapscript, error) {
+	*waddrmgr.Tapscript, uint32, error) {
 
 	if len(cfg.PolicyTemplate) > 0 {
 		template, err := arkscript.DecodePolicyTemplate(
 			cfg.PolicyTemplate,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("decode incoming VTXO "+
+			return nil, nil, 0, fmt.Errorf("decode incoming VTXO "+
 				"policy: %w", err)
 		}
 
 		if !template.MatchesPkScript(pkScript) {
-			return nil, nil, fmt.Errorf("incoming VTXO policy " +
+			return nil, nil, 0, fmt.Errorf("incoming VTXO policy " +
 				"does not match ark output pkscript")
 		}
 
-		tapscript, err := standardTapscriptIfApplicable(template)
+		tapscript, relativeExpiry, err := incomingPolicyExitDelay(
+			template, cfg.ClientKey.PubKey, cfg.OperatorKey,
+		)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
 
 		return append(
 			[]byte(nil), cfg.PolicyTemplate...,
-		), tapscript, nil
+		), tapscript, relativeExpiry, nil
 	}
 
 	tapscript, err := arkscript.VTXOTapScript(
 		cfg.ClientKey.PubKey, cfg.OperatorKey, cfg.ExitDelay,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("derive vtxo tapscript: %w", err)
+		return nil, nil, 0, fmt.Errorf("derive vtxo tapscript: %w", err)
 	}
 
 	tapKey, err := arkscript.VTXOTapKey(
 		cfg.ClientKey.PubKey, cfg.OperatorKey, cfg.ExitDelay,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("derive vtxo tapkey: %w", err)
+		return nil, nil, 0, fmt.Errorf("derive vtxo tapkey: %w", err)
 	}
 
 	expectedPkScript, err := txscript.PayToTaprootScript(tapKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("derive vtxo pkscript: %w", err)
+		return nil, nil, 0, fmt.Errorf("derive vtxo pkscript: %w", err)
 	}
 
 	if !bytes.Equal(expectedPkScript, pkScript) {
-		return nil, nil, fmt.Errorf("ark output pkscript does not " +
+		return nil, nil, 0, fmt.Errorf("ark output pkscript does not " +
 			"match derived vtxo pkscript")
 	}
 
@@ -242,15 +252,18 @@ func incomingOutputPolicy(pkScript []byte, cfg IncomingVTXOConfig) ([]byte,
 		cfg.ClientKey.PubKey, cfg.OperatorKey, cfg.ExitDelay,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("encode incoming VTXO policy: %w",
-			err)
+		return nil, nil, 0, fmt.Errorf("encode incoming VTXO "+
+			"policy: %w", err)
 	}
 
-	return policyTemplate, tapscript, nil
+	return policyTemplate, tapscript, cfg.ExitDelay, nil
 }
 
-func standardTapscriptIfApplicable(template *arkscript.PolicyTemplate) (
-	*waddrmgr.Tapscript, error) {
+// incomingPolicyExitDelay derives the earliest authenticated owner exit delay
+// from a matching standard or custom policy template.
+func incomingPolicyExitDelay(template *arkscript.PolicyTemplate,
+	clientKey, operatorKey *btcec.PublicKey) (*waddrmgr.Tapscript, uint32,
+	error) {
 
 	params, decodeErr := arkscript.DecodeStandardVTXOParams(template)
 	if decodeErr == nil {
@@ -258,14 +271,43 @@ func standardTapscriptIfApplicable(template *arkscript.PolicyTemplate) (
 			params.OwnerKey, params.OperatorKey, params.ExitDelay,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("derive standard vtxo "+
+			return nil, 0, fmt.Errorf("derive standard vtxo "+
 				"tapscript: %w", err)
 		}
 
-		return tapscript, nil
+		return tapscript, params.ExitDelay, nil
 	}
 
-	return nil, nil
+	pairs, err := template.SettlementPairsForParticipant(
+		clientKey, operatorKey,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("derive incoming VTXO exit paths: %w",
+			err)
+	}
+
+	var earliest uint32
+	for _, pair := range pairs {
+		if pair.AuthPath == nil {
+			continue
+		}
+
+		sequence := pair.AuthPath.RequiredSequence
+		if sequence == 0 ||
+			sequence > uint32(wire.SequenceLockTimeMask) {
+
+			continue
+		}
+		if earliest == 0 || sequence < earliest {
+			earliest = sequence
+		}
+	}
+	if earliest == 0 {
+		return nil, 0, fmt.Errorf("incoming VTXO policy has no " +
+			"authenticated relative expiry")
+	}
+
+	return nil, earliest, nil
 }
 
 // validateIncomingAncestry runs the structural cross-checks that bind

--- a/oor/incoming_vtxo_test.go
+++ b/oor/incoming_vtxo_test.go
@@ -11,6 +11,7 @@ import (
 	lib_tree "github.com/lightninglabs/wavelength/lib/tree"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -393,7 +394,7 @@ func TestBuildIncomingVTXODescriptorPreservesMatchingPolicyTemplate(
 				PubKey: recipientKey.PubKey(),
 			},
 			OperatorKey:    operatorKey,
-			ExitDelay:      10,
+			ExitDelay:      11,
 			PolicyTemplate: template,
 			Metadata: IncomingVTXOMetadata{
 				RoundID:        "test-round",
@@ -409,6 +410,38 @@ func TestBuildIncomingVTXODescriptorPreservesMatchingPolicyTemplate(
 	)
 	require.NoError(t, err)
 	require.Equal(t, template, desc.PolicyTemplate)
+	require.Equal(t, uint32(10), desc.RelativeExpiry)
+}
+
+// TestIncomingPolicyExitDelayUsesCustomBlockCSV verifies custom policies use
+// decoded block-mode CSV delays rather than raw non-final sequence sentinels.
+func TestIncomingPolicyExitDelayUsesCustomBlockCSV(t *testing.T) {
+	t.Parallel()
+
+	sender, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	receiver, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operator, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:                               sender.PubKey(),
+		Receiver:                             receiver.PubKey(),
+		Server:                               operator.PubKey(),
+		PreimageHash:                         lntypes.Hash{1},
+		RefundLocktime:                       500,
+		UnilateralClaimDelay:                 30,
+		UnilateralRefundDelay:                20,
+		UnilateralRefundWithoutReceiverDelay: 10,
+	})
+	require.NoError(t, err)
+
+	_, delay, err := incomingPolicyExitDelay(
+		policy.Template, sender.PubKey(), operator.PubKey(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint32(10), delay)
 }
 
 // TestBuildIncomingVTXODescriptorRejectsMismatchedPolicyTemplate verifies that

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -45,6 +45,11 @@ type IncomingMetadataResolver func(ctx context.Context, sessionID SessionID,
 	recipient ArkRecipientOutput, ark *psbt.Packet,
 	finalCheckpoints []*psbt.Packet) (IncomingVTXOMetadata, error)
 
+// IncomingExpiryAuthenticator derives one metadata record's batch expiry from
+// authenticated ancestry and local chain confirmation evidence.
+type IncomingExpiryAuthenticator func(ctx context.Context,
+	ancestry []vtxo.Ancestry) (int32, error)
+
 // IncomingMetadataRecipientFilter filters an incoming Ark package down to the
 // recipient outputs controlled by the local wallet.
 type IncomingMetadataRecipientFilter interface {
@@ -113,6 +118,11 @@ type LocalPersistenceOutboxHandler struct {
 	// metadata for each incoming recipient output.
 	ResolveIncomingMetadata IncomingMetadataResolver
 
+	// AuthenticateIncomingExpiry replaces the indexer's expiry hint with a
+	// locally derived value before materialization starts its DB
+	// transaction.
+	AuthenticateIncomingExpiry IncomingExpiryAuthenticator
+
 	// NotifyIncomingVTXOs is invoked after incoming VTXOs are persisted.
 	// Production wiring should use this to notify the VTXO manager so newly
 	// received OOR VTXOs are actively monitored when the handler is used
@@ -137,6 +147,9 @@ func (h *LocalPersistenceOutboxHandler) Handle(ctx context.Context,
 	case *QueryIncomingMetadataRequest:
 		return h.handleQueryIncomingMetadata(ctx, msg)
 
+	case *AuthenticateIncomingMetadataRequest:
+		return h.handleAuthenticateIncomingMetadata(ctx, msg)
+
 	case *MaterializeIncomingVTXOsRequest:
 		return h.handleMaterializeIncoming(ctx, msg)
 
@@ -150,6 +163,45 @@ func (h *LocalPersistenceOutboxHandler) Handle(ctx context.Context,
 
 		return h.Next.Handle(ctx, sessionID, outbox)
 	}
+}
+
+// handleAuthenticateIncomingMetadata performs chain I/O before the durable
+// materialization transaction begins.
+func (h *LocalPersistenceOutboxHandler) handleAuthenticateIncomingMetadata(
+	ctx context.Context, msg *AuthenticateIncomingMetadataRequest) ([]Event,
+	error) {
+
+	if msg == nil {
+		return nil, fmt.Errorf("incoming metadata authentication " +
+			"request must be provided")
+	}
+	if h.AuthenticateIncomingExpiry == nil {
+		return nil, fmt.Errorf("incoming expiry authenticator must " +
+			"be provided")
+	}
+
+	matches := make([]IncomingMetadataMatch, len(msg.Matches))
+	copy(matches, msg.Matches)
+	for i := range matches {
+		expiry, err := h.AuthenticateIncomingExpiry(
+			ctx, matches[i].Metadata.Ancestry,
+		)
+		if err != nil {
+			if errors.Is(err, vtxo.ErrInvalidBatchExpiryEvidence) {
+				return nil, &terminalOutboxError{cause: err}
+			}
+
+			return nil, err
+		}
+
+		matches[i].Metadata.BatchExpiry = expiry
+		matches[i].Metadata.ExpiryAuthenticated = true
+	}
+
+	return []Event{&IncomingMetadataResolvedEvent{
+		Matches:             matches,
+		ExpiryAuthenticated: true,
+	}}, nil
 }
 
 // handleMaterializeIncoming persists recipient VTXOs for an incoming transfer
@@ -190,6 +242,15 @@ func (h *LocalPersistenceOutboxHandler) validateMaterializeIncoming(
 
 	if len(msg.Recipients) == 0 {
 		return fmt.Errorf("incoming recipients must be provided")
+	}
+
+	for i := range msg.MetadataMatches {
+		metadata := msg.MetadataMatches[i].Metadata
+		if !metadata.ExpiryAuthenticated || metadata.BatchExpiry <= 0 {
+			return fmt.Errorf("incoming output %d batch expiry is "+
+				"not authenticated",
+				msg.MetadataMatches[i].OutputIndex)
+		}
 	}
 
 	// Revalidate on every materialization attempt. A restored snapshot or
@@ -299,6 +360,8 @@ func (h *LocalPersistenceOutboxHandler) FilterIncomingMetadataRecipients(
 // materializeIncoming persists recipient VTXOs for an incoming transfer and
 // optionally notifies the VTXO manager directly when the caller is not
 // resuming the durable actor with a follow-up event.
+//
+//nolint:funlen // Keep the materialization transaction in one visible boundary.
 func (h *LocalPersistenceOutboxHandler) materializeIncoming(ctx context.Context,
 	msg *MaterializeIncomingVTXOsRequest, notifyIncoming bool) ([]Event,
 	error) {
@@ -392,6 +455,27 @@ func (h *LocalPersistenceOutboxHandler) materializeIncoming(ctx context.Context,
 					recipient.OutputIndex),
 				defaultRetryDelay,
 			)
+		}
+		if !metadata.ExpiryAuthenticated {
+			if h.AuthenticateIncomingExpiry == nil {
+				return nil, fmt.Errorf("incoming output %d "+
+					"batch expiry authenticator must be "+
+					"provided", recipient.OutputIndex)
+			}
+
+			expiry, err := h.AuthenticateIncomingExpiry(
+				ctx, metadata.Ancestry,
+			)
+			if err != nil {
+				return nil, err
+			}
+			metadata.BatchExpiry = expiry
+			metadata.ExpiryAuthenticated = true
+		}
+		if metadata.BatchExpiry <= 0 {
+			return nil, fmt.Errorf("incoming output %d "+
+				"authenticated batch expiry must be positive",
+				recipient.OutputIndex)
 		}
 
 		logger(ctx).DebugS(ctx, "Resolved incoming metadata",

--- a/oor/local_persistence_handler_test.go
+++ b/oor/local_persistence_handler_test.go
@@ -216,6 +216,52 @@ func (s *testVTXOStore) DeleteVTXO(_ context.Context,
 	return nil
 }
 
+// TestLocalPersistenceOutboxHandlerAuthenticatesIncomingExpiry verifies the
+// indexer scalar is replaced before the materialization transaction.
+func TestLocalPersistenceOutboxHandlerAuthenticatesIncomingExpiry(
+	t *testing.T) {
+
+	t.Parallel()
+
+	commitment := chainhash.Hash{1, 2, 3}
+	matches := []IncomingMetadataMatch{{
+		OutputIndex: 2,
+		Metadata: IncomingVTXOMetadata{
+			RoundID:        "round-auth",
+			CommitmentTxID: commitment,
+			BatchExpiry:    999999,
+			Ancestry: []vtxo.Ancestry{{
+				CommitmentTxID: commitment,
+			}},
+		},
+	}}
+	handler := &LocalPersistenceOutboxHandler{
+		AuthenticateIncomingExpiry: func(_ context.Context,
+			ancestry []vtxo.Ancestry) (int32, error) {
+
+			require.Len(t, ancestry, 1)
+
+			return 2048, nil
+		},
+	}
+
+	events, err := handler.Handle(
+		t.Context(), SessionID{}, &AuthenticateIncomingMetadataRequest{
+			Matches: matches,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	event, ok := events[0].(*IncomingMetadataResolvedEvent)
+	require.True(t, ok)
+	require.True(t, event.ExpiryAuthenticated)
+	require.Len(t, event.Matches, 1)
+	require.Equal(t, int32(2048), event.Matches[0].Metadata.BatchExpiry)
+	require.True(t, event.Matches[0].Metadata.ExpiryAuthenticated)
+	require.Equal(t, int32(999999), matches[0].Metadata.BatchExpiry)
+}
+
 // TestLocalPersistenceOutboxHandlerMaterializeIncoming asserts incoming
 // materialization persists recipient VTXOs and emits IncomingHandledEvent.
 func TestLocalPersistenceOutboxHandlerMaterializeIncoming(t *testing.T) {
@@ -232,11 +278,19 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncoming(t *testing.T) {
 	packageStore := &testPackageStore{}
 
 	notifyCalls := 0
+	authCalls := 0
 	handler := &LocalPersistenceOutboxHandler{
 		Store:        store,
 		PackageStore: packageStore,
 		OperatorKey:  operatorKey,
 		ExitDelay:    10,
+		AuthenticateIncomingExpiry: func(context.Context,
+			[]vtxo.Ancestry) (int32, error) {
+
+			authCalls++
+
+			return 1000, nil
+		},
 		NotifyIncomingVTXOs: func(_ context.Context,
 			_ []*vtxo.Descriptor) error {
 
@@ -269,7 +323,6 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncoming(t *testing.T) {
 			return IncomingVTXOMetadata{
 				RoundID:        "round-incoming",
 				CommitmentTxID: parentCommitment,
-				BatchExpiry:    1000,
 				Ancestry: validTestIncomingAncestry(
 					parentCommitment,
 				),
@@ -290,6 +343,7 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncoming(t *testing.T) {
 	require.Len(t, events, 1)
 	require.IsType(t, &IncomingHandledEvent{}, events[0])
 	require.Equal(t, 1, notifyCalls)
+	require.Equal(t, 1, authCalls)
 
 	handledEvt, ok := events[0].(*IncomingHandledEvent)
 	require.True(t, ok)
@@ -315,6 +369,7 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncoming(t *testing.T) {
 	require.Equal(t, 2, packageStore.bindingCalls)
 	require.Equal(t, PackageDirectionIncoming, packageStore.lastDirection)
 	require.Equal(t, chainhash.Hash(sessionID), packageStore.lastSessionID)
+	require.Equal(t, 2, authCalls)
 }
 
 // TestLocalPersistenceOutboxHandlerRejectsInvalidAncestorPackage asserts
@@ -560,10 +615,11 @@ func TestLocalPersistenceOutboxHandlerUsesMetadataOperatorKey(t *testing.T) {
 		MetadataMatches: []IncomingMetadataMatch{{
 			OutputIndex: recipients[0].OutputIndex,
 			Metadata: IncomingVTXOMetadata{
-				RoundID:        "round-incoming",
-				CommitmentTxID: parentCommitment,
-				BatchExpiry:    1000,
-				OperatorKey:    operatorKey,
+				RoundID:             "round-incoming",
+				CommitmentTxID:      parentCommitment,
+				BatchExpiry:         1000,
+				ExpiryAuthenticated: true,
+				OperatorKey:         operatorKey,
 				Ancestry: validTestIncomingAncestry(
 					parentCommitment,
 				),
@@ -647,9 +703,10 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncomingSkipsNotOwned(
 			metadataCalls++
 
 			return IncomingVTXOMetadata{
-				RoundID:        "round-incoming",
-				CommitmentTxID: parentCommitment,
-				BatchExpiry:    1000,
+				RoundID:             "round-incoming",
+				CommitmentTxID:      parentCommitment,
+				BatchExpiry:         1000,
+				ExpiryAuthenticated: true,
 				Ancestry: validTestIncomingAncestry(
 					parentCommitment,
 				),
@@ -787,9 +844,10 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncomingNotifierFailure(
 			_ = finalCheckpoints
 
 			return IncomingVTXOMetadata{
-				RoundID:        "round-incoming",
-				CommitmentTxID: parentCommitment,
-				BatchExpiry:    1000,
+				RoundID:             "round-incoming",
+				CommitmentTxID:      parentCommitment,
+				BatchExpiry:         1000,
+				ExpiryAuthenticated: true,
 				Ancestry: validTestIncomingAncestry(
 					parentCommitment,
 				),
@@ -853,9 +911,10 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncomingRequiresNotifier(
 			_ = finalCheckpoints
 
 			return IncomingVTXOMetadata{
-				RoundID:        "round-incoming",
-				CommitmentTxID: parentCommitment,
-				BatchExpiry:    1000,
+				RoundID:             "round-incoming",
+				CommitmentTxID:      parentCommitment,
+				BatchExpiry:         1000,
+				ExpiryAuthenticated: true,
 				Ancestry: validTestIncomingAncestry(
 					parentCommitment,
 				),
@@ -1001,9 +1060,10 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncomingSelfTransferPackageReus
 			_ = finalCheckpoints
 
 			return IncomingVTXOMetadata{
-				RoundID:        "round-incoming",
-				CommitmentTxID: parentCommitment,
-				BatchExpiry:    1000,
+				RoundID:             "round-incoming",
+				CommitmentTxID:      parentCommitment,
+				BatchExpiry:         1000,
+				ExpiryAuthenticated: true,
 				Ancestry: validTestIncomingAncestry(
 					parentCommitment,
 				),

--- a/oor/outbox_factory.go
+++ b/oor/outbox_factory.go
@@ -49,6 +49,10 @@ type OutboxHandlerConfig struct {
 	// ResolveIncomingMetadata resolves lineage metadata for
 	// incoming VTXOs.
 	ResolveIncomingMetadata IncomingMetadataResolver
+
+	// AuthenticateIncomingExpiry derives the batch expiry from confirmed
+	// ancestry before incoming VTXOs are materialized.
+	AuthenticateIncomingExpiry IncomingExpiryAuthenticator
 }
 
 // NewOutboxHandler constructs the standard two-layer outbox handler chain from
@@ -65,13 +69,14 @@ func NewOutboxHandler(cfg OutboxHandlerConfig) *LocalPersistenceOutboxHandler {
 	}
 
 	return &LocalPersistenceOutboxHandler{
-		Next:                     signingHandler,
-		Store:                    cfg.Store,
-		PackageStore:             cfg.PackageStore,
-		OperatorKey:              cfg.OperatorKey,
-		ExitDelay:                cfg.ExitDelay,
-		NotifyIncomingVTXOs:      cfg.NotifyIncomingVTXOs,
-		ResolveIncomingClientKey: cfg.ResolveIncomingClientKey,
-		ResolveIncomingMetadata:  cfg.ResolveIncomingMetadata,
+		Next:                       signingHandler,
+		Store:                      cfg.Store,
+		PackageStore:               cfg.PackageStore,
+		OperatorKey:                cfg.OperatorKey,
+		ExitDelay:                  cfg.ExitDelay,
+		NotifyIncomingVTXOs:        cfg.NotifyIncomingVTXOs,
+		ResolveIncomingClientKey:   cfg.ResolveIncomingClientKey,
+		ResolveIncomingMetadata:    cfg.ResolveIncomingMetadata,
+		AuthenticateIncomingExpiry: cfg.AuthenticateIncomingExpiry,
 	}
 }

--- a/oor/outbox_factory_test.go
+++ b/oor/outbox_factory_test.go
@@ -1,0 +1,45 @@
+package oor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewOutboxHandlerForwardsExpiryAuthenticator proves the shared handler
+// factory retains the chain-authentication dependency used by incoming OOR
+// materialization.
+func TestNewOutboxHandlerForwardsExpiryAuthenticator(t *testing.T) {
+	t.Parallel()
+
+	const authenticatedExpiry = int32(144)
+	var calls int
+	handler := NewOutboxHandler(OutboxHandlerConfig{
+		AuthenticateIncomingExpiry: func(_ context.Context,
+			_ []vtxo.Ancestry) (int32, error) {
+
+			calls++
+
+			return authenticatedExpiry, nil
+		},
+	})
+
+	events, err := handler.Handle(
+		t.Context(), SessionID{}, &AuthenticateIncomingMetadataRequest{
+			Matches: []IncomingMetadataMatch{{}},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	require.Len(t, events, 1)
+
+	resolved, ok := events[0].(*IncomingMetadataResolvedEvent)
+	require.True(t, ok)
+	require.True(t, resolved.ExpiryAuthenticated)
+	require.Equal(
+		t, authenticatedExpiry,
+		resolved.Matches[0].Metadata.BatchExpiry,
+	)
+}

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -432,6 +432,23 @@ func (m *QueryIncomingMetadataRequest) outboxType() string {
 // outboxSealed marks this as implementing the sealed OutboxEvent interface.
 func (m *QueryIncomingMetadataRequest) outboxSealed() {}
 
+// AuthenticateIncomingMetadataRequest asks the local chain boundary to
+// replace indexer expiry hints with authenticated absolute expiries before
+// materialization enters the durable database transaction.
+type AuthenticateIncomingMetadataRequest struct {
+	actor.BaseMessage
+
+	Matches []IncomingMetadataMatch
+}
+
+// outboxType returns a stable identifier for this outbox message.
+func (m *AuthenticateIncomingMetadataRequest) outboxType() string {
+	return "AuthenticateIncomingMetadataRequest"
+}
+
+// outboxSealed marks this as implementing the sealed OutboxEvent interface.
+func (m *AuthenticateIncomingMetadataRequest) outboxSealed() {}
+
 // MaterializeIncomingVTXOsRequest asks the wallet/state layer to materialize
 // the incoming transfer into local VTXO records.
 //

--- a/oor/receive_limits_test.go
+++ b/oor/receive_limits_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/internal/expiryfixture"
 	lib_tree "github.com/lightninglabs/wavelength/lib/tree"
 	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
 	"github.com/stretchr/testify/require"
@@ -84,17 +85,13 @@ func TestIncomingMetadataMatchesFromResponseUsesConfiguredMatchLimit(
 
 	t.Parallel()
 
-	sessionID := SessionID(chainhash.Hash{1, 2, 3})
-	commitmentTxID := chainhash.Hash{4, 5, 6}
-
+	candidate, _ := expiryfixture.Merge(t, false)
+	var sessionID SessionID
+	copy(sessionID[:], candidate.Outpoint.Txid)
 	resp := &arkrpc.ListVTXOsByScriptsResponse{
 		Vtxos: []*arkrpc.VTXO{
-			testIncomingMetadataVTXO(
-				sessionID, commitmentTxID, 0,
-			),
-			testIncomingMetadataVTXO(
-				sessionID, commitmentTxID, 1,
-			),
+			candidate,
+			candidate,
 		},
 	}
 
@@ -149,24 +146,6 @@ func TestDecodeLengthPrefixedBlobListUsesConfiguredCountLimit(t *testing.T) {
 		},
 	)
 	require.ErrorContains(t, err, "blob list count 2 exceeds limit 1")
-}
-
-// testIncomingMetadataVTXO builds a minimal RPC VTXO that can be converted
-// into an IncomingMetadataMatch by the response adapter.
-func testIncomingMetadataVTXO(sessionID SessionID,
-	commitmentTxID chainhash.Hash, outputIndex uint32) *arkrpc.VTXO {
-
-	return &arkrpc.VTXO{
-		Outpoint: &arkrpc.OutPoint{
-			Txid: sessionID[:],
-			Vout: outputIndex,
-		},
-		RoundId:        "round-configured-limit",
-		CommitmentTxid: commitmentTxID[:],
-		AncestryPaths: []*arkrpc.AncestryPath{
-			testValidAncestryPath(commitmentTxID),
-		},
-	}
 }
 
 // testValidAncestryPath returns an AncestryPath whose reconstructed

--- a/oor/receive_session_test.go
+++ b/oor/receive_session_test.go
@@ -176,6 +176,17 @@ func TestReceiveSessionAcksAfterHandled(t *testing.T) {
 	result := fut.Await(ctx)
 	require.False(t, result.IsErr())
 
+	authOutbox := result.UnwrapOr(nil)
+	require.Len(t, authOutbox, 1)
+	require.IsType(
+		t, &AuthenticateIncomingMetadataRequest{}, authOutbox[0],
+	)
+
+	fut = sess.FSM.AskEvent(ctx, &IncomingMetadataResolvedEvent{
+		ExpiryAuthenticated: true,
+	})
+	result = fut.Await(ctx)
+	require.False(t, result.IsErr())
 	materializeOutbox := result.UnwrapOr(nil)
 	require.Len(t, materializeOutbox, 1)
 	require.IsType(
@@ -215,7 +226,9 @@ func TestReceiveSessionRetriesMetadataAfterRetryableMaterializationFailure(
 	sess, _, err := DriveIncomingTransfer(ctx, sessionID, arkPSBT)
 	require.NoError(t, err)
 
-	fut := sess.FSM.AskEvent(ctx, &IncomingMetadataResolvedEvent{})
+	fut := sess.FSM.AskEvent(ctx, &IncomingMetadataResolvedEvent{
+		ExpiryAuthenticated: true,
+	})
 	result := fut.Await(ctx)
 	require.False(t, result.IsErr())
 

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -462,6 +462,21 @@ func (s *ReceiveNotified) ProcessEvent(ctx context.Context, event Event,
 
 	switch evt := event.(type) {
 	case *IncomingMetadataResolvedEvent:
+		if !evt.ExpiryAuthenticated {
+			authenticate := &AuthenticateIncomingMetadataRequest{
+				Matches: evt.Matches,
+			}
+
+			return &StateTransition{
+				NextState: s,
+				NewEvents: fn.Some(EmittedEvent{
+					Outbox: []OutboxEvent{
+						authenticate,
+					},
+				}),
+			}, nil
+		}
+
 		recipients := CloneArkRecipients(s.Recipients)
 		if len(recipients) == 0 {
 			extracted, err := ExtractArkRecipients(s.ArkPSBT)

--- a/oor/session_actor.go
+++ b/oor/session_actor.go
@@ -900,6 +900,29 @@ func (b *sessionBehavior) driveOutboxEvents(ctx context.Context,
 				return err
 			}
 
+		// Expiry authentication performs chain I/O before the durable
+		// materialization transaction starts. Its follow-up event
+		// carries only the derived scalar into the commit closure.
+		case *AuthenticateIncomingMetadataRequest:
+			if b.cfg.IncomingHandler == nil {
+				return fmt.Errorf("incoming handler must be " +
+					"provided")
+			}
+
+			followUps, err := b.cfg.IncomingHandler.Handle(
+				ctx, b.sessionID, m,
+			)
+			if err != nil {
+				return err
+			}
+			for _, followUp := range followUps {
+				if err := b.continueWith(
+					ctx, followUp,
+				); err != nil {
+					return err
+				}
+			}
+
 		// Input-reservation release: a pre-point-of-no-return terminal
 		// failure (e.g. a typed submit rejection) returns the reserved
 		// inputs to LiveState. This is BEST-EFFORT and must never fail

--- a/oor/session_actor_flow_test.go
+++ b/oor/session_actor_flow_test.go
@@ -215,7 +215,9 @@ func TestSessionActorIncomingMaterializeFullFlow(t *testing.T) {
 
 	res := b.Receive(ctx, &DriveEventRequest{
 		SessionID: sid,
-		Event:     &IncomingMetadataResolvedEvent{},
+		Event: &IncomingMetadataResolvedEvent{
+			ExpiryAuthenticated: true,
+		},
 	}, ax)
 	require.True(t, res.IsOk(), res.Err())
 
@@ -384,7 +386,9 @@ func TestSessionActorIncomingReloadsAfterFailedCommit(t *testing.T) {
 	// terminal FSM standing on an uncommitted advance.
 	drive := &DriveEventRequest{
 		SessionID: sid,
-		Event:     &IncomingMetadataResolvedEvent{},
+		Event: &IncomingMetadataResolvedEvent{
+			ExpiryAuthenticated: true,
+		},
 	}
 	res := b.Receive(ctx, drive, ax)
 	require.True(t, res.IsErr())

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -288,6 +288,11 @@ state transitions and validation rules live under [Invariants](#invariants).
   v3 ephemeral-anchor relay. The later quote-authoritative leaf check closes
   the value chain from the committed root to the client's accepted amount
   before nonces, signatures, or persistence.
+- **Round sweep policy is authenticated before signing.** After the commitment
+  output/tree binding check, `validateRoundSweepPolicy` reconstructs the sweep
+  leaf from the advertised key and delay and requires its tap hash to match
+  every VTXO tree's sweep root. Confirmation persists the absolute expiry as
+  `height + delay` with overflow rejection.
 - **Seal-time fee handshake (#270)**: the server is the amount
   authority. When `QuoteReceivedState.Quote` is non-nil, it threads
   through `RoundJoinedState` → `CommitmentTxReceivedState`, which

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -288,6 +288,11 @@ state transitions and validation rules live under [Invariants](#invariants).
   v3 ephemeral-anchor relay. The later quote-authoritative leaf check closes
   the value chain from the committed root to the client's accepted amount
   before nonces, signatures, or persistence.
+- **Round sweep policy is authenticated before signing.** After the commitment
+  output/tree binding check, `validateRoundSweepPolicy` reconstructs the sweep
+  leaf from the advertised key and delay and requires its tap hash to match
+  every VTXO tree's sweep root. Confirmation persists the absolute expiry as
+  `height + delay` with overflow rejection.
 - **Seal-time fee handshake (#270)**: the server is the amount
   authority. When `QuoteReceivedState.Quote` is non-nil, it threads
   through `RoundJoinedState` → `CommitmentTxReceivedState`, which

--- a/round/asset_vtxo_validation_test.go
+++ b/round/asset_vtxo_validation_test.go
@@ -64,6 +64,8 @@ type boundAssetVTXOFixture struct {
 	sealedPackage []byte
 }
 
+// newBoundAssetVTXOFixture binds asset policy data and the advertised sweep
+// policy so transition tests reach the asset-verification boundary.
 func newBoundAssetVTXOFixture(t *testing.T,
 	h *boardingTestHarness) *boundAssetVTXOFixture {
 
@@ -120,7 +122,11 @@ func newBoundAssetVTXOFixture(t *testing.T,
 		},
 	}
 
-	sweepRoot := chainhash.HashH([]byte("sweep"))
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		h.operatorPubKey, 1008,
+	)
+	require.NoError(t, err)
+	sweepRoot := sweepLeaf.TapHash()
 	assetTree, err := tree.NewTree(
 		wire.OutPoint{Hash: commitment.TxHash()}, commitment.TxOut[0],
 		[]tree.LeafDescriptor{{
@@ -150,6 +156,8 @@ func newBoundAssetVTXOFixture(t *testing.T,
 	}
 }
 
+// TestCommitmentTxReceivedVerifiesAssetVTXO checks asset verification and
+// owned-script registration after the round sweep policy is authenticated.
 func TestCommitmentTxReceivedVerifiesAssetVTXO(t *testing.T) {
 	t.Parallel()
 
@@ -165,6 +173,7 @@ func TestCommitmentTxReceivedVerifiesAssetVTXO(t *testing.T) {
 		CommitmentTx: fixture.commitmentTx,
 		TxID:         fixture.commitmentTx.UnsignedTx.TxHash(),
 		SweepDelay:   1008,
+		SweepKey:     h.operatorPubKey,
 		VTXOTreePaths: map[int]*tree.Tree{
 			0: fixture.tree,
 		},
@@ -278,6 +287,8 @@ func TestValidateVTXOTreeBindingUsesAssetRoot(t *testing.T) {
 	)
 }
 
+// TestCommitmentTxReceivedRejectsUnverifiedAssetVTXO ensures a valid sweep
+// policy cannot bypass missing asset verification or sealed package data.
 func TestCommitmentTxReceivedRejectsUnverifiedAssetVTXO(t *testing.T) {
 	t.Parallel()
 
@@ -312,6 +323,7 @@ func TestCommitmentTxReceivedRejectsUnverifiedAssetVTXO(t *testing.T) {
 				TxID: fixture.commitmentTx.UnsignedTx.
 					TxHash(),
 				SweepDelay: 1008,
+				SweepKey:   h.operatorPubKey,
 				VTXOTreePaths: map[int]*tree.Tree{
 					0: fixture.tree,
 				},

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -743,7 +743,11 @@ func (h *boardingTestHarness) newTestVTXOTree(numLeaves int) (*tree.Tree,
 		PkScript: batchPkScript,
 	}
 
-	sweepRoot := sha256.Sum256([]byte("test-sweep-root"))
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		h.operatorPubKey, 1008,
+	)
+	require.NoError(h.t, err)
+	sweepRoot := sweepLeaf.TapHash()
 
 	vtxtTree, err := tree.NewTree(
 		batchOutpoint, batchOutput, leaves, h.operatorPubKey,
@@ -785,7 +789,11 @@ func (h *boardingTestHarness) newTestVTXOTreeForIntents(
 		PkScript: batchPkScript,
 	}
 
-	sweepRoot := sha256.Sum256([]byte("test-sweep-root"))
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		h.operatorPubKey, 1008,
+	)
+	require.NoError(h.t, err)
+	sweepRoot := sweepLeaf.TapHash()
 
 	vtxtTree, err := tree.NewTree(
 		batchOutpoint, batchOutput, leaves, h.operatorPubKey,
@@ -1052,6 +1060,8 @@ func (h *boardingTestHarness) newCommitmentTxReceivedState(roundID RoundID,
 			VTXOs:    vtxoReqs,
 		},
 		ClientTrees: make(map[SignerKey]*tree.Tree),
+		SweepKey:    h.operatorPubKey,
+		SweepDelay:  1008,
 	}
 }
 
@@ -2273,7 +2283,11 @@ func (h *boardingTestHarness) newMinimalVTXOTree() *tree.Tree {
 		PkScript: batchPkScript,
 	}
 
-	sweepRoot := sha256.Sum256([]byte("test-sweep-root"))
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		h.operatorPubKey, 1008,
+	)
+	require.NoError(h.t, err)
+	sweepRoot := sweepLeaf.TapHash()
 
 	vtxtTree, err := tree.NewTree(
 		batchOutpoint, batchOutput, leaves, h.operatorPubKey,

--- a/round/sweep_policy.go
+++ b/round/sweep_policy.go
@@ -1,0 +1,48 @@
+package round
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+)
+
+// validateRoundSweepPolicy proves that the round-advertised sweep key and
+// delay are the policy committed by each VTXO tree. The later confirmation
+// transition may then safely derive BatchExpiry as confirmationHeight+delay.
+func validateRoundSweepPolicy(sweepKey *btcec.PublicKey, sweepDelay uint32,
+	vtxoTrees map[int]*tree.Tree) error {
+
+	if sweepKey == nil {
+		return fmt.Errorf("sweep key must be provided")
+	}
+	if sweepDelay == 0 {
+		return fmt.Errorf("sweep delay must be positive")
+	}
+
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		sweepKey, sweepDelay,
+	)
+	if err != nil {
+		return fmt.Errorf("build sweep leaf: %w", err)
+	}
+	sweepRoot := sweepLeaf.TapHash()
+
+	for outputIdx, vtxoTree := range vtxoTrees {
+		if vtxoTree == nil {
+			return fmt.Errorf("vtxo tree at output %d is nil",
+				outputIdx)
+		}
+		if !bytes.Equal(
+			sweepRoot[:], vtxoTree.SweepTapscriptRoot,
+		) {
+			return fmt.Errorf("vtxo tree at output %d has a sweep "+
+				"root that does not match the advertised key "+
+				"and delay", outputIdx)
+		}
+	}
+
+	return nil
+}

--- a/round/sweep_policy_test.go
+++ b/round/sweep_policy_test.go
@@ -1,0 +1,77 @@
+package round
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateRoundSweepPolicy verifies the advertised key and delay against
+// every committed VTXO-tree sweep root.
+func TestValidateRoundSweepPolicy(t *testing.T) {
+	t.Parallel()
+
+	sweepKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	otherKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const sweepDelay = uint32(1008)
+	leaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		sweepKey.PubKey(), sweepDelay,
+	)
+	require.NoError(t, err)
+	root := leaf.TapHash()
+
+	trees := map[int]*tree.Tree{
+		0: {
+			SweepTapscriptRoot: root[:],
+		},
+		1: {
+			SweepTapscriptRoot: root[:],
+		},
+	}
+	require.NoError(
+		t,
+		validateRoundSweepPolicy(
+			sweepKey.PubKey(), sweepDelay, trees,
+		),
+	)
+
+	require.ErrorContains(
+		t, validateRoundSweepPolicy(
+			nil, sweepDelay, trees,
+		),
+		"sweep key must be provided",
+	)
+	require.ErrorContains(
+		t,
+		validateRoundSweepPolicy(
+			sweepKey.PubKey(), 0, trees,
+		),
+		"sweep delay must be positive",
+	)
+	require.ErrorContains(
+		t,
+		validateRoundSweepPolicy(
+			otherKey.PubKey(), sweepDelay, trees,
+		),
+		"does not match",
+	)
+
+	randomRoot := make([]byte, len(root))
+	_, err = rand.Read(randomRoot)
+	require.NoError(t, err)
+	trees[1] = &tree.Tree{SweepTapscriptRoot: randomRoot}
+	require.ErrorContains(
+		t,
+		validateRoundSweepPolicy(
+			sweepKey.PubKey(), sweepDelay, trees,
+		),
+		"output 1",
+	)
+}

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -2391,6 +2391,17 @@ func (s *CommitmentTxReceivedState) processEvent(ctx context.Context,
 			), nil
 		}
 
+		// Bind the advertised key and delay to every tree's committed
+		// sweep root before any nonce or signature leaves the client.
+		if err := validateRoundSweepPolicy(
+			s.SweepKey, s.SweepDelay, s.VTXOTreePaths,
+		); err != nil {
+			return failBeforeForfeitSigning(
+				"invalid round sweep policy", err, false,
+				s.RoundID, s.Intents.Forfeits,
+			), nil
+		}
+
 		clientTrees := make(map[SignerKey]*tree.Tree)
 
 		// Next, we'll make sure that each of the VTXO requests that we
@@ -5070,10 +5081,15 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 		// ExpiryStatusUnknown — the VTXO stays live and spendable,
 		// only expiry monitoring is disabled, and the authoritative
 		// expiry can still be recovered from the operator's indexer.
-		sweepDelay := int32(s.SweepDelay)
 		batchExpiry := int32(0)
-		if sweepDelay > 0 {
-			batchExpiry = evt.BlockHeight + sweepDelay
+		if s.SweepDelay > 0 {
+			expiry := int64(evt.BlockHeight) + int64(s.SweepDelay)
+			if expiry > math.MaxInt32 {
+				return nil, fmt.Errorf("round batch expiry "+
+					"overflows int32: height=%d delay=%d",
+					evt.BlockHeight, s.SweepDelay)
+			}
+			batchExpiry = int32(expiry)
 		} else {
 			env.Log.ErrorS(ctx, "Round has no recorded sweep "+
 				"delay; leaving batch expiry unstamped",

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -1303,6 +1303,8 @@ func TestRoundJoinedState(t *testing.T) {
 	})
 }
 
+// TestCommitmentTxReceivedState verifies commitment, tree, and sweep-policy
+// validation before the client advances toward round signing.
 func TestCommitmentTxReceivedState(t *testing.T) {
 	t.Parallel()
 
@@ -1330,6 +1332,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 				VTXOs:    vtxos,
 			},
 			ClientTrees: make(map[SignerKey]*tree.Tree),
+			SweepKey:    h.operatorPubKey,
 			SweepDelay:  1008,
 		}
 		h.withState(state)
@@ -1391,6 +1394,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 				},
 			},
 			ClientTrees: make(map[SignerKey]*tree.Tree),
+			SweepKey:    h.operatorPubKey,
 			SweepDelay:  1008,
 		}
 		h.withState(state)
@@ -1460,6 +1464,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 				VTXOs:    vtxos,
 			},
 			ClientTrees: make(map[SignerKey]*tree.Tree),
+			SweepKey:    h.operatorPubKey,
 			SweepDelay:  1008,
 			Quote: &ClientQuote{
 				OperatorFeeSat: 1500,
@@ -1538,6 +1543,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 				VTXOs:    vtxos,
 			},
 			ClientTrees: make(map[SignerKey]*tree.Tree),
+			SweepKey:    h.operatorPubKey,
 			SweepDelay:  1008,
 			Quote: &ClientQuote{
 				OperatorFeeSat: 1500,
@@ -1628,6 +1634,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 				Leaves:   leaves,
 			},
 			ClientTrees: make(map[SignerKey]*tree.Tree),
+			SweepKey:    h.operatorPubKey,
 			SweepDelay:  1008,
 			Quote: &ClientQuote{
 				OperatorFeeSat: 1500,
@@ -3662,6 +3669,7 @@ func TestRefreshOnlyRoundValidation(t *testing.T) {
 		},
 		Intents:     emptyIntents,
 		ClientTrees: make(map[SignerKey]*tree.Tree),
+		SweepKey:    h.operatorPubKey,
 		SweepDelay:  1008,
 	}
 	h.withState(state)

--- a/round/vtxo_tree_binding_test.go
+++ b/round/vtxo_tree_binding_test.go
@@ -404,6 +404,7 @@ func TestCommitmentTxReceivedRejectsUnboundTree(t *testing.T) {
 		RoundID:      roundID,
 		CommitmentTx: commitmentTx,
 		TxID:         commitmentTx.UnsignedTx.TxHash(),
+		SweepKey:     h.operatorPubKey,
 		SweepDelay:   1008,
 		VTXOTreePaths: map[int]*tree.Tree{
 			0: vtxtTree,
@@ -491,6 +492,7 @@ func TestCommitmentTxReceivedRejectsCommitmentSiphon(t *testing.T) {
 		RoundID:      roundID,
 		CommitmentTx: commitment,
 		TxID:         commitment.UnsignedTx.TxHash(),
+		SweepKey:     h.operatorPubKey,
 		SweepDelay:   1008,
 		VTXOTreePaths: map[int]*tree.Tree{
 			0: vtxtTree,

--- a/systest/oor_vtxo_manager_test.go
+++ b/systest/oor_vtxo_manager_test.go
@@ -124,9 +124,10 @@ func TestOORIncomingMaterializationSpawnsVTXOActor(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := &oor.LocalPersistenceOutboxHandler{
-		Store:       f.vtxoStore,
-		OperatorKey: operatorKey,
-		ExitDelay:   10,
+		Store:                      f.vtxoStore,
+		OperatorKey:                operatorKey,
+		ExitDelay:                  10,
+		AuthenticateIncomingExpiry: authenticateSystemTestExpiry,
 		NotifyIncomingVTXOs: func(_ context.Context,
 			_ []*vtxo.Descriptor) error {
 
@@ -221,9 +222,10 @@ func TestOORSelfChangeMaterializationSkipsExternalRecipient(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := &oor.LocalPersistenceOutboxHandler{
-		Store:       f.vtxoStore,
-		OperatorKey: operatorKey,
-		ExitDelay:   10,
+		Store:                      f.vtxoStore,
+		OperatorKey:                operatorKey,
+		ExitDelay:                  10,
+		AuthenticateIncomingExpiry: authenticateSystemTestExpiry,
 		NotifyIncomingVTXOs: func(_ context.Context,
 			_ []*vtxo.Descriptor) error {
 
@@ -362,7 +364,9 @@ func driveIncomingOutbox(ctx context.Context, session *oor.ReceiveSession,
 				}
 			}
 
-		case *oor.QueryIncomingMetadataRequest:
+		case *oor.QueryIncomingMetadataRequest,
+			*oor.AuthenticateIncomingMetadataRequest:
+
 			followUps, err := handler.Handle(
 				ctx, sessionID, typedMsg,
 			)
@@ -429,6 +433,18 @@ func activeVTXOCount(ctx context.Context,
 	}
 
 	return countResp.Count, nil
+}
+
+// authenticateSystemTestExpiry stands in for the chain-authentication
+// boundary in materialization-focused system tests.
+func authenticateSystemTestExpiry(_ context.Context,
+	ancestry []vtxo.Ancestry) (int32, error) {
+
+	if len(ancestry) == 0 {
+		return 0, fmt.Errorf("expiry ancestry must be provided")
+	}
+
+	return 1000, nil
 }
 
 // seedIncomingRound inserts the round row referenced by the incoming VTXO
@@ -875,10 +891,12 @@ func TestOORConcurrentIncomingMaterialization(t *testing.T) {
 
 		recvMetadata := metadata
 		recvKey := recipientKey
+		authExpiry := authenticateSystemTestExpiry
 		handler := &oor.LocalPersistenceOutboxHandler{
-			Store:       f.vtxoStore,
-			OperatorKey: operatorKey,
-			ExitDelay:   10,
+			Store:                      f.vtxoStore,
+			OperatorKey:                operatorKey,
+			ExitDelay:                  10,
+			AuthenticateIncomingExpiry: authExpiry,
 			NotifyIncomingVTXOs: func(_ context.Context,
 				_ []*vtxo.Descriptor) error {
 

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -88,11 +88,18 @@ when the local wallet owns the receive script.
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
 - `GetActiveVTXOCountRequest` / `GetActiveVTXOCountResponse` — Ask-message for querying active VTXO count from the manager.
 - `ManagerMsg` / `ManagerResp` — Type aliases for `actormsg.VTXOManagerMsg` / `actormsg.VTXOManagerResp` (admission types live in `lib/actormsg` to avoid import cycles).
-- `IncomingVTXOHandler` — Actor that consumes `arkrpc.IncomingVTXOEvent` push notifications, looks up the receive script in the owned-script store, builds a `Descriptor` (with tapscript derived via `lib/arkscript`), persists it via `VTXOSaver`, and tells the manager via `VTXOsMaterializedNotification`. Only `VTXO_EVENT_TYPE_CREATED` events are acted on; unknown event kinds and unowned scripts are silently ignored. Inputs are validated for outpoint shape, pkScript presence, and `int64`/`MaxSatoshi` value bounds before any DB write.
-- `IncomingVTXOMsg` / `IncomingVTXOResp` — Actor envelope wrapping an `arkrpc.IncomingVTXOEvent` and the `any`-typed response.
+- `IncomingVTXOHandler` — Actor that consumes `arkrpc.IncomingVTXOEvent` push
+  notifications through a durable mailbox, looks up the receive script,
+  fetches ancestry, requires a positive chain-authenticated batch expiry,
+  persists the descriptor, and tells the manager via
+  `VTXOsMaterializedNotification`. Transient failures postpone the durable
+  event without consuming its retry budget. The push's expiry and
+  relative-expiry scalars are not trusted. Only created events are acted on;
+  unknown event kinds and unowned scripts are silently ignored.
+- `IncomingVTXOMsg` / `IncomingVTXOResp` — Durable actor envelope wrapping an `arkrpc.IncomingVTXOEvent` and the `any`-typed response. Its TLV codec preserves the full protobuf across restart redelivery.
 - `IncomingVTXOServiceKey` — Well-known service key (`"incoming-vtxo-handler"`) used by `waved` to register the actor and by `serverconn.EventRouter` to dispatch routed events.
 - `OwnedReceiveScript` / `OwnedScriptLookup` — Read-only view of the owned receive scripts store used by the incoming handler. `LookupOwnedReceiveScript` returns `sql.ErrNoRows` for unknown scripts; the handler treats this as "not ours" and exits cleanly.
-- `VTXOSaver` — Narrow persistence interface (`SaveVTXO(ctx, *Descriptor)`) the incoming handler uses; the production implementation is the `db` VTXO store, which serializes a missing tree path as an empty blob.
+- `IncomingVTXOStore` — Narrow persistence interface (`SaveVTXO` plus `GetVTXO`) used by the incoming handler. Reload closes the save-before-ack crash window by matching the immutable identity and authenticated expiry, then returning the canonical stored descriptor for manager notification.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
 - `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory preview** before each auto-refresh emission to estimate the per-input operator fee for UX surfaces. Under the seal-time fee handshake (#270) the server is the binding fee authority — the quoter's return value is no longer attached to the wire intent. Nil quoter (legacy and test paths) yields `OperatorFee=0` on the harness-local `RefreshVTXORequest`, which has no effect on the round protocol.
@@ -135,7 +142,9 @@ when the local wallet owns the receive script.
   commitment txid when the inputs sat at different leaves of one
   commitment tree — each leaf needs its own root-to-leaf path.
 - Each `Ancestry` carries `TreePath`, `CommitmentTxID`, `InputIndices`
-  (Ark tx input indices the fragment serves), and `TreeDepth`.
+  (Ark tx input indices the fragment serves), `TreeDepth`, the commitment
+  height hint, and the sweep key/delay evidence bound to the tree's sweep
+  tapscript root.
 - `Descriptor.MaxTreeDepth()` returns `max(TreeDepth)` across the
   ancestry slice for callers that need worst-case unilateral-exit
   timing (e.g. `expiry.go`).
@@ -145,6 +154,21 @@ when the local wallet owns the receive script.
   ancestry join and only load it when the unroller resolves an exit.
 
 ## Invariants
+
+- Indexed VTXOs pass `vtxo.IndexedAncestryFromRPC` before new acceptance.
+  It verifies signed tree/transaction paths to the exact target outpoint,
+  value, and script. OOR inventory includes `ancestry_packages` to connect
+  round leaves to the target. Sweep expiry is then derived separately from
+  locally confirmed batch outputs. A valid unrelated batch cannot authorize
+  a received target. Existing persisted live rows are outside this check.
+
+- **New incoming expiry is authenticated before persistence.** The thin
+  indexer event is only a wake-up hint. `AuthenticateBatchExpiry` reconstructs
+  the sweep leaf, recomputes the tree-root output script, byte-matches that
+  output in a locally confirmed commitment transaction, and derives the
+  earliest `confirmation height + sweep delay` across ancestry fragments.
+  Lookup or save failures leave the durable event pending for retry. Existing
+  persisted rows are not rewritten by this path.
 
 - **Expiry is persisted and non-terminal.** `LiveState` + `ExpiryStatusExpired`
   transitions to `ExpiredState` and emits `VTXOStatusUpdate{Expired}`. It does
@@ -228,7 +252,7 @@ when the local wallet owns the receive script.
 - Admission types (`SelectAndReserveSpendRequest`, `SelectAndReserveForfeitRequest`, `ReserveForfeitRequest`, etc.) are defined in `lib/actormsg` and re-exported as type aliases to avoid wallet → vtxo → round → wallet import cycles.
 - `selectAndReserveVTXOs` is a shared helper parameterized by `reserveParams` that serves both the OOR spend and cooperative forfeit coin selection paths, avoiding code duplication.
 - `IncomingVTXOHandler` only handles `VTXO_EVENT_TYPE_CREATED` events. Other event kinds, missing/short outpoints, empty pkScripts, oversized values (`> int64` or `> MaxSatoshi`), and tapscript derivation failures all return success without persisting — they cannot crash the actor or block the indexer push stream. Real DB lookup/save errors are surfaced.
-- Incoming VTXOs are saved with `Status: VTXOStatusLive` and empty `Ancestry` (the round commitment tree is not pushed alongside the event); `db.VTXOPersistenceStore.descriptorToInsertParams` accepts an empty tree-path blob to support this.
+- Incoming VTXOs are saved with `Status: VTXOStatusLive` only after the ancestry fetcher supplies the commitment-tree proof and chain-authenticated batch expiry. The thin push alone cannot create a live row.
 - The `CommitmentTxID` on a materialized incoming VTXO comes from `IncomingVTXOEvent.CommitmentTxid`, which is the round commitment txid — **not** the leaf txid in the outpoint.
 - Per-subsystem logging: `ManagerConfig.Log` provides an optional instance logger; falls back to `build.LoggerFromContext` (no global mutable loggers).
 

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -88,11 +88,18 @@ when the local wallet owns the receive script.
 - `FilterOptions` / `FilterDescriptors` — VTXO filtering by expiry status, spend state, etc.
 - `GetActiveVTXOCountRequest` / `GetActiveVTXOCountResponse` — Ask-message for querying active VTXO count from the manager.
 - `ManagerMsg` / `ManagerResp` — Type aliases for `actormsg.VTXOManagerMsg` / `actormsg.VTXOManagerResp` (admission types live in `lib/actormsg` to avoid import cycles).
-- `IncomingVTXOHandler` — Actor that consumes `arkrpc.IncomingVTXOEvent` push notifications, looks up the receive script in the owned-script store, builds a `Descriptor` (with tapscript derived via `lib/arkscript`), persists it via `VTXOSaver`, and tells the manager via `VTXOsMaterializedNotification`. Only `VTXO_EVENT_TYPE_CREATED` events are acted on; unknown event kinds and unowned scripts are silently ignored. Inputs are validated for outpoint shape, pkScript presence, and `int64`/`MaxSatoshi` value bounds before any DB write.
-- `IncomingVTXOMsg` / `IncomingVTXOResp` — Actor envelope wrapping an `arkrpc.IncomingVTXOEvent` and the `any`-typed response.
+- `IncomingVTXOHandler` — Actor that consumes `arkrpc.IncomingVTXOEvent` push
+  notifications through a durable mailbox, looks up the receive script,
+  fetches ancestry, requires a positive chain-authenticated batch expiry,
+  persists the descriptor, and tells the manager via
+  `VTXOsMaterializedNotification`. Transient failures postpone the durable
+  event without consuming its retry budget. The push's expiry and
+  relative-expiry scalars are not trusted. Only created events are acted on;
+  unknown event kinds and unowned scripts are silently ignored.
+- `IncomingVTXOMsg` / `IncomingVTXOResp` — Durable actor envelope wrapping an `arkrpc.IncomingVTXOEvent` and the `any`-typed response. Its TLV codec preserves the full protobuf across restart redelivery.
 - `IncomingVTXOServiceKey` — Well-known service key (`"incoming-vtxo-handler"`) used by `waved` to register the actor and by `serverconn.EventRouter` to dispatch routed events.
 - `OwnedReceiveScript` / `OwnedScriptLookup` — Read-only view of the owned receive scripts store used by the incoming handler. `LookupOwnedReceiveScript` returns `sql.ErrNoRows` for unknown scripts; the handler treats this as "not ours" and exits cleanly.
-- `VTXOSaver` — Narrow persistence interface (`SaveVTXO(ctx, *Descriptor)`) the incoming handler uses; the production implementation is the `db` VTXO store, which serializes a missing tree path as an empty blob.
+- `IncomingVTXOStore` — Narrow persistence interface (`SaveVTXO` plus `GetVTXO`) used by the incoming handler. Reload closes the save-before-ack crash window by matching the immutable identity and authenticated expiry, then returning the canonical stored descriptor for manager notification.
 - `VTXOsMaterializedNotification` — Manager-facing notification carrying already-persisted descriptors; the manager spawns one actor per descriptor without performing another store write. Used by both the OOR receive path and the new incoming round VTXO handler.
 - `LazyChainResolver` — Forwarding `TellOnlyRef[ExpiringNotification]` that buffers notifications until `Set()` wires the real chain-resolver target. Breaks the init-order dependency between the VTXO manager (which spawns `LazyChainResolver` at startup) and the unroll registry (which is wired after the VTXO manager starts). Buffered notifications are replayed in-order on `Set()`.
 - `RefreshFeeQuoter` — Function type `func(ctx, amount btcutil.Amount, remainingBlocks uint32) btcutil.Amount`. Optional hook on `VTXOActorConfig`; invoked as an **advisory preview** before each auto-refresh emission to estimate the per-input operator fee for UX surfaces. Under the seal-time fee handshake (#270) the server is the binding fee authority — the quoter's return value is no longer attached to the wire intent. Nil quoter (legacy and test paths) yields `OperatorFee=0` on the harness-local `RefreshVTXORequest`, which has no effect on the round protocol.
@@ -135,7 +142,9 @@ when the local wallet owns the receive script.
   commitment txid when the inputs sat at different leaves of one
   commitment tree — each leaf needs its own root-to-leaf path.
 - Each `Ancestry` carries `TreePath`, `CommitmentTxID`, `InputIndices`
-  (Ark tx input indices the fragment serves), and `TreeDepth`.
+  (Ark tx input indices the fragment serves), `TreeDepth`, the commitment
+  height hint, and the sweep key/delay evidence bound to the tree's sweep
+  tapscript root.
 - `Descriptor.MaxTreeDepth()` returns `max(TreeDepth)` across the
   ancestry slice for callers that need worst-case unilateral-exit
   timing (e.g. `expiry.go`).
@@ -145,6 +154,21 @@ when the local wallet owns the receive script.
   ancestry join and only load it when the unroller resolves an exit.
 
 ## Invariants
+
+- Indexed VTXOs pass `vtxo.IndexedAncestryFromRPC` before new acceptance.
+  It verifies signed tree/transaction paths to the exact target outpoint,
+  value, and script. OOR inventory includes `ancestry_packages` to connect
+  round leaves to the target. Sweep expiry is then derived separately from
+  locally confirmed batch outputs. A valid unrelated batch cannot authorize
+  a received target. Existing persisted live rows are outside this check.
+
+- **New incoming expiry is authenticated before persistence.** The thin
+  indexer event is only a wake-up hint. `AuthenticateBatchExpiry` reconstructs
+  the sweep leaf, recomputes the tree-root output script, byte-matches that
+  output in a locally confirmed commitment transaction, and derives the
+  earliest `confirmation height + sweep delay` across ancestry fragments.
+  Lookup or save failures leave the durable event pending for retry. Existing
+  persisted rows are not rewritten by this path.
 
 - **Expiry is persisted and non-terminal.** `LiveState` + `ExpiryStatusExpired`
   transitions to `ExpiredState` and emits `VTXOStatusUpdate{Expired}`. It does
@@ -228,7 +252,7 @@ when the local wallet owns the receive script.
 - Admission types (`SelectAndReserveSpendRequest`, `SelectAndReserveForfeitRequest`, `ReserveForfeitRequest`, etc.) are defined in `lib/actormsg` and re-exported as type aliases to avoid wallet → vtxo → round → wallet import cycles.
 - `selectAndReserveVTXOs` is a shared helper parameterized by `reserveParams` that serves both the OOR spend and cooperative forfeit coin selection paths, avoiding code duplication.
 - `IncomingVTXOHandler` only handles `VTXO_EVENT_TYPE_CREATED` events. Other event kinds, missing/short outpoints, empty pkScripts, oversized values (`> int64` or `> MaxSatoshi`), and tapscript derivation failures all return success without persisting — they cannot crash the actor or block the indexer push stream. Real DB lookup/save errors are surfaced.
-- Incoming VTXOs are saved with `Status: VTXOStatusLive` and empty `Ancestry` (the round commitment tree is not pushed alongside the event); `db.VTXOPersistenceStore.descriptorToInsertParams` accepts an empty tree-path blob to support this.
+- Incoming VTXOs are saved with `Status: VTXOStatusLive` only after the ancestry fetcher supplies the commitment-tree proof and chain-authenticated batch expiry. The thin push alone cannot create a live row.
 - The `CommitmentTxID` on a materialized incoming VTXO comes from `IncomingVTXOEvent.CommitmentTxid`, which is the round commitment txid — **not** the leaf txid in the outpoint.
 - Per-subsystem logging: `ManagerConfig.Log` provides an optional instance logger; falls back to `build.LoggerFromContext` (no global mutable loggers).
 

--- a/vtxo/authenticated_expiry.go
+++ b/vtxo/authenticated_expiry.go
@@ -1,0 +1,213 @@
+package vtxo
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+)
+
+// ErrInvalidBatchExpiryEvidence identifies malformed or conflicting expiry
+// evidence. Unlike a confirmation lookup failure, retrying the same evidence
+// cannot repair this error.
+var ErrInvalidBatchExpiryEvidence = errors.New("invalid batch expiry evidence")
+
+// CommitmentConfirmation is the chain-authenticated transaction and height
+// used to derive one commitment's absolute sweep expiry.
+type CommitmentConfirmation struct {
+	Tx          *wire.MsgTx
+	BlockHeight int32
+}
+
+// CommitmentConfirmationResolver resolves a commitment transaction's current
+// confirmation snapshot. PkScript and heightHint select and optimize the
+// chain lookup; callers must not treat either as authentication by itself.
+type CommitmentConfirmationResolver func(ctx context.Context,
+	txid chainhash.Hash, pkScript []byte,
+	heightHint uint32) (CommitmentConfirmation, error)
+
+// AuthenticateBatchExpiry derives the earliest absolute expiry across all
+// ancestry fragments. Each delay is authenticated against its tree root, and
+// each tree's claimed batch output is checked against the transaction returned
+// by the local chain source before the confirmation height is used.
+func AuthenticateBatchExpiry(ctx context.Context, ancestry []Ancestry,
+	resolve CommitmentConfirmationResolver) (int32, error) {
+
+	if len(ancestry) == 0 {
+		return 0, invalidBatchExpiry("ancestry must be provided")
+	}
+	if resolve == nil {
+		return 0, fmt.Errorf("confirmation resolver must be provided")
+	}
+
+	type commitmentGroup struct {
+		fragments  []Ancestry
+		pkScript   []byte
+		heightHint uint32
+	}
+
+	groups := make(map[chainhash.Hash]*commitmentGroup, len(ancestry))
+	for i := range ancestry {
+		fragment := ancestry[i]
+		if err := validateExpiryFragment(fragment); err != nil {
+			return 0, fmt.Errorf("ancestry fragment %d: %w", i, err)
+		}
+
+		group := groups[fragment.CommitmentTxID]
+		if group == nil {
+			group = &commitmentGroup{
+				pkScript: bytes.Clone(
+					fragment.TreePath.BatchOutput.PkScript,
+				),
+			}
+			groups[fragment.CommitmentTxID] = group
+		}
+		group.fragments = append(group.fragments, fragment)
+		if fragment.CommitmentHeight > 0 &&
+			(group.heightHint == 0 ||
+				uint32(fragment.CommitmentHeight) <
+					group.heightHint) {
+
+			group.heightHint = uint32(fragment.CommitmentHeight)
+		}
+	}
+
+	var earliest int64
+	for txid, group := range groups {
+		confirmation, err := resolve(
+			ctx, txid, group.pkScript, group.heightHint,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("resolve commitment %s: %w", txid,
+				err)
+		}
+		if confirmation.Tx == nil {
+			return 0, fmt.Errorf("commitment %s confirmation has "+
+				"no transaction", txid)
+		}
+		if confirmation.BlockHeight <= 0 {
+			return 0, fmt.Errorf("commitment %s has invalid "+
+				"confirmation height %d", txid,
+				confirmation.BlockHeight)
+		}
+		if confirmation.Tx.TxHash() != txid {
+			return 0, invalidBatchExpiry(
+				"confirmation transaction does not match "+
+					"commitment %s", txid,
+			)
+		}
+
+		for _, fragment := range group.fragments {
+			idx := fragment.TreePath.BatchOutpoint.Index
+			if idx >= uint32(len(confirmation.Tx.TxOut)) {
+				return 0, invalidBatchExpiry(
+					"commitment %s output %d is out of "+
+						"range", txid, idx,
+				)
+			}
+
+			claimed := fragment.TreePath.BatchOutput
+			actual := confirmation.Tx.TxOut[idx]
+			if claimed.Value != actual.Value || !bytes.Equal(
+				claimed.PkScript, actual.PkScript,
+			) {
+				return 0, invalidBatchExpiry(
+					"commitment %s output %d does not "+
+						"match ancestry", txid, idx,
+				)
+			}
+
+			expiry := int64(confirmation.BlockHeight) +
+				int64(fragment.CommitmentSweepDelay)
+			if expiry > math.MaxInt32 {
+				return 0, invalidBatchExpiry(
+					"commitment %s expiry overflows int32",
+					txid,
+				)
+			}
+			if earliest == 0 || expiry < earliest {
+				earliest = expiry
+			}
+		}
+	}
+
+	if earliest == 0 {
+		return 0, invalidBatchExpiry("no expiry was derived")
+	}
+
+	return int32(earliest), nil
+}
+
+// validateExpiryFragment binds one ancestry tree to its sweep policy and
+// recomputed root output.
+func validateExpiryFragment(fragment Ancestry) error {
+	if fragment.TreePath == nil || fragment.TreePath.BatchOutput == nil {
+		return invalidBatchExpiry(
+			"tree path and batch output are required",
+		)
+	}
+	if fragment.TreePath.Root == nil {
+		return invalidBatchExpiry("tree root is required")
+	}
+	if fragment.TreePath.BatchOutpoint.Hash != fragment.CommitmentTxID {
+		return invalidBatchExpiry(
+			"tree batch outpoint does not match commitment txid",
+		)
+	}
+	if fragment.CommitmentSweepDelay == 0 {
+		return invalidBatchExpiry("sweep delay must be positive")
+	}
+	if fragment.CommitmentSweepKey == nil {
+		return invalidBatchExpiry("sweep key must be provided")
+	}
+
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		fragment.CommitmentSweepKey, fragment.CommitmentSweepDelay,
+	)
+	if err != nil {
+		return invalidBatchExpiry("build sweep leaf: %v", err)
+	}
+	sweepRoot := sweepLeaf.TapHash()
+	if !bytes.Equal(
+		sweepRoot[:], fragment.TreePath.SweepTapscriptRoot,
+	) {
+		return invalidBatchExpiry(
+			"sweep key and delay do not match committed sweep root",
+		)
+	}
+
+	finalKey, err := tree.ComputeFinalKey(
+		fragment.TreePath.Root.CoSigners,
+		fragment.TreePath.SweepTapscriptRoot,
+	)
+	if err != nil {
+		return invalidBatchExpiry("recompute tree root key: %v", err)
+	}
+	expectedScript, err := txscript.PayToTaprootScript(finalKey)
+	if err != nil {
+		return invalidBatchExpiry("recompute tree root script: %v", err)
+	}
+	if !bytes.Equal(
+		expectedScript, fragment.TreePath.BatchOutput.PkScript,
+	) {
+		return invalidBatchExpiry(
+			"batch output does not match tree root",
+		)
+	}
+
+	return nil
+}
+
+// invalidBatchExpiry wraps a permanent evidence failure with the public
+// classification sentinel.
+func invalidBatchExpiry(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidBatchExpiryEvidence, fmt.Sprintf(
+		format, args...))
+}

--- a/vtxo/authenticated_expiry_test.go
+++ b/vtxo/authenticated_expiry_test.go
@@ -1,0 +1,230 @@
+package vtxo
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuthenticateBatchExpiryUsesEarliestCommitment verifies multi-parent
+// expiry selection and per-commitment lookup deduplication.
+func TestAuthenticateBatchExpiryUsesEarliestCommitment(t *testing.T) {
+	t.Parallel()
+
+	first, firstConfirmation := testExpiryAncestry(t, 50, 100)
+	second, secondConfirmation := testExpiryAncestry(t, 20, 120)
+	duplicate := first
+	duplicate.InputIndices = []uint32{1}
+
+	confirmations := map[chainhash.Hash]CommitmentConfirmation{
+		first.CommitmentTxID:  firstConfirmation,
+		second.CommitmentTxID: secondConfirmation,
+	}
+	resolveCalls := make(map[chainhash.Hash]int)
+	expiry, err := AuthenticateBatchExpiry(
+		t.Context(), []Ancestry{first, duplicate, second},
+		func(_ context.Context, txid chainhash.Hash, _ []byte,
+			_ uint32) (CommitmentConfirmation, error) {
+
+			resolveCalls[txid]++
+
+			return confirmations[txid], nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(140), expiry)
+	require.Equal(t, 1, resolveCalls[first.CommitmentTxID])
+	require.Equal(t, 1, resolveCalls[second.CommitmentTxID])
+}
+
+// TestAuthenticateBatchExpiryRejectsInvalidEvidence verifies every untrusted
+// proof boundary and transient resolver classification.
+func TestAuthenticateBatchExpiryRejectsInvalidEvidence(t *testing.T) {
+	t.Parallel()
+
+	fragment, confirmation := testExpiryAncestry(t, 50, 100)
+
+	t.Run("output mismatch", func(t *testing.T) {
+		bad := confirmation
+		bad.Tx = bad.Tx.Copy()
+		bad.Tx.TxOut[0].Value++
+
+		_, err := AuthenticateBatchExpiry(
+			t.Context(), []Ancestry{fragment},
+			func(context.Context, chainhash.Hash, []byte, uint32) (
+				CommitmentConfirmation, error) {
+
+				return bad, nil
+			},
+		)
+		require.ErrorIs(t, err, ErrInvalidBatchExpiryEvidence)
+		require.ErrorContains(t, err, "does not match commitment")
+	})
+
+	t.Run("sweep mismatch", func(t *testing.T) {
+		bad := fragment
+		bad.CommitmentSweepDelay++
+
+		_, err := AuthenticateBatchExpiry(
+			t.Context(), []Ancestry{bad},
+			func(context.Context, chainhash.Hash, []byte, uint32) (
+				CommitmentConfirmation, error) {
+
+				return confirmation, nil
+			},
+		)
+		require.ErrorIs(t, err, ErrInvalidBatchExpiryEvidence)
+		require.ErrorContains(t, err, "committed sweep root")
+	})
+
+	t.Run("tree root substitution", func(t *testing.T) {
+		bad := fragment
+		otherKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		bad.TreePath = &tree.Tree{
+			Root: &tree.Node{
+				CoSigners: []*btcec.PublicKey{
+					otherKey.PubKey(),
+				},
+			},
+			BatchOutpoint: fragment.TreePath.BatchOutpoint,
+			BatchOutput:   fragment.TreePath.BatchOutput,
+			SweepTapscriptRoot: fragment.TreePath.
+				SweepTapscriptRoot,
+		}
+
+		_, err = AuthenticateBatchExpiry(
+			t.Context(), []Ancestry{bad},
+			func(context.Context, chainhash.Hash, []byte, uint32) (
+				CommitmentConfirmation, error) {
+
+				return confirmation, nil
+			},
+		)
+		require.ErrorIs(t, err, ErrInvalidBatchExpiryEvidence)
+		require.ErrorContains(
+			t, err, "batch output does not match tree root",
+		)
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		badConfirmation := confirmation
+		badConfirmation.BlockHeight = math.MaxInt32 - 10
+
+		_, err := AuthenticateBatchExpiry(
+			t.Context(), []Ancestry{fragment},
+			func(context.Context, chainhash.Hash, []byte, uint32) (
+				CommitmentConfirmation, error) {
+
+				return badConfirmation, nil
+			},
+		)
+		require.ErrorIs(t, err, ErrInvalidBatchExpiryEvidence)
+		require.ErrorContains(t, err, "overflows")
+	})
+
+	t.Run("resolver error remains retryable", func(t *testing.T) {
+		resolverErr := errors.New("chain backend unavailable")
+		_, err := AuthenticateBatchExpiry(
+			t.Context(), []Ancestry{fragment},
+			func(context.Context, chainhash.Hash, []byte, uint32) (
+				CommitmentConfirmation, error) {
+
+				return CommitmentConfirmation{}, resolverErr
+			},
+		)
+		require.ErrorIs(t, err, resolverErr)
+		require.NotErrorIs(t, err, ErrInvalidBatchExpiryEvidence)
+	})
+
+	t.Run("incomplete confirmation remains retryable", func(t *testing.T) {
+		tests := []CommitmentConfirmation{
+			{
+				BlockHeight: confirmation.BlockHeight,
+			},
+			{
+				Tx: confirmation.Tx,
+			},
+		}
+		for _, incomplete := range tests {
+			_, err := AuthenticateBatchExpiry(
+				t.Context(), []Ancestry{fragment},
+				func(context.Context, chainhash.Hash, []byte,
+					uint32) (CommitmentConfirmation,
+					error) {
+
+					return incomplete, nil
+				},
+			)
+			require.Error(t, err)
+			require.NotErrorIs(
+				t, err, ErrInvalidBatchExpiryEvidence,
+			)
+		}
+	})
+}
+
+// testExpiryAncestry builds internally consistent tree and chain evidence.
+func testExpiryAncestry(t *testing.T, delay uint32,
+	height int32) (Ancestry, CommitmentConfirmation) {
+
+	t.Helper()
+
+	sweepKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		sweepKey.PubKey(), delay,
+	)
+	require.NoError(t, err)
+	sweepRoot := sweepLeaf.TapHash()
+	ownerKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	cosigners := []*btcec.PublicKey{ownerKey.PubKey()}
+	finalKey, err := tree.ComputeFinalKey(cosigners, sweepRoot[:])
+	require.NoError(t, err)
+	batchScript, err := txscript.PayToTaprootScript(finalKey)
+	require.NoError(t, err)
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(
+		&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{
+				Hash: chainhash.Hash{byte(delay)},
+			},
+		},
+	)
+	tx.AddTxOut(&wire.TxOut{
+		Value:    int64(delay) * 100,
+		PkScript: batchScript,
+	})
+	txid := tx.TxHash()
+
+	return Ancestry{
+			TreePath: &tree.Tree{
+				Root: &tree.Node{
+					CoSigners: cosigners,
+				},
+				BatchOutpoint: wire.OutPoint{
+					Hash: txid,
+				},
+				BatchOutput:        tx.TxOut[0],
+				SweepTapscriptRoot: sweepRoot[:],
+			},
+			CommitmentTxID:       txid,
+			CommitmentHeight:     height,
+			CommitmentSweepDelay: delay,
+			CommitmentSweepKey:   sweepKey.PubKey(),
+		}, CommitmentConfirmation{
+			Tx:          tx,
+			BlockHeight: height,
+		}
+}

--- a/vtxo/expiry_target.go
+++ b/vtxo/expiry_target.go
@@ -1,0 +1,140 @@
+package vtxo
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/recovery"
+)
+
+// expiryTarget binds an expiry decision to the received output. Transactions
+// contains finalized OOR transactions between the round leaves and the target;
+// round-direct targets need no additional transactions.
+type expiryTarget struct {
+	Outpoint     wire.OutPoint
+	Output       *wire.TxOut
+	Transactions []*wire.MsgTx
+}
+
+// validateExpiryTarget reuses tree structure and recovery graph validation,
+// then executes every spend against its actual parent output. A valid unrelated
+// batch or a forged child signed under an unrelated key cannot authorize the
+// target.
+func validateExpiryTarget(target expiryTarget, ancestry []Ancestry) error {
+	if target.Output == nil {
+		return fmt.Errorf("target output is required")
+	}
+
+	nodes := make(map[chainhash.Hash]*recovery.Node)
+	prevouts := txscript.NewMultiPrevOutFetcher(nil)
+	add := func(tx *wire.MsgTx) error {
+		if tx == nil {
+			return fmt.Errorf("nil proof transaction")
+		}
+		txid := tx.TxHash()
+		if previous, ok := nodes[txid]; ok {
+			var a, b bytes.Buffer
+			if err := previous.Tx.Serialize(&a); err != nil {
+				return err
+			}
+			if err := tx.Serialize(&b); err != nil {
+				return err
+			}
+			if !bytes.Equal(a.Bytes(), b.Bytes()) {
+				return fmt.Errorf("conflicting proof "+
+					"transaction %s", txid)
+			}
+
+			return nil
+		}
+		nodes[txid] = &recovery.Node{Tx: tx}
+		for i, output := range tx.TxOut {
+			prevouts.AddPrevOut(
+				wire.OutPoint{
+					Hash:  txid,
+					Index: uint32(i),
+				},
+				output,
+			)
+		}
+
+		return nil
+	}
+
+	for _, fragment := range ancestry {
+		if err := validateExpiryFragment(fragment); err != nil {
+			return err
+		}
+		path := fragment.TreePath
+		if err := path.Verify(); err != nil {
+			return fmt.Errorf("tree path: %w", err)
+		}
+		prevouts.AddPrevOut(path.BatchOutpoint, path.BatchOutput)
+		for node := range path.Root.NodesIter() {
+			tx, err := node.ToSignedTx()
+			if err != nil {
+				return err
+			}
+			if err := add(tx); err != nil {
+				return err
+			}
+		}
+	}
+	for _, tx := range target.Transactions {
+		if err := add(tx); err != nil {
+			return err
+		}
+	}
+
+	proofNodes := make([]*recovery.Node, 0, len(nodes))
+	for _, node := range nodes {
+		proofNodes = append(proofNodes, node)
+	}
+	proof, err := recovery.NewProof(target.Outpoint, 0, proofNodes...)
+	if err != nil {
+		return err
+	}
+	output, err := proof.TargetOutput()
+	if err != nil {
+		return err
+	}
+	if output.Value != target.Output.Value ||
+		!bytes.Equal(output.PkScript, target.Output.PkScript) {
+		return fmt.Errorf("target output does not match proof")
+	}
+
+	for _, node := range proofNodes {
+		tx := node.Tx
+		for _, in := range tx.TxIn {
+			previous := prevouts.FetchPrevOutput(
+				in.PreviousOutPoint,
+			)
+			if previous == nil {
+				return fmt.Errorf("proof input %s has no "+
+					"authenticated parent",
+					in.PreviousOutPoint)
+			}
+		}
+		sigHashes := txscript.NewTxSigHashes(tx, prevouts)
+		for i, in := range tx.TxIn {
+			prev := prevouts.FetchPrevOutput(in.PreviousOutPoint)
+			engine, err := txscript.NewEngine(
+				prev.PkScript, tx, i,
+				txscript.StandardVerifyFlags, nil, sigHashes,
+				prev.Value, prevouts,
+			)
+			if err != nil {
+				return err
+			}
+			if err := engine.Execute(); err != nil {
+				return fmt.Errorf("proof transaction %s input "+
+					"%d: %w", tx.TxHash(), i, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/vtxo/expiry_target_test.go
+++ b/vtxo/expiry_target_test.go
@@ -1,0 +1,139 @@
+package vtxo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/internal/expiryfixture"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestIndexedAncestryBindsTarget proves a valid later-expiring batch for
+// another VTXO cannot authenticate the received target, including a forged leaf
+// body.
+func TestIndexedAncestryBindsTarget(t *testing.T) {
+	t.Parallel()
+	original, commitment := expiryfixture.Round(
+		t, 10000, []byte{0x51}, 50, 100, 1,
+	)
+	other, _ := expiryfixture.Round(t, 10000, []byte{0x51}, 200, 100, 2)
+	ancestry, err := IndexedAncestryFromRPC(original)
+	require.NoError(t, err)
+	expiry, err := AuthenticateBatchExpiry(t.Context(), ancestry,
+		func(context.Context, chainhash.Hash, []byte, uint32) (
+			CommitmentConfirmation, error) {
+
+			return CommitmentConfirmation{
+				Tx:          commitment,
+				BlockHeight: 100,
+			}, nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, int32(150), expiry)
+
+	for _, mutation := range []struct {
+		name  string
+		apply func(*arkrpc.VTXO)
+	}{
+		{
+			"different batch",
+			func(v *arkrpc.VTXO) {
+				v.AncestryPaths = other.AncestryPaths
+			},
+		},
+		{
+			"different outpoint",
+			func(v *arkrpc.VTXO) {
+				v.Outpoint = other.Outpoint
+			},
+		},
+		{
+			"wrong index",
+			func(v *arkrpc.VTXO) {
+				v.Outpoint.Vout = 1
+			},
+		},
+		{
+			"wrong value",
+			func(v *arkrpc.VTXO) {
+				v.ValueSat++
+			},
+		},
+		{
+			"wrong script",
+			func(v *arkrpc.VTXO) {
+				v.PkScript = []byte{
+					0x52,
+				}
+			},
+		},
+	} {
+		t.Run(mutation.name, func(t *testing.T) {
+			bad, ok := proto.Clone(original).(*arkrpc.VTXO)
+			require.True(t, ok)
+			mutation.apply(bad)
+			_, err := IndexedAncestryFromRPC(bad)
+			require.ErrorIs(t, err, ErrInvalidBatchExpiryEvidence)
+		})
+	}
+}
+
+// TestIndexedAncestryMultiParentExpiry verifies the authenticated graph retains
+// every contributing batch and selects the earliest actual confirmation+delay.
+func TestIndexedAncestryMultiParentExpiry(t *testing.T) {
+	t.Parallel()
+	candidate, commits := expiryfixture.Merge(t, false)
+	ancestry, err := IndexedAncestryFromRPC(candidate)
+	require.NoError(t, err)
+	require.Len(t, ancestry, 2)
+	lookup := make(map[chainhash.Hash]CommitmentConfirmation)
+	for i, tx := range commits {
+		lookup[tx.TxHash()] = CommitmentConfirmation{
+			Tx:          tx,
+			BlockHeight: int32(100 + 20*i),
+		}
+	}
+	expiry, err := AuthenticateBatchExpiry(t.Context(), ancestry,
+		func(_ context.Context, txid chainhash.Hash, _ []byte,
+			_ uint32) (CommitmentConfirmation, error) {
+
+			return lookup[txid], nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, int32(140), expiry)
+
+	// Removing the earlier-expiring parent's path cannot make the later
+	// parent's otherwise valid evidence authorize the complete target.
+	candidate.AncestryPaths = candidate.AncestryPaths[:1]
+	_, err = IndexedAncestryFromRPC(candidate)
+	require.ErrorIs(t, err, ErrInvalidBatchExpiryEvidence)
+	require.ErrorContains(t, err, "no authenticated parent")
+}
+
+// TestIndexedAncestryRejectsForgedLeafBody checks that matching a reconstructed
+// target txid is insufficient when its signed parent never authorized the leaf.
+func TestIndexedAncestryRejectsForgedLeafBody(t *testing.T) {
+	t.Parallel()
+	candidate, _ := expiryfixture.Round(t, 10000, []byte{0x51}, 50, 100, 3)
+	originalPath := candidate.AncestryPaths[0]
+	path, err := arkrpc.AncestryPathToTree(originalPath)
+	require.NoError(t, err)
+	path.Root.Outputs[0].PkScript = []byte{0x52}
+	forged, err := arkrpc.AncestryPathFromTree(
+		path, path.BatchOutpoint.Hash, nil,
+	)
+	require.NoError(t, err)
+	forged.CommitmentSweepKey = originalPath.CommitmentSweepKey
+	forged.CommitmentSweepDelay = originalPath.CommitmentSweepDelay
+	candidate.AncestryPaths = []*arkrpc.AncestryPath{forged}
+	hash, err := path.Root.TXID()
+	require.NoError(t, err)
+	candidate.Outpoint.Txid = hash[:]
+	candidate.PkScript = []byte{0x52}
+	_, err = IndexedAncestryFromRPC(candidate)
+	require.ErrorIs(t, err, ErrInvalidBatchExpiryEvidence)
+	require.ErrorContains(t, err, "proof transaction")
+}

--- a/vtxo/incoming_ancestry.go
+++ b/vtxo/incoming_ancestry.go
@@ -1,10 +1,13 @@
 package vtxo
 
 import (
+	"bytes"
 	"fmt"
 	"slices"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
 )
 
 // MaxAncestryPaths bounds the per-VTXO ancestry slice the indexer is
@@ -55,6 +58,10 @@ func AncestryFromRPC(paths []*arkrpc.AncestryPath) ([]Ancestry, error) {
 			return nil, fmt.Errorf("path[%d] commitment: %w", i,
 				err)
 		}
+		if p.GetCommitmentHeight() < 0 {
+			return nil, fmt.Errorf("path[%d] commitment height "+
+				"must not be negative", i)
+		}
 
 		// Validate the indexer-supplied tree_depth against the
 		// reconstructed path before it can be persisted. A zero or
@@ -70,12 +77,52 @@ func AncestryFromRPC(paths []*arkrpc.AncestryPath) ([]Ancestry, error) {
 			return nil, fmt.Errorf("path[%d] depth: %w", i, err)
 		}
 
+		sweepDelay := p.GetCommitmentSweepDelay()
+		rawSweepKey := p.GetCommitmentSweepKey()
+		var sweepKey *btcec.PublicKey
+		switch {
+		case sweepDelay == 0 && len(rawSweepKey) == 0:
+			// Older indexers omitted both additive fields.
+			// Conversion remains possible, but
+			// AuthenticateBatchExpiry rejects the missing evidence
+			// before any new descriptor is accepted.
+
+		case sweepDelay == 0 || len(rawSweepKey) == 0:
+			return nil, fmt.Errorf("path[%d] sweep key and delay "+
+				"must both be provided", i)
+
+		default:
+			sweepKey, err = btcec.ParsePubKey(rawSweepKey)
+			if err != nil {
+				return nil, fmt.Errorf("path[%d] sweep key: %w",
+					i, err)
+			}
+
+			sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+				sweepKey, sweepDelay,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("path[%d] sweep "+
+					"leaf: %w", i, err)
+			}
+			sweepRoot := sweepLeaf.TapHash()
+			if !bytes.Equal(
+				sweepRoot[:], treePath.SweepTapscriptRoot,
+			) {
+				return nil, fmt.Errorf("path[%d] sweep key "+
+					"and delay do not match committed "+
+					"sweep root", i)
+			}
+		}
+
 		out = append(out, Ancestry{
-			TreePath:         treePath,
-			CommitmentTxID:   commitmentTxID,
-			InputIndices:     slices.Clone(p.GetInputIndices()),
-			TreeDepth:        p.GetTreeDepth(),
-			CommitmentHeight: p.GetCommitmentHeight(),
+			TreePath:             treePath,
+			CommitmentTxID:       commitmentTxID,
+			InputIndices:         slices.Clone(p.GetInputIndices()),
+			TreeDepth:            p.GetTreeDepth(),
+			CommitmentHeight:     p.GetCommitmentHeight(),
+			CommitmentSweepDelay: sweepDelay,
+			CommitmentSweepKey:   sweepKey,
 		})
 	}
 

--- a/vtxo/incoming_ancestry_resolver.go
+++ b/vtxo/incoming_ancestry_resolver.go
@@ -79,16 +79,20 @@ func ResolveIncomingAncestry(ctx context.Context, query IncomingAncestryQuery,
 				continue
 			}
 
-			ancestry, err := AncestryFromRPC(
-				candidate.GetAncestryPaths(),
-			)
+			ancestry, err := IndexedAncestryFromRPC(candidate)
 			if err != nil {
 				return IncomingVTXOExtras{}, fmt.Errorf(
 					"convert ancestry paths: %w", err)
 			}
 
 			return IncomingVTXOExtras{
-				Ancestry:      ancestry,
+				Ancestry: ancestry,
+				Output: &wire.TxOut{
+					Value: int64(candidate.GetValueSat()),
+					PkScript: bytes.Clone(
+						candidate.GetPkScript(),
+					),
+				},
 				CreatedHeight: candidate.GetCreatedHeight(),
 			}, nil
 		}

--- a/vtxo/incoming_ancestry_resolver_test.go
+++ b/vtxo/incoming_ancestry_resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/internal/expiryfixture"
 	"github.com/lightninglabs/wavelength/internal/indexerlimits"
 	lib_tree "github.com/lightninglabs/wavelength/lib/tree"
 	"github.com/stretchr/testify/require"
@@ -19,10 +20,11 @@ import (
 func TestResolveIncomingAncestryMatchesPaginatedOutpoint(t *testing.T) {
 	t.Parallel()
 
-	target := wire.OutPoint{
-		Hash:  testAncestryTxID(1),
-		Index: 7,
-	}
+	candidate, _ := expiryfixture.Round(
+		t, 1000, testAncestryPkScript, 50, 42, 1,
+	)
+	var target wire.OutPoint
+	copy(target.Hash[:], candidate.Outpoint.Txid)
 	query := newScriptedAncestryQuery(
 		testIncomingAncestryResponse(
 			[]byte("next"), &arkrpc.VTXO{
@@ -33,7 +35,7 @@ func TestResolveIncomingAncestryMatchesPaginatedOutpoint(t *testing.T) {
 			},
 		),
 		testIncomingAncestryResponse(
-			nil, testIncomingAncestryVTXO(target, 42),
+			nil, candidate,
 		),
 	)
 

--- a/vtxo/incoming_handler.go
+++ b/vtxo/incoming_handler.go
@@ -1,12 +1,15 @@
 package vtxo
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
@@ -19,6 +22,8 @@ import (
 	"github.com/lightninglabs/wavelength/metrics"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/tlv"
+	"google.golang.org/protobuf/proto"
 )
 
 // OwnedReceiveScript holds the metadata returned when looking up a
@@ -51,6 +56,17 @@ type VTXOSaver interface {
 	SaveVTXO(ctx context.Context, desc *Descriptor) error
 }
 
+// IncomingVTXOStore persists and reloads materialized descriptors. Reloading
+// makes durable redelivery idempotent across the save-before-ack crash window.
+type IncomingVTXOStore interface {
+	VTXOSaver
+
+	// GetVTXO reloads the canonical descriptor, including terminal state,
+	// before a replay notifies the manager about materialization.
+	GetVTXO(ctx context.Context,
+		outpoint wire.OutPoint) (*Descriptor, error)
+}
+
 // IncomingVTXOMsg wraps an IncomingVTXOEvent for the handler actor.
 type IncomingVTXOMsg struct {
 	actor.BaseMessage
@@ -58,8 +74,50 @@ type IncomingVTXOMsg struct {
 }
 
 // MessageType returns a human-readable message identifier.
-func (m IncomingVTXOMsg) MessageType() string {
+func (m *IncomingVTXOMsg) MessageType() string {
 	return fmt.Sprintf("IncomingVTXOMsg(event_id=%d)", m.Event.GetEventId())
+}
+
+const (
+	incomingVTXOMsgTLVType   tlv.Type = 0
+	incomingVTXORedriveDelay          = 30 * time.Second
+)
+
+// TLVType returns the durable-mailbox type identifier for an incoming event.
+func (m *IncomingVTXOMsg) TLVType() tlv.Type {
+	return incomingVTXOMsgTLVType
+}
+
+// Encode serializes the pushed protobuf for durable redelivery.
+func (m *IncomingVTXOMsg) Encode(w io.Writer) error {
+	if m.Event == nil {
+		return fmt.Errorf("incoming VTXO event must be provided")
+	}
+
+	raw, err := (proto.MarshalOptions{Deterministic: true}).Marshal(m.Event)
+	if err != nil {
+		return fmt.Errorf("marshal incoming VTXO event: %w", err)
+	}
+
+	_, err = w.Write(raw)
+
+	return err
+}
+
+// Decode restores a pushed protobuf from the durable mailbox.
+func (m *IncomingVTXOMsg) Decode(r io.Reader) error {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	event := &arkrpc.IncomingVTXOEvent{}
+	if err := proto.Unmarshal(raw, event); err != nil {
+		return fmt.Errorf("unmarshal incoming VTXO event: %w", err)
+	}
+	m.Event = event
+
+	return nil
 }
 
 // IncomingVTXOResp is the handler's response type.
@@ -70,17 +128,31 @@ const incomingVTXOServiceKeyName = "incoming-vtxo-handler"
 // IncomingVTXOServiceKey returns the well-known service key for the
 // incoming VTXO handler actor.
 func IncomingVTXOServiceKey() actor.ServiceKey[
-	IncomingVTXOMsg, IncomingVTXOResp] {
+	*IncomingVTXOMsg, IncomingVTXOResp] {
 
-	return actor.NewServiceKey[IncomingVTXOMsg, IncomingVTXOResp](
+	return actor.NewServiceKey[*IncomingVTXOMsg, IncomingVTXOResp](
 		incomingVTXOServiceKeyName,
 	)
+}
+
+// NewIncomingVTXOCodec builds the codec used by the durable incoming-event
+// mailbox.
+func NewIncomingVTXOCodec() *actor.MessageCodec {
+	codec := actor.NewMessageCodec()
+	codec.MustRegister(incomingVTXOMsgTLVType, func() actor.TLVMessage {
+		return &IncomingVTXOMsg{}
+	})
+
+	return codec
 }
 
 // IncomingVTXOExtras carries the descriptor fields the unilateral-exit
 // unroll path needs but the lightweight IncomingVTXOEvent push doesn't
 // carry. Resolved synchronously by IncomingAncestryFetcher.
 type IncomingVTXOExtras struct {
+	// Output is the target output authenticated by the fetched proof.
+	Output *wire.TxOut
+
 	// Ancestry is the set of rooted commitment-tree fragments
 	// required to claim this VTXO unilaterally on-chain. Empty
 	// fails the validateProofDescriptorShape gate; the unroll FSM
@@ -93,6 +165,10 @@ type IncomingVTXOExtras struct {
 	// to which block its round commit confirmed in, or sweep
 	// scheduling has no reference point).
 	CreatedHeight int32
+
+	// BatchExpiry is derived from locally confirmed commitment
+	// transactions and the sweep policy authenticated by Ancestry.
+	BatchExpiry int32
 }
 
 // IncomingAncestryFetcher resolves the per-VTXO metadata the
@@ -103,12 +179,8 @@ type IncomingVTXOExtras struct {
 // descriptor carries full lineage from the first save.
 //
 // The handler routes per-script signing via clientKey so the
-// implementation can issue an indexer ListVTXOsByScripts query under
-// the owner's proof-of-control. A nil fetcher (legacy harnesses /
-// non-waved consumers) causes the handler to persist without
-// extras — the cooperative spend paths (refresh, OOR, leave) still
-// work; only unilateral exit is impossible until backfill. Production
-// wiring (see waved) supplies an indexer-backed implementation.
+// implementation can issue an indexer ListVTXOsByScripts query under the
+// owner's proof-of-control and authenticate the returned expiry evidence.
 type IncomingAncestryFetcher func(ctx context.Context,
 	outpoint wire.OutPoint, pkScript []byte,
 	clientKey keychain.KeyDescriptor) (IncomingVTXOExtras, error)
@@ -124,17 +196,15 @@ type IncomingVTXOHandlerConfig struct {
 
 	// VTXOStore is the persistence store used to save materialized
 	// VTXO descriptors.
-	VTXOStore VTXOSaver
+	VTXOStore IncomingVTXOStore
 
 	// VTXOManager is a tell-only reference to the VTXO manager
 	// actor, used to notify it of newly materialized VTXOs.
 	VTXOManager actor.TellOnlyRef[ManagerMsg]
 
-	// AncestryFetcher resolves the round commit tree fragments
-	// required to unilaterally exit each incoming VTXO. Nil falls
-	// back to persisting without ancestry; production must supply
-	// a non-nil implementation to keep the unilateral exit path
-	// usable for received VTXOs (see bug-3 in BUGS_FOUND.md).
+	// AncestryFetcher resolves the authenticated expiry and round commit
+	// tree fragments required to accept and unilaterally exit each incoming
+	// VTXO. A nil fetcher rejects relevant events for durable retry.
 	AncestryFetcher IncomingAncestryFetcher
 
 	// MetricsSink is an optional reference to the client-side metrics
@@ -187,13 +257,15 @@ func (h *IncomingVTXOHandler) emitReceived(ctx context.Context, status string) {
 	})
 }
 
-// Receive processes IncomingVTXOEvent messages.
-func (h *IncomingVTXOHandler) Receive(ctx context.Context,
-	msg IncomingVTXOMsg) fn.Result[IncomingVTXOResp] {
+// prepare validates an incoming event and builds its authenticated descriptor.
+// It performs no persistence writes or manager notifications, so a durable
+// caller can keep its slow proof I/O outside the acknowledgement transaction.
+func (h *IncomingVTXOHandler) prepare(ctx context.Context,
+	msg *IncomingVTXOMsg) fn.Result[*Descriptor] {
 
 	evt := msg.Event
 	if evt == nil {
-		return fn.Ok[IncomingVTXOResp](nil)
+		return fn.Ok[*Descriptor](nil)
 	}
 
 	// We only handle VTXO_CREATED events. Log unexpected types
@@ -203,7 +275,7 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 			slog.Int("type", int(evt.Type)),
 		)
 
-		return fn.Ok[IncomingVTXOResp](nil)
+		return fn.Ok[*Descriptor](nil)
 	}
 
 	op := evt.GetOutpoint()
@@ -211,7 +283,7 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 		h.log.WarnS(ctx, "IncomingVTXOEvent has invalid "+
 			"or missing outpoint", nil)
 
-		return fn.Ok[IncomingVTXOResp](nil)
+		return fn.Ok[*Descriptor](nil)
 	}
 
 	pkScript := evt.GetPkScript()
@@ -219,31 +291,7 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 		h.log.WarnS(ctx, "IncomingVTXOEvent has empty "+
 			"pkScript", nil)
 
-		return fn.Ok[IncomingVTXOResp](nil)
-	}
-
-	// The batch expiry is copied verbatim onto the persisted descriptor
-	// and every later expiry decision is derived from it, so refuse to
-	// materialize a VTXO we could never reason about. A non-positive
-	// expiry reads back as "expired by the entire height of the chain"
-	// and would route a brand-new VTXO straight to the expiry path.
-	//
-	// Dropping is the safer failure: the wallet still re-derives this
-	// VTXO from ListVTXOsByScripts, which reads the authoritative expiry
-	// off the server's round row, whereas a poisoned expiry persists
-	// locally and is never rewritten.
-	if evt.GetBatchExpiryHeight() <= 0 {
-		h.log.WarnS(ctx, "IncomingVTXOEvent has unusable batch "+
-			"expiry; not materializing", nil,
-			slog.Int(
-				"batch_expiry",
-				int(
-					evt.GetBatchExpiryHeight(),
-				),
-			),
-		)
-
-		return fn.Ok[IncomingVTXOResp](nil)
+		return fn.Ok[*Descriptor](nil)
 	}
 
 	var outpoint wire.OutPoint
@@ -257,7 +305,7 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 	)
 
 	if h.cfg.ScriptStore == nil {
-		return fn.Ok[IncomingVTXOResp](nil)
+		return fn.Ok[*Descriptor](nil)
 	}
 
 	// Look up the pkScript in owned receive scripts.
@@ -269,14 +317,15 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 		// Any other error is a real store failure that
 		// should be surfaced.
 		if errors.Is(err, sql.ErrNoRows) {
-			return fn.Ok[IncomingVTXOResp](nil)
+			return fn.Ok[*Descriptor](nil)
 		}
 
-		// A real store failure means we could not process an
-		// incoming event; count it as a failed receive.
-		h.emitReceived(ctx, "failed")
+		h.log.WarnS(ctx, "Failed to look up incoming VTXO script",
+			err,
+			slog.String("outpoint", outpoint.String()),
+		)
 
-		return fn.Err[IncomingVTXOResp](
+		return fn.Err[*Descriptor](
 			fmt.Errorf("lookup owned receive script: %w", err),
 		)
 	}
@@ -286,7 +335,7 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 			"client pubkey", nil,
 			slog.String("outpoint", outpoint.String()))
 
-		return fn.Ok[IncomingVTXOResp](nil)
+		return fn.Ok[*Descriptor](nil)
 	}
 
 	// Reject server-provided values that would overflow int64
@@ -299,7 +348,7 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 			slog.String("outpoint", outpoint.String()),
 			slog.Uint64("value_sat", evt.ValueSat))
 
-		return fn.Ok[IncomingVTXOResp](nil)
+		return fn.Ok[*Descriptor](nil)
 	}
 
 	// Build the tapscript for the descriptor.
@@ -314,7 +363,7 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 			"for incoming VTXO", err,
 			slog.String("outpoint", outpoint.String()))
 
-		return fn.Ok[IncomingVTXOResp](nil)
+		return fn.Ok[*Descriptor](nil)
 	}
 
 	// Use the commitment tx ID from the event, which references
@@ -334,7 +383,7 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 			slog.String("outpoint", outpoint.String()),
 		)
 
-		return fn.Ok[IncomingVTXOResp](nil)
+		return fn.Ok[*Descriptor](nil)
 	}
 
 	desc := &Descriptor{
@@ -347,54 +396,131 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 		TapScript:      tapscript,
 		RoundID:        evt.RoundId,
 		CommitmentTxID: commitTxID,
-		BatchExpiry:    evt.BatchExpiryHeight,
-		RelativeExpiry: evt.RelativeExpiry,
+		BatchExpiry:    0,
+		RelativeExpiry: exitDelay,
 		Status:         VTXOStatusLive,
 	}
 
-	// Resolve ancestry before persisting so the descriptor lands
-	// with full unilateral-exit material from the first write. The
-	// indexer push (IncomingVTXOEvent) is intentionally thin and
-	// carries no tree fragments; without this fetch the unroll
-	// path fails with "descriptor missing ancestry" on every
-	// in-round-received VTXO (see bug-3 in BUGS_FOUND.md). A nil
-	// fetcher preserves the legacy degraded behavior: cooperative
-	// spend paths still work, only unilateral exit is blocked.
-	// Fetch failures are warn-logged but do not block
-	// materialization, since the receive must still succeed for
-	// cooperative use.
-	if h.cfg.AncestryFetcher != nil {
-		extras, err := h.cfg.AncestryFetcher(
-			ctx, outpoint, pkScript, rec.ClientKey,
+	// The indexer push is intentionally only a notification. Resolve the
+	// ancestry and chain-authenticated expiry before the first write.
+	// Returning an error keeps the durable event pending for retry instead
+	// of accepting a new live VTXO with unauthenticated safety metadata.
+	if h.cfg.AncestryFetcher == nil {
+		h.log.WarnS(ctx, "Cannot authenticate incoming VTXO expiry",
+			nil,
+			slog.String("outpoint", outpoint.String()),
 		)
-		if err != nil {
-			h.log.WarnS(ctx, "Failed to fetch incoming VTXO "+
-				"ancestry; persisting without — unilateral "+
-				"exit will be unavailable until backfill",
-				err,
-				slog.String("outpoint", outpoint.String()),
-			)
-		} else {
-			desc.Ancestry = extras.Ancestry
-			desc.CreatedHeight = extras.CreatedHeight
-		}
-	}
 
-	// Persist the VTXO. A save failure signals a database or
-	// schema inconsistency that must be surfaced.
-	if h.cfg.VTXOStore != nil {
-		saveErr := h.cfg.VTXOStore.SaveVTXO(ctx, desc)
-		if saveErr != nil {
+		return fn.Err[*Descriptor](
+			fmt.Errorf(
+				"authenticate incoming VTXO %s: ancestry "+
+					"fetcher not configured",
+				outpoint.String(),
+			),
+		)
+	}
+	extras, err := h.cfg.AncestryFetcher(
+		ctx, outpoint, pkScript, rec.ClientKey,
+	)
+	if err != nil {
+		h.log.WarnS(ctx, "Failed to authenticate incoming VTXO expiry",
+			err,
+			slog.String("outpoint", outpoint.String()),
+		)
+		if errors.Is(err, ErrInvalidBatchExpiryEvidence) {
 			h.emitReceived(ctx, "failed")
-
-			return fn.Err[IncomingVTXOResp](
-				fmt.Errorf(
-					"save incoming VTXO %s: %w",
-					outpoint.String(), saveErr,
-				),
-			)
 		}
+
+		return fn.Err[*Descriptor](
+			fmt.Errorf(
+				"authenticate incoming VTXO %s: %w",
+				outpoint.String(), err,
+			),
+		)
 	}
+	if extras.Output == nil || extras.Output.Value != int64(desc.Amount) ||
+		!bytes.Equal(extras.Output.PkScript, desc.PkScript) {
+		return fn.Err[*Descriptor](
+			invalidBatchExpiry(
+				"incoming event output does not match " +
+					"authenticated target",
+			),
+		)
+	}
+	if extras.BatchExpiry <= 0 {
+		err := fmt.Errorf("%w: derived batch expiry must be positive",
+			ErrInvalidBatchExpiryEvidence)
+		h.log.WarnS(ctx, "Failed to authenticate incoming VTXO expiry",
+			err,
+			slog.String("outpoint", outpoint.String()),
+		)
+		h.emitReceived(ctx, "failed")
+
+		return fn.Err[*Descriptor](
+			fmt.Errorf(
+				"authenticate incoming VTXO %s: %w",
+				outpoint.String(), err,
+			),
+		)
+	}
+	desc.Ancestry = extras.Ancestry
+	desc.CreatedHeight = extras.CreatedHeight
+	desc.BatchExpiry = extras.BatchExpiry
+
+	return fn.Ok(desc)
+}
+
+// persist stores the authenticated descriptor, then reloads the canonical
+// row. This closes the save-before-ack crash window without reviving a VTXO
+// whose status changed before redelivery.
+func (h *IncomingVTXOHandler) persist(ctx context.Context, desc *Descriptor) (
+	*Descriptor, error) {
+
+	if h.cfg.VTXOStore == nil {
+		return desc, nil
+	}
+
+	saveErr := h.cfg.VTXOStore.SaveVTXO(ctx, desc)
+	existing, loadErr := h.cfg.VTXOStore.GetVTXO(ctx, desc.Outpoint)
+	if loadErr == nil && sameIncomingVTXO(existing, desc) {
+		return existing, nil
+	}
+	if saveErr != nil {
+		return nil, fmt.Errorf("save incoming VTXO %s: %w",
+			desc.Outpoint.String(), saveErr)
+	}
+	if loadErr != nil {
+		return nil, fmt.Errorf("reload incoming VTXO %s: %w",
+			desc.Outpoint.String(), loadErr)
+	}
+
+	return nil, fmt.Errorf("reloaded incoming VTXO %s does not match event",
+		desc.Outpoint.String())
+}
+
+// sameIncomingVTXO proves persistence found the row for this event. The
+// immutable script, round, chain anchor, and
+// authenticated expiry must all match before the duplicate is accepted.
+func sameIncomingVTXO(existing, incoming *Descriptor) bool {
+	if existing == nil || incoming == nil {
+		return false
+	}
+
+	return existing.Outpoint == incoming.Outpoint &&
+		existing.Amount == incoming.Amount &&
+		bytes.Equal(existing.PolicyTemplate, incoming.PolicyTemplate) &&
+		bytes.Equal(existing.PkScript, incoming.PkScript) &&
+		existing.RoundID == incoming.RoundID &&
+		existing.CommitmentTxID == incoming.CommitmentTxID &&
+		existing.BatchExpiry == incoming.BatchExpiry &&
+		existing.RelativeExpiry == incoming.RelativeExpiry &&
+		existing.CreatedHeight == incoming.CreatedHeight &&
+		len(existing.Ancestry) > 0
+}
+
+// notifyMaterialized publishes best-effort effects after persistence commits.
+func (h *IncomingVTXOHandler) notifyMaterialized(ctx context.Context,
+	desc *Descriptor) {
 
 	// The owned incoming VTXO is now persisted: count it as a
 	// materialized receive. This is the authoritative success point —
@@ -417,10 +543,147 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 	}
 
 	h.log.InfoS(ctx, "Materialized incoming VTXO",
-		slog.String("outpoint", outpoint.String()),
+		slog.String("outpoint", desc.Outpoint.String()),
 		slog.Int64("amount", int64(desc.Amount)),
-		slog.String("round_id", evt.RoundId),
+		slog.String("round_id", desc.RoundID),
 	)
+}
+
+// Receive processes an incoming event outside a durable mailbox. Production
+// uses incomingVTXODurableBehavior; this direct entry point remains useful to
+// focused tests and callers that own their own retry boundary.
+func (h *IncomingVTXOHandler) Receive(ctx context.Context,
+	msg *IncomingVTXOMsg) fn.Result[IncomingVTXOResp] {
+
+	desc, err := h.prepare(ctx, msg).Unpack()
+	if err != nil {
+		return fn.Err[IncomingVTXOResp](err)
+	}
+	if desc == nil {
+		return fn.Ok[IncomingVTXOResp](nil)
+	}
+
+	persisted, err := h.persist(ctx, desc)
+	if err != nil {
+		h.log.WarnS(ctx, "Failed to persist incoming VTXO",
+			err,
+			slog.String("outpoint", desc.Outpoint.String()),
+		)
+		h.emitReceived(ctx, "failed")
+
+		return fn.Err[IncomingVTXOResp](err)
+	}
+	if persisted.Status == VTXOStatusLive {
+		h.notifyMaterialized(ctx, persisted)
+	}
 
 	return fn.Ok[IncomingVTXOResp](nil)
+}
+
+// incomingVTXODurableBehavior keeps slow indexer and chain I/O outside the
+// delivery-store writer transaction. Persistence and manager notification are
+// replay-safe, then one short Commit consumes the durable event. Transient
+// failures are postponed without spending the mailbox attempt budget.
+type incomingVTXODurableBehavior struct {
+	handler *IncomingVTXOHandler
+}
+
+// Receive validates and materializes an incoming event. Retriable failures
+// retain the delivery; a replay reloads the canonical persisted descriptor.
+func (b *incomingVTXODurableBehavior) Receive(ctx context.Context,
+	msg *IncomingVTXOMsg,
+	ax actor.Exec[struct{}]) fn.Result[IncomingVTXOResp] {
+
+	desc, err := b.handler.prepare(ctx, msg).Unpack()
+	if err != nil {
+		if errors.Is(err, ErrInvalidBatchExpiryEvidence) {
+			return fn.Err[IncomingVTXOResp](err)
+		}
+
+		return fn.Err[IncomingVTXOResp](
+			fmt.Errorf(
+				"%w: %w", err,
+				actor.Postpone(incomingVTXORedriveDelay),
+			),
+		)
+	}
+
+	var persisted *Descriptor
+	if desc != nil {
+		persisted, err = b.handler.persist(ctx, desc)
+		if err != nil {
+			b.handler.log.WarnS(
+				ctx,
+				"Failed to persist incoming VTXO",
+				err,
+				slog.String("outpoint", desc.Outpoint.String()),
+			)
+			postpone := actor.Postpone(incomingVTXORedriveDelay)
+
+			return fn.Err[IncomingVTXOResp](
+				fmt.Errorf("%w: %w", err, postpone),
+			)
+		}
+
+		if persisted.Status == VTXOStatusLive {
+			b.handler.notifyMaterialized(ctx, persisted)
+		}
+	}
+
+	err = ax.Commit(ctx, func(context.Context, struct{}) error {
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, actor.ErrLeaseLost) {
+			return fn.Err[IncomingVTXOResp](err)
+		}
+		b.handler.log.WarnS(ctx, "Failed to acknowledge incoming VTXO",
+			err,
+		)
+
+		return fn.Err[IncomingVTXOResp](
+			fmt.Errorf(
+				"%w: %w", err,
+				actor.Postpone(incomingVTXORedriveDelay),
+			),
+		)
+	}
+
+	return fn.Ok[IncomingVTXOResp](nil)
+}
+
+// NewIncomingVTXODurableActor creates the crash-safe incoming-event consumer.
+// The caller owns Start, Stop, and receptionist registration.
+func NewIncomingVTXODurableActor(cfg IncomingVTXOHandlerConfig,
+	store actor.DeliveryStore) (*actor.DurableActor[
+	*IncomingVTXOMsg, IncomingVTXOResp], error) {
+
+	if store == nil {
+		return nil, fmt.Errorf("delivery store must be provided")
+	}
+
+	behavior := &incomingVTXODurableBehavior{
+		handler: NewIncomingVTXOHandler(cfg),
+	}
+	durableCfg := actor.DefaultDurableTxActorConfig[
+		*IncomingVTXOMsg, IncomingVTXOResp, struct{},
+	](
+		incomingVTXOServiceKeyName, behavior,
+		func(context.Context, actor.DeliveryStore) struct{} {
+			return struct{}{}
+		},
+		store, NewIncomingVTXOCodec(),
+	)
+	durableCfg.Log = cfg.Log
+	durableCfg.TellRetryPolicy = func(err error, attempts int) (bool,
+		time.Duration) {
+
+		if errors.Is(err, ErrInvalidBatchExpiryEvidence) {
+			return false, 0
+		}
+
+		return actor.DefaultTellRetryPolicy(err, attempts)
+	}
+
+	return actor.NewDurableActor(durableCfg).Unpack()
 }

--- a/vtxo/incoming_handler_test.go
+++ b/vtxo/incoming_handler_test.go
@@ -3,6 +3,7 @@ package vtxo
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -10,8 +11,10 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 // mockScriptLookup implements OwnedScriptLookup for testing.
@@ -32,13 +35,306 @@ func (m *mockScriptLookup) LookupOwnedReceiveScript(_ context.Context,
 
 // mockVTXOSaver implements VTXOSaver for testing.
 type mockVTXOSaver struct {
-	saved []*Descriptor
+	saved                  []*Descriptor
+	failures               int
+	err                    error
+	succeedOnDuplicateSave bool
 }
 
+type recordingIncomingExec struct {
+	commits  int
+	failures int
+	err      error
+}
+
+// Read executes the durable test read callback.
+func (e *recordingIncomingExec) Read(ctx context.Context,
+	fn func(context.Context, struct{}) error) error {
+
+	return fn(ctx, struct{}{})
+}
+
+// Stage records the pending test write callback.
+func (e *recordingIncomingExec) Stage(ctx context.Context,
+	fn func(context.Context, struct{}) error) error {
+
+	return fn(ctx, struct{}{})
+}
+
+// Commit injects an acknowledgement failure or applies the staged callback.
+func (e *recordingIncomingExec) Commit(ctx context.Context,
+	fn func(context.Context, struct{}) error) error {
+
+	if e.failures > 0 {
+		e.failures--
+
+		return e.err
+	}
+	e.commits++
+
+	return fn(ctx, struct{}{})
+}
+
+// SaveVTXO injects a write failure before retaining a descriptor copy.
 func (m *mockVTXOSaver) SaveVTXO(_ context.Context, desc *Descriptor) error {
+	if m.failures > 0 {
+		m.failures--
+
+		return m.err
+	}
+	for _, saved := range m.saved {
+		if saved.Outpoint == desc.Outpoint {
+			if m.succeedOnDuplicateSave {
+				return nil
+			}
+
+			return errors.New("duplicate VTXO")
+		}
+	}
 	m.saved = append(m.saved, desc)
 
 	return nil
+}
+
+// GetVTXO returns the canonical test row for crash-window redelivery.
+func (m *mockVTXOSaver) GetVTXO(_ context.Context, outpoint wire.OutPoint) (
+	*Descriptor, error) {
+
+	for _, saved := range m.saved {
+		if saved.Outpoint == outpoint {
+			return saved, nil
+		}
+	}
+
+	return nil, ErrVTXONotFound
+}
+
+// TestIncomingVTXOHandlerRetriesAuthenticatedExpiryWrite proves a failed save
+// does not consume the event or lose the authenticated scalar. Redelivery
+// recomputes the proof and persists the same expiry before notification.
+func TestIncomingVTXOHandlerRetriesAuthenticatedExpiryWrite(t *testing.T) {
+	t.Parallel()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pkScript := []byte{0x51, 0x20, 0xaa, 0xcc}
+	lookup := &mockScriptLookup{scripts: map[string]*OwnedReceiveScript{
+		string(pkScript): {
+			ClientKey: keychain.KeyDescriptor{
+				PubKey: clientKey.PubKey(),
+			},
+			OperatorPubKey: operatorKey.PubKey(),
+			ExitDelay:      144,
+		},
+	}}
+	saveErr := errors.New("database unavailable")
+	saver := &mockVTXOSaver{failures: 1, err: saveErr}
+	fetches := 0
+	handler := NewIncomingVTXOHandler(IncomingVTXOHandlerConfig{
+		ScriptStore: lookup,
+		VTXOStore:   saver,
+		AncestryFetcher: func(context.Context, wire.OutPoint, []byte,
+			keychain.KeyDescriptor) (IncomingVTXOExtras, error) {
+
+			fetches++
+
+			return IncomingVTXOExtras{
+				Output: &wire.TxOut{
+					Value:    50_000,
+					PkScript: pkScript,
+				},
+				Ancestry: []Ancestry{
+					{},
+				},
+				BatchExpiry: 800_144,
+			}, nil
+		},
+	})
+
+	var txid chainhash.Hash
+	txid[0] = 0x42
+	msg := &IncomingVTXOMsg{Event: newTestEvent(
+		txid, 0, pkScript, 50_000, "round-retry",
+	)}
+
+	_, err = handler.Receive(t.Context(), msg).Unpack()
+	require.ErrorIs(t, err, saveErr)
+	require.Empty(t, saver.saved)
+
+	_, err = handler.Receive(t.Context(), msg).Unpack()
+	require.NoError(t, err)
+	require.Len(t, saver.saved, 1)
+	require.Equal(t, int32(800_144), saver.saved[0].BatchExpiry)
+	require.Equal(t, 2, fetches)
+}
+
+// TestIncomingVTXODurableBehaviorPostponesAuthenticationFailure proves a
+// transient proof failure leaves the durable event unconsumed. A later retry
+// persists the VTXO and commits the mailbox acknowledgement.
+func TestIncomingVTXODurableBehaviorPostponesAuthenticationFailure(
+	t *testing.T) {
+
+	t.Parallel()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pkScript := []byte{0x51, 0x20, 0xbb, 0xcc}
+	lookup := &mockScriptLookup{scripts: map[string]*OwnedReceiveScript{
+		string(pkScript): {
+			ClientKey: keychain.KeyDescriptor{
+				PubKey: clientKey.PubKey(),
+			},
+			OperatorPubKey: operatorKey.PubKey(),
+			ExitDelay:      144,
+		},
+	}}
+	saver := &mockVTXOSaver{}
+	fetches := 0
+	handler := NewIncomingVTXOHandler(IncomingVTXOHandlerConfig{
+		ScriptStore: lookup,
+		VTXOStore:   saver,
+		AncestryFetcher: func(context.Context, wire.OutPoint, []byte,
+			keychain.KeyDescriptor) (IncomingVTXOExtras, error) {
+
+			fetches++
+			if fetches == 1 {
+				return IncomingVTXOExtras{},
+					errors.New("chain backend catching up")
+			}
+
+			return IncomingVTXOExtras{
+				Output: &wire.TxOut{
+					Value:    50_000,
+					PkScript: pkScript,
+				},
+				Ancestry: []Ancestry{
+					{},
+				},
+				BatchExpiry: 900_144,
+			}, nil
+		},
+	})
+	behavior := &incomingVTXODurableBehavior{handler: handler}
+	exec := &recordingIncomingExec{}
+
+	var txid chainhash.Hash
+	txid[0] = 0x52
+	msg := &IncomingVTXOMsg{Event: newTestEvent(
+		txid, 0, pkScript, 50_000, "round-durable-retry",
+	)}
+
+	_, err = behavior.Receive(t.Context(), msg, exec).Unpack()
+	require.ErrorIs(t, err, actor.ErrPostponed)
+	require.Zero(t, exec.commits)
+	require.Empty(t, saver.saved)
+
+	exec.failures = 1
+	exec.err = errors.New("ack transaction unavailable")
+	_, err = behavior.Receive(t.Context(), msg, exec).Unpack()
+	require.ErrorIs(t, err, actor.ErrPostponed)
+	require.Zero(t, exec.commits)
+	require.Len(t, saver.saved, 1)
+
+	_, err = behavior.Receive(t.Context(), msg, exec).Unpack()
+	require.NoError(t, err)
+	require.Equal(t, 1, exec.commits)
+	require.Len(t, saver.saved, 1)
+	require.Equal(t, int32(900_144), saver.saved[0].BatchExpiry)
+}
+
+// TestIncomingVTXODurableBehaviorReloadsTerminatedReplay proves a production
+// upsert followed by redelivery uses the stored status and does not notify the
+// manager to revive a VTXO that terminated after the first delivery.
+func TestIncomingVTXODurableBehaviorReloadsTerminatedReplay(t *testing.T) {
+	t.Parallel()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pkScript := []byte{0x51, 0x20, 0xbc, 0xcd}
+	saver := &mockVTXOSaver{succeedOnDuplicateSave: true}
+	manager := &capturingManagerRef{}
+	ownedScript := &OwnedReceiveScript{
+		ClientKey: keychain.KeyDescriptor{
+			PubKey: clientKey.PubKey(),
+		},
+		OperatorPubKey: operatorKey.PubKey(),
+		ExitDelay:      144,
+	}
+	handler := NewIncomingVTXOHandler(
+		IncomingVTXOHandlerConfig{
+			ScriptStore: &mockScriptLookup{
+				scripts: map[string]*OwnedReceiveScript{
+					string(pkScript): ownedScript,
+				},
+			},
+			VTXOStore:   saver,
+			VTXOManager: manager,
+			AncestryFetcher: func(context.Context, wire.OutPoint,
+				[]byte, keychain.KeyDescriptor) (
+				IncomingVTXOExtras, error) {
+
+				return IncomingVTXOExtras{
+					Output: &wire.TxOut{
+						Value:    50_000,
+						PkScript: pkScript,
+					},
+					Ancestry: []Ancestry{
+						{},
+					},
+					BatchExpiry: 900_144,
+				}, nil
+			},
+		},
+	)
+	behavior := &incomingVTXODurableBehavior{handler: handler}
+	exec := &recordingIncomingExec{
+		failures: 1,
+		err:      errors.New("ack transaction unavailable"),
+	}
+
+	var txid chainhash.Hash
+	txid[0] = 0x54
+	msg := &IncomingVTXOMsg{Event: newTestEvent(
+		txid, 0, pkScript, 50_000, "round-terminated-replay",
+	)}
+
+	_, err = behavior.Receive(t.Context(), msg, exec).Unpack()
+	require.ErrorIs(t, err, actor.ErrPostponed)
+	require.Len(t, manager.captured(), 1)
+	require.Len(t, saver.saved, 1)
+
+	saver.saved[0].Status = VTXOStatusSpent
+	_, err = behavior.Receive(t.Context(), msg, exec).Unpack()
+	require.NoError(t, err)
+	require.Len(t, manager.captured(), 1)
+	require.Equal(t, VTXOStatusSpent, saver.saved[0].Status)
+}
+
+// TestIncomingVTXOCodecRoundTrip proves the complete push event survives the
+// durable-mailbox encoding used for restart redelivery.
+func TestIncomingVTXOCodecRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var txid chainhash.Hash
+	txid[0] = 0x53
+	msg := &IncomingVTXOMsg{Event: newTestEvent(
+		txid, 3, []byte{0x51, 0x20, 0xdd}, 75_000, "round-codec",
+	)}
+	codec := NewIncomingVTXOCodec()
+
+	raw, err := codec.Encode(msg)
+	require.NoError(t, err)
+	decoded, err := codec.Decode(raw)
+	require.NoError(t, err)
+	decodedMsg, ok := decoded.(*IncomingVTXOMsg)
+	require.True(t, ok)
+	require.True(t, proto.Equal(msg.Event, decodedMsg.Event))
 }
 
 // newTestEvent creates an IncomingVTXOEvent with the given parameters.
@@ -99,7 +395,15 @@ func TestIncomingVTXOHandlerOwnedScript(t *testing.T) {
 			keychain.KeyDescriptor) (IncomingVTXOExtras, error) {
 
 			return IncomingVTXOExtras{
+				Output: &wire.TxOut{
+					Value:    50_000,
+					PkScript: pkScript,
+				},
 				CreatedHeight: 799_500,
+				BatchExpiry:   800_000,
+				Ancestry: []Ancestry{
+					{},
+				},
 			}, nil
 		},
 	})
@@ -108,7 +412,7 @@ func TestIncomingVTXOHandlerOwnedScript(t *testing.T) {
 	txid[0] = 0x01
 
 	evt := newTestEvent(txid, 0, pkScript, 50_000, "round-1")
-	msg := IncomingVTXOMsg{Event: evt}
+	msg := &IncomingVTXOMsg{Event: evt}
 
 	result := handler.Receive(t.Context(), msg)
 	_, resultErr := result.Unpack()
@@ -151,7 +455,7 @@ func TestIncomingVTXOHandlerUnownedScript(t *testing.T) {
 	evt := newTestEvent(
 		txid, 0, []byte{0x51, 0x20, 0xff}, 10_000, "round-2",
 	)
-	msg := IncomingVTXOMsg{Event: evt}
+	msg := &IncomingVTXOMsg{Event: evt}
 
 	result := handler.Receive(t.Context(), msg)
 	_, resultErr := result.Unpack()
@@ -174,7 +478,7 @@ func TestIncomingVTXOHandlerNonCreatedEvent(t *testing.T) {
 		EventId: 2,
 		Type:    arkrpc.VTXOEventType_VTXO_EVENT_TYPE_STATUS_CHANGED,
 	}
-	msg := IncomingVTXOMsg{Event: evt}
+	msg := &IncomingVTXOMsg{Event: evt}
 
 	result := handler.Receive(t.Context(), msg)
 	_, resultErr := result.Unpack()
@@ -183,12 +487,9 @@ func TestIncomingVTXOHandlerNonCreatedEvent(t *testing.T) {
 	require.Empty(t, saver.saved)
 }
 
-// TestIncomingVTXOHandlerUnusableBatchExpiry verifies that an event carrying
-// an expiry the wallet could never reason about is dropped rather than
-// materialized. Persisting it would stamp the bad expiry onto the descriptor
-// permanently, and every later expiry decision reads it back as a deadline
-// that has already passed.
-func TestIncomingVTXOHandlerUnusableBatchExpiry(t *testing.T) {
+// TestIncomingVTXOHandlerIgnoresEventBatchExpiry verifies that the thin push's
+// unauthenticated scalar is never copied onto the descriptor.
+func TestIncomingVTXOHandlerIgnoresEventBatchExpiry(t *testing.T) {
 	t.Parallel()
 
 	privKey, err := btcec.NewPrivateKey()
@@ -199,7 +500,7 @@ func TestIncomingVTXOHandlerUnusableBatchExpiry(t *testing.T) {
 
 	pkScript := []byte{0x51, 0x20, 0xaa, 0xbb}
 
-	// The script IS owned, so a drop here can only be the expiry guard.
+	output := &wire.TxOut{Value: 50_000, PkScript: pkScript}
 	newLookup := func() *mockScriptLookup {
 		return &mockScriptLookup{
 			scripts: map[string]*OwnedReceiveScript{
@@ -230,6 +531,19 @@ func TestIncomingVTXOHandlerUnusableBatchExpiry(t *testing.T) {
 				IncomingVTXOHandlerConfig{
 					ScriptStore: newLookup(),
 					VTXOStore:   saver,
+					AncestryFetcher: func(context.Context,
+						wire.OutPoint, []byte,
+						keychain.KeyDescriptor) (
+						IncomingVTXOExtras, error) {
+
+						return IncomingVTXOExtras{
+							Output: output,
+							Ancestry: []Ancestry{
+								{},
+							},
+							BatchExpiry: 800_144,
+						}, nil
+					},
 				},
 			)
 
@@ -239,18 +553,62 @@ func TestIncomingVTXOHandlerUnusableBatchExpiry(t *testing.T) {
 			evt.BatchExpiryHeight = expiry
 
 			result := handler.Receive(
-				t.Context(), IncomingVTXOMsg{
+				t.Context(), &IncomingVTXOMsg{
 					Event: evt,
 				},
 			)
 			_, resultErr := result.Unpack()
 
-			// Dropping must stay silent: the handler cannot crash
-			// the actor or block the indexer push stream.
 			require.NoError(t, resultErr)
-			require.Empty(t, saver.saved)
+			require.Len(t, saver.saved, 1)
+			require.Equal(
+				t, int32(800_144), saver.saved[0].BatchExpiry,
+			)
+			require.Equal(
+				t, uint32(144), saver.saved[0].RelativeExpiry,
+			)
 		})
 	}
+}
+
+// TestIncomingVTXOHandlerRequiresAuthenticatedExpiry verifies that a thin
+// push cannot create a new live row without the local authentication path.
+func TestIncomingVTXOHandlerRequiresAuthenticatedExpiry(t *testing.T) {
+	t.Parallel()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pkScript := []byte{0x51, 0x20, 0xaa, 0xdd}
+	saver := &mockVTXOSaver{}
+	handler := NewIncomingVTXOHandler(
+		IncomingVTXOHandlerConfig{
+			ScriptStore: &mockScriptLookup{
+				scripts: map[string]*OwnedReceiveScript{
+					string(pkScript): {
+						ClientKey: keychain.
+							KeyDescriptor{
+							PubKey: clientKey.
+								PubKey(),
+						},
+						OperatorPubKey: operatorKey.
+							PubKey(),
+						ExitDelay: 144,
+					},
+				},
+			},
+			VTXOStore: saver,
+		},
+	)
+
+	var txid chainhash.Hash
+	txid[0] = 0x43
+	_, err = handler.Receive(t.Context(), &IncomingVTXOMsg{
+		Event: newTestEvent(txid, 0, pkScript, 50_000, "round-auth"),
+	}).Unpack()
+	require.ErrorContains(t, err, "ancestry fetcher not configured")
+	require.Empty(t, saver.saved)
 }
 
 // TestIncomingVTXOHandlerNilEvent verifies that a nil event is
@@ -260,7 +618,7 @@ func TestIncomingVTXOHandlerNilEvent(t *testing.T) {
 
 	handler := NewIncomingVTXOHandler(IncomingVTXOHandlerConfig{})
 
-	msg := IncomingVTXOMsg{Event: nil}
+	msg := &IncomingVTXOMsg{Event: nil}
 
 	result := handler.Receive(t.Context(), msg)
 	_, resultErr := result.Unpack()

--- a/vtxo/indexed_ancestry.go
+++ b/vtxo/indexed_ancestry.go
@@ -1,0 +1,91 @@
+package vtxo
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/arkrpc"
+	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
+)
+
+// IndexedAncestryFromRPC converts indexed ancestry only after proving that its
+// signed paths fund the indexed target outpoint, value, and script. This is the
+// shared ingress boundary for incoming, recovered, and custom-refresh VTXOs.
+// Sweep expiry still requires the separate local confirmation check.
+func IndexedAncestryFromRPC(candidate *arkrpc.VTXO) ([]Ancestry, error) {
+	ancestry, err := AncestryFromRPC(candidate.GetAncestryPaths())
+	if err != nil {
+		return nil, err
+	}
+	op := candidate.GetOutpoint()
+	if len(op.GetTxid()) != chainhash.HashSize ||
+		candidate.GetValueSat() > math.MaxInt64 {
+		return nil, invalidBatchExpiry(
+			"invalid target outpoint or value",
+		)
+	}
+	var txid chainhash.Hash
+	copy(txid[:], op.GetTxid())
+	target := expiryTarget{
+		Outpoint: wire.OutPoint{
+			Hash:  txid,
+			Index: op.GetVout(),
+		},
+		Output: &wire.TxOut{
+			Value:    int64(candidate.GetValueSat()),
+			PkScript: candidate.GetPkScript(),
+		},
+	}
+	for i, pkg := range candidate.GetAncestryPackages() {
+		if pkg == nil {
+			return nil, invalidBatchExpiry(
+				"nil ancestry package %d", i,
+			)
+		}
+		rawPackets := append(
+			[][]byte{pkg.GetArkPsbt()}, pkg.GetCheckpointPsbts()...,
+		)
+		for j, raw := range rawPackets {
+			tx, err := expiryPackageTransaction(raw)
+			if err != nil {
+				return nil, invalidBatchExpiry(
+					"package %d transaction %d: %v", i, j,
+					err,
+				)
+			}
+			target.Transactions = append(target.Transactions, tx)
+		}
+	}
+	if err := validateExpiryTarget(target, ancestry); err != nil {
+		return nil, invalidBatchExpiry("target proof: %v", err)
+	}
+
+	return ancestry, nil
+}
+
+// expiryPackageTransaction reconstructs the signed wire transaction without
+// trusting PSBT prevout metadata. The target proof supplies actual parent
+// outputs to the script engine, so a forged WitnessUtxo cannot authenticate a
+// spend.
+func expiryPackageTransaction(raw []byte) (*wire.MsgTx, error) {
+	pkt, err := psbtutil.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(pkt.Inputs) != len(pkt.UnsignedTx.TxIn) {
+		return nil, fmt.Errorf("PSBT input count mismatch")
+	}
+	tx := pkt.UnsignedTx.Copy()
+	for i, in := range pkt.Inputs {
+		witness, err := oortx.BuildTaprootWitness(in)
+		if err != nil {
+			return nil, err
+		}
+		tx.TxIn[i].Witness = witness
+	}
+
+	return tx, nil
+}

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -46,6 +46,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 
 ## Invariants
 
+- Indexed VTXOs pass `vtxo.IndexedAncestryFromRPC` before new acceptance.
+  It verifies signed tree/transaction paths to the exact target outpoint,
+  value, and script. OOR inventory includes `ancestry_packages` to connect
+  round leaves to the target. Sweep expiry is then derived separately from
+  locally confirmed batch outputs. A valid unrelated batch cannot authorize
+  a received target. Existing persisted live rows are outside this check.
+
 - The lnd wallet account (`lnd.account`, empty = lnd's `default`) bounds what
   this daemon may **spend**: `ListWalletUnspent` (fee inputs and the exit
   preflight), `NewWalletAddress` (the deposit address), and the
@@ -154,6 +161,17 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   Regtest, simnet, unknown networks, and a configured floor above the current
   tip use block 1. Existing unroll jobs keep that fallback for this process,
   while successful repairs apply to later admissions and restarts.
+- `batchExpiryAuthenticator` is the shared acceptance boundary for new indexed
+  VTXOs. It uses bounded one-shot chain-source confirmation futures, validates
+  the confirmed transaction through `vtxo.AuthenticateBatchExpiry`, and
+  unregisters each watch. Thin incoming events, OOR receives, indexed recovery,
+  and custom refresh metadata use it before persistence or signing. Existing
+  live rows are deliberately left unchanged. The single incoming-event actor
+  caps its complete indexer-and-chain evidence lookup at 2 seconds and relies
+  on durable redelivery; other callers retain the 30-second lookup bound.
+  Indexed recovery skips bad
+  entries so later VTXOs are examined, then returns the first authentication
+  error so a partial scan is never reported as complete.
 - `initUnrollSubsystem` boot ordering is policy-preserving.
   `recoverySvc.RestoreNonTerminal` (in-flight vHTLC recovery jobs, each
   carrying its durable exit policy) runs **before** the chain resolver is

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -46,6 +46,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 
 ## Invariants
 
+- Indexed VTXOs pass `vtxo.IndexedAncestryFromRPC` before new acceptance.
+  It verifies signed tree/transaction paths to the exact target outpoint,
+  value, and script. OOR inventory includes `ancestry_packages` to connect
+  round leaves to the target. Sweep expiry is then derived separately from
+  locally confirmed batch outputs. A valid unrelated batch cannot authorize
+  a received target. Existing persisted live rows are outside this check.
+
 - The lnd wallet account (`lnd.account`, empty = lnd's `default`) bounds what
   this daemon may **spend**: `ListWalletUnspent` (fee inputs and the exit
   preflight), `NewWalletAddress` (the deposit address), and the
@@ -154,6 +161,17 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   Regtest, simnet, unknown networks, and a configured floor above the current
   tip use block 1. Existing unroll jobs keep that fallback for this process,
   while successful repairs apply to later admissions and restarts.
+- `batchExpiryAuthenticator` is the shared acceptance boundary for new indexed
+  VTXOs. It uses bounded one-shot chain-source confirmation futures, validates
+  the confirmed transaction through `vtxo.AuthenticateBatchExpiry`, and
+  unregisters each watch. Thin incoming events, OOR receives, indexed recovery,
+  and custom refresh metadata use it before persistence or signing. Existing
+  live rows are deliberately left unchanged. The single incoming-event actor
+  caps its complete indexer-and-chain evidence lookup at 2 seconds and relies
+  on durable redelivery; other callers retain the 30-second lookup bound.
+  Indexed recovery skips bad
+  entries so later VTXOs are examined, then returns the first authentication
+  error so a partial scan is never reported as complete.
 - `initUnrollSubsystem` boot ordering is policy-preserving.
   `recoverySvc.RestoreNonTerminal` (in-flight vHTLC recovery jobs, each
   carrying its durable exit policy) runs **before** the chain resolver is

--- a/waved/authenticated_expiry.go
+++ b/waved/authenticated_expiry.go
@@ -1,0 +1,135 @@
+package waved
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/google/uuid"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/chainsource"
+	"github.com/lightninglabs/wavelength/oor"
+	"github.com/lightninglabs/wavelength/vtxo"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+const (
+	expiryAuthenticationTimeout         = 30 * time.Second
+	incomingExpiryAuthenticationTimeout = 2 * time.Second
+	expiryConfirmationCleanupTimeout    = 5 * time.Second
+)
+
+type chainSourceRef = actor.ActorRef[
+	chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+]
+
+type confRef = actor.TellOnlyRef[chainsource.ConfirmationEvent]
+
+type confirmationRegistration = chainsource.RegisterConfResponse
+
+// NewBatchExpiryAuthenticator adapts the chain-source actor's one-shot
+// confirmation API to the pure VTXO expiry verifier. A fresh caller id keeps
+// concurrent acceptance checks independent; each one-shot watch is removed
+// after its future resolves.
+func NewBatchExpiryAuthenticator(chainSource actor.ActorRef[
+	chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+]) oor.IncomingExpiryAuthenticator {
+
+	return batchExpiryAuthenticatorWithTimeout(
+		chainSource, expiryAuthenticationTimeout,
+	)
+}
+
+// batchExpiryAuthenticatorWithTimeout builds the expiry authenticator with a
+// bounded chain lookup. Durable callers retry a timed-out lookup instead of
+// holding their actor turn and delivery lease indefinitely.
+func batchExpiryAuthenticatorWithTimeout(chainSource chainSourceRef,
+	timeout time.Duration) oor.IncomingExpiryAuthenticator {
+
+	return func(ctx context.Context, ancestry []vtxo.Ancestry) (int32,
+		error) {
+
+		if chainSource == nil {
+			return 0, fmt.Errorf("chain source must be provided")
+		}
+		if timeout <= 0 {
+			return 0, fmt.Errorf("expiry authentication timeout " +
+				"must be positive")
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		callerID := "expiry-auth-" + uuid.NewString()
+		noNotify := fn.None[confRef]()
+
+		return vtxo.AuthenticateBatchExpiry(
+			ctx, ancestry,
+			func(ctx context.Context, txid chainhash.Hash,
+				pkScript []byte, heightHint uint32) (
+				vtxo.CommitmentConfirmation, error) {
+
+				var empty vtxo.CommitmentConfirmation
+
+				request := &chainsource.RegisterConfRequest{
+					CallerID:    callerID,
+					Txid:        &txid,
+					PkScript:    pkScript,
+					TargetConfs: 1,
+					HeightHint:  heightHint,
+					NotifyActor: noNotify,
+				}
+				defer unregisterExpiryConfirmation(
+					ctx, chainSource, callerID, txid,
+					pkScript,
+				)
+
+				response, err := chainSource.Ask(
+					ctx, request,
+				).Await(ctx).Unpack()
+				if err != nil {
+					return empty, err
+				}
+
+				registered, ok :=
+					response.(*confirmationRegistration)
+				if !ok || registered.Future == nil {
+					return empty, fmt.Errorf("unexpected "+
+						"response %T", response)
+				}
+
+				confirmation, err := registered.Future.
+					Await(ctx).
+					Unpack()
+				if err != nil {
+					return empty, err
+				}
+
+				return vtxo.CommitmentConfirmation{
+					Tx:          confirmation.Tx,
+					BlockHeight: confirmation.BlockHeight,
+				}, nil
+			},
+		)
+	}
+}
+
+// unregisterExpiryConfirmation releases a one-shot confirmation watch with a
+// cleanup deadline independent of the completed acceptance request.
+func unregisterExpiryConfirmation(ctx context.Context,
+	chainSource chainSourceRef, callerID string, txid chainhash.Hash,
+	pkScript []byte) {
+
+	cleanupCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), expiryConfirmationCleanupTimeout,
+	)
+	defer cancel()
+
+	_ = chainSource.Tell(cleanupCtx, &chainsource.UnregisterConfRequest{
+		CallerID:    callerID,
+		Txid:        &txid,
+		PkScript:    pkScript,
+		TargetConfs: 1,
+	})
+}

--- a/waved/authenticated_expiry_test.go
+++ b/waved/authenticated_expiry_test.go
@@ -1,0 +1,183 @@
+package waved
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/chainsource"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/vtxo"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type testChainFuture = actor.Future[chainsource.ChainSourceResp]
+
+// TestBatchExpiryAuthenticatorTimesOut verifies that a confirmation backend
+// which never resolves releases the durable caller for retry and unregisters
+// its one-shot watch.
+func TestBatchExpiryAuthenticatorTimesOut(t *testing.T) {
+	t.Parallel()
+
+	chainSource := &blockingExpiryChainSource{
+		unregistered: make(chan struct{}, 1),
+	}
+	authenticate := batchExpiryAuthenticatorWithTimeout(
+		chainSource, 10*time.Millisecond,
+	)
+
+	_, err := authenticate(t.Context(), []vtxo.Ancestry{
+		testExpiryAuthenticationAncestry(t),
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	select {
+	case <-chainSource.unregistered:
+	case <-time.After(time.Second):
+		t.Fatal("confirmation watch was not unregistered")
+	}
+}
+
+// TestBatchExpiryAuthenticatorRegistrationTimeoutUnregisters proves cleanup
+// is armed before the registration Ask resolves. The chain-source actor may
+// still create the watch after the caller's deadline.
+func TestBatchExpiryAuthenticatorRegistrationTimeoutUnregisters(t *testing.T) {
+	t.Parallel()
+
+	chainSource := &blockingExpiryChainSource{
+		unregistered:        make(chan struct{}, 1),
+		registrationBlocked: true,
+	}
+	authenticate := batchExpiryAuthenticatorWithTimeout(
+		chainSource, 10*time.Millisecond,
+	)
+
+	_, err := authenticate(t.Context(), []vtxo.Ancestry{
+		testExpiryAuthenticationAncestry(t),
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	select {
+	case <-chainSource.unregistered:
+	case <-time.After(time.Second):
+		t.Fatal("timed-out registration was not unregistered")
+	}
+}
+
+type blockingExpiryChainSource struct {
+	unregistered        chan struct{}
+	registrationBlocked bool
+}
+
+// ID supplies a stable identity for the confirmation actor stub.
+func (b *blockingExpiryChainSource) ID() string {
+	return "blocking-expiry-chain-source"
+}
+
+// Tell records confirmation-watch cleanup requests.
+func (b *blockingExpiryChainSource) Tell(_ context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	if _, ok := msg.(*chainsource.UnregisterConfRequest); ok {
+		select {
+		case b.unregistered <- struct{}{}:
+		default:
+		}
+	}
+
+	return nil
+}
+
+// TryTell delegates nonblocking test delivery to Tell.
+func (b *blockingExpiryChainSource) TryTell(ctx context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	return b.Tell(ctx, msg)
+}
+
+// Ask supplies the scripted one-shot confirmation registration.
+func (b *blockingExpiryChainSource) Ask(_ context.Context,
+	msg chainsource.ChainSourceMsg) testChainFuture {
+
+	response := actor.NewPromise[chainsource.ChainSourceResp]()
+	if _, ok := msg.(*chainsource.RegisterConfRequest); !ok {
+		response.Complete(
+			fn.Err[chainsource.ChainSourceResp](
+				fmt.Errorf("unexpected request %T", msg),
+			),
+		)
+
+		return response.Future()
+	}
+	if b.registrationBlocked {
+		return response.Future()
+	}
+
+	confirmation := actor.NewPromise[chainsource.ConfirmationEvent]()
+	response.Complete(
+		fn.Ok[chainsource.ChainSourceResp](
+			&chainsource.RegisterConfResponse{
+				Future: confirmation.Future(),
+			},
+		),
+	)
+
+	return response.Future()
+}
+
+// testExpiryAuthenticationAncestry constructs sweep evidence for testing
+// bounded chain waits and cleanup independently of target-proof validation.
+func testExpiryAuthenticationAncestry(t *testing.T) vtxo.Ancestry {
+	t.Helper()
+
+	const delay = uint32(144)
+	sweepKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		sweepKey.PubKey(), delay,
+	)
+	require.NoError(t, err)
+	sweepRoot := sweepLeaf.TapHash()
+	ownerKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	cosigners := []*btcec.PublicKey{ownerKey.PubKey()}
+	finalKey, err := tree.ComputeFinalKey(cosigners, sweepRoot[:])
+	require.NoError(t, err)
+	batchScript, err := txscript.PayToTaprootScript(finalKey)
+	require.NoError(t, err)
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{1}},
+	})
+	tx.AddTxOut(&wire.TxOut{
+		Value:    10_000,
+		PkScript: batchScript,
+	})
+	txid := tx.TxHash()
+
+	return vtxo.Ancestry{
+		TreePath: &tree.Tree{
+			Root: &tree.Node{
+				CoSigners: cosigners,
+			},
+			BatchOutpoint: wire.OutPoint{
+				Hash: txid,
+			},
+			BatchOutput:        tx.TxOut[0],
+			SweepTapscriptRoot: sweepRoot[:],
+		},
+		CommitmentTxID:       txid,
+		CommitmentHeight:     100,
+		CommitmentSweepDelay: delay,
+		CommitmentSweepKey:   sweepKey.PubKey(),
+	}
+}

--- a/waved/commitment_height_repair.go
+++ b/waved/commitment_height_repair.go
@@ -70,7 +70,7 @@ func (s *Server) repairLegacyCommitmentHeights(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("build indexer proof signer: %w", err)
 	}
-	fetcher, err := incomingAncestryFetcher(s.indexer, signerFactory)
+	fetcher, err := incomingAncestryOnlyFetcher(s.indexer, signerFactory)
 	if err != nil {
 		return fmt.Errorf("build ancestry fetcher: %w", err)
 	}

--- a/waved/incoming_ancestry_fetcher.go
+++ b/waved/incoming_ancestry_fetcher.go
@@ -3,6 +3,7 @@ package waved
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
@@ -11,6 +12,23 @@ import (
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightningnetwork/lnd/keychain"
 )
+
+// incomingAncestryFetcherWithTimeout bounds the complete indexer-and-chain
+// lookup. A stalled indexer must release the durable actor turn so the pending
+// event can be postponed and retried.
+func incomingAncestryFetcherWithTimeout(fetcher vtxo.IncomingAncestryFetcher,
+	timeout time.Duration) vtxo.IncomingAncestryFetcher {
+
+	return func(ctx context.Context, outpoint wire.OutPoint,
+		pkScript []byte, clientKey keychain.KeyDescriptor) (
+		vtxo.IncomingVTXOExtras, error) {
+
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		return fetcher(ctx, outpoint, pkScript, clientKey)
+	}
+}
 
 // incomingAncestryFetcher returns a vtxo.IncomingAncestryFetcher that resolves
 // the round commit tree fragments needed for the unilateral exit unroll CPFP
@@ -23,13 +41,39 @@ import (
 // runs with a broken dependency in production.
 //
 // The fetched ancestry travels through the same vtxo.AncestryFromRPC validator
-// the OOR receive path uses; structural errors (missing or over-cap paths)
-// surface as fetch failures and the handler then persists without ancestry
-// rather than dropping the VTXO entirely. This keeps cooperative spend paths
-// usable on the receiver even if the indexer is temporarily unhealthy — only
-// unilateral exit is degraded.
+// the OOR receive path uses. Structural or authentication errors keep the
+// durable incoming event pending for retry; no VTXO is accepted without the
+// expiry evidence needed to enforce its safety margins.
 func incomingAncestryFetcher(idx *indexer.Client,
+	signerFactory OORReceiveScriptSignerFactory,
+	authenticateExpiry oor.IncomingExpiryAuthenticator) (
+	vtxo.IncomingAncestryFetcher, error) {
+
+	if authenticateExpiry == nil {
+		return nil, fmt.Errorf("expiry authenticator not initialized")
+	}
+
+	return newIncomingAncestryFetcher(
+		idx, signerFactory, authenticateExpiry,
+	)
+}
+
+// incomingAncestryOnlyFetcher builds the fetch-only variant used by the
+// legacy commitment-height repair. New VTXO acceptance must use
+// incomingAncestryFetcher so expiry authentication cannot be omitted.
+func incomingAncestryOnlyFetcher(idx *indexer.Client,
 	signerFactory OORReceiveScriptSignerFactory) (
+	vtxo.IncomingAncestryFetcher, error) {
+
+	return newIncomingAncestryFetcher(idx, signerFactory, nil)
+}
+
+// newIncomingAncestryFetcher binds indexed ancestry to the requested target
+// and optionally derives expiry from local confirmations. The fetch-only form
+// remains reserved for the existing commitment-height repair.
+func newIncomingAncestryFetcher(idx *indexer.Client,
+	signerFactory OORReceiveScriptSignerFactory,
+	authenticateExpiry oor.IncomingExpiryAuthenticator) (
 	vtxo.IncomingAncestryFetcher, error) {
 
 	if idx == nil {
@@ -62,10 +106,26 @@ func incomingAncestryFetcher(idx *indexer.Client,
 			)
 		}
 
-		return vtxo.ResolveIncomingAncestry(
+		extras, err := vtxo.ResolveIncomingAncestry(
 			ctx, query, outpoint, pkScript,
 			vtxo.DefaultIncomingAncestryIndexPageSize,
 			uint64(oor.DefaultMaxVTXOMatches),
 		)
+		if err != nil {
+			return vtxo.IncomingVTXOExtras{}, err
+		}
+
+		if authenticateExpiry != nil {
+			extras.BatchExpiry, err = authenticateExpiry(
+				ctx, extras.Ancestry,
+			)
+			if err != nil {
+				return vtxo.IncomingVTXOExtras{}, fmt.Errorf(
+					"authenticate batch "+
+						"expiry: %w", err)
+			}
+		}
+
+		return extras, nil
 	}, nil
 }

--- a/waved/incoming_ancestry_fetcher_test.go
+++ b/waved/incoming_ancestry_fetcher_test.go
@@ -1,0 +1,34 @@
+package waved
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIncomingAncestryFetcherWithTimeout proves a stalled indexer lookup
+// returns control to the durable incoming actor for postponement.
+func TestIncomingAncestryFetcherWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	fetcher := incomingAncestryFetcherWithTimeout(
+		func(ctx context.Context, _ wire.OutPoint, _ []byte,
+			_ keychain.KeyDescriptor) (vtxo.IncomingVTXOExtras,
+			error) {
+
+			<-ctx.Done()
+
+			return vtxo.IncomingVTXOExtras{}, ctx.Err()
+		}, 10*time.Millisecond,
+	)
+
+	_, err := fetcher(
+		t.Context(), wire.OutPoint{}, nil, keychain.KeyDescriptor{},
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/waved/incoming_metadata.go
+++ b/waved/incoming_metadata.go
@@ -251,7 +251,7 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (oor.IncomingVTXOMetadata,
 			"missing commitment txid")
 	}
 
-	ancestry, err := vtxo.AncestryFromRPC(candidate.GetAncestryPaths())
+	ancestry, err := vtxo.IndexedAncestryFromRPC(candidate)
 	if err != nil {
 		return oor.IncomingVTXOMetadata{}, fmt.Errorf("convert "+
 			"ancestry paths: %w", err)
@@ -263,7 +263,7 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (oor.IncomingVTXOMetadata,
 	return oor.IncomingVTXOMetadata{
 		RoundID:        candidate.GetRoundId(),
 		CommitmentTxID: commitmentTxID,
-		BatchExpiry:    candidate.GetBatchExpiryHeight(),
+		BatchExpiry:    0,
 		ChainDepth:     int(candidate.GetChainDepth()),
 		CreatedHeight:  candidate.GetCreatedHeight(),
 		Ancestry:       ancestry,

--- a/waved/incoming_metadata_test.go
+++ b/waved/incoming_metadata_test.go
@@ -12,6 +12,7 @@ import (
 	btclog "github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/indexer"
+	"github.com/lightninglabs/wavelength/internal/expiryfixture"
 	"github.com/lightninglabs/wavelength/internal/indexerlimits"
 	lib_tree "github.com/lightninglabs/wavelength/lib/tree"
 	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
@@ -187,7 +188,9 @@ func TestResolveIncomingMetadataFromIndexerAllowsMatchAtScanLimit(
 
 	t.Parallel()
 
-	sessionID := oor.SessionID(testTxID(1))
+	candidate, _ := expiryfixture.Merge(t, false)
+	var sessionID oor.SessionID
+	copy(sessionID[:], candidate.Outpoint.Txid)
 	idx, rpcClient, recipient, _ := newTestIncomingMetadataIndexer(
 		t,
 		testIncomingMetadataResponse(
@@ -197,9 +200,10 @@ func TestResolveIncomingMetadataFromIndexerAllowsMatchAtScanLimit(
 					Vout: 0,
 				},
 			},
-			testIncomingVTXO(sessionID, recipientIndex),
+			candidate,
 		),
 	)
+	recipient.OutputIndex = candidate.Outpoint.Vout
 
 	metadata, err := ResolveIncomingMetadataFromIndexerWithLimits(
 		t.Context(), idx, sessionID, recipient, oor.ReceiveLimits{
@@ -207,7 +211,7 @@ func TestResolveIncomingMetadataFromIndexerAllowsMatchAtScanLimit(
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, testTxID(10).String(), metadata.RoundID)
+	require.Equal(t, candidate.RoundId, metadata.RoundID)
 	require.Equal(t, 1, rpcClient.sendCount())
 }
 
@@ -223,18 +227,16 @@ func TestResolveIncomingMetadataFromIndexerAllowsMatchAtScanLimit(
 func TestResolveIncomingMetadataSameCommitmentMultiLeaf(t *testing.T) {
 	t.Parallel()
 
-	sessionID := oor.SessionID(testTxID(1))
-	commitment := testTxID(13)
-
-	candidate := testIncomingVTXO(sessionID, recipientIndex)
-	candidate.AncestryPaths = []*arkrpc.AncestryPath{
-		testAncestryPathAtIndex(commitment, 0, []uint32{0}),
-		testAncestryPathAtIndex(commitment, 1, []uint32{1}),
-	}
+	candidate, _ := expiryfixture.Merge(t, true)
+	var sessionID oor.SessionID
+	copy(sessionID[:], candidate.Outpoint.Txid)
+	var commitment chainhash.Hash
+	copy(commitment[:], candidate.CommitmentTxid)
 
 	idx, _, recipient, _ := newTestIncomingMetadataIndexer(
 		t, testIncomingMetadataResponse(nil, candidate),
 	)
+	recipient.OutputIndex = candidate.Outpoint.Vout
 
 	metadata, err := ResolveIncomingMetadataFromIndexerWithLimits(
 		t.Context(), idx, sessionID, recipient, oor.ReceiveLimits{
@@ -266,13 +268,15 @@ func TestResolveIncomingMetadataSameCommitmentMultiLeaf(t *testing.T) {
 func TestResolveIncomingMetadataRecoveryRetriesShedPage(t *testing.T) {
 	t.Parallel()
 
-	sessionID := oor.SessionID(testTxID(1))
+	candidate, _ := expiryfixture.Merge(t, false)
+	var sessionID oor.SessionID
+	copy(sessionID[:], candidate.Outpoint.Txid)
 	idx, rpcClient, recipient, _ := newTestIncomingMetadataIndexer(
-		t,
-		testIncomingMetadataResponse(
-			nil, testIncomingVTXO(sessionID, recipientIndex),
+		t, testIncomingMetadataResponse(
+			nil, candidate,
 		),
 	)
+	recipient.OutputIndex = candidate.Outpoint.Vout
 
 	// The operator sheds the first two attempts, then serves the page.
 	rpcClient.shedFirst = 2
@@ -284,7 +288,7 @@ func TestResolveIncomingMetadataRecoveryRetriesShedPage(t *testing.T) {
 		retryRecoveryIndexerRPC,
 	)
 	require.NoError(t, err)
-	require.Equal(t, testTxID(10).String(), metadata.RoundID)
+	require.Equal(t, candidate.RoundId, metadata.RoundID)
 
 	// Every attempt at the page has to carry the same key, or the operator
 	// bills three separate scans for the one page we asked for.

--- a/waved/rpc_custom_refresh_metadata.go
+++ b/waved/rpc_custom_refresh_metadata.go
@@ -56,6 +56,9 @@ func (r *RPCServer) enrichCustomRefreshInputs(ctx context.Context,
 	return nil
 }
 
+// resolveCustomRefreshMetadata requires the indexed input to match the
+// requested output and verifies its target proof and locally confirmed expiry
+// before the caller can sign a custom refresh.
 func (r *RPCServer) resolveCustomRefreshMetadata(ctx context.Context,
 	input wallet.CustomRefreshInput) (customRefreshMetadata, error) {
 
@@ -110,6 +113,22 @@ func (r *RPCServer) resolveCustomRefreshMetadata(ctx context.Context,
 					input.Outpoint, err)
 			}
 
+			if r.server.expiryAuthenticator == nil {
+				return customRefreshMetadata{}, status.Error(
+					codes.Unavailable,
+					"expiry authenticator not initialized",
+				)
+			}
+			meta.BatchExpiry, err = r.server.expiryAuthenticator(
+				ctx, meta.Ancestry,
+			)
+			if err != nil {
+				return customRefreshMetadata{}, status.Errorf(
+					codes.FailedPrecondition,
+					"authenticate refresh expiry for "+
+						"%s: %v", input.Outpoint, err)
+			}
+
 			return meta, nil
 		}
 
@@ -134,6 +153,8 @@ type customRefreshMetadata struct {
 	Ancestry       []vtxo.Ancestry
 }
 
+// customRefreshMetadataFromRPC validates the indexed target proof and
+// converts lineage metadata without trusting the advertised batch expiry.
 func customRefreshMetadataFromRPC(candidate *arkrpc.VTXO) (
 	customRefreshMetadata, error) {
 
@@ -152,7 +173,7 @@ func customRefreshMetadataFromRPC(candidate *arkrpc.VTXO) (
 			"missing commitment txid")
 	}
 
-	ancestry, err := vtxo.AncestryFromRPC(candidate.GetAncestryPaths())
+	ancestry, err := vtxo.IndexedAncestryFromRPC(candidate)
 	if err != nil {
 		return customRefreshMetadata{}, fmt.Errorf("convert ancestry "+
 			"paths: %w", err)
@@ -164,7 +185,7 @@ func customRefreshMetadataFromRPC(candidate *arkrpc.VTXO) (
 	return customRefreshMetadata{
 		RoundID:        candidate.GetRoundId(),
 		CommitmentTxID: commitmentTxID,
-		BatchExpiry:    candidate.GetBatchExpiryHeight(),
+		BatchExpiry:    0,
 		ChainDepth:     int(candidate.GetChainDepth()),
 		CreatedHeight:  candidate.GetCreatedHeight(),
 		Ancestry:       ancestry,

--- a/waved/server.go
+++ b/waved/server.go
@@ -360,10 +360,18 @@ type Server struct {
 
 	actorSystem  *actor.ActorSystem
 	chainBackend chainsource.ChainBackend
-	walletRef    fn.Option[actor.ActorRef[
+
+	// expiryAuthenticator is published with the chain-source actor and
+	// reused by every new-VTXO acceptance path. Existing persisted VTXOs
+	// are intentionally left unchanged.
+	expiryAuthenticator oor.IncomingExpiryAuthenticator
+	walletRef           fn.Option[actor.ActorRef[
 		wallet.WalletMsg, wallet.WalletResp,
 	]]
-	oorRegistry        *oor.OORRegistryActor
+	oorRegistry       *oor.OORRegistryActor
+	incomingVTXOActor *actor.DurableActor[
+		*vtxo.IncomingVTXOMsg, vtxo.IncomingVTXOResp,
+	]
 	creditRegistry     *credit.Registry
 	vhtlcRecoveryStore *db.VHTLCRecoveryStoreDB
 	vhtlcRecovery      *coordinator.Service
@@ -1278,6 +1286,15 @@ func (s *Server) runInner(ctx context.Context, shutdownFn func()) error {
 
 		if s.oorRegistry != nil {
 			s.oorRegistry.Stop()
+		}
+
+		if s.incomingVTXOActor != nil {
+			//nolint:contextcheck // bounded shutdown
+			err := s.incomingVTXOActor.StopAndWait(shutdownCtx)
+			if err != nil {
+				s.log.WarnS(ctx, "Incoming VTXO actor shutdown "+
+					"failed", err)
+			}
 		}
 
 		if s.creditRegistry != nil {
@@ -2637,6 +2654,8 @@ func (s *Server) startWalletDependentActors(ctx context.Context,
 	],
 	timeoutRef actor.TellOnlyRef[timeout.Msg]) error {
 
+	s.expiryAuthenticator = NewBatchExpiryAuthenticator(chainSourceRef)
+
 	// -------------------------------------------------------
 	// 9. Register the wallet (boarding) actor.
 	// -------------------------------------------------------
@@ -3153,7 +3172,7 @@ func (s *Server) registerIncomingVTXOEventRoute(
 	vtxoKey := vtxo.IncomingVTXOServiceKey()
 
 	serverconn.AddRoute(router, serverconn.EventRouteConfig[
-		vtxo.IncomingVTXOMsg, vtxo.IncomingVTXOResp,
+		*vtxo.IncomingVTXOMsg, vtxo.IncomingVTXOResp,
 	]{
 		Service: arkServiceName,
 		Method:  MethodIncomingVTXO,
@@ -3161,7 +3180,7 @@ func (s *Server) registerIncomingVTXOEventRoute(
 			return &arkrpc.IncomingVTXOEvent{}
 		},
 		Key: vtxoKey,
-		Adapt: func(p proto.Message) (vtxo.IncomingVTXOMsg, error) {
+		Adapt: func(p proto.Message) (*vtxo.IncomingVTXOMsg, error) {
 			evt, ok := p.(*arkrpc.IncomingVTXOEvent)
 			if !ok {
 				// A malformed push never reaches the handler,
@@ -3174,7 +3193,7 @@ func (s *Server) registerIncomingVTXOEventRoute(
 					},
 				)
 
-				return vtxo.IncomingVTXOMsg{},
+				return nil,
 					fmt.Errorf("expected "+
 						"IncomingVTXOEvent, got %T", p)
 			}
@@ -3185,7 +3204,7 @@ func (s *Server) registerIncomingVTXOEventRoute(
 			// relevant and the save succeeded. Counting here at
 			// adapt time would report a materialization before the
 			// handler verified ownership and persisted the VTXO.
-			return vtxo.IncomingVTXOMsg{
+			return &vtxo.IncomingVTXOMsg{
 				Event: evt,
 			}, nil
 		},
@@ -4778,11 +4797,12 @@ func (s *Server) initOORActor(ctx context.Context,
 	// delegate of the local-persistence handler for retry scheduling.
 
 	outboxHandler := &oor.LocalPersistenceOutboxHandler{
-		Next:         signingHandler,
-		Store:        vtxoStore,
-		PackageStore: packageStore,
-		OperatorKey:  operatorTerms.PubKey,
-		ExitDelay:    operatorTerms.VTXOExitDelay,
+		Next:                       signingHandler,
+		Store:                      vtxoStore,
+		PackageStore:               packageStore,
+		OperatorKey:                operatorTerms.PubKey,
+		ExitDelay:                  operatorTerms.VTXOExitDelay,
+		AuthenticateIncomingExpiry: s.expiryAuthenticator,
 		NotifyIncomingVTXOs: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 
@@ -4881,56 +4901,80 @@ func (s *Server) initOORActor(ctx context.Context,
 	// IncomingVTXOEvent push notifications from the indexer and
 	// materializes VTXOs for registered receive scripts.
 	//
-	// The ancestry fetcher is wired so the materialized descriptor
-	// carries the round commit tree fragments needed for unilateral
-	// exit (bug-3 in BUGS_FOUND.md). A wiring failure (no indexer or
-	// no proof-key backend) is non-fatal: the handler runs without
-	// the fetcher, persisting incoming VTXOs without ancestry, which
-	// preserves the legacy degraded behavior (cooperative paths work,
-	// unilateral exit blocked) rather than dropping incoming events
-	// on the floor.
+	// The ancestry fetcher is wired so the materialized descriptor carries
+	// authenticated expiry evidence and the round commit tree fragments
+	// needed for unilateral exit. A wiring failure leaves relevant durable
+	// events pending rather than accepting incomplete safety metadata.
 	var ancestryFetcher vtxo.IncomingAncestryFetcher
 	incomingSignerFactory, fetcherErr := s.indexerProofSignerFactory()
 	if fetcherErr != nil {
 		s.log.WarnS(ctx,
-			"Incoming VTXO ancestry fetch disabled; received "+
-				"VTXOs will not be unilaterally exitable",
+			"Incoming VTXO acceptance disabled; ancestry fetch "+
+				"cannot be authenticated",
 			fetcherErr,
 		)
 	} else {
 		ancestryFetcher, fetcherErr = incomingAncestryFetcher(
-			s.indexer, incomingSignerFactory,
+			s.indexer, incomingSignerFactory, s.expiryAuthenticator,
 		)
 		if fetcherErr != nil {
 			s.log.WarnS(ctx,
-				"Incoming VTXO ancestry fetch disabled; "+
-					"received VTXOs will not be "+
-					"unilaterally exitable",
+				"Incoming VTXO acceptance disabled; ancestry "+
+					"fetch cannot be authenticated",
 				fetcherErr,
+			)
+		} else {
+			ancestryFetcher = incomingAncestryFetcherWithTimeout(
+				ancestryFetcher,
+				incomingExpiryAuthenticationTimeout,
 			)
 		}
 	}
 
 	incomingVTXOStore := dbStore.NewVTXOStore(s.clk)
-	incomingHandler := vtxo.NewIncomingVTXOHandler(
-		vtxo.IncomingVTXOHandlerConfig{
-			Log: fn.Some(s.subLogger(Subsystem)),
-			ScriptStore: &ownedScriptLookupAdapter{
-				store: packageStore,
-			},
-			VTXOStore:       incomingVTXOStore,
-			VTXOManager:     vtxoManagerRef,
-			AncestryFetcher: ancestryFetcher,
-			MetricsSink:     s.metricsSink,
+	err = s.startIncomingVTXOActor(vtxo.IncomingVTXOHandlerConfig{
+		Log: fn.Some(s.subLogger(Subsystem)),
+		ScriptStore: &ownedScriptLookupAdapter{
+			store: packageStore,
 		},
-	)
-	incomingKey := vtxo.IncomingVTXOServiceKey()
-	actor.RegisterWithSystem(
-		s.actorSystem, "incoming-vtxo-handler", incomingKey,
-		incomingHandler,
-	)
+		VTXOStore:       incomingVTXOStore,
+		VTXOManager:     vtxoManagerRef,
+		AncestryFetcher: ancestryFetcher,
+		MetricsSink:     s.metricsSink,
+	})
+	if err != nil {
+		return err
+	}
 
 	s.log.InfoS(ctx, "Incoming VTXO handler started")
+
+	return nil
+}
+
+// startIncomingVTXOActor starts and registers the durable incoming-event
+// consumer. The server retains it for ordered shutdown before the actor system.
+func (s *Server) startIncomingVTXOActor(
+	cfg vtxo.IncomingVTXOHandlerConfig) error {
+
+	incomingActor, err := vtxo.NewIncomingVTXODurableActor(
+		cfg, s.deliveryStore,
+	)
+	if err != nil {
+		return fmt.Errorf("create incoming VTXO actor: %w", err)
+	}
+	incomingActor.Start()
+	s.incomingVTXOActor = incomingActor
+
+	incomingKey := vtxo.IncomingVTXOServiceKey()
+	if err := actor.RegisterWithReceptionist(
+		s.actorSystem.Receptionist(), incomingKey, incomingActor.Ref(),
+	); err != nil {
+
+		incomingActor.Stop()
+		s.incomingVTXOActor = nil
+
+		return fmt.Errorf("register incoming VTXO actor: %w", err)
+	}
 
 	return nil
 }

--- a/waved/wallet_recovery.go
+++ b/waved/wallet_recovery.go
@@ -266,10 +266,14 @@ func (s *Server) recoveryBoardingBackend() (wallet.BoardingBackend, error) {
 	}
 }
 
+// recoverIndexedVTXOs scans one key family and accepts outputs only after
+// target-proof and expiry authentication. Invalid entries do not stop later
+// recovery; the first error is returned so an incomplete scan can be retried.
 func (r *RPCServer) recoverIndexedVTXOs(ctx context.Context,
 	terms *libtypes.OperatorTerms, family keychain.KeyFamily, window uint32,
 	result *WalletRecoveryResult) error {
 
+	var firstExpiryErr error
 	for i := uint32(0); i < window; i++ {
 		keyDesc, err := r.server.proofKeyBackend.DeriveKey(
 			ctx, keychain.KeyLocator{
@@ -344,12 +348,42 @@ func (r *RPCServer) recoverIndexedVTXOs(ctx context.Context,
 					indexed, *keyDesc, terms,
 				)
 				if err != nil {
-					return fmt.Errorf("convert VTXO for "+
-						"key %d: %w", i, err)
+					if firstExpiryErr == nil {
+						firstExpiryErr = fmt.Errorf(
+							"convert VTXO for key "+
+								"%d: %w",
+							i, err)
+					}
+
+					continue
 				}
 				if !ok {
 					continue
 				}
+
+				if r.server.expiryAuthenticator == nil {
+					return fmt.Errorf("expiry " +
+						"authenticator not initialized")
+				}
+				expiry, err := r.server.expiryAuthenticator(
+					ctx, desc.Ancestry,
+				)
+				if err != nil {
+					if firstExpiryErr == nil {
+						firstExpiryErr = fmt.Errorf(
+							"authenticate VTXO %s "+
+								"expiry: %w",
+							desc.Outpoint, err)
+					}
+					r.server.log.WarnS(
+						ctx, "Skipping recovered VTXO with "+
+							"unauthenticated expiry", err,
+						"outpoint", desc.Outpoint.String(),
+					)
+
+					continue
+				}
+				desc.BatchExpiry = expiry
 
 				saved, err := r.saveRecoveredVTXO(ctx, desc)
 				if err != nil {
@@ -367,9 +401,12 @@ func (r *RPCServer) recoverIndexedVTXOs(ctx context.Context,
 		}
 	}
 
-	return nil
+	return firstExpiryErr
 }
 
+// recoveryDescriptorFromIndexer binds the indexed output to signed ancestry
+// and reconstructs its local receive policy. The caller must authenticate the
+// batch confirmation before persisting the descriptor.
 func recoveryDescriptorFromIndexer(indexed *arkrpc.VTXO,
 	keyDesc keychain.KeyDescriptor, terms *libtypes.OperatorTerms) (
 	*vtxo.Descriptor, bool, error) {
@@ -428,7 +465,7 @@ func recoveryDescriptorFromIndexer(indexed *arkrpc.VTXO,
 		return nil, false, fmt.Errorf("encode policy: %w", err)
 	}
 
-	ancestry, err := vtxo.AncestryFromRPC(indexed.GetAncestryPaths())
+	ancestry, err := vtxo.IndexedAncestryFromRPC(indexed)
 	if err != nil {
 		return nil, false, fmt.Errorf("convert ancestry: %w", err)
 	}
@@ -451,7 +488,7 @@ func recoveryDescriptorFromIndexer(indexed *arkrpc.VTXO,
 		Ancestry:       ancestry,
 		RoundID:        indexed.GetRoundId(),
 		CommitmentTxID: *commitmentTxID,
-		BatchExpiry:    indexed.GetBatchExpiryHeight(),
+		BatchExpiry:    0,
 		RelativeExpiry: exitDelay,
 		ChainDepth:     int(indexed.GetChainDepth()),
 		CreatedHeight:  indexed.GetCreatedHeight(),
@@ -663,16 +700,19 @@ func (r *RPCServer) recoverOORReceiveScripts(ctx context.Context,
 	return nil
 }
 
+// recoveryOORHandler wires the same expiry and persistence boundaries used
+// by live OOR receive into the indexed event replay path.
 func (r *RPCServer) recoveryOORHandler(
 	terms *libtypes.OperatorTerms,
 	packageStore *db.OORArtifactPersistenceStore,
 ) *oor.LocalPersistenceOutboxHandler {
 
 	return &oor.LocalPersistenceOutboxHandler{
-		Store:        r.server.vtxoStore,
-		PackageStore: packageStore,
-		OperatorKey:  terms.PubKey,
-		ExitDelay:    terms.VTXOExitDelay,
+		Store:                      r.server.vtxoStore,
+		PackageStore:               packageStore,
+		OperatorKey:                terms.PubKey,
+		ExitDelay:                  terms.VTXOExitDelay,
+		AuthenticateIncomingExpiry: r.server.expiryAuthenticator,
 		NotifyIncomingVTXOs: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 
@@ -756,6 +796,9 @@ func (r *RPCServer) recoverOOREventsForScript(ctx context.Context,
 	return nil
 }
 
+// materializeRecoveredOOREvent replays a recovered package with freshly
+// authenticated target ancestry and expiry. Existing package and descriptor
+// persistence keep redelivery idempotent.
 func (r *RPCServer) materializeRecoveredOOREvent(ctx context.Context,
 	idx *indexer.Client, event *arkrpc.OORRecipientEvent,
 	handler *oor.LocalPersistenceOutboxHandler) error {
@@ -813,6 +856,19 @@ func (r *RPCServer) materializeRecoveredOOREvent(ctx context.Context,
 		if err != nil {
 			return err
 		}
+
+		if r.server.expiryAuthenticator == nil {
+			return fmt.Errorf("expiry authenticator not " +
+				"initialized")
+		}
+		metadata.BatchExpiry, err = r.server.expiryAuthenticator(
+			ctx, metadata.Ancestry,
+		)
+		if err != nil {
+			return fmt.Errorf("authenticate recovered OOR output "+
+				"%d expiry: %w", recipient.OutputIndex, err)
+		}
+		metadata.ExpiryAuthenticated = true
 
 		metadataMatches = append(metadataMatches,
 			oor.IncomingMetadataMatch{

--- a/waved/wallet_recovery_descriptor_test.go
+++ b/waved/wallet_recovery_descriptor_test.go
@@ -3,9 +3,8 @@ package waved
 import (
 	"testing"
 
-	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
-	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/internal/expiryfixture"
 	libtypes "github.com/lightninglabs/wavelength/lib/types"
 	"github.com/stretchr/testify/require"
 )
@@ -33,25 +32,11 @@ func TestRecoveryDescriptorFromIndexerRebuildsIndexerScript(t *testing.T) {
 		t, uint32(batchRelativeExpiry), terms.VTXOExitDelay,
 	)
 
-	commitmentTxID := chainhash.Hash{0xcc}
-	outpointTxID := chainhash.Hash{0xdd}
-	indexed := &arkrpc.VTXO{
-		Outpoint: &arkrpc.OutPoint{
-			Txid: outpointTxID[:],
-			Vout: 0,
-		},
-		ValueSat:          28674,
-		PkScript:          pkScript,
-		Status:            arkrpc.VTXOStatus_VTXO_STATUS_LIVE,
-		RoundId:           "round-1",
-		CommitmentTxid:    commitmentTxID[:],
-		CreatedHeight:     964273,
-		BatchExpiryHeight: 965281,
-		RelativeExpiry:    batchRelativeExpiry,
-		AncestryPaths: []*arkrpc.AncestryPath{
-			recoveryTestAncestryPath(t, commitmentTxID),
-		},
-	}
+	indexed, _ := expiryfixture.Round(
+		t, 28674, pkScript, batchRelativeExpiry, 964273, 1,
+	)
+	indexed.BatchExpiryHeight = 965281
+	indexed.RelativeExpiry = batchRelativeExpiry
 
 	desc, ok, err := recoveryDescriptorFromIndexer(
 		indexed, clientKey, terms,

--- a/waved/wallet_recovery_oor_family_test.go
+++ b/waved/wallet_recovery_oor_family_test.go
@@ -7,15 +7,14 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/chainhash/v2"
-	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/indexer"
-	libtree "github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/internal/expiryfixture"
 	libtypes "github.com/lightninglabs/wavelength/lib/types"
 	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
+	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -26,28 +25,6 @@ import (
 // recoveryTestExitDelay is the operator's VTXO exit delay used to build the
 // receive scripts under test.
 const recoveryTestExitDelay = 144
-
-// recoveryTestAncestryPath builds the minimal valid ancestry path an indexer
-// VTXO needs to survive recovery's conversion step.
-func recoveryTestAncestryPath(t *testing.T,
-	commitmentTxID chainhash.Hash) *arkrpc.AncestryPath {
-
-	t.Helper()
-
-	tree := &libtree.Tree{
-		Root: &libtree.Node{},
-		BatchOutpoint: wire.OutPoint{
-			Hash: commitmentTxID,
-		},
-	}
-
-	path, err := arkrpc.AncestryPathFromTree(
-		tree, commitmentTxID, []uint32{0},
-	)
-	require.NoError(t, err)
-
-	return path
-}
 
 // recoveryKeyBackend derives a distinct deterministic key per key locator so a
 // test can tell the families recovery scans apart by the scripts they produce.
@@ -201,6 +178,11 @@ func newRecoveryScanServer(t *testing.T, liveScript []byte,
 			btclog.Disabled,
 		).NewVTXOStore(clk),
 		proofKeyBackend: &recoveryKeyBackend{},
+		expiryAuthenticator: func(context.Context, []vtxo.Ancestry) (
+			int32, error) {
+
+			return 965281, nil
+		},
 		indexer: indexer.New(
 			stub, nil, "test-server", "client:test",
 			fn.None[btclog.Logger](),
@@ -232,25 +214,10 @@ func TestRecoverIndexedVTXOsCoversOORReceiveScripts(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	commitmentTxID := chainhash.Hash{0xaa}
-	outpointTxID := chainhash.Hash{0xbb}
-	live := &arkrpc.VTXO{
-		Outpoint: &arkrpc.OutPoint{
-			Txid: outpointTxID[:],
-			Vout: 0,
-		},
-		ValueSat:          28674,
-		PkScript:          oorScript,
-		Status:            arkrpc.VTXOStatus_VTXO_STATUS_LIVE,
-		RoundId:           "round-1",
-		CommitmentTxid:    commitmentTxID[:],
-		CreatedHeight:     964273,
-		BatchExpiryHeight: 965281,
-		RelativeExpiry:    recoveryTestExitDelay,
-		AncestryPaths: []*arkrpc.AncestryPath{
-			recoveryTestAncestryPath(t, commitmentTxID),
-		},
-	}
+	live, _ := expiryfixture.Round(t, 28674, oorScript,
+		1008, 964273, 2)
+	live.BatchExpiryHeight = 965281
+	live.RelativeExpiry = recoveryTestExitDelay
 
 	// The VTXO-owner family alone never queries the OOR receive script.
 	ownerOnly, ownerStub := newRecoveryScanServer(t, oorScript, live)
@@ -286,4 +253,59 @@ func TestRecoverIndexedVTXOsCoversOORReceiveScripts(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, saved)
 	require.Equal(t, oorScript, saved.PkScript)
+}
+
+// TestRecoveryContinuesAfterForgedTarget proves one unrelated ancestry response
+// leaves its target uncredited while later valid outputs remain recoverable.
+func TestRecoveryContinuesAfterForgedTarget(t *testing.T) {
+	t.Parallel()
+	operatorKey := testKeyDescriptor(t, 201)
+	terms := &libtypes.OperatorTerms{
+		PubKey:        operatorKey.PubKey,
+		VTXOExitDelay: recoveryTestExitDelay,
+	}
+	backend := &recoveryKeyBackend{}
+	var scripts [][]byte
+	var entries []*arkrpc.VTXO
+	for i := uint32(0); i < 2; i++ {
+		key, err := backend.DeriveKey(
+			t.Context(), keychain.KeyLocator{
+				Family: oorReceiveKeyFamily,
+				Index:  i,
+			},
+		)
+		require.NoError(t, err)
+		script, err := BuildPubKeyVTXOReceiveScript(
+			key.PubKey, terms.PubKey, terms.VTXOExitDelay,
+		)
+		require.NoError(t, err)
+		entry, _ := expiryfixture.Round(
+			t, 10000, script, 50, 100, byte(i+20),
+		)
+		scripts = append(scripts, script)
+		entries = append(entries, entry)
+	}
+	// Keep the queried outpoint and script, but substitute a valid tree
+	// belonging to the other output.
+	entries[0].AncestryPaths = entries[1].AncestryPaths
+	rpc, stub := newRecoveryScanServer(t, scripts[0], entries[0])
+	stub.byScript[string(scripts[1])] = entries[1]
+	var result WalletRecoveryResult
+	err := rpc.recoverIndexedVTXOs(
+		t.Context(), terms, oorReceiveKeyFamily, 2, &result,
+	)
+	require.ErrorIs(t, err, vtxo.ErrInvalidBatchExpiryEvidence)
+	require.Equal(t, uint32(1), result.VTXOs)
+	for i, entry := range entries {
+		op, err := recoveryOutpoint(entry.Outpoint)
+		require.NoError(t, err)
+		saved, err := rpc.server.vtxoStore.GetVTXO(t.Context(), op)
+		if i == 0 {
+			require.Error(t, err)
+			require.Nil(t, saved)
+			continue
+		}
+		require.NoError(t, err)
+		require.Equal(t, op, saved.Outpoint)
+	}
 }


### PR DESCRIPTION
**Stack status:** Rebuilt on `main` at `a43d0b005fa12ac680327662a9ca796497d86bdc` after #1199 merged. The nine signed, Verified commits contain only the intended expiry/proof work; the obsolete #1199 prefix and #1262 duplicate are removed. Current head: `3c744aa6c6ea9152450889a7bca99417fc963ae5`. Local final-base checks pass. Exact-head Gateway review found no blocker or major. All 17 CI jobs pass after retrying the two runner-loss failures. The coordinated final producer pass remains pending.

## The problem

A received virtual transaction output (VTXO) needs an expiry tied to the batches that actually fund it. An indexer-provided expiry height is only a hint.

Authenticating a supplied batch is insufficient. Suppose target A expires at height 150. The indexer supplies a real, confirmed batch for unrelated output B that expires at height 300. B can even have the same value and receive script as A. Accepting B's expiry for A would delay A's refresh or unilateral exit past its real deadline.

## The fix

Before accepting an indexed output, the client validates its complete signed transaction path to the exact target outpoint, value, and script. It reuses tree validation and the recovery proof graph, then executes each spend against its actual parent output. This rejects both a valid unrelated batch and a fabricated leaf whose signature does not authorize its contents.

Out-of-round (OOR) inventory now includes finalized ancestry packages. These connect the round-tree leaves through checkpoint and Ark transactions to the target. Every supplied proof node must contribute to that target, and every input must have a parent in the proof or an authenticated batch output.

The client then reconstructs each committed sweep policy, matches its batch output against a locally confirmed transaction, and derives the earliest confirmation height plus sweep delay across all parents. Advertised expiry heights are discarded. Round signing also verifies the committed sweep policy.

Incoming events, OOR receive, indexed recovery, and custom refresh use these checks before accepting the expiry. Chain and index outages remain retryable. The incoming event actor bounds its complete evidence lookup at two seconds and uses durable redelivery. Recovery continues past rejected entries and returns the first error, so it does not report an incomplete scan as successful.

## Safety rule

A new target receives an expiry only after its signed funding path and every contributing batch's sweep deadline are authenticated. A later-expiring batch for another output cannot authorize it.

Existing live VTXOs retain their spend and exit behavior. Optional legacy commitment-height repair also passes through target-proof validation; if the indexer lacks that evidence, maintenance retains the configured safe unroll lookback floor. This change adds no continuous canonicality tracker or legacy-record repair subsystem.

## Tests

- Valid signed target; unrelated confirmed ancestry; mismatched outpoint, output index, value, or script; forged signed leaf contents.
- Multi-parent earliest expiry; omitted earlier-expiring parent; distinct leaf paths within one commitment.
- Transient index and chain failures, bounded confirmation waits, and watch cleanup after cancellation.
- Failed persistence, durable redelivery, save-before-ack replay, and reload of a terminal row without resurrecting it.
- Recovery rejects one forged target while saving a later valid output.
- Incoming materialization, self-change, and concurrent receive with SQLite and PostgreSQL.
- Real-chain directed receive and chained/multi-input OOR receive using the actual producer's signed evidence.

## Compatibility and rollout

Deploy a server that exports the committed sweep key/delay and complete OOR ancestry packages **before** deploying this client. The protobuf fields are additive, so old clients can continue using the upgraded server. New clients fail closed when required evidence is absent; deploying them first can delay receive, recovery, or custom refresh until the server is upgraded.

## Review status and bounded follow-ups

Gateway reviewed final head `3c744aa6c6ea9152450889a7bca99417fc963ae5` after the dependency rebuild and found **zero blocker or major findings**. Its four minor findings are tracked below. All 17 CI jobs pass, including both complete system-test suites, race, lint, static checks, and all cross-builds. Two jobs lost their self-hosted runners on the first attempt and passed on retry. Final paired verification remains pending.

- Add shared package/checkpoint count limits at indexed ingress after confirming the producer contract. Transport already bounds message bytes; this follow-up concerns parsing cost.
- Separate structural-only legacy height maintenance from full target-proof validation while keeping every new-acceptance path strict.
- Continue independent recovered OOR events after a per-event failure, retaining an explicit partial-recovery error and atomic materialization within each event.
- Before enabling asset rounds, authenticate sweep-leaf inclusion in the combined asset signing root. The builder includes the leaf, but the existing client asset-context validation does not prove that relationship. The current operator has no asset-tree producer, and indexed acceptance rejects combined roots without the required proof context. This PR adds no asset bypass.

The reported oversized sweep-delay confirmation path is rejected before signing by the existing canonical CSV range check. Activation-depth policy remains owned by #1199.
