### PR TITLE
multi: request asset VTXOs

### DIFF
--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
@@ -276,6 +278,12 @@ type VTXORequest struct {
 	// output is not eligible for the implicit-change exception.
 	FixedAmount bool
 
+	// AssetRef identifies the asset carried by this VTXO.
+	AssetRef string
+
+	// AssetAmount is the number of asset units carried by this VTXO.
+	AssetAmount uint64
+
 	// PolicyTemplate is the semantic arkscript policy for the requested
 	// output. This is the authoritative join-round representation.
 	PolicyTemplate []byte
@@ -320,6 +328,33 @@ type VTXORequest struct {
 	// output per automatic-refresh input even when siblings share the same
 	// effective pkScript. It is never serialized over the round wire.
 	RefreshSourceOutpoint *wire.OutPoint
+}
+
+// ValidateAssetFields checks the fields that distinguish an asset request.
+func (r *VTXORequest) ValidateAssetFields() error {
+	if r == nil {
+		return fmt.Errorf("VTXO request is required")
+	}
+
+	switch {
+	case r.AssetRef == "" && r.AssetAmount == 0:
+		return nil
+
+	case r.AssetRef == "":
+		return fmt.Errorf("asset reference is required")
+
+	case r.AssetAmount == 0:
+		return fmt.Errorf("asset amount is required")
+
+	case !r.FixedAmount:
+		return fmt.Errorf("asset VTXO amount must be fixed")
+
+	case r.IsChange:
+		return fmt.Errorf("asset VTXO cannot be change")
+
+	default:
+		return nil
+	}
 }
 
 // HasLocalOwner reports whether the request carries a local owner descriptor

--- a/lib/types/boarding_test.go
+++ b/lib/types/boarding_test.go
@@ -58,3 +58,79 @@ func TestOperatorTermsMinVTXOAmountFloor(t *testing.T) {
 		})
 	}
 }
+
+func TestVTXORequestValidateAssetFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		request *VTXORequest
+		errText string
+	}{
+		{
+			name:    "bitcoin request",
+			request: &VTXORequest{},
+		},
+		{
+			name: "asset request",
+			request: &VTXORequest{
+				AssetRef:    "asset",
+				AssetAmount: 1,
+				FixedAmount: true,
+			},
+		},
+		{
+			name: "missing reference",
+			request: &VTXORequest{
+				AssetAmount: 1,
+			},
+			errText: "asset reference is required",
+		},
+		{
+			name: "missing amount",
+			request: &VTXORequest{
+				AssetRef: "asset",
+			},
+			errText: "asset amount is required",
+		},
+		{
+			name: "variable amount",
+			request: &VTXORequest{
+				AssetRef:    "asset",
+				AssetAmount: 1,
+			},
+			errText: "asset VTXO amount must be fixed",
+		},
+		{
+			name: "change output",
+			request: &VTXORequest{
+				AssetRef:    "asset",
+				AssetAmount: 1,
+				FixedAmount: true,
+				IsChange:    true,
+			},
+			errText: "asset VTXO cannot be change",
+		},
+		{
+			name:    "nil request",
+			request: nil,
+			errText: "VTXO request is required",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.request.ValidateAssetFields()
+			if test.errText == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorContains(t, err, test.errText)
+		})
+	}
+}

--- a/lib/types/codec.go
+++ b/lib/types/codec.go
@@ -52,6 +52,8 @@ const (
 	joinRoundAuthVTXOSigningKeyRecordType  tlv.Type = 3
 	joinRoundAuthVTXOIsChangeRecordType    tlv.Type = 4
 	joinRoundAuthVTXOFixedAmountRecordType tlv.Type = 5
+	joinRoundAuthVTXOAssetRefRecordType    tlv.Type = 6
+	joinRoundAuthVTXOAssetAmountRecordType tlv.Type = 7
 )
 
 const (
@@ -108,8 +110,8 @@ type JoinRoundAuth struct {
 //	| type  | field                                     |
 //	+-------+-------------------------------------------+
 //	|   1   | version   (uint64, currently 3)           |
-//	|   2   | domain    ("wavelength-join-round-auth")   |
-//	|   3   | identifier (33-byte compressed pubkey)    |
+//	|   2   | domain    ("wavelength-join-round-auth") |
+//	|   3   | identifier (33-byte compressed pubkey)   |
 //	|   4   | boarding  (blob list)                     |
 //	|   5   | vtxos     (blob list)                     |
 //	|   6   | forfeits  (blob list)                     |
@@ -122,13 +124,16 @@ type JoinRoundAuth struct {
 //
 // Boarding entry TLV:
 //
-//	1: outpoint hash  |  2: outpoint index
-//	3: client key     |  4: operator key   |  5: exit delay
+//	1: outpoint hash  |  2: outpoint index  |  3: policy template
 //
 // VTXO entry TLV:
 //
-//	1: amount      |  2: pkScript   |  3: expiry
-//	4: client key  |  5: operator key  |  6: signing key
+//	1: amount       |  2: policy template  |  3: signing key
+//	4: is change    |  5: fixed amount
+//	6: asset ref    |  7: asset amount
+//
+// Asset reference and amount are omitted together for Bitcoin VTXOs, which
+// preserves the existing canonical encoding for those requests.
 //
 // Forfeit entry TLV:
 //
@@ -137,7 +142,7 @@ type JoinRoundAuth struct {
 //
 // Leave entry TLV:
 //
-//	1: value  |  2: pkScript
+//	1: value  |  2: pkScript  |  3: is change
 func JoinRoundAuthMessage(req *JoinRoundRequest) ([]byte, error) {
 	if req == nil {
 		return nil, fmt.Errorf("join round request must be provided")
@@ -493,11 +498,13 @@ func decodeJoinAuthVTXORequests(raw []byte) ([]*VTXORequest, error) {
 // decodeJoinAuthVTXORequest parses one VTXO request entry.
 func decodeJoinAuthVTXORequest(raw []byte) (*VTXORequest, error) {
 	var (
-		amount     uint64
-		policy     []byte
-		signingKey []byte
-		isChange   uint8
-		fixedAmt   uint8
+		amount      uint64
+		policy      []byte
+		signingKey  []byte
+		isChange    uint8
+		fixedAmt    uint8
+		assetRef    []byte
+		assetAmount uint64
 	)
 
 	stream, err := tlv.NewStream(
@@ -515,6 +522,12 @@ func decodeJoinAuthVTXORequest(raw []byte) (*VTXORequest, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			joinRoundAuthVTXOFixedAmountRecordType, &fixedAmt,
+		),
+		tlv.MakePrimitiveRecord(
+			joinRoundAuthVTXOAssetRefRecordType, &assetRef,
+		),
+		tlv.MakePrimitiveRecord(
+			joinRoundAuthVTXOAssetAmountRecordType, &assetAmount,
 		),
 	)
 	if err != nil {
@@ -551,6 +564,12 @@ func decodeJoinAuthVTXORequest(raw []byte) (*VTXORequest, error) {
 	if err != nil {
 		return nil, err
 	}
+	_, hasAssetRef := parsedTypes[joinRoundAuthVTXOAssetRefRecordType]
+	_, hasAssetAmount := parsedTypes[joinRoundAuthVTXOAssetAmountRecordType]
+	if hasAssetRef != hasAssetAmount {
+		return nil, fmt.Errorf("asset reference and amount records " +
+			"must appear together")
+	}
 
 	if amount > math.MaxInt64 {
 		return nil, fmt.Errorf("vtxo amount %d exceeds int64", amount)
@@ -571,9 +590,14 @@ func decodeJoinAuthVTXORequest(raw []byte) (*VTXORequest, error) {
 		IsChange:       isChange != 0,
 		FixedAmount:    fixedAmt != 0,
 		PolicyTemplate: bytes.Clone(policy),
+		AssetRef:       string(assetRef),
+		AssetAmount:    assetAmount,
 		SigningKey: keychain.KeyDescriptor{
 			PubKey: signingPubKey,
 		},
+	}
+	if err := req.ValidateAssetFields(); err != nil {
+		return nil, err
 	}
 
 	_, err = req.DecodePolicyTemplate()
@@ -931,6 +955,9 @@ func encodeJoinAuthVTXORequests(requests []*VTXORequest) ([]byte, error) {
 
 // encodeJoinAuthVTXORequest serializes one VTXO request as TLV.
 func encodeJoinAuthVTXORequest(req *VTXORequest) ([]byte, error) {
+	if err := req.ValidateAssetFields(); err != nil {
+		return nil, err
+	}
 	if req.Amount < 0 {
 		return nil, fmt.Errorf("amount must be non-negative")
 	}
@@ -954,6 +981,8 @@ func encodeJoinAuthVTXORequest(req *VTXORequest) ([]byte, error) {
 	if req.FixedAmount {
 		fixedAmt = 1
 	}
+	assetRef := []byte(req.AssetRef)
+	assetAmount := req.AssetAmount
 
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(
@@ -971,6 +1000,17 @@ func encodeJoinAuthVTXORequest(req *VTXORequest) ([]byte, error) {
 		tlv.MakePrimitiveRecord(
 			joinRoundAuthVTXOFixedAmountRecordType, &fixedAmt,
 		),
+	}
+	if req.AssetRef != "" {
+		records = append(
+			records, tlv.MakePrimitiveRecord(
+				joinRoundAuthVTXOAssetRefRecordType, &assetRef,
+			),
+			tlv.MakePrimitiveRecord(
+				joinRoundAuthVTXOAssetAmountRecordType,
+				&assetAmount,
+			),
+		)
 	}
 
 	return encodeJoinAuthTLV(records)

--- a/lib/types/codec_test.go
+++ b/lib/types/codec_test.go
@@ -69,12 +69,57 @@ func TestJoinRoundAuthMessageBindsForfeitSpendPaths(t *testing.T) {
 	require.NotEqual(t, baseline, differentForfeit)
 }
 
+func TestJoinRoundAuthMessageBindsAssetFields(t *testing.T) {
+	t.Parallel()
+
+	req := testJoinRoundAuthRequest(t)
+	req.VTXOReqs[0].AssetRef = "asset-a"
+	req.VTXOReqs[0].AssetAmount = 100
+	req.VTXOReqs[0].FixedAmount = true
+
+	baseline, err := JoinRoundAuthMessage(req)
+	require.NoError(t, err)
+
+	differentRef := testJoinRoundAuthRequest(t)
+	differentRef.VTXOReqs[0].AssetRef = "asset-b"
+	differentRef.VTXOReqs[0].AssetAmount = 100
+	differentRef.VTXOReqs[0].FixedAmount = true
+	refChanged, err := JoinRoundAuthMessage(differentRef)
+	require.NoError(t, err)
+	require.NotEqual(t, baseline, refChanged)
+
+	differentAmount := testJoinRoundAuthRequest(t)
+	differentAmount.VTXOReqs[0].AssetRef = "asset-a"
+	differentAmount.VTXOReqs[0].AssetAmount = 101
+	differentAmount.VTXOReqs[0].FixedAmount = true
+	amountChanged, err := JoinRoundAuthMessage(differentAmount)
+	require.NoError(t, err)
+	require.NotEqual(t, baseline, amountChanged)
+}
+
 // TestDecodeJoinRoundAuthMessageRoundTrip asserts decode reconstructs join
 // requests from canonical message bytes.
 func TestDecodeJoinRoundAuthMessageRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	req := testJoinRoundAuthRequest(t)
+
+	raw, err := JoinRoundAuthMessage(req)
+	require.NoError(t, err)
+
+	decodedReq, err := DecodeJoinRoundAuthMessage(raw)
+	require.NoError(t, err)
+
+	requireJoinRoundAuthRequestEqual(t, req, decodedReq)
+}
+
+func TestDecodeJoinRoundAuthMessageAssetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	req := testJoinRoundAuthRequest(t)
+	req.VTXOReqs[0].AssetRef = "asset-a"
+	req.VTXOReqs[0].AssetAmount = 100
+	req.VTXOReqs[0].FixedAmount = true
 
 	raw, err := JoinRoundAuthMessage(req)
 	require.NoError(t, err)
@@ -350,6 +395,8 @@ func requireJoinRoundAuthRequestEqual(t *testing.T, expected *JoinRoundRequest,
 		require.NotNil(t, actualReq)
 
 		require.Equal(t, expectedReq.Amount, actualReq.Amount)
+		require.Equal(t, expectedReq.AssetRef, actualReq.AssetRef)
+		require.Equal(t, expectedReq.AssetAmount, actualReq.AssetAmount)
 		require.Equal(t, expectedReq.FixedAmount, actualReq.FixedAmount)
 		require.Equal(
 			t, expectedReq.PolicyTemplate, actualReq.PolicyTemplate,

--- a/round/actor.go
+++ b/round/actor.go
@@ -1813,9 +1813,9 @@ func buildBoardingIntentFromWallet(walletIntent *wallet.BoardingIntent) (
 func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 	msg *RegisterVTXORequestsRequest) fn.Result[actormsg.RoundActorResp] {
 
-	if len(msg.Amounts) == 0 {
+	if len(msg.Amounts) == 0 && len(msg.Assets) == 0 {
 		return fn.Err[actormsg.RoundActorResp](
-			fmt.Errorf("VTXO request amounts are empty"),
+			fmt.Errorf("VTXO requests are empty"),
 		)
 	}
 	if msg.ChangeIndex != nil &&
@@ -1826,7 +1826,9 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 		)
 	}
 
-	requests := make([]types.VTXORequest, 0, len(msg.Amounts))
+	requests := make(
+		[]types.VTXORequest, 0, len(msg.Amounts)+len(msg.Assets),
+	)
 	for i, amount := range msg.Amounts {
 		if amount <= 0 {
 			return fn.Err[actormsg.RoundActorResp](
@@ -1861,6 +1863,41 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 		// that marker centrally via designateChangeMarker over
 		// the fully-composed intent, so this loop leaves
 		// IsChange unset.
+
+		requests = append(requests, *req)
+	}
+
+	for i, asset := range msg.Assets {
+		if asset.AmountSat <= 0 {
+			return fn.Err[actormsg.RoundActorResp](
+				fmt.Errorf("asset VTXO amount %d is "+
+					"invalid: %v", i, asset.AmountSat),
+			)
+		}
+		candidate := &types.VTXORequest{
+			Amount:      asset.AmountSat,
+			AssetRef:    asset.AssetRef,
+			AssetAmount: asset.AssetAmount,
+			FixedAmount: true,
+		}
+		if err := validateAssetRequest(candidate); err != nil {
+			return fn.Err[actormsg.RoundActorResp](
+				fmt.Errorf("asset VTXO request %d: %w", i, err),
+			)
+		}
+
+		req, err := a.buildVTXORequest(
+			ctx, asset.AmountSat, types.VTXOOriginUnknown,
+		)
+		if err != nil {
+			return fn.Err[actormsg.RoundActorResp](
+				fmt.Errorf("build asset VTXO request %d: %w",
+					i, err),
+			)
+		}
+		req.AssetRef = asset.AssetRef
+		req.AssetAmount = asset.AssetAmount
+		req.FixedAmount = true
 
 		requests = append(requests, *req)
 	}

--- a/round/actor_messages.go
+++ b/round/actor_messages.go
@@ -210,11 +210,19 @@ type RegisterVTXORequestsRequest struct {
 	actor.BaseMessage
 
 	Amounts []btcutil.Amount
+	Assets  []AssetVTXORequest
 
 	// ChangeIndex explicitly selects the request that receives the
 	// seal-time residual. Nil lets the client choose the largest non-fixed
 	// request when the composed intent is registered.
 	ChangeIndex *int
+}
+
+// AssetVTXORequest describes one asset output requested from a round.
+type AssetVTXORequest struct {
+	AmountSat   btcutil.Amount
+	AssetRef    string
+	AssetAmount uint64
 }
 
 // MessageType returns the message type name.

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
 	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/lightninglabs/wavelength/baselib/protofsm"
 	"github.com/lightninglabs/wavelength/internal/testutils"
@@ -352,6 +353,71 @@ func TestActorStart(t *testing.T) {
 		require.Len(t, assembly.VTXOs, 2)
 		require.False(t, assembly.VTXOs[0].IsChange)
 		require.True(t, assembly.VTXOs[1].IsChange)
+	})
+
+	t.Run("registers_asset_vtxo_request", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+		require.NoError(t, h.start())
+
+		ownerKey := &keychain.KeyDescriptor{
+			PubKey: h.clientPubKey,
+			KeyLocator: keychain.KeyLocator{
+				Family: types.VTXOOwnerKeyFamily,
+				Index:  0,
+			},
+		}
+		h.wallet.On(
+			"DeriveNextKey", mock.Anything,
+			types.VTXOOwnerKeyFamily,
+		).Return(ownerKey, nil).Once()
+
+		assetRef := tapsdk.AssetRefFromAssetID(
+			tapsdk.AssetID{1},
+		).String()
+		result := h.receive(&RegisterVTXORequestsRequest{
+			Assets: []AssetVTXORequest{{
+				AmountSat:   330,
+				AssetRef:    assetRef,
+				AssetAmount: 100,
+			}},
+		})
+		require.True(t, result.IsOk())
+
+		states := h.queryState()
+		tempState, found := h.findTempState(states)
+		require.True(t, found)
+		assembly, ok := tempState.State.(*PendingRoundAssembly)
+		require.True(t, ok)
+		require.Len(t, assembly.VTXOs, 1)
+
+		request := assembly.VTXOs[0]
+		require.Equal(t, btcutil.Amount(330), request.Amount)
+		require.Equal(t, assetRef, request.AssetRef)
+		require.Equal(t, uint64(100), request.AssetAmount)
+		require.True(t, request.FixedAmount)
+		require.False(t, request.IsChange)
+	})
+
+	t.Run("rejects_invalid_asset_vtxo_request", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+		require.NoError(t, h.start())
+
+		result := h.receive(&RegisterVTXORequestsRequest{
+			Assets: []AssetVTXORequest{{
+				AmountSat:   330,
+				AssetRef:    "invalid",
+				AssetAmount: 100,
+			}},
+		})
+		require.True(t, result.IsErr())
+		require.ErrorContains(t, result.Err(), "asset reference")
+		require.Empty(t, h.queryState())
 	})
 }
 

--- a/round/asset_request.go
+++ b/round/asset_request.go
@@ -1,0 +1,27 @@
+package round
+
+import (
+	"fmt"
+
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/types"
+)
+
+func validateAssetRequest(req *types.VTXORequest) error {
+	if err := req.ValidateAssetFields(); err != nil {
+		return err
+	}
+	if req.AssetRef == "" {
+		return nil
+	}
+
+	assetRef, err := tapsdk.ParseAssetRef(req.AssetRef)
+	if err != nil {
+		return fmt.Errorf("asset reference: %w", err)
+	}
+	if assetRef.String() != req.AssetRef {
+		return fmt.Errorf("asset reference must use canonical encoding")
+	}
+
+	return nil
+}

--- a/round/asset_request_test.go
+++ b/round/asset_request_test.go
@@ -1,0 +1,111 @@
+package round
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/lightninglabs/wavelength/rpc/roundpb"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateAssetRequest(t *testing.T) {
+	t.Parallel()
+
+	assetRef := tapsdk.AssetRefFromAssetID(tapsdk.AssetID{1}).String()
+	tests := []struct {
+		name    string
+		request *types.VTXORequest
+		errText string
+	}{
+		{
+			name:    "bitcoin request",
+			request: &types.VTXORequest{},
+		},
+		{
+			name: "asset request",
+			request: &types.VTXORequest{
+				AssetRef:    assetRef,
+				AssetAmount: 1,
+				FixedAmount: true,
+			},
+		},
+		{
+			name: "invalid reference",
+			request: &types.VTXORequest{
+				AssetRef:    "invalid",
+				AssetAmount: 1,
+				FixedAmount: true,
+			},
+			errText: "asset reference",
+		},
+		{
+			name: "noncanonical reference",
+			request: &types.VTXORequest{
+				AssetRef:    strings.ToUpper(assetRef),
+				AssetAmount: 1,
+				FixedAmount: true,
+			},
+			errText: "canonical encoding",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateAssetRequest(test.request)
+			if test.errText == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorContains(t, err, test.errText)
+		})
+	}
+}
+
+func TestAssetVTXORequestProtoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	signingPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy, err := arkscript.EncodeStandardVTXOTemplate(
+		clientPriv.PubKey(), operatorPriv.PubKey(), 144,
+	)
+	require.NoError(t, err)
+
+	assetRef := tapsdk.AssetRefFromAssetID(tapsdk.AssetID{2}).String()
+	request := JoinRoundRequest{
+		VTXORequests: []types.VTXORequest{{
+			Amount:         330,
+			FixedAmount:    true,
+			AssetRef:       assetRef,
+			AssetAmount:    42,
+			PolicyTemplate: policy,
+			SigningKey: keychain.KeyDescriptor{
+				PubKey: signingPriv.PubKey(),
+			},
+		}},
+	}
+
+	message := request.ToProto().UnwrapOrFail(t)
+	pbRequest, ok := message.(*roundpb.JoinRoundRequest)
+	require.True(t, ok)
+
+	var decoded JoinRoundRequest
+	require.NoError(t, decoded.FromProto(pbRequest))
+	require.Len(t, decoded.VTXORequests, 1)
+	require.Equal(t, request.VTXORequests[0], decoded.VTXORequests[0])
+}

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -556,6 +556,8 @@ func (m *JoinRoundRequest) FromProto(p proto.Message) error {
 			IsChange:       vr.IsChange,
 			FixedAmount:    vr.FixedAmount,
 			PolicyTemplate: bytes.Clone(vr.PolicyTemplate),
+			AssetRef:       vr.AssetRef,
+			AssetAmount:    vr.AssetAmount,
 		}
 
 		if len(vr.SigningKey) > 0 {
@@ -575,6 +577,9 @@ func (m *JoinRoundRequest) FromProto(p proto.Message) error {
 		if err != nil {
 			return fmt.Errorf(
 				"vtxo_requests[%d].policy_template: %w", i, err)
+		}
+		if err := validateAssetRequest(&req); err != nil {
+			return fmt.Errorf("vtxo_requests[%d]: %w", i, err)
 		}
 
 		m.VTXORequests[i] = req

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -312,6 +312,12 @@ func (m *JoinRoundRequest) ToProto() fn.Result[proto.Message] {
 		[]*roundpb.VTXORequest, len(m.VTXORequests),
 	)
 	for i, req := range m.VTXORequests {
+		if err := validateAssetRequest(&req); err != nil {
+			return fn.Err[proto.Message](
+				fmt.Errorf("vtxo request %d: %w", i, err),
+			)
+		}
+
 		policyTemplate, err := req.EffectivePolicyTemplate()
 		if err != nil {
 			return fn.Err[proto.Message](
@@ -325,6 +331,8 @@ func (m *JoinRoundRequest) ToProto() fn.Result[proto.Message] {
 			IsChange:        req.IsChange,
 			FixedAmount:     req.FixedAmount,
 			PolicyTemplate:  policyTemplate,
+			AssetRef:        req.AssetRef,
+			AssetAmount:     req.AssetAmount,
 		}
 		if req.SigningKey.PubKey != nil {
 			vr.SigningKey = req.SigningKey.PubKey.

--- a/rpc/roundpb/round.pb.go
+++ b/rpc/roundpb/round.pb.go
@@ -1396,7 +1396,12 @@ type VTXORequest struct {
 	// exactly. When this is set on a single-output intent, the single-output
 	// implicit-change exception is disabled and the intent must include a
 	// separate fee-bearing change output if fees need to be paid.
-	FixedAmount   bool `protobuf:"varint,5,opt,name=fixed_amount,json=fixedAmount,proto3" json:"fixed_amount,omitempty"`
+	FixedAmount bool `protobuf:"varint,5,opt,name=fixed_amount,json=fixedAmount,proto3" json:"fixed_amount,omitempty"`
+	// asset_ref identifies the asset requested for this VTXO. Empty for a
+	// Bitcoin VTXO.
+	AssetRef string `protobuf:"bytes,6,opt,name=asset_ref,json=assetRef,proto3" json:"asset_ref,omitempty"`
+	// asset_amount is the number of asset units requested.
+	AssetAmount   uint64 `protobuf:"varint,7,opt,name=asset_amount,json=assetAmount,proto3" json:"asset_amount,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1464,6 +1469,20 @@ func (x *VTXORequest) GetFixedAmount() bool {
 		return x.FixedAmount
 	}
 	return false
+}
+
+func (x *VTXORequest) GetAssetRef() string {
+	if x != nil {
+		return x.AssetRef
+	}
+	return ""
+}
+
+func (x *VTXORequest) GetAssetAmount() uint64 {
+	if x != nil {
+		return x.AssetAmount
+	}
+	return 0
 }
 
 // ForfeitRequest specifies a VTXO the client wants to forfeit.
@@ -2964,14 +2983,16 @@ const file_round_proto_rawDesc = "" +
 	"\x0fBoardingRequest\x12.\n" +
 	"\boutpoint\x18\x01 \x01(\v2\x12.round.v1.OutpointR\boutpoint\x12'\n" +
 	"\x0fpolicy_template\x18\x02 \x01(\fR\x0epolicyTemplate\x12\x19\n" +
-	"\btx_proof\x18\x03 \x01(\fR\atxProof\"\xc3\x01\n" +
+	"\btx_proof\x18\x03 \x01(\fR\atxProof\"\x83\x02\n" +
 	"\vVTXORequest\x12*\n" +
 	"\x11target_amount_sat\x18\x01 \x01(\x03R\x0ftargetAmountSat\x12'\n" +
 	"\x0fpolicy_template\x18\x02 \x01(\fR\x0epolicyTemplate\x12\x1f\n" +
 	"\vsigning_key\x18\x03 \x01(\fR\n" +
 	"signingKey\x12\x1b\n" +
 	"\tis_change\x18\x04 \x01(\bR\bisChange\x12!\n" +
-	"\ffixed_amount\x18\x05 \x01(\bR\vfixedAmount\"\x9f\x01\n" +
+	"\ffixed_amount\x18\x05 \x01(\bR\vfixedAmount\x12\x1b\n" +
+	"\tasset_ref\x18\x06 \x01(\tR\bassetRef\x12!\n" +
+	"\fasset_amount\x18\a \x01(\x04R\vassetAmount\"\x9f\x01\n" +
 	"\x0eForfeitRequest\x127\n" +
 	"\rvtxo_outpoint\x18\x01 \x01(\v2\x12.round.v1.OutpointR\fvtxoOutpoint\x12&\n" +
 	"\x0fauth_spend_path\x18\x02 \x01(\fR\rauthSpendPath\x12,\n" +

--- a/rpc/roundpb/round.proto
+++ b/rpc/roundpb/round.proto
@@ -406,6 +406,13 @@ message VTXORequest {
     // implicit-change exception is disabled and the intent must include a
     // separate fee-bearing change output if fees need to be paid.
     bool fixed_amount = 5;
+
+    // asset_ref identifies the asset requested for this VTXO. Empty for a
+    // Bitcoin VTXO.
+    string asset_ref = 6;
+
+    // asset_amount is the number of asset units requested.
+    uint64 asset_amount = 7;
 }
 
 // ForfeitRequest specifies a VTXO the client wants to forfeit.


### PR DESCRIPTION
## Summary

- carry asset identity and amount in VTXO round requests
- bind asset fields into join authorization
- require asset requests to use a fixed carrier amount and canonical asset reference
- let the client round actor enqueue asset VTXO requests