### PR TITLE
multi: carry asset tree context

### DIFF
--- a/db/tree_codec.go
+++ b/db/tree_codec.go
@@ -20,6 +20,7 @@ type (
 	tlvTreeBatchOutput   = tlv.TlvType1
 	tlvTreeSweepRoot     = tlv.TlvType2
 	tlvTreeRootNode      = tlv.TlvType3
+	tlvTreeAssetRef      = tlv.TlvType4
 )
 
 // Tree-decode safety bounds. The wire layer feeds DeserializeTree from
@@ -46,12 +47,16 @@ const (
 
 // TLV type aliases for Node serialization.
 type (
-	tlvNodeInput     = tlv.TlvType0
-	tlvNodeOutputs   = tlv.TlvType1
-	tlvNodeCoSigners = tlv.TlvType2
-	tlvNodeSignature = tlv.TlvType3
-	tlvNodeFinalKey  = tlv.TlvType4
-	tlvNodeChildren  = tlv.TlvType5
+	tlvNodeInput         = tlv.TlvType0
+	tlvNodeOutputs       = tlv.TlvType1
+	tlvNodeCoSigners     = tlv.TlvType2
+	tlvNodeSignature     = tlv.TlvType3
+	tlvNodeFinalKey      = tlv.TlvType4
+	tlvNodeChildren      = tlv.TlvType5
+	tlvNodeSigningTweak  = tlv.TlvType6
+	tlvNodeSealedPackage = tlv.TlvType7
+	tlvNodeAssetAmount   = tlv.TlvType8
+	tlvNodeLeafAssetRoot = tlv.TlvType9
 )
 
 // outpointRecord is a TLV record for wire.OutPoint. It implements
@@ -491,6 +496,9 @@ type tlvTree struct {
 	// RootNodeData is the serialized root node. Uses tlv.Blob (primitive
 	// []byte) directly.
 	RootNodeData tlv.RecordT[tlvTreeRootNode, tlv.Blob]
+
+	// AssetRef identifies the asset carried by the tree.
+	AssetRef tlv.RecordT[tlvTreeAssetRef, tlv.Blob]
 }
 
 // newTlvTree creates a new tlvTree with initialized RecordT fields.
@@ -506,22 +514,38 @@ func newTlvTree() *tlvTree {
 		RootNodeData: tlv.NewPrimitiveRecord[tlvTreeRootNode, tlv.Blob](
 			nil,
 		),
+		AssetRef: tlv.NewPrimitiveRecord[
+			tlvTreeAssetRef, tlv.Blob,
+		](
+			nil,
+		),
 	}
 }
 
 // EncodeRecords returns the TLV records for encoding.
 func (t *tlvTree) EncodeRecords() []tlv.Record {
-	return []tlv.Record{
+	records := []tlv.Record{
 		t.BatchOutpoint.Record(),
 		t.BatchOutput.Record(),
 		t.SweepRoot.Record(),
 		t.RootNodeData.Record(),
 	}
+	if len(t.AssetRef.Val) != 0 {
+		records = append(records, t.AssetRef.Record())
+	}
+
+	return records
 }
 
 // DecodeRecords returns the TLV records for decoding.
 func (t *tlvTree) DecodeRecords() []tlv.Record {
-	return t.EncodeRecords()
+	return []tlv.Record{
+		t.BatchOutpoint.Record(),
+		t.BatchOutput.Record(),
+		t.SweepRoot.Record(),
+		t.RootNodeData.Record(),
+		t.AssetRef.Record(),
+	}
 }
 
 // Encode serializes the tlvTree to a writer.
@@ -563,6 +587,18 @@ type tlvNode struct {
 
 	// Children is the serialized children data.
 	Children tlv.RecordT[tlvNodeChildren, childrenDataRecord]
+
+	// SigningTweak is the node's taproot tweak in an asset tree.
+	SigningTweak tlv.RecordT[tlvNodeSigningTweak, tlv.Blob]
+
+	// SealedPackage is the node's asset transition package.
+	SealedPackage tlv.RecordT[tlvNodeSealedPackage, tlv.Blob]
+
+	// AssetAmount is the number of asset units in this subtree.
+	AssetAmount tlv.RecordT[tlvNodeAssetAmount, uint64]
+
+	// LeafAssetRoot is the asset commitment root created by a leaf.
+	LeafAssetRoot tlv.RecordT[tlvNodeLeafAssetRoot, tlv.Blob]
 }
 
 // newTlvNode creates a new tlvNode with initialized RecordT fields.
@@ -579,6 +615,26 @@ func newTlvNode() *tlvNode {
 		FinalKey:  tlv.NewRecordT[tlvNodeFinalKey](pubKeyRecord{}),
 		Children: tlv.NewRecordT[tlvNodeChildren](
 			childrenDataRecord{},
+		),
+		SigningTweak: tlv.NewPrimitiveRecord[
+			tlvNodeSigningTweak, tlv.Blob,
+		](
+			nil,
+		),
+		SealedPackage: tlv.NewPrimitiveRecord[
+			tlvNodeSealedPackage, tlv.Blob,
+		](
+			nil,
+		),
+		AssetAmount: tlv.NewPrimitiveRecord[
+			tlvNodeAssetAmount, uint64,
+		](
+			0,
+		),
+		LeafAssetRoot: tlv.NewPrimitiveRecord[
+			tlvNodeLeafAssetRoot, tlv.Blob,
+		](
+			nil,
 		),
 	}
 }
@@ -600,6 +656,18 @@ func (n *tlvNode) EncodeRecords() []tlv.Record {
 	}
 
 	records = append(records, n.Children.Record())
+	if len(n.SigningTweak.Val) != 0 {
+		records = append(records, n.SigningTweak.Record())
+	}
+	if len(n.SealedPackage.Val) != 0 {
+		records = append(records, n.SealedPackage.Record())
+	}
+	if n.AssetAmount.Val != 0 {
+		records = append(records, n.AssetAmount.Record())
+	}
+	if len(n.LeafAssetRoot.Val) != 0 {
+		records = append(records, n.LeafAssetRoot.Record())
+	}
 
 	return records
 }
@@ -615,6 +683,10 @@ func (n *tlvNode) DecodeRecords() []tlv.Record {
 		n.Signature.Record(),
 		n.FinalKey.Record(),
 		n.Children.Record(),
+		n.SigningTweak.Record(),
+		n.SealedPackage.Record(),
+		n.AssetAmount.Record(),
+		n.LeafAssetRoot.Record(),
 	}
 }
 
@@ -648,6 +720,11 @@ func SerializeTree(t *tree.Tree) ([]byte, error) {
 	if t == nil {
 		return nil, fmt.Errorf("cannot serialize nil tree")
 	}
+	if t.AssetContext != nil {
+		if err := t.AssetContext.Validate(t.Root); err != nil {
+			return nil, fmt.Errorf("asset tree: %w", err)
+		}
+	}
 
 	tlvT := newTlvTree()
 
@@ -661,10 +738,13 @@ func SerializeTree(t *tree.Tree) ([]byte, error) {
 
 	// Set SweepRoot.
 	tlvT.SweepRoot.Val = t.SweepTapscriptRoot
+	if t.AssetContext != nil {
+		tlvT.AssetRef.Val = []byte(t.AssetContext.AssetRef())
+	}
 
 	// Serialize RootNode recursively.
 	if t.Root != nil {
-		rootData, err := serializeNode(t.Root)
+		rootData, err := serializeNode(t.Root, t.AssetContext)
 		if err != nil {
 			return nil, fmt.Errorf("serialize root node: %w", err)
 		}
@@ -706,11 +786,18 @@ func DeserializeTree(data []byte) (*tree.Tree, error) {
 		}
 	}
 
+	assetCtx := tree.NewAssetTreeContext()
+	if len(tlvT.AssetRef.Val) != 0 {
+		assetCtx.SetAssetRef(string(tlvT.AssetRef.Val))
+	}
+
 	// Deserialize root node. Depth starts at 1 so a root with no
 	// children still counts as depth 1, matching the convention used
 	// by tree.Node.Depth.
 	if len(tlvT.RootNodeData.Val) > 0 {
-		rootNode, err := deserializeNode(tlvT.RootNodeData.Val, 1)
+		rootNode, err := deserializeNode(
+			tlvT.RootNodeData.Val, 1, assetCtx,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("deserialize root node: %w", err)
 		}
@@ -718,11 +805,20 @@ func DeserializeTree(data []byte) (*tree.Tree, error) {
 		t.Root = rootNode
 	}
 
+	if !assetCtx.IsEmpty() {
+		if err := assetCtx.Validate(t.Root); err != nil {
+			return nil, fmt.Errorf("asset tree: %w", err)
+		}
+		t.AssetContext = assetCtx
+	}
+
 	return t, nil
 }
 
 // serializeNode serializes a tree.Node to bytes using TLV encoding.
-func serializeNode(n *tree.Node) ([]byte, error) {
+func serializeNode(n *tree.Node,
+	assetCtx *tree.AssetTreeContext) ([]byte, error) {
+
 	if n == nil {
 		return nil, fmt.Errorf("cannot serialize nil node")
 	}
@@ -747,9 +843,15 @@ func serializeNode(n *tree.Node) ([]byte, error) {
 	if n.FinalKey != nil {
 		tlvN.FinalKey.Val.Key = n.FinalKey
 	}
+	if assetCtx != nil {
+		tlvN.SigningTweak.Val = assetCtx.SigningTweak(n.Input)
+		tlvN.SealedPackage.Val = assetCtx.SealedPackage(n.Input)
+		tlvN.AssetAmount.Val = assetCtx.NodeAssetAmount(n)
+		tlvN.LeafAssetRoot.Val = assetCtx.LeafAssetRoot(n.Input)
+	}
 
 	// Serialize children recursively.
-	childrenData, err := serializeChildren(n.Children)
+	childrenData, err := serializeChildren(n.Children, assetCtx)
 	if err != nil {
 		return nil, fmt.Errorf("serialize children: %w", err)
 	}
@@ -768,7 +870,9 @@ func serializeNode(n *tree.Node) ([]byte, error) {
 // encoding. depth is the current recursion depth (1 for the root) and
 // is enforced against MaxTreeDeserializeDepth to prevent untrusted
 // blobs from triggering goroutine stack overflow.
-func deserializeNode(data []byte, depth int) (*tree.Node, error) {
+func deserializeNode(data []byte, depth int,
+	assetCtx *tree.AssetTreeContext) (*tree.Node, error) {
+
 	if len(data) == 0 {
 		return nil, fmt.Errorf("cannot deserialize empty node data")
 	}
@@ -799,10 +903,24 @@ func deserializeNode(data []byte, depth int) (*tree.Node, error) {
 	if tlvN.FinalKey.Val.Key != nil {
 		n.FinalKey = tlvN.FinalKey.Val.Key
 	}
+	if len(tlvN.SigningTweak.Val) != 0 {
+		assetCtx.SetSigningTweak(n.Input, tlvN.SigningTweak.Val)
+	}
+	if len(tlvN.SealedPackage.Val) != 0 {
+		assetCtx.SetSealedPackage(n.Input, tlvN.SealedPackage.Val)
+	}
+	if tlvN.AssetAmount.Val != 0 {
+		assetCtx.SetNodeAssetAmount(n, tlvN.AssetAmount.Val)
+	}
+	if len(tlvN.LeafAssetRoot.Val) != 0 {
+		assetCtx.SetLeafAssetRoot(n.Input, tlvN.LeafAssetRoot.Val)
+	}
 
 	// Deserialize children with depth+1 so a deep chain is rejected
 	// well before the goroutine stack grows.
-	children, err := deserializeChildren(tlvN.Children.Val.Data, depth+1)
+	children, err := deserializeChildren(
+		tlvN.Children.Val.Data, depth+1, assetCtx,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("deserialize children: %w", err)
 	}
@@ -813,7 +931,9 @@ func deserializeNode(data []byte, depth int) (*tree.Node, error) {
 }
 
 // serializeChildren serializes a map of children nodes.
-func serializeChildren(children map[uint32]*tree.Node) ([]byte, error) {
+func serializeChildren(children map[uint32]*tree.Node,
+	assetCtx *tree.AssetTreeContext) ([]byte, error) {
+
 	var buf bytes.Buffer
 	var scratch [8]byte
 
@@ -844,7 +964,7 @@ func serializeChildren(children map[uint32]*tree.Node) ([]byte, error) {
 		}
 
 		// Serialize the child node.
-		childData, err := serializeNode(child)
+		childData, err := serializeNode(child, assetCtx)
 		if err != nil {
 			return nil, fmt.Errorf("serialize child at index "+
 				"%d: %w", idx, err)
@@ -873,8 +993,8 @@ func serializeChildren(children map[uint32]*tree.Node) ([]byte, error) {
 // the recursion depth at which these children sit (i.e. the parent's
 // depth+1) and is forwarded to deserializeNode so a deep linear chain
 // is rejected before the goroutine stack grows.
-func deserializeChildren(data []byte,
-	depth int) (map[uint32]*tree.Node, error) {
+func deserializeChildren(data []byte, depth int,
+	assetCtx *tree.AssetTreeContext) (map[uint32]*tree.Node, error) {
 
 	if len(data) == 0 {
 		return make(map[uint32]*tree.Node), nil
@@ -929,7 +1049,7 @@ func deserializeChildren(data []byte,
 		}
 
 		// Deserialize the child node.
-		child, err := deserializeNode(nodeData, depth)
+		child, err := deserializeNode(nodeData, depth, assetCtx)
 		if err != nil {
 			return nil, fmt.Errorf("deserialize child at index "+
 				"%d: %w", idx, err)

--- a/db/tree_codec_asset_test.go
+++ b/db/tree_codec_asset_test.go
@@ -1,0 +1,149 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/stretchr/testify/require"
+)
+
+// newAssetCodecTree returns an asset tree with persistent node metadata.
+func newAssetCodecTree(t *testing.T) *tree.Tree {
+	t.Helper()
+
+	key, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	rootInput := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("batch")),
+		Index: 1,
+	}
+	leafInput := wire.OutPoint{
+		Hash: chainhash.HashH([]byte("root-tx")),
+	}
+	leaf := &tree.Node{
+		Input: leafInput,
+		Outputs: []*wire.TxOut{{
+			Value: 2_000,
+			PkScript: []byte{
+				0x51,
+			},
+		}},
+		CoSigners: []*btcec.PublicKey{
+			key.PubKey(),
+		},
+		Children: make(map[uint32]*tree.Node),
+	}
+	root := &tree.Node{
+		Input: rootInput,
+		Outputs: []*wire.TxOut{{
+			Value: 2_000,
+			PkScript: []byte{
+				0x52,
+			},
+		}},
+		CoSigners: []*btcec.PublicKey{
+			key.PubKey(),
+		},
+		Children: map[uint32]*tree.Node{
+			0: leaf,
+		},
+	}
+
+	assetCtx := tree.NewAssetTreeContext()
+	assetCtx.SetAssetRef(
+		tapsdk.AssetRefFromAssetID(tapsdk.AssetID{0xbb}).String(),
+	)
+	assetCtx.SetSigningTweak(rootInput, assetCodecHash("root-tweak"))
+	assetCtx.SetSigningTweak(leafInput, assetCodecHash("leaf-tweak"))
+	assetCtx.SetSealedPackage(rootInput, []byte{0xaa, 0xbb})
+	assetCtx.SetSealedPackage(leafInput, []byte{0xcc})
+	assetCtx.SetNodeAssetAmount(root, 700)
+	assetCtx.SetNodeAssetAmount(leaf, 700)
+	assetCtx.SetLeafAssetRoot(leafInput, assetCodecHash("leaf-root"))
+
+	return &tree.Tree{
+		Root:          root,
+		BatchOutpoint: rootInput,
+		BatchOutput: &wire.TxOut{
+			Value: 2_000,
+			PkScript: []byte{
+				0x52,
+			},
+		},
+		SweepTapscriptRoot: assetCodecHash("sweep"),
+		AssetContext:       assetCtx,
+	}
+}
+
+// TestTreeCodecAssetRoundTrip tests asset tree persistence.
+func TestTreeCodecAssetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := newAssetCodecTree(t)
+	encoded, err := SerializeTree(original)
+	require.NoError(t, err)
+
+	decoded, err := DeserializeTree(encoded)
+	require.NoError(t, err)
+	require.NotNil(t, decoded.AssetContext)
+	require.Equal(
+		t, original.AssetContext.AssetRef(),
+		decoded.AssetContext.AssetRef(),
+	)
+
+	originalLeaf := original.Root.Children[0]
+	decodedLeaf := decoded.Root.Children[0]
+	for _, pair := range [][2]*tree.Node{
+		{
+			original.Root,
+			decoded.Root,
+		},
+		{
+			originalLeaf,
+			decodedLeaf,
+		},
+	} {
+		require.Equal(
+			t, original.AssetContext.SigningTweak(pair[0].Input),
+			decoded.AssetContext.SigningTweak(pair[1].Input),
+		)
+		require.Equal(
+			t, original.AssetContext.SealedPackage(pair[0].Input),
+			decoded.AssetContext.SealedPackage(pair[1].Input),
+		)
+		require.Equal(
+			t, original.AssetContext.NodeAssetAmount(pair[0]),
+			decoded.AssetContext.NodeAssetAmount(pair[1]),
+		)
+	}
+	require.Equal(
+		t, original.AssetContext.LeafAssetRoot(originalLeaf.Input),
+		decoded.AssetContext.LeafAssetRoot(decodedLeaf.Input),
+	)
+}
+
+// TestTreeCodecBitcoinEncodingHasNoAssetContext tests optional records.
+func TestTreeCodecBitcoinEncodingHasNoAssetContext(t *testing.T) {
+	t.Parallel()
+
+	original := newAssetCodecTree(t)
+	original.AssetContext = nil
+
+	encoded, err := SerializeTree(original)
+	require.NoError(t, err)
+	decoded, err := DeserializeTree(encoded)
+	require.NoError(t, err)
+	require.Nil(t, decoded.AssetContext)
+}
+
+// assetCodecHash returns a deterministic 32-byte value.
+func assetCodecHash(value string) []byte {
+	hash := chainhash.HashH([]byte(value))
+
+	return hash[:]
+}

--- a/db/tree_codec_test.go
+++ b/db/tree_codec_test.go
@@ -469,7 +469,7 @@ func TestTreeCodecRejectsHugeNumChildren(t *testing.T) {
 		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 	}
 
-	_, err := deserializeChildren(payload, 2)
+	_, err := deserializeChildren(payload, 2, tree.NewAssetTreeContext())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exceeds max")
 }

--- a/lib/tree/asset_tree_context.go
+++ b/lib/tree/asset_tree_context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 )
 
@@ -93,6 +94,105 @@ func (c *AssetTreeContext) IsEmpty() bool {
 	return len(c.amountsByNode) == 0 && len(c.amountsByInput) == 0 &&
 		len(c.leafRootsByInput) == 0 && len(c.tweaksByInput) == 0 &&
 		len(c.packagesByInput) == 0 && c.assetRef == ""
+}
+
+// Validate checks that the context completely describes the given asset
+// tree.
+func (c *AssetTreeContext) Validate(root *Node) error {
+	if c == nil {
+		return nil
+	}
+	if root == nil {
+		return fmt.Errorf("asset tree root is required")
+	}
+	if c.assetRef == "" {
+		return fmt.Errorf("asset reference is required")
+	}
+
+	if err := validateUniqueAssetInputs(
+		root, make(map[wire.OutPoint]struct{}),
+	); err != nil {
+		return err
+	}
+
+	_, err := c.validateNode(root)
+
+	return err
+}
+
+// validateUniqueAssetInputs checks that outpoint-keyed metadata cannot
+// collide between nodes.
+func validateUniqueAssetInputs(node *Node,
+	seen map[wire.OutPoint]struct{}) error {
+
+	if node == nil {
+		return fmt.Errorf("asset tree node is required")
+	}
+	if _, ok := seen[node.Input]; ok {
+		return fmt.Errorf("input %s is used by multiple nodes",
+			node.Input)
+	}
+	seen[node.Input] = struct{}{}
+
+	for _, child := range node.Children {
+		if err := validateUniqueAssetInputs(child, seen); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateNode checks one subtree and returns its asset amount.
+func (c *AssetTreeContext) validateNode(node *Node) (uint64, error) {
+	if node == nil {
+		return 0, fmt.Errorf("asset tree node is required")
+	}
+
+	amount := c.NodeAssetAmount(node)
+	if amount == 0 {
+		return 0, fmt.Errorf("node %s has no asset amount", node.Input)
+	}
+
+	tweak := c.SigningTweak(node.Input)
+	if len(tweak) != chainhash.HashSize {
+		return 0, fmt.Errorf("node %s signing tweak must be %d bytes",
+			node.Input, chainhash.HashSize)
+	}
+
+	leafRoot := c.LeafAssetRoot(node.Input)
+	if len(node.Children) == 0 {
+		if len(leafRoot) != chainhash.HashSize {
+			return 0, fmt.Errorf("leaf %s asset commitment root "+
+				"must be %d bytes", node.Input,
+				chainhash.HashSize)
+		}
+
+		return amount, nil
+	}
+	if len(leafRoot) != 0 {
+		return 0, fmt.Errorf("branch %s has an asset commitment root",
+			node.Input)
+	}
+
+	var childTotal uint64
+	for _, child := range node.Children {
+		childAmount, err := c.validateNode(child)
+		if err != nil {
+			return 0, err
+		}
+		if childAmount > math.MaxUint64-childTotal {
+			return 0, fmt.Errorf("asset amount overflow at node %s",
+				node.Input)
+		}
+		childTotal += childAmount
+	}
+	if childTotal > amount {
+		return 0, fmt.Errorf("node %s child asset total %d exceeds "+
+			"parent amount %d", node.Input, childTotal, amount)
+	}
+
+	return amount, nil
 }
 
 // tweakLookup returns the signing tweak for a node's input.

--- a/lib/tree/asset_tree_context_test.go
+++ b/lib/tree/asset_tree_context_test.go
@@ -218,3 +218,53 @@ func TestAssetTreeContextAmountsAfterExtraction(t *testing.T) {
 		t, 42, extracted.AssetContext.NodeAssetAmount(extractedLeaf),
 	)
 }
+
+// TestAssetTreeContextValidate tests asset tree context validation.
+func TestAssetTreeContextValidate(t *testing.T) {
+	t.Parallel()
+
+	newContext := func() (*AssetTreeContext, *Node, *Node) {
+		rootInput := wire.OutPoint{Index: 1}
+		rootInput.Hash[0] = 0x01
+		leafInput := wire.OutPoint{Index: 2}
+		leafInput.Hash[0] = 0x02
+
+		leaf := &Node{
+			Input:    leafInput,
+			Children: make(map[uint32]*Node),
+		}
+		root := &Node{
+			Input: rootInput,
+			Children: map[uint32]*Node{
+				0: leaf,
+			},
+		}
+
+		ctx := NewAssetTreeContext()
+		ctx.SetAssetRef("asset")
+		ctx.SetSigningTweak(rootInput, bytes.Repeat([]byte{1}, 32))
+		ctx.SetSigningTweak(leafInput, bytes.Repeat([]byte{2}, 32))
+		ctx.SetNodeAssetAmount(root, 10)
+		ctx.SetNodeAssetAmount(leaf, 10)
+		ctx.SetLeafAssetRoot(leafInput, bytes.Repeat([]byte{3}, 32))
+
+		return ctx, root, leaf
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		ctx, root, _ := newContext()
+		require.NoError(t, ctx.Validate(root))
+	})
+
+	t.Run("duplicate input", func(t *testing.T) {
+		ctx, root, leaf := newContext()
+		leaf.Input = root.Input
+		require.ErrorContains(t, ctx.Validate(root), "multiple nodes")
+	})
+
+	t.Run("child exceeds parent", func(t *testing.T) {
+		ctx, root, leaf := newContext()
+		ctx.SetNodeAssetAmount(leaf, 11)
+		require.ErrorContains(t, ctx.Validate(root), "exceeds")
+	})
+}

--- a/rpc/roundpb/convert.go
+++ b/rpc/roundpb/convert.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
 	"github.com/lightninglabs/wavelength/lib/tree"
 	"github.com/lightninglabs/wavelength/lib/types"
 )
@@ -229,6 +230,9 @@ func TreeToProto(t *tree.Tree) (*VTXOTree, error) {
 	if t == nil {
 		return nil, nil
 	}
+	if err := validateAssetTree(t); err != nil {
+		return nil, err
+	}
 
 	// Flatten nodes in pre-order.
 	var nodes []*TreeNode
@@ -239,12 +243,28 @@ func TreeToProto(t *tree.Tree) (*VTXOTree, error) {
 		return nil, err
 	}
 
-	return &VTXOTree{
+	pt := &VTXOTree{
 		Nodes:              nodes,
 		BatchOutpoint:      OutpointToProto(t.BatchOutpoint),
 		BatchOutput:        TxOutToProto(t.BatchOutput),
 		SweepTapscriptRoot: t.SweepTapscriptRoot,
-	}, nil
+	}
+
+	if t.AssetContext != nil {
+		pt.AssetRef = t.AssetContext.AssetRef()
+		for node, idx := range nodeIndex {
+			pn := nodes[idx]
+			pn.SigningTweak = t.AssetContext.SigningTweak(
+				node.Input,
+			)
+			pn.AssetAmount = t.AssetContext.NodeAssetAmount(node)
+			pn.AssetCommitmentRoot = t.AssetContext.LeafAssetRoot(
+				node.Input,
+			)
+		}
+	}
+
+	return pt, nil
 }
 
 // flattenNode recursively flattens a tree node into the nodes slice.
@@ -338,9 +358,7 @@ func WithMaxTreeNodes(maxNodes int) TreeFromProtoOption {
 // TreeFromProto converts a proto VTXOTree back to a tree.Tree by
 // reconstructing the recursive node structure.
 //
-// NOTE: The returned tree nodes will have a nil FinalKey. Callers that
-// need the aggregated taproot key must run Materialize on the tree to
-// recompute FinalKey from CoSigners and the sweep tapscript root.
+// FinalKey is recomputed from each node's cosigners and taproot tweak.
 func TreeFromProto(pt *VTXOTree,
 	opts ...TreeFromProtoOption) (*tree.Tree, error) {
 
@@ -454,15 +472,25 @@ func TreeFromProto(pt *VTXOTree,
 			"multiple roots", len(pt.Nodes), len(parentOf))
 	}
 
+	assetCtx, err := assetContextFromProto(pt, goNodes)
+	if err != nil {
+		return nil, err
+	}
+
 	// Compute FinalKey for each node now that we have the
 	// sweep tapscript root. The constructors (NewLeafNode,
 	// NewBranchNode) normally do this, but proto deserialization
 	// bypasses them. Without FinalKey, signature verification
 	// in VerifySigned will fail. Nodes without cosigners (e.g.
 	// certain connector nodes) are skipped.
-	for _, node := range goNodes {
+	for i, node := range goNodes {
 		if len(node.CoSigners) == 0 {
 			continue
+		}
+
+		taprootTweak := pt.SweepTapscriptRoot
+		if assetCtx != nil {
+			taprootTweak = assetCtx.SigningTweak(node.Input)
 		}
 
 		// Copy cosigners before computing the final key
@@ -475,10 +503,11 @@ func TreeFromProto(pt *VTXOTree,
 		copy(csCopy, node.CoSigners)
 
 		fk, fkErr := tree.ComputeFinalKey(
-			csCopy, pt.SweepTapscriptRoot,
+			csCopy, taprootTweak,
 		)
 		if fkErr != nil {
-			return nil, fmt.Errorf("compute final key: %w", fkErr)
+			return nil, fmt.Errorf("node[%d] compute final key: %w",
+				i, fkErr)
 		}
 
 		node.FinalKey = fk
@@ -499,7 +528,77 @@ func TreeFromProto(pt *VTXOTree,
 		BatchOutpoint:      batchOP,
 		BatchOutput:        batchOut,
 		SweepTapscriptRoot: pt.SweepTapscriptRoot,
+		AssetContext:       assetCtx,
 	}, nil
+}
+
+// assetContextFromProto validates and rebuilds a tree's asset context.
+func assetContextFromProto(pt *VTXOTree,
+	nodes []*tree.Node) (*tree.AssetTreeContext, error) {
+
+	hasAssetFields := false
+	for _, node := range pt.Nodes {
+		if len(node.SigningTweak) != 0 || node.AssetAmount != 0 ||
+			len(node.AssetCommitmentRoot) != 0 {
+
+			hasAssetFields = true
+			break
+		}
+	}
+
+	if pt.AssetRef == "" {
+		if hasAssetFields {
+			return nil, fmt.Errorf("asset tree fields require " +
+				"asset_ref")
+		}
+
+		return nil, nil
+	}
+
+	assetRef, err := tapsdk.ParseAssetRef(pt.AssetRef)
+	if err != nil {
+		return nil, fmt.Errorf("asset_ref: %w", err)
+	}
+	if assetRef.String() != pt.AssetRef {
+		return nil, fmt.Errorf("asset_ref must use canonical encoding")
+	}
+
+	assetCtx := tree.NewAssetTreeContext()
+	assetCtx.SetAssetRef(pt.AssetRef)
+	for i, node := range pt.Nodes {
+		goNode := nodes[i]
+
+		assetCtx.SetSigningTweak(goNode.Input, node.SigningTweak)
+		assetCtx.SetNodeAssetAmount(goNode, node.AssetAmount)
+		assetCtx.SetLeafAssetRoot(
+			goNode.Input, node.AssetCommitmentRoot,
+		)
+	}
+	if err := assetCtx.Validate(nodes[0]); err != nil {
+		return nil, fmt.Errorf("asset tree: %w", err)
+	}
+
+	return assetCtx, nil
+}
+
+// validateAssetTree checks the asset reference and per-node context.
+func validateAssetTree(t *tree.Tree) error {
+	if t.AssetContext == nil {
+		return nil
+	}
+	if err := t.AssetContext.Validate(t.Root); err != nil {
+		return fmt.Errorf("asset tree: %w", err)
+	}
+
+	assetRef, err := tapsdk.ParseAssetRef(t.AssetContext.AssetRef())
+	if err != nil {
+		return fmt.Errorf("asset_ref: %w", err)
+	}
+	if assetRef.String() != t.AssetContext.AssetRef() {
+		return fmt.Errorf("asset_ref must use canonical encoding")
+	}
+
+	return nil
 }
 
 // treeNodeFromProto converts a single proto TreeNode to a tree.Node.

--- a/rpc/roundpb/convert_asset_test.go
+++ b/rpc/roundpb/convert_asset_test.go
@@ -1,0 +1,233 @@
+package roundpb
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/stretchr/testify/require"
+)
+
+// newAssetTestTree returns a materialized two-node asset tree.
+func newAssetTestTree(t *testing.T) *tree.Tree {
+	t.Helper()
+
+	rootKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	leafKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	rootInput := wire.OutPoint{
+		Hash: chainhash.HashH([]byte("batch")),
+	}
+	leafInput := wire.OutPoint{
+		Hash: chainhash.HashH([]byte("root-tx")),
+	}
+	leaf := &tree.Node{
+		Input: leafInput,
+		Outputs: []*wire.TxOut{{
+			Value: 1_000,
+			PkScript: []byte{
+				0x51,
+			},
+		}},
+		CoSigners: []*btcec.PublicKey{
+			leafKey.PubKey(), rootKey.PubKey(),
+		},
+		Children: make(map[uint32]*tree.Node),
+	}
+	root := &tree.Node{
+		Input: rootInput,
+		Outputs: []*wire.TxOut{{
+			Value: 1_000,
+			PkScript: []byte{
+				0x52,
+			},
+		}},
+		CoSigners: []*btcec.PublicKey{
+			leafKey.PubKey(), rootKey.PubKey(),
+		},
+		Children: map[uint32]*tree.Node{
+			0: leaf,
+		},
+	}
+
+	assetCtx := tree.NewAssetTreeContext()
+	assetCtx.SetAssetRef(
+		tapsdk.AssetRefFromAssetID(tapsdk.AssetID{0xaa}).String(),
+	)
+	assetCtx.SetSigningTweak(rootInput, assetTestHash("root-tweak"))
+	assetCtx.SetSigningTweak(leafInput, assetTestHash("leaf-tweak"))
+	assetCtx.SetNodeAssetAmount(root, 500)
+	assetCtx.SetNodeAssetAmount(leaf, 500)
+	assetCtx.SetLeafAssetRoot(leafInput, assetTestHash("leaf-root"))
+
+	return &tree.Tree{
+		Root:          root,
+		BatchOutpoint: rootInput,
+		BatchOutput: &wire.TxOut{
+			Value: 1_000,
+			PkScript: []byte{
+				0x52,
+			},
+		},
+		SweepTapscriptRoot: assetTestHash("sweep"),
+		AssetContext:       assetCtx,
+	}
+}
+
+// TestTreeProtoAssetRoundTrip tests asset tree wire encoding.
+func TestTreeProtoAssetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := newAssetTestTree(t)
+	encoded, err := TreeToProto(original)
+	require.NoError(t, err)
+	require.Equal(t, original.AssetContext.AssetRef(), encoded.AssetRef)
+	require.Len(t, encoded.Nodes, 2)
+	require.Empty(t, encoded.Nodes[0].AssetCommitmentRoot)
+	require.NotEmpty(t, encoded.Nodes[1].AssetCommitmentRoot)
+
+	decoded, err := TreeFromProto(encoded)
+	require.NoError(t, err)
+	require.NotNil(t, decoded.AssetContext)
+	require.Equal(
+		t, original.AssetContext.AssetRef(),
+		decoded.AssetContext.AssetRef(),
+	)
+
+	decodedLeaf := decoded.Root.Children[0]
+	for _, node := range []*tree.Node{decoded.Root, decodedLeaf} {
+		require.EqualValues(
+			t, 500, decoded.AssetContext.NodeAssetAmount(node),
+		)
+
+		finalKey, keyErr := tree.ComputeFinalKey(
+			append(
+				[]*btcec.PublicKey(nil), node.CoSigners...,
+			),
+			decoded.AssetContext.SigningTweak(node.Input),
+		)
+		require.NoError(t, keyErr)
+		require.True(t, finalKey.IsEqual(node.FinalKey))
+	}
+	require.Equal(
+		t, original.AssetContext.LeafAssetRoot(
+			original.Root.Children[0].Input,
+		),
+		decoded.AssetContext.LeafAssetRoot(decodedLeaf.Input),
+	)
+}
+
+// TestTreeProtoBitcoinRoundTrip tests that Bitcoin trees remain asset-free.
+func TestTreeProtoBitcoinRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := newAssetTestTree(t)
+	original.AssetContext = nil
+
+	encoded, err := TreeToProto(original)
+	require.NoError(t, err)
+	require.Empty(t, encoded.AssetRef)
+	for _, node := range encoded.Nodes {
+		require.Empty(t, node.SigningTweak)
+		require.Zero(t, node.AssetAmount)
+		require.Empty(t, node.AssetCommitmentRoot)
+	}
+
+	decoded, err := TreeFromProto(encoded)
+	require.NoError(t, err)
+	require.Nil(t, decoded.AssetContext)
+}
+
+// TestTreeFromProtoRejectsIncompleteAssetData tests asset field validation.
+func TestTreeFromProtoRejectsIncompleteAssetData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*VTXOTree)
+		wantErr string
+	}{
+		{
+			name: "missing asset ref",
+			mutate: func(encoded *VTXOTree) {
+				encoded.AssetRef = ""
+			},
+			wantErr: "require asset_ref",
+		},
+		{
+			name: "invalid asset ref",
+			mutate: func(encoded *VTXOTree) {
+				encoded.AssetRef = "invalid"
+			},
+			wantErr: "asset_ref",
+		},
+		{
+			name: "missing signing tweak",
+			mutate: func(encoded *VTXOTree) {
+				encoded.Nodes[0].SigningTweak = nil
+			},
+			wantErr: "signing tweak",
+		},
+		{
+			name: "missing asset amount",
+			mutate: func(encoded *VTXOTree) {
+				encoded.Nodes[1].AssetAmount = 0
+			},
+			wantErr: "asset amount",
+		},
+		{
+			name: "missing leaf root",
+			mutate: func(encoded *VTXOTree) {
+				encoded.Nodes[1].AssetCommitmentRoot = nil
+			},
+			wantErr: "asset commitment root",
+		},
+		{
+			name: "branch leaf root",
+			mutate: func(encoded *VTXOTree) {
+				encoded.Nodes[0].AssetCommitmentRoot =
+					assetTestHash("unexpected")
+			},
+			wantErr: "branch",
+		},
+		{
+			name: "child exceeds parent",
+			mutate: func(encoded *VTXOTree) {
+				encoded.Nodes[1].AssetAmount = 501
+			},
+			wantErr: "exceeds parent",
+		},
+		{
+			name: "duplicate input",
+			mutate: func(encoded *VTXOTree) {
+				encoded.Nodes[1].Input = encoded.Nodes[0].Input
+			},
+			wantErr: "multiple nodes",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			encoded, err := TreeToProto(newAssetTestTree(t))
+			require.NoError(t, err)
+			test.mutate(encoded)
+
+			_, err = TreeFromProto(encoded)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+// assetTestHash returns a deterministic 32-byte value.
+func assetTestHash(value string) []byte {
+	hash := chainhash.HashH([]byte(value))
+
+	return hash[:]
+}

--- a/rpc/roundpb/round.pb.go
+++ b/rpc/roundpb/round.pb.go
@@ -345,9 +345,18 @@ type TreeNode struct {
 	Amount int64 `protobuf:"varint,5,opt,name=amount,proto3" json:"amount,omitempty"`
 	// signature is the final aggregated MuSig2 schnorr signature (64 bytes)
 	// for the input. Empty if unsigned.
-	Signature     []byte `protobuf:"bytes,6,opt,name=signature,proto3" json:"signature,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Signature []byte `protobuf:"bytes,6,opt,name=signature,proto3" json:"signature,omitempty"`
+	// signing_tweak is the node's taproot tweak for an asset tree. Empty for
+	// Bitcoin-only trees, which use sweep_tapscript_root.
+	SigningTweak []byte `protobuf:"bytes,7,opt,name=signing_tweak,json=signingTweak,proto3" json:"signing_tweak,omitempty"`
+	// asset_amount is the number of asset units carried by this subtree.
+	// Zero for Bitcoin-only trees.
+	AssetAmount uint64 `protobuf:"varint,8,opt,name=asset_amount,json=assetAmount,proto3" json:"asset_amount,omitempty"`
+	// asset_commitment_root is set on asset leaves so the owner can verify
+	// and persist the composed VTXO output.
+	AssetCommitmentRoot []byte `protobuf:"bytes,9,opt,name=asset_commitment_root,json=assetCommitmentRoot,proto3" json:"asset_commitment_root,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *TreeNode) Reset() {
@@ -422,6 +431,27 @@ func (x *TreeNode) GetSignature() []byte {
 	return nil
 }
 
+func (x *TreeNode) GetSigningTweak() []byte {
+	if x != nil {
+		return x.SigningTweak
+	}
+	return nil
+}
+
+func (x *TreeNode) GetAssetAmount() uint64 {
+	if x != nil {
+		return x.AssetAmount
+	}
+	return 0
+}
+
+func (x *TreeNode) GetAssetCommitmentRoot() []byte {
+	if x != nil {
+		return x.AssetCommitmentRoot
+	}
+	return nil
+}
+
 // VTXOTree is a flattened representation of a VTXO or connector tree.
 // The root node is always at index 0.
 type VTXOTree struct {
@@ -437,8 +467,11 @@ type VTXOTree struct {
 	// sweep_tapscript_root is the tapscript root hash for tweaking branch
 	// outputs. Empty for connector trees.
 	SweepTapscriptRoot []byte `protobuf:"bytes,4,opt,name=sweep_tapscript_root,json=sweepTapscriptRoot,proto3" json:"sweep_tapscript_root,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// asset_ref identifies the asset carried by the tree. Empty for
+	// Bitcoin-only trees.
+	AssetRef      string `protobuf:"bytes,5,opt,name=asset_ref,json=assetRef,proto3" json:"asset_ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *VTXOTree) Reset() {
@@ -497,6 +530,13 @@ func (x *VTXOTree) GetSweepTapscriptRoot() []byte {
 		return x.SweepTapscriptRoot
 	}
 	return nil
+}
+
+func (x *VTXOTree) GetAssetRef() string {
+	if x != nil {
+		return x.AssetRef
+	}
+	return ""
 }
 
 // ConnectorLeafInfo contains information about a connector leaf assigned to a
@@ -2832,7 +2872,7 @@ const file_round_proto_rawDesc = "" +
 	"\foutput_index\x18\x02 \x01(\rR\voutputIndex\":\n" +
 	"\x05TxOut\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\x03R\x05value\x12\x1b\n" +
-	"\tpk_script\x18\x02 \x01(\fR\bpkScript\"\xaf\x02\n" +
+	"\tpk_script\x18\x02 \x01(\fR\bpkScript\"\xab\x03\n" +
 	"\bTreeNode\x12(\n" +
 	"\x05input\x18\x01 \x01(\v2\x12.round.v1.OutpointR\x05input\x12)\n" +
 	"\aoutputs\x18\x02 \x03(\v2\x0f.round.v1.TxOutR\aoutputs\x12\x1d\n" +
@@ -2840,15 +2880,19 @@ const file_round_proto_rawDesc = "" +
 	"co_signers\x18\x03 \x03(\fR\tcoSigners\x12<\n" +
 	"\bchildren\x18\x04 \x03(\v2 .round.v1.TreeNode.ChildrenEntryR\bchildren\x12\x16\n" +
 	"\x06amount\x18\x05 \x01(\x03R\x06amount\x12\x1c\n" +
-	"\tsignature\x18\x06 \x01(\fR\tsignature\x1a;\n" +
+	"\tsignature\x18\x06 \x01(\fR\tsignature\x12#\n" +
+	"\rsigning_tweak\x18\a \x01(\fR\fsigningTweak\x12!\n" +
+	"\fasset_amount\x18\b \x01(\x04R\vassetAmount\x122\n" +
+	"\x15asset_commitment_root\x18\t \x01(\fR\x13assetCommitmentRoot\x1a;\n" +
 	"\rChildrenEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\rR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\rR\x05value:\x028\x01\"\xd5\x01\n" +
+	"\x05value\x18\x02 \x01(\rR\x05value:\x028\x01\"\xf2\x01\n" +
 	"\bVTXOTree\x12(\n" +
 	"\x05nodes\x18\x01 \x03(\v2\x12.round.v1.TreeNodeR\x05nodes\x129\n" +
 	"\x0ebatch_outpoint\x18\x02 \x01(\v2\x12.round.v1.OutpointR\rbatchOutpoint\x122\n" +
 	"\fbatch_output\x18\x03 \x01(\v2\x0f.round.v1.TxOutR\vbatchOutput\x120\n" +
-	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"\xfe\x01\n" +
+	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\x12\x1b\n" +
+	"\tasset_ref\x18\x05 \x01(\tR\bassetRef\"\xfe\x01\n" +
 	"\x11ConnectorLeafInfo\x127\n" +
 	"\rleaf_outpoint\x18\x01 \x01(\v2\x12.round.v1.OutpointR\fleafOutpoint\x120\n" +
 	"\vleaf_output\x18\x02 \x01(\v2\x0f.round.v1.TxOutR\n" +

--- a/rpc/roundpb/round.proto
+++ b/rpc/roundpb/round.proto
@@ -54,6 +54,18 @@ message TreeNode {
     // signature is the final aggregated MuSig2 schnorr signature (64 bytes)
     // for the input. Empty if unsigned.
     bytes signature = 6;
+
+    // signing_tweak is the node's taproot tweak for an asset tree. Empty for
+    // Bitcoin-only trees, which use sweep_tapscript_root.
+    bytes signing_tweak = 7;
+
+    // asset_amount is the number of asset units carried by this subtree.
+    // Zero for Bitcoin-only trees.
+    uint64 asset_amount = 8;
+
+    // asset_commitment_root is set on asset leaves so the owner can verify
+    // and persist the composed VTXO output.
+    bytes asset_commitment_root = 9;
 }
 
 // VTXOTree is a flattened representation of a VTXO or connector tree.
@@ -73,6 +85,10 @@ message VTXOTree {
     // sweep_tapscript_root is the tapscript root hash for tweaking branch
     // outputs. Empty for connector trees.
     bytes sweep_tapscript_root = 4;
+
+    // asset_ref identifies the asset carried by the tree. Empty for
+    // Bitcoin-only trees.
+    string asset_ref = 5;
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add optional asset reference, subtree amount, signing tweak, and leaf commitment root fields to VTXO tree messages
- rebuild and validate asset tree context before deriving each node final key
- persist asset references and per-node metadata, including sealed transfer packages and leaf commitment roots, in optional tree TLV records
- reject incomplete metadata, duplicate input outpoints, invalid asset references, and child asset totals above their parent

Asset metadata is emitted only for trees with an asset context.