### PR TITLE
multi: verify asset VTXO trees

### DIFF
--- a/lib/tree/asset_tree_context.go
+++ b/lib/tree/asset_tree_context.go
@@ -75,6 +75,30 @@ func (c *AssetTreeContext) SealedPackage(input wire.OutPoint) []byte {
 	return append([]byte(nil), c.packagesByInput[input]...)
 }
 
+// cloneForRoot copies the context used by an extracted tree path.
+func (c *AssetTreeContext) cloneForRoot(root *Node) *AssetTreeContext {
+	if c == nil {
+		return nil
+	}
+
+	clone := NewAssetTreeContext()
+	clone.SetAssetRef(c.assetRef)
+	for node := range root.NodesIter() {
+		clone.SetNodeAssetAmount(node, c.NodeAssetAmount(node))
+		clone.SetSigningTweak(
+			node.Input, c.SigningTweak(node.Input),
+		)
+		clone.SetLeafAssetRoot(
+			node.Input, c.LeafAssetRoot(node.Input),
+		)
+		if pkg := c.SealedPackage(node.Input); len(pkg) != 0 {
+			clone.SetSealedPackage(node.Input, pkg)
+		}
+	}
+
+	return clone
+}
+
 // SetAssetRef records the tree's asset reference.
 func (c *AssetTreeContext) SetAssetRef(ref string) {
 	c.assetRef = ref

--- a/lib/tree/asset_tree_context_test.go
+++ b/lib/tree/asset_tree_context_test.go
@@ -208,6 +208,7 @@ func TestAssetTreeContextAmountsAfterExtraction(t *testing.T) {
 	}).ExtractPathForCoSigners(key)
 	require.NoError(t, err)
 	require.NotSame(t, root, extracted.Root)
+	require.NotSame(t, assetCtx, extracted.AssetContext)
 	require.EqualValues(
 		t, 42, extracted.AssetContext.NodeAssetAmount(extracted.Root),
 	)
@@ -217,6 +218,9 @@ func TestAssetTreeContextAmountsAfterExtraction(t *testing.T) {
 	require.EqualValues(
 		t, 42, extracted.AssetContext.NodeAssetAmount(extractedLeaf),
 	)
+
+	extracted.AssetContext.SetSealedPackage(rootInput, []byte{1})
+	require.Empty(t, assetCtx.SealedPackage(rootInput))
 }
 
 // TestAssetTreeContextValidate tests asset tree context validation.

--- a/lib/tree/tree.go
+++ b/lib/tree/tree.go
@@ -136,7 +136,7 @@ func (t *Tree) ExtractPathForCoSigners(targetKeys ...*btcec.PublicKey) (*Tree,
 		BatchOutpoint:      t.BatchOutpoint,
 		BatchOutput:        t.BatchOutput,
 		SweepTapscriptRoot: t.SweepTapscriptRoot,
-		AssetContext:       t.AssetContext,
+		AssetContext:       t.AssetContext.cloneForRoot(extractedRoot),
 	}, nil
 }
 
@@ -169,7 +169,7 @@ func (t *Tree) ExtractPathForIndices(leafIndices ...int) (*Tree, error) {
 		BatchOutpoint:      t.BatchOutpoint,
 		BatchOutput:        t.BatchOutput,
 		SweepTapscriptRoot: t.SweepTapscriptRoot,
-		AssetContext:       t.AssetContext,
+		AssetContext:       t.AssetContext.cloneForRoot(extractedRoot),
 	}, nil
 }
 

--- a/round/actor.go
+++ b/round/actor.go
@@ -523,6 +523,7 @@ func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
 		Log:                    actorLog,
 		DisableJoinRequestAuth: cfg.DisableJoinRequestAuth,
 		OwnedScriptChecker:     cfg.OwnedScriptChecker,
+		OwnedScriptRegistrar:   cfg.OwnedScriptRegistrar,
 	}
 	if env.SigningExecutor == nil {
 		env.SigningExecutor = NewSigningExecutor(1)
@@ -946,6 +947,7 @@ func (a *RoundClientActor) createRoundFSMFromDB(ctx context.Context,
 		StatusReconcileTimeout: a.env.StatusReconcileTimeout,
 		RoundKey:               RoundKeyStr(roundID.KeyString()),
 		OwnedScriptChecker:     a.cfg.OwnedScriptChecker,
+		OwnedScriptRegistrar:   a.cfg.OwnedScriptRegistrar,
 	}
 	fsmCfg := ClientStateMachineCfg{
 		Logger:        fsmLogger,
@@ -1022,6 +1024,7 @@ func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM,
 		StatusReconcileTimeout: a.env.StatusReconcileTimeout,
 		RoundKey:               RoundKeyStr(tempKey.KeyString()),
 		OwnedScriptChecker:     a.cfg.OwnedScriptChecker,
+		OwnedScriptRegistrar:   a.cfg.OwnedScriptRegistrar,
 	}
 	fsmCfg := ClientStateMachineCfg{
 		Logger:        fsmLogger,
@@ -1886,7 +1889,7 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 			)
 		}
 
-		req, err := a.buildVTXORequest(
+		req, err := a.deriveVTXORequest(
 			ctx, asset.AmountSat, types.VTXOOriginUnknown,
 		)
 		if err != nil {
@@ -1983,13 +1986,43 @@ func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
 	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
-// buildVTXORequest derives a fresh owner key and constructs a locally owned
-// VTXO request for the provided amount. The round FSM derives the ephemeral
-// signing key later during registration. Origin is set by the caller so
+// buildVTXORequest derives and registers a locally owned VTXO request for the
+// provided amount. The round FSM derives the ephemeral signing key later
+// during registration. Origin is set by the caller so
 // the downstream ledger emission gets the right Source: boarding flows
 // pass VTXOOriginRoundBoarding, other in-round producers pass their
 // respective origin.
 func (a *RoundClientActor) buildVTXORequest(ctx context.Context,
+	amount btcutil.Amount, origin types.VTXOOrigin) (*types.VTXORequest,
+	error) {
+
+	req, err := a.deriveVTXORequest(ctx, amount, origin)
+	if err != nil {
+		return nil, err
+	}
+
+	if a.cfg.OwnedScriptRegistrar != nil {
+		pkScript, err := req.EffectivePkScript()
+		if err != nil {
+			return nil, fmt.Errorf("derive vtxo pkScript: %w", err)
+		}
+
+		regErr := a.cfg.OwnedScriptRegistrar.RegisterOwnedScript(
+			ctx, pkScript, req.OwnerKey,
+		)
+		if regErr != nil {
+			return nil, fmt.Errorf("register owned script: %w",
+				regErr)
+		}
+	}
+
+	return req, nil
+}
+
+// deriveVTXORequest constructs a locally owned request without registering
+// its output script. Asset requests use it because their final script depends
+// on the commitment root disclosed with the tree.
+func (a *RoundClientActor) deriveVTXORequest(ctx context.Context,
 	amount btcutil.Amount, origin types.VTXOOrigin) (*types.VTXORequest,
 	error) {
 
@@ -2015,21 +2048,6 @@ func (a *RoundClientActor) buildVTXORequest(ctx context.Context,
 		ClientKey:      keyDesc.PubKey,
 		OwnerKey:       *keyDesc,
 		Origin:         origin,
-	}
-
-	if a.cfg.OwnedScriptRegistrar != nil {
-		pkScript, err := req.EffectivePkScript()
-		if err != nil {
-			return nil, fmt.Errorf("derive vtxo pkScript: %w", err)
-		}
-
-		regErr := a.cfg.OwnedScriptRegistrar.RegisterOwnedScript(
-			ctx, pkScript, *keyDesc,
-		)
-		if regErr != nil {
-			return nil, fmt.Errorf("register owned script: %w",
-				regErr)
-		}
 	}
 
 	return req, nil

--- a/round/asset_vtxo_validation_test.go
+++ b/round/asset_vtxo_validation_test.go
@@ -1,0 +1,348 @@
+package round
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingAssetVTXOVerifier struct {
+	calls         int
+	assetRef      string
+	assetAmount   uint64
+	commitmentTx  *wire.MsgTx
+	clientTree    *tree.Tree
+	sealedPackage []byte
+	err           error
+}
+
+type recordingOwnedScriptRegistrar struct {
+	pkScript []byte
+	ownerKey keychain.KeyDescriptor
+}
+
+func (r *recordingOwnedScriptRegistrar) RegisterOwnedScript(_ context.Context,
+	pkScript []byte, ownerKey keychain.KeyDescriptor) error {
+
+	r.pkScript = append([]byte(nil), pkScript...)
+	r.ownerKey = ownerKey
+
+	return nil
+}
+
+func (v *recordingAssetVTXOVerifier) VerifyAssetVTXO(_ context.Context,
+	assetRef string, assetAmount uint64, commitmentTx *wire.MsgTx,
+	clientTree *tree.Tree, sealedPackage []byte) error {
+
+	v.calls++
+	v.assetRef = assetRef
+	v.assetAmount = assetAmount
+	v.commitmentTx = commitmentTx
+	v.clientTree = clientTree
+	v.sealedPackage = append([]byte(nil), sealedPackage...)
+
+	return v.err
+}
+
+type boundAssetVTXOFixture struct {
+	intent        BoardingIntent
+	request       types.VTXORequest
+	commitmentTx  *psbt.Packet
+	tree          *tree.Tree
+	leafOutpoint  wire.OutPoint
+	sealedPackage []byte
+}
+
+func newBoundAssetVTXOFixture(t *testing.T,
+	h *boardingTestHarness) *boundAssetVTXOFixture {
+
+	t.Helper()
+
+	intent := h.newTestBoardingIntent()
+	request := h.newTestVTXORequestForIntent(intent)
+	request.AssetRef = tapsdk.AssetRefFromAssetID(
+		tapsdk.AssetID{1},
+	).String()
+	request.AssetAmount = 500
+	request.FixedAmount = true
+
+	assetRoot := chainhash.HashH([]byte("leaf asset root"))
+	policy, err := request.DecodePolicyTemplate()
+	require.NoError(t, err)
+	compiled, err := policy.Compile()
+	require.NoError(t, err)
+	composed, err := arkscript.ComposeWithSiblingRoot(
+		compiled, assetRoot,
+	)
+	require.NoError(t, err)
+	leafScript, err := txscript.PayToTaprootScript(composed.OutputKey())
+	require.NoError(t, err)
+
+	rootTweak := chainhash.HashH([]byte("batch asset root"))
+	rootKey, err := tree.ComputeFinalKey(
+		tree.UniqueCosigners(
+			[]*btcec.PublicKey{
+				h.clientPubKey, h.operatorPubKey,
+			},
+		),
+		rootTweak[:],
+	)
+	require.NoError(t, err)
+	batchScript, err := txscript.PayToTaprootScript(rootKey)
+	require.NoError(t, err)
+
+	commitment := wire.NewMsgTx(3)
+	commitment.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: intent.Outpoint,
+	})
+	commitment.AddTxOut(&wire.TxOut{
+		Value:    int64(request.Amount),
+		PkScript: batchScript,
+	})
+	commitment.AddTxOut(arkscript.AnchorOutput())
+	packet, err := psbt.NewFromUnsignedTx(commitment)
+	require.NoError(t, err)
+	packet.Inputs[0] = psbt.PInput{
+		WitnessUtxo: &wire.TxOut{
+			Value:    int64(intent.ChainInfo.Amount),
+			PkScript: intent.Address.Address.ScriptAddress(),
+		},
+	}
+
+	sweepRoot := chainhash.HashH([]byte("sweep"))
+	assetTree, err := tree.NewTree(
+		wire.OutPoint{Hash: commitment.TxHash()}, commitment.TxOut[0],
+		[]tree.LeafDescriptor{{
+			Amount:      request.Amount,
+			PkScript:    leafScript,
+			CoSignerKey: request.SigningKey.PubKey,
+		}}, h.operatorPubKey, sweepRoot[:], 2,
+	)
+	require.NoError(t, err)
+	assetContext := tree.NewAssetTreeContext()
+	assetContext.SetAssetRef(request.AssetRef)
+	assetContext.SetNodeAssetAmount(assetTree.Root, request.AssetAmount)
+	assetContext.SetSigningTweak(assetTree.Root.Input, rootTweak[:])
+	assetContext.SetLeafAssetRoot(assetTree.Root.Input, assetRoot[:])
+	assetTree.AssetContext = assetContext
+
+	leafOutpoint, err := assetTree.Root.GetNonAnchorOutpoint()
+	require.NoError(t, err)
+
+	return &boundAssetVTXOFixture{
+		intent:        intent,
+		request:       request,
+		commitmentTx:  packet,
+		tree:          assetTree,
+		leafOutpoint:  *leafOutpoint,
+		sealedPackage: []byte("sealed package"),
+	}
+}
+
+func TestCommitmentTxReceivedVerifiesAssetVTXO(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	fixture := newBoundAssetVTXOFixture(t, h)
+	verifier := &recordingAssetVTXOVerifier{}
+	registrar := &recordingOwnedScriptRegistrar{}
+	h.env.AssetVTXOVerifier = verifier
+	h.env.OwnedScriptRegistrar = registrar
+	roundID := testRoundIDTr("asset-vtxo")
+	h.withState(&CommitmentTxReceivedState{
+		RoundID:      roundID,
+		CommitmentTx: fixture.commitmentTx,
+		TxID:         fixture.commitmentTx.UnsignedTx.TxHash(),
+		SweepDelay:   1008,
+		VTXOTreePaths: map[int]*tree.Tree{
+			0: fixture.tree,
+		},
+		AssetLeafPackages: map[wire.OutPoint][]byte{
+			fixture.leafOutpoint: fixture.sealedPackage,
+		},
+		Intents: Intents{
+			Boarding: []BoardingIntent{fixture.intent},
+			VTXOs:    []types.VTXORequest{fixture.request},
+		},
+		ClientTrees: make(map[SignerKey]*tree.Tree),
+	})
+
+	transition, err := h.sendEvent(&CommitmentTxBuilt{
+		RoundID: roundID,
+		Tx:      fixture.commitmentTx,
+		VTXOTreePaths: map[int]*tree.Tree{
+			0: fixture.tree,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, transition)
+	validated := assertStateType[*CommitmentTxValidatedState](h)
+	require.Equal(t, 1, verifier.calls)
+	require.Equal(t, fixture.request.AssetRef, verifier.assetRef)
+	require.Equal(t, fixture.request.AssetAmount, verifier.assetAmount)
+	require.Same(t, fixture.commitmentTx.UnsignedTx, verifier.commitmentTx)
+	require.Equal(t, fixture.sealedPackage, verifier.sealedPackage)
+
+	signerKey := NewSignerKey(fixture.request.SigningKey.PubKey)
+	clientTree := validated.ClientTrees[signerKey]
+	require.NotNil(t, clientTree)
+	leaf := clientTree.Root.GetLeafNodes()[0]
+	leafOutput, err := leafNonAnchorOutput(leaf)
+	require.NoError(t, err)
+	require.Equal(t, leafOutput.PkScript, registrar.pkScript)
+	require.True(
+		t, fixture.request.OwnerKey.PubKey.IsEqual(
+			registrar.ownerKey.PubKey,
+		),
+	)
+	plainScript, err := fixture.request.EffectivePkScript()
+	require.NoError(t, err)
+	require.NotEqual(t, plainScript, registrar.pkScript)
+	require.Equal(
+		t, fixture.sealedPackage,
+		clientTree.AssetContext.SealedPackage(leaf.Input),
+	)
+	require.Empty(
+		t, fixture.tree.AssetContext.SealedPackage(
+			fixture.tree.Root.Input,
+		),
+	)
+
+	vtxos, err := buildClientVTXOs(
+		t.Context(), newMockOwnedScriptChecker(registrar.pkScript),
+		Intents{
+			VTXOs: []types.VTXORequest{fixture.request},
+		}, map[SignerKey]*tree.Tree{
+			signerKey: clientTree,
+		},
+		roundID,
+	)
+	require.NoError(t, err)
+	require.Len(t, vtxos, 1)
+	require.Equal(t, leafOutput.PkScript, vtxos[0].PkScript)
+}
+
+func TestValidateRequestedAssetVTXO(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	fixture := newBoundAssetVTXOFixture(t, h)
+
+	clientTree, err := validateRequestedVTXO(
+		fixture.tree, fixture.request, fixture.request.Amount,
+		h.operatorPubKey,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, clientTree)
+
+	fixture.tree.Root.Outputs[0].PkScript[2] ^= 1
+	_, err = validateRequestedVTXO(
+		fixture.tree, fixture.request, fixture.request.Amount,
+		h.operatorPubKey,
+	)
+	require.ErrorContains(t, err, "VTXO script mismatch")
+}
+
+func TestValidateVTXOTreeBindingUsesAssetRoot(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	fixture := newBoundAssetVTXOFixture(t, h)
+	trees := map[int]*tree.Tree{0: fixture.tree}
+	require.NoError(
+		t, validateVTXOTreeBinding(
+			fixture.commitmentTx.UnsignedTx, trees,
+		),
+	)
+
+	wrongRoot := chainhash.HashH([]byte("wrong batch asset root"))
+	fixture.tree.AssetContext.SetSigningTweak(
+		fixture.tree.Root.Input, wrongRoot[:],
+	)
+	require.ErrorContains(
+		t, validateVTXOTreeBinding(
+			fixture.commitmentTx.UnsignedTx, trees,
+		),
+		"recomputed tree root",
+	)
+}
+
+func TestCommitmentTxReceivedRejectsUnverifiedAssetVTXO(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name      string
+		configure func(*boardingTestHarness, *boundAssetVTXOFixture)
+	}{
+		{
+			name: "missing verifier",
+		},
+		{
+			name: "missing package",
+			configure: func(h *boardingTestHarness,
+				fixture *boundAssetVTXOFixture) {
+
+				h.env.AssetVTXOVerifier =
+					&recordingAssetVTXOVerifier{}
+				fixture.sealedPackage = nil
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			h := newTestHarness(t)
+			fixture := newBoundAssetVTXOFixture(t, h)
+			if testCase.configure != nil {
+				testCase.configure(h, fixture)
+			}
+			roundID := testRoundIDTr(testCase.name)
+			h.withState(&CommitmentTxReceivedState{
+				RoundID:      roundID,
+				CommitmentTx: fixture.commitmentTx,
+				TxID: fixture.commitmentTx.UnsignedTx.
+					TxHash(),
+				SweepDelay: 1008,
+				VTXOTreePaths: map[int]*tree.Tree{
+					0: fixture.tree,
+				},
+				AssetLeafPackages: map[wire.OutPoint][]byte{
+					fixture.leafOutpoint: fixture.
+						sealedPackage,
+				},
+				Intents: Intents{
+					Boarding: []BoardingIntent{
+						fixture.intent,
+					},
+					VTXOs: []types.VTXORequest{
+						fixture.request,
+					},
+				},
+				ClientTrees: make(map[SignerKey]*tree.Tree),
+			})
+
+			_, err := h.sendEvent(&CommitmentTxBuilt{
+				RoundID: roundID,
+				Tx:      fixture.commitmentTx,
+				VTXOTreePaths: map[int]*tree.Tree{
+					0: fixture.tree,
+				},
+			})
+			require.NoError(t, err)
+			failed := assertStateType[*ClientFailedState](h)
+			require.Contains(
+				t, failed.Reason,
+				"asset VTXO verification failed",
+			)
+		})
+	}
+}

--- a/round/events.go
+++ b/round/events.go
@@ -159,6 +159,10 @@ type CommitmentTxBuilt struct {
 	// unilateral exit if needed.
 	VTXOTreePaths map[int]*tree.Tree
 
+	// AssetLeafPackages contains the sealed package for each asset VTXO,
+	// keyed by the VTXO outpoint.
+	AssetLeafPackages map[wire.OutPoint][]byte
+
 	// ForfeitMappings maps each VTXO outpoint to its connector leaf info.
 	// This allows VTXO actors to find their connector output and construct
 	// the forfeit transaction. Only set when refresh requests are present.

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -226,6 +226,31 @@ func (e *CommitmentTxBuilt) FromProto(p proto.Message) error {
 		}
 	}
 
+	if len(pb.AssetLeafPackages) != 0 {
+		e.AssetLeafPackages = make(
+			map[wire.OutPoint][]byte, len(pb.AssetLeafPackages),
+		)
+		for key, sealedPackage := range pb.AssetLeafPackages {
+			outpoint, err := roundpb.OutpointFromMapKey(key)
+			if err != nil {
+				return fmt.Errorf("asset_leaf_packages key "+
+					"%q: %w", key, err)
+			}
+			if roundpb.OutpointToMapKey(outpoint) != key {
+				return fmt.Errorf("asset_leaf_packages key %q "+
+					"is not canonical", key)
+			}
+			if len(sealedPackage) == 0 {
+				return fmt.Errorf("asset_leaf_packages[%q] "+
+					"is empty", key)
+			}
+
+			e.AssetLeafPackages[outpoint] = append(
+				[]byte(nil), sealedPackage...,
+			)
+		}
+	}
+
 	// Convert connector leaf map. The server sends ConnectorLeafInfo
 	// with LeafOutpoint and LeafOutput, which maps to the client's
 	// ConnectorLeafInfo with ConnectorOutpoint, ConnectorPkScript, and

--- a/round/from_proto_test.go
+++ b/round/from_proto_test.go
@@ -443,3 +443,80 @@ func TestCommitmentTxBuiltFromProtoSigningKeys(t *testing.T) {
 	var gotBad CommitmentTxBuilt
 	require.Error(t, gotBad.FromProto(pbBad))
 }
+
+func TestCommitmentTxBuiltFromProtoAssetPackages(t *testing.T) {
+	t.Parallel()
+
+	roundID := [16]byte{1}
+	outpoint := wire.OutPoint{
+		Hash: chainhash.Hash{
+			2,
+		},
+		Index: 3,
+	}
+	key := roundpb.OutpointToMapKey(outpoint)
+	pkg := []byte{4, 5, 6}
+	pb := &roundpb.ClientBatchInfo{
+		RoundId:   roundID[:],
+		BatchPsbt: validPSBTBytes(t),
+		AssetLeafPackages: map[string][]byte{
+			key: pkg,
+		},
+	}
+
+	var event CommitmentTxBuilt
+	require.NoError(t, event.FromProto(pb))
+	require.Equal(t, pkg, event.AssetLeafPackages[outpoint])
+
+	// The event owns its package bytes.
+	pkg[0] = 0xff
+	require.Equal(t, byte(4), event.AssetLeafPackages[outpoint][0])
+}
+
+func TestCommitmentTxBuiltFromProtoRejectsInvalidAssetPackages(t *testing.T) {
+	t.Parallel()
+
+	roundID := [16]byte{1}
+	newEvent := func(packages map[string][]byte) error {
+		var event CommitmentTxBuilt
+
+		return event.FromProto(&roundpb.ClientBatchInfo{
+			RoundId:           roundID[:],
+			BatchPsbt:         validPSBTBytes(t),
+			AssetLeafPackages: packages,
+		})
+	}
+
+	require.ErrorContains(
+		t,
+		newEvent(
+			map[string][]byte{
+				"not-an-outpoint": {1},
+			},
+		),
+		"asset_leaf_packages key",
+	)
+
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{2}, Index: 3}
+	key := roundpb.OutpointToMapKey(outpoint)
+	require.ErrorContains(
+		t,
+		newEvent(
+			map[string][]byte{
+				key: nil,
+			},
+		),
+		"is empty",
+	)
+
+	nonCanonical := outpoint.Hash.String() + ":03"
+	require.ErrorContains(
+		t,
+		newEvent(
+			map[string][]byte{
+				nonCanonical: {1},
+			},
+		),
+		"is not canonical",
+	)
+}

--- a/round/fsm_environment.go
+++ b/round/fsm_environment.go
@@ -118,6 +118,14 @@ type ClientEnvironment struct {
 	// the owned receive scripts store.
 	OwnedScriptChecker OwnedScriptChecker
 
+	// OwnedScriptRegistrar records the composed script of a locally owned
+	// asset VTXO once the client has validated its tree path.
+	OwnedScriptRegistrar OwnedScriptRegistrar
+
+	// AssetVTXOVerifier verifies asset VTXOs before signing. It is only
+	// required for rounds containing asset requests.
+	AssetVTXOVerifier AssetVTXOVerifier
+
 	// Now returns the current wall-clock time. evaluateQuote
 	// uses this to enforce the server-advertised
 	// `quote_expires_at`; a nil value falls back to time.Now so

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -559,10 +559,17 @@ type OwnedScriptChecker interface {
 	IsOwnedScript(ctx context.Context, pkScript []byte) fn.Result[bool]
 }
 
-// OwnedScriptRegistrar registers a pkScript as locally owned. The
-// round actor calls this when building VTXO intents (boarding,
-// refresh, change) so the OwnedScriptChecker can recognize them
-// when the round confirms.
+// AssetVTXOVerifier verifies the asset transition behind a VTXO before the
+// client signs its tree path.
+type AssetVTXOVerifier interface {
+	VerifyAssetVTXO(ctx context.Context, assetRef string,
+		assetAmount uint64, commitmentTx *wire.MsgTx,
+		clientTree *tree.Tree, sealedPackage []byte) error
+}
+
+// OwnedScriptRegistrar registers a pkScript as locally owned. Ordinary VTXO
+// intents are registered when they are built; asset VTXOs are registered after
+// their composed output scripts have been validated.
 type OwnedScriptRegistrar interface {
 	// RegisterOwnedScript persists a pkScript + owner key as
 	// locally owned.

--- a/round/signing_executor.go
+++ b/round/signing_executor.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
-	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/lightninglabs/wavelength/lib/tree"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -25,14 +24,9 @@ type CreateSignerSessionJob struct {
 	// SigningKey is the private-key locator for this VTXO path.
 	SigningKey keychain.KeyDescriptor
 
-	// SweepTapscriptRoot tweaks the VTXO tree key-spend path.
-	SweepTapscriptRoot []byte
-
-	// PrevOuts provides the outputs spent by transactions in the path.
-	PrevOuts txscript.PrevOutputFetcher
-
-	// Root is the root of the VTXO tree containing the signer path.
-	Root *tree.Node
+	// Tree keeps the batch prevout and per-node Taproot signing tweaks
+	// together for this validated path.
+	Tree *tree.Tree
 }
 
 // SignerSessionResult is an index-stable signer session and its public
@@ -98,9 +92,12 @@ func NewSigningExecutor(maxWorkers int) SigningExecutor {
 		createSession: func(job CreateSignerSessionJob) (
 			*tree.SignerSession, error) {
 
-			return tree.NewSignerSession(
+			if job.Tree == nil {
+				return nil, fmt.Errorf("tree is required")
+			}
+
+			return job.Tree.NewTreeSignerSession(
 				job.Signer, &job.SigningKey,
-				job.SweepTapscriptRoot, job.PrevOuts, job.Root,
 			)
 		},
 		getNonces: func(

--- a/round/signing_executor_test.go
+++ b/round/signing_executor_test.go
@@ -423,11 +423,6 @@ func TestSigningExecutorRealMuSigManager(t *testing.T) {
 	})
 
 	vtxoTree, _ := h.newTestVTXOTree(8)
-	prevOuts, err := vtxoTree.Root.PrevOutputFetcher(
-		vtxoTree.BatchOutput,
-	)
-	require.NoError(t, err)
-
 	jobs := make([]CreateSignerSessionJob, 8)
 	for index := range jobs {
 		jobs[index] = CreateSignerSessionJob{
@@ -438,9 +433,7 @@ func TestSigningExecutorRealMuSigManager(t *testing.T) {
 			SigningKey: keychain.KeyDescriptor{
 				PubKey: h.clientPubKey,
 			},
-			SweepTapscriptRoot: vtxoTree.SweepTapscriptRoot,
-			PrevOuts:           prevOuts,
-			Root:               vtxoTree.Root,
+			Tree: vtxoTree,
 		}
 	}
 

--- a/round/states.go
+++ b/round/states.go
@@ -276,6 +276,10 @@ type CommitmentTxReceivedState struct {
 	// VTXOTreePaths maps commitment tx output indices to VTXO tree paths.
 	VTXOTreePaths map[int]*tree.Tree
 
+	// AssetLeafPackages contains the sealed package for each asset VTXO,
+	// keyed by the VTXO outpoint.
+	AssetLeafPackages map[wire.OutPoint][]byte
+
 	// TreeCosignKey is the operator's per-round VTXO-tree MuSig2 cosigner
 	// key delivered with the commitment tx. Used to validate the VTXO tree
 	// (and, via the extracted client trees, sign it) instead of the global

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1980,6 +1980,7 @@ func (s *RoundJoinedState) processEvent(ctx context.Context, event ClientEvent,
 				CommitmentTx:         evt.Tx,
 				TxID:                 txid,
 				VTXOTreePaths:        evt.VTXOTreePaths,
+				AssetLeafPackages:    evt.AssetLeafPackages,
 				TreeCosignKey:        evt.TreeCosignKey,
 				ConnectorOperatorKey: evt.ConnectorOperatorKey,
 				SweepKey:             evt.SweepKey,
@@ -2396,17 +2397,6 @@ func (s *CommitmentTxReceivedState) processEvent(ctx context.Context,
 		// originally requested are actually present in the VTXT trees
 		// that the server sent us.
 		for i, vtxoReq := range s.Intents.VTXOs {
-			pkScript, err := vtxoReq.EffectivePkScript()
-			if err != nil {
-				derivedErr := fmt.Errorf("derive pkScript for "+
-					"VTXO request %d: %w", i, err)
-
-				return failBeforeForfeitSigning(
-					"VTXT validation failed", derivedErr,
-					true, s.RoundID, s.Intents.Forfeits,
-				), nil
-			}
-
 			// The quote (when present) is the authoritative source
 			// for the amount each VTXO leaf carries — the client's
 			// intent target is a hint rather than a commitment
@@ -2414,20 +2404,13 @@ func (s *CommitmentTxReceivedState) processEvent(ctx context.Context,
 			// for harness paths that bypass the quote handshake.
 			expectedAmount := quoteVTXOAmount(s.Quote, i, vtxoReq)
 
-			// Convert VTXORequest to LeafDescriptor for validation.
-			expectedLeaf := tree.LeafDescriptor{
-				Amount:      expectedAmount,
-				PkScript:    pkScript,
-				CoSignerKey: vtxoReq.SigningKey.PubKey,
-			}
-
 			// Search through all VTXO trees to find the one
 			// containing this VTXO request.
 			var clientTree *tree.Tree
 			var validateErr error
 			for _, vtxoTree := range s.VTXOTreePaths {
-				clientTree, validateErr = vtxoTree.ValidatePath(
-					vtxoReq.SigningKey.PubKey, expectedLeaf,
+				clientTree, validateErr = validateRequestedVTXO(
+					vtxoTree, vtxoReq, expectedAmount,
 					treeCosignKey,
 				)
 				if validateErr == nil {
@@ -2459,6 +2442,28 @@ func (s *CommitmentTxReceivedState) processEvent(ctx context.Context,
 						"found"),
 					false,
 					s.RoundID,
+					s.Intents.Forfeits,
+				), nil
+			}
+
+			err := verifyRequestedAssetVTXO(
+				ctx, env.AssetVTXOVerifier, vtxoReq,
+				s.CommitmentTx.UnsignedTx, clientTree,
+				s.AssetLeafPackages,
+			)
+			if err != nil {
+				return failBeforeForfeitSigning(
+					"asset VTXO verification failed", err,
+					false, s.RoundID, s.Intents.Forfeits,
+				), nil
+			}
+			if err := registerRequestedAssetVTXO(
+				ctx, env.OwnedScriptRegistrar, vtxoReq,
+				clientTree,
+			); err != nil {
+				return failBeforeForfeitSigning(
+					"asset VTXO ownership registration "+
+						"failed", err, false, s.RoundID,
 					s.Intents.Forfeits,
 				), nil
 			}
@@ -2716,34 +2721,21 @@ func (s *CommitmentTxValidatedState) processEvent(ctx context.Context,
 			}
 			seenSignerKeys[signerKey] = struct{}{}
 
-			// Get the client tree for this signer key.
-			// The sweep tweak and batch output are
-			// properties of the tree that were set when
-			// the operator built it.
+			// Get the client tree for this signer key. The batch
+			// output and Taproot signing tweaks are properties of
+			// the tree that were set when the operator built it.
 			clientTree := s.ClientTrees[signerKey]
 			if clientTree == nil {
 				return nil, fmt.Errorf("no client tree for "+
 					"signer key %x", signerKey[:])
 			}
 
-			sweepTweak := clientTree.SweepTapscriptRoot
-			batchOut := clientTree.BatchOutput
-			root := clientTree.Root
-			prevOutFetcher, err := root.PrevOutputFetcher(batchOut)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create prev "+
-					"output fetcher for signer %x: %w",
-					signerKey[:], err)
-			}
-
 			sessionJobs = append(
 				sessionJobs, CreateSignerSessionJob{
-					SignerKey:          signerKey,
-					Signer:             env.Wallet,
-					SigningKey:         vtxoReq.SigningKey,
-					SweepTapscriptRoot: sweepTweak,
-					PrevOuts:           prevOutFetcher,
-					Root:               root,
+					SignerKey:  signerKey,
+					Signer:     env.Wallet,
+					SigningKey: vtxoReq.SigningKey,
+					Tree:       clientTree,
 				},
 			)
 		}
@@ -4134,6 +4126,149 @@ func connectorLeafOutput(leaf *tree.Node) (*wire.TxOut, error) {
 	return found, nil
 }
 
+func validateRequestedVTXO(vtxoTree *tree.Tree, request types.VTXORequest,
+	expectedAmount btcutil.Amount,
+	operatorKey *btcec.PublicKey) (*tree.Tree, error) {
+
+	pkScript, err := request.EffectivePkScript()
+	if err != nil {
+		return nil, fmt.Errorf("derive VTXO script: %w", err)
+	}
+	if request.AssetRef == "" {
+		return vtxoTree.ValidatePath(
+			request.SigningKey.PubKey, tree.LeafDescriptor{
+				Amount:      expectedAmount,
+				PkScript:    pkScript,
+				CoSignerKey: request.SigningKey.PubKey,
+			}, operatorKey,
+		)
+	}
+
+	if vtxoTree == nil || vtxoTree.AssetContext == nil {
+		return nil, fmt.Errorf("asset VTXO requires an asset tree")
+	}
+	if err := vtxoTree.AssetContext.Validate(vtxoTree.Root); err != nil {
+		return nil, fmt.Errorf("asset tree context: %w", err)
+	}
+	if vtxoTree.AssetContext.AssetRef() != request.AssetRef {
+		return nil, fmt.Errorf("tree asset %q does not match "+
+			"request %q", vtxoTree.AssetContext.AssetRef(),
+			request.AssetRef)
+	}
+
+	path, err := vtxoTree.ExtractPathForCoSigners(
+		request.SigningKey.PubKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("extract asset VTXO path: %w", err)
+	}
+	if path == nil {
+		return nil, fmt.Errorf("asset VTXO path not found")
+	}
+	leaves := path.Root.GetLeafNodes()
+	if len(leaves) != 1 {
+		return nil, fmt.Errorf("expected one asset VTXO leaf, got %d",
+			len(leaves))
+	}
+	leaf := leaves[0]
+	if amount := path.AssetContext.NodeAssetAmount(leaf); amount !=
+		request.AssetAmount {
+		return nil, fmt.Errorf("asset VTXO amount %d does not match "+
+			"request %d", amount, request.AssetAmount)
+	}
+
+	var assetRoot chainhash.Hash
+	copy(assetRoot[:], path.AssetContext.LeafAssetRoot(leaf.Input))
+	policy, err := request.DecodePolicyTemplate()
+	if err != nil {
+		return nil, fmt.Errorf("decode asset VTXO policy: %w", err)
+	}
+	compiled, err := policy.Compile()
+	if err != nil {
+		return nil, fmt.Errorf("compile asset VTXO policy: %w", err)
+	}
+	composed, err := arkscript.ComposeWithSiblingRoot(
+		compiled, assetRoot,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("compose asset VTXO policy: %w", err)
+	}
+	pkScript, err = txscript.PayToTaprootScript(composed.OutputKey())
+	if err != nil {
+		return nil, fmt.Errorf("derive composed VTXO script: %w", err)
+	}
+
+	return vtxoTree.ValidatePath(
+		request.SigningKey.PubKey, tree.LeafDescriptor{
+			Amount:      expectedAmount,
+			PkScript:    pkScript,
+			CoSignerKey: request.SigningKey.PubKey,
+		}, operatorKey,
+	)
+}
+
+func verifyRequestedAssetVTXO(ctx context.Context, verifier AssetVTXOVerifier,
+	request types.VTXORequest, commitmentTx *wire.MsgTx,
+	clientTree *tree.Tree, packages map[wire.OutPoint][]byte) error {
+
+	if request.AssetRef == "" {
+		return nil
+	}
+	if verifier == nil {
+		return fmt.Errorf("asset VTXO verifier is not configured")
+	}
+
+	leaf := clientTree.Root.GetLeafNodes()[0]
+	outpoint, err := leaf.GetNonAnchorOutpoint()
+	if err != nil {
+		return err
+	}
+	sealedPackage := packages[*outpoint]
+	if len(sealedPackage) == 0 {
+		return fmt.Errorf("asset VTXO %s has no sealed package",
+			outpoint)
+	}
+
+	if err := verifier.VerifyAssetVTXO(
+		ctx, request.AssetRef, request.AssetAmount, commitmentTx,
+		clientTree, sealedPackage,
+	); err != nil {
+		return err
+	}
+
+	clientTree.AssetContext.SetSealedPackage(leaf.Input, sealedPackage)
+
+	return nil
+}
+
+// registerRequestedAssetVTXO records the composed output script after the
+// asset tree and sealed package have been validated. The asset root is not
+// known when the client creates the request, so its final output script cannot
+// be registered at intent time.
+func registerRequestedAssetVTXO(ctx context.Context,
+	registrar OwnedScriptRegistrar, request types.VTXORequest,
+	clientTree *tree.Tree) error {
+
+	if request.AssetRef == "" || !request.HasLocalOwner() ||
+		registrar == nil {
+		return nil
+	}
+
+	leaves := clientTree.Root.GetLeafNodes()
+	if len(leaves) != 1 {
+		return fmt.Errorf("expected one asset VTXO leaf, got %d",
+			len(leaves))
+	}
+	leafOutput, err := leafNonAnchorOutput(leaves[0])
+	if err != nil {
+		return err
+	}
+
+	return registrar.RegisterOwnedScript(
+		ctx, leafOutput.PkScript, request.OwnerKey,
+	)
+}
+
 // validateVTXOTreeBinding proves that every operator-supplied VTXO tree is
 // rooted in this round's commitment tx. Internal tree self-consistency is not
 // enough: a tree's BatchOutpoint and BatchOutput come from the same untrusted
@@ -4150,7 +4285,7 @@ func connectorLeafOutput(leaf *tree.Node) (*wire.TxOut, error) {
 // that the index is in range, that the committed output byte-matches the
 // tree's BatchOutput, that every reachable transaction is funded by the
 // output it spends, and that the committed script equals the taproot script
-// recomputed from the tree root's cosigner set and sweep tapscript root (so a
+// recomputed from the tree root's cosigner set and signing tweak (so a
 // substituted-but-self-consistent script is rejected).
 func validateVTXOTreeBinding(commitmentTx *wire.MsgTx,
 	vtxoTrees map[int]*tree.Tree) error {
@@ -4181,7 +4316,7 @@ func validateVTXOTreeBinding(commitmentTx *wire.MsgTx,
 // commitment output named by outputIdx, that each reachable node conserves
 // value from that committed output, and that the committed output matches both
 // the tree's claimed BatchOutput and the taproot script recomputed from the
-// tree's declared cosigner set and sweep tapscript root.
+// tree's declared cosigner set and signing tweak.
 func verifyVTXOTreeRoot(commitmentTx *wire.MsgTx, commitmentTxID chainhash.Hash,
 	outputIdx int, vtxoTree *tree.Tree) error {
 
@@ -4240,17 +4375,28 @@ func verifyVTXOTreeRoot(commitmentTx *wire.MsgTx, commitmentTxID chainhash.Hash,
 			"batch output script")
 	}
 
+	rootTweak := vtxoTree.SweepTapscriptRoot
+	if vtxoTree.AssetContext != nil {
+		err := vtxoTree.AssetContext.Validate(vtxoTree.Root)
+		if err != nil {
+			return fmt.Errorf("asset tree context: %w", err)
+		}
+		rootTweak = vtxoTree.AssetContext.SigningTweak(
+			vtxoTree.Root.Input,
+		)
+	}
+
 	// Finally, recompute the root taproot script from the tree's declared
-	// cosigner set and sweep tapscript root and require it to equal the
-	// committed script. BatchOutput.PkScript is operator-supplied, so the
-	// byte-match above only proves the operator put the same bytes on-chain
-	// and in the tree; without this an operator could commit a taproot
-	// output whose key is not the aggregate of the declared cosigners,
-	// leaving the co-signed tree unable to ever spend it. We recompute from
-	// the declared parameters rather than trusting Root.FinalKey, which is
+	// cosigner set and signing tweak and require it to equal the committed
+	// script. BatchOutput.PkScript is operator-supplied, so the byte-match
+	// above only proves the operator put the same bytes on-chain and in the
+	// tree; without this an operator could commit a taproot output whose
+	// key is not the aggregate of the declared cosigners, leaving the
+	// co-signed tree unable to ever spend it. We recompute from the
+	// declared parameters rather than trusting Root.FinalKey, which is
 	// itself operator-supplied.
 	finalKey, err := tree.ComputeFinalKey(
-		vtxoTree.Root.CoSigners, vtxoTree.SweepTapscriptRoot,
+		vtxoTree.Root.CoSigners, rootTweak,
 	)
 	if err != nil {
 		return fmt.Errorf("recompute tree root key: %w", err)
@@ -4261,7 +4407,7 @@ func verifyVTXOTreeRoot(commitmentTx *wire.MsgTx, commitmentTxID chainhash.Hash,
 	}
 	if !bytes.Equal(rootScript, committed.PkScript) {
 		return fmt.Errorf("committed output script does not match " +
-			"script recomputed from tree cosigners and sweep root")
+			"the recomputed tree root")
 	}
 
 	// BatchOutput is operator-supplied, so validate values only after the
@@ -4387,8 +4533,8 @@ func computeClientOperatorFee(intents Intents, ownedVTXOs []*ClientVTXO) int64 {
 	// Amount is the pre-fee target — the server's quote residual is what
 	// actually seals into the leaf — so summing intent amounts cancels the
 	// inputs exactly and computes a zero fee for every fee-charging round.
-	// The built ClientVTXO carries the sealed leaf value
-	// (leafNonAnchorAmount), making input − output the true operator fee.
+	// The built ClientVTXO carries the sealed leaf value, making input −
+	// output the true operator fee.
 	// Foreign outputs (directed-send recipient slots) never materialize as
 	// owned VTXOs, so their intent amount remains the only local record of
 	// their value and is used as-is.
@@ -4493,24 +4639,46 @@ func roundOperatorFeeType(intents Intents) string {
 	return ledger.FeeTypeRefresh
 }
 
+// leafNonAnchorOutput returns the non-anchor output of a leaf node. Its value
+// contains the server's seal-time quote residual, and an asset leaf's script
+// contains its asset commitment root. Both are authoritative for persistence.
+func leafNonAnchorOutput(leaf *tree.Node) (*wire.TxOut, error) {
+	if leaf == nil {
+		return nil, fmt.Errorf("nil leaf node")
+	}
+
+	anchorScript := arkscript.AnchorOutput().PkScript
+	var found *wire.TxOut
+	for _, out := range leaf.Outputs {
+		if bytes.Equal(out.PkScript, anchorScript) {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("leaf node has multiple " +
+				"non-anchor outputs")
+		}
+		found = out
+	}
+	if found == nil {
+		return nil, fmt.Errorf("no non-anchor output found in leaf " +
+			"node")
+	}
+
+	return found, nil
+}
+
 // leafNonAnchorAmount returns the value of the non-anchor output of
 // a leaf Node. The leaf's tx has exactly two outputs: the VTXO (or
 // connector) output and the P2A anchor. Returns the VTXO/connector
 // amount, which under the #270 handshake reflects the server's
 // seal-time quote residual — authoritative for local persistence.
 func leafNonAnchorAmount(leaf *tree.Node) (btcutil.Amount, error) {
-	if leaf == nil {
-		return 0, fmt.Errorf("nil leaf node")
+	output, err := leafNonAnchorOutput(leaf)
+	if err != nil {
+		return 0, err
 	}
 
-	anchorScript := arkscript.AnchorOutput().PkScript
-	for _, out := range leaf.Outputs {
-		if !bytes.Equal(out.PkScript, anchorScript) {
-			return btcutil.Amount(out.Value), nil
-		}
-	}
-
-	return 0, fmt.Errorf("no non-anchor output found in leaf node")
+	return btcutil.Amount(output.Value), nil
 }
 
 // buildClientVTXOs constructs locally owned ClientVTXO instances from the
@@ -4525,25 +4693,6 @@ func buildClientVTXOs(ctx context.Context, checker OwnedScriptChecker,
 	for _, req := range intents.VTXOs {
 		if !req.HasLocalOwner() {
 			continue
-		}
-
-		pkScript, err := req.EffectivePkScript()
-		if err != nil {
-			return nil, fmt.Errorf("derive VTXO pkScript: %w", err)
-		}
-
-		if checker != nil {
-			owned, err := checker.IsOwnedScript(
-				ctx, pkScript,
-			).Unpack()
-			if err != nil {
-				return nil, fmt.Errorf("check owned script: %w",
-					err)
-			}
-
-			if !owned {
-				continue
-			}
 		}
 
 		params, err := req.DecodeStandardPolicyTemplate()
@@ -4575,10 +4724,25 @@ func buildClientVTXOs(ctx context.Context, checker OwnedScriptChecker,
 		// tree, so the leaf's non-anchor output carries the quoted
 		// value rather than the intent target (which is zero for
 		// change outputs). Reading req.Amount here would persist
-		// stale data.
-		leafAmount, err := leafNonAnchorAmount(leaf)
+		// stale data. The output script is authoritative too: asset
+		// VTXOs commit the asset root into the policy's Taproot tree.
+		leafOutput, err := leafNonAnchorOutput(leaf)
 		if err != nil {
-			return nil, fmt.Errorf("derive leaf amount: %w", err)
+			return nil, fmt.Errorf("derive leaf output: %w", err)
+		}
+
+		if checker != nil {
+			owned, err := checker.IsOwnedScript(
+				ctx, leafOutput.PkScript,
+			).Unpack()
+			if err != nil {
+				return nil, fmt.Errorf("check owned script: %w",
+					err)
+			}
+
+			if !owned {
+				continue
+			}
 		}
 
 		policyTemplate, _ := req.EffectivePolicyTemplate()
@@ -4595,9 +4759,9 @@ func buildClientVTXOs(ctx context.Context, checker OwnedScriptChecker,
 
 		vtxo := &ClientVTXO{
 			Outpoint:       *outpoint,
-			Amount:         leafAmount,
+			Amount:         btcutil.Amount(leafOutput.Value),
 			PolicyTemplate: policyTemplate,
-			PkScript:       pkScript,
+			PkScript:       bytes.Clone(leafOutput.PkScript),
 			OwnerKey:       req.OwnerKey,
 			Ancestry:       ancestry,
 			RoundID:        fn.Some(roundID),

--- a/rpc/roundpb/round.pb.go
+++ b/rpc/roundpb/round.pb.go
@@ -844,9 +844,12 @@ type ClientBatchInfo struct {
 	// under which the operator created this round. The client records the
 	// same value so both sides agree on how the round was conducted. Today
 	// the only understood value is 1.
-	FlowVersion   uint32 `protobuf:"varint,10,opt,name=flow_version,json=flowVersion,proto3" json:"flow_version,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	FlowVersion uint32 `protobuf:"varint,10,opt,name=flow_version,json=flowVersion,proto3" json:"flow_version,omitempty"`
+	// asset_leaf_packages contains the sealed transfer package for each
+	// asset VTXO created for this client, keyed by VTXO outpoint.
+	AssetLeafPackages map[string][]byte `protobuf:"bytes,11,rep,name=asset_leaf_packages,json=assetLeafPackages,proto3" json:"asset_leaf_packages,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *ClientBatchInfo) Reset() {
@@ -947,6 +950,13 @@ func (x *ClientBatchInfo) GetFlowVersion() uint32 {
 		return x.FlowVersion
 	}
 	return 0
+}
+
+func (x *ClientBatchInfo) GetAssetLeafPackages() map[string][]byte {
+	if x != nil {
+		return x.AssetLeafPackages
+	}
+	return nil
 }
 
 // ClientAwaitingInputSigsResp notifies a client that the server is ready
@@ -2933,7 +2943,7 @@ const file_round_proto_rawDesc = "" +
 	"\x11ClientSuccessResp\x12\x19\n" +
 	"\bround_id\x18\x01 \x01(\fR\aroundId\x12R\n" +
 	"\x1baccepted_boarding_outpoints\x18\x02 \x03(\v2\x12.round.v1.OutpointR\x19acceptedBoardingOutpoints\x12J\n" +
-	"\x17accepted_vtxo_outpoints\x18\x03 \x03(\v2\x12.round.v1.OutpointR\x15acceptedVtxoOutpoints\"\x98\x05\n" +
+	"\x17accepted_vtxo_outpoints\x18\x03 \x03(\v2\x12.round.v1.OutpointR\x15acceptedVtxoOutpoints\"\xc0\x06\n" +
 	"\x0fClientBatchInfo\x12\x19\n" +
 	"\bround_id\x18\x01 \x01(\fR\aroundId\x12\x1d\n" +
 	"\n" +
@@ -2948,13 +2958,17 @@ const file_round_proto_rawDesc = "" +
 	"\vforfeit_key\x18\t \x01(\fR\n" +
 	"forfeitKey\x12!\n" +
 	"\fflow_version\x18\n" +
-	" \x01(\rR\vflowVersion\x1aT\n" +
+	" \x01(\rR\vflowVersion\x12`\n" +
+	"\x13asset_leaf_packages\x18\v \x03(\v20.round.v1.ClientBatchInfo.AssetLeafPackagesEntryR\x11assetLeafPackages\x1aT\n" +
 	"\x12VtxoTreePathsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\x05R\x03key\x12(\n" +
 	"\x05value\x18\x02 \x01(\v2\x12.round.v1.VTXOTreeR\x05value:\x028\x01\x1a`\n" +
 	"\x15ConnectorLeafMapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x121\n" +
-	"\x05value\x18\x02 \x01(\v2\x1b.round.v1.ConnectorLeafInfoR\x05value:\x028\x01\"8\n" +
+	"\x05value\x18\x02 \x01(\v2\x1b.round.v1.ConnectorLeafInfoR\x05value:\x028\x01\x1aD\n" +
+	"\x16AssetLeafPackagesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"8\n" +
 	"\x1bClientAwaitingInputSigsResp\x12\x19\n" +
 	"\bround_id\x18\x01 \x01(\fR\aroundId\"\xbb\x01\n" +
 	"\x13ClientVTXOAggNonces\x12\x19\n" +
@@ -3140,7 +3154,7 @@ func file_round_proto_rawDescGZIP() []byte {
 }
 
 var file_round_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_round_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
+var file_round_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
 var file_round_proto_goTypes = []any{
 	(RoundFailureCode)(0),                // 0: round.v1.RoundFailureCode
 	(RoundLifecycleStatus)(0),            // 1: round.v1.RoundLifecycleStatus
@@ -3184,12 +3198,13 @@ var file_round_proto_goTypes = []any{
 	nil,                                  // 39: round.v1.TreeNode.ChildrenEntry
 	nil,                                  // 40: round.v1.ClientBatchInfo.VtxoTreePathsEntry
 	nil,                                  // 41: round.v1.ClientBatchInfo.ConnectorLeafMapEntry
-	nil,                                  // 42: round.v1.ClientVTXOAggNonces.AggNoncesEntry
-	nil,                                  // 43: round.v1.ClientVTXOAggSigs.AggSigsEntry
-	nil,                                  // 44: round.v1.SubmitNoncesRequest.NoncesEntry
-	nil,                                  // 45: round.v1.SignerNonces.TxNoncesEntry
-	nil,                                  // 46: round.v1.SubmitPartialSigRequest.SignaturesEntry
-	nil,                                  // 47: round.v1.SignerPartialSigs.TxSigsEntry
+	nil,                                  // 42: round.v1.ClientBatchInfo.AssetLeafPackagesEntry
+	nil,                                  // 43: round.v1.ClientVTXOAggNonces.AggNoncesEntry
+	nil,                                  // 44: round.v1.ClientVTXOAggSigs.AggSigsEntry
+	nil,                                  // 45: round.v1.SubmitNoncesRequest.NoncesEntry
+	nil,                                  // 46: round.v1.SignerNonces.TxNoncesEntry
+	nil,                                  // 47: round.v1.SubmitPartialSigRequest.SignaturesEntry
+	nil,                                  // 48: round.v1.SignerPartialSigs.TxSigsEntry
 }
 var file_round_proto_depIdxs = []int32{
 	3,  // 0: round.v1.TreeNode.input:type_name -> round.v1.Outpoint
@@ -3205,55 +3220,56 @@ var file_round_proto_depIdxs = []int32{
 	3,  // 10: round.v1.ClientSuccessResp.accepted_vtxo_outpoints:type_name -> round.v1.Outpoint
 	40, // 11: round.v1.ClientBatchInfo.vtxo_tree_paths:type_name -> round.v1.ClientBatchInfo.VtxoTreePathsEntry
 	41, // 12: round.v1.ClientBatchInfo.connector_leaf_map:type_name -> round.v1.ClientBatchInfo.ConnectorLeafMapEntry
-	42, // 13: round.v1.ClientVTXOAggNonces.agg_nonces:type_name -> round.v1.ClientVTXOAggNonces.AggNoncesEntry
-	43, // 14: round.v1.ClientVTXOAggSigs.agg_sigs:type_name -> round.v1.ClientVTXOAggSigs.AggSigsEntry
-	0,  // 15: round.v1.ClientRoundFailedResp.failure_code:type_name -> round.v1.RoundFailureCode
-	1,  // 16: round.v1.ClientRoundStatusReport.status:type_name -> round.v1.RoundLifecycleStatus
-	3,  // 17: round.v1.BoardingRequest.outpoint:type_name -> round.v1.Outpoint
-	3,  // 18: round.v1.ForfeitRequest.vtxo_outpoint:type_name -> round.v1.Outpoint
-	17, // 19: round.v1.JoinRoundRequest.boarding_requests:type_name -> round.v1.BoardingRequest
-	18, // 20: round.v1.JoinRoundRequest.vtxo_requests:type_name -> round.v1.VTXORequest
-	19, // 21: round.v1.JoinRoundRequest.forfeit_requests:type_name -> round.v1.ForfeitRequest
-	20, // 22: round.v1.JoinRoundRequest.leave_requests:type_name -> round.v1.LeaveRequest
-	21, // 23: round.v1.JoinRoundRequest.auth:type_name -> round.v1.JoinRoundAuth
-	24, // 24: round.v1.JoinRoundQuote.vtxo_quotes:type_name -> round.v1.VTXOQuote
-	25, // 25: round.v1.JoinRoundQuote.leave_quotes:type_name -> round.v1.LeaveQuote
-	23, // 26: round.v1.JoinRoundQuote.breakdown:type_name -> round.v1.FeeBreakdown
-	2,  // 27: round.v1.JoinRoundQuote.reject_reason:type_name -> round.v1.QuoteReason
-	44, // 28: round.v1.SubmitNoncesRequest.nonces:type_name -> round.v1.SubmitNoncesRequest.NoncesEntry
-	45, // 29: round.v1.SignerNonces.tx_nonces:type_name -> round.v1.SignerNonces.TxNoncesEntry
-	46, // 30: round.v1.SubmitPartialSigRequest.signatures:type_name -> round.v1.SubmitPartialSigRequest.SignaturesEntry
-	47, // 31: round.v1.SignerPartialSigs.tx_sigs:type_name -> round.v1.SignerPartialSigs.TxSigsEntry
-	3,  // 32: round.v1.BoardingInputSignature.outpoint:type_name -> round.v1.Outpoint
-	33, // 33: round.v1.SubmitForfeitSigRequest.signatures:type_name -> round.v1.BoardingInputSignature
-	3,  // 34: round.v1.ForfeitTxSig.vtxo_outpoint:type_name -> round.v1.Outpoint
-	35, // 35: round.v1.ForfeitTxSig.participant_sigs:type_name -> round.v1.ForfeitParticipantSig
-	36, // 36: round.v1.SubmitVTXOForfeitSigsRequest.forfeit_txs:type_name -> round.v1.ForfeitTxSig
-	6,  // 37: round.v1.ClientBatchInfo.VtxoTreePathsEntry.value:type_name -> round.v1.VTXOTree
-	7,  // 38: round.v1.ClientBatchInfo.ConnectorLeafMapEntry.value:type_name -> round.v1.ConnectorLeafInfo
-	30, // 39: round.v1.SubmitNoncesRequest.NoncesEntry.value:type_name -> round.v1.SignerNonces
-	32, // 40: round.v1.SubmitPartialSigRequest.SignaturesEntry.value:type_name -> round.v1.SignerPartialSigs
-	22, // 41: round.v1.RoundService.JoinRound:input_type -> round.v1.JoinRoundRequest
-	27, // 42: round.v1.RoundService.AcceptQuote:input_type -> round.v1.JoinRoundAccept
-	28, // 43: round.v1.RoundService.RejectQuote:input_type -> round.v1.JoinRoundReject
-	29, // 44: round.v1.RoundService.SubmitNonces:input_type -> round.v1.SubmitNoncesRequest
-	31, // 45: round.v1.RoundService.SubmitPartialSigs:input_type -> round.v1.SubmitPartialSigRequest
-	34, // 46: round.v1.RoundService.SubmitForfeitSigs:input_type -> round.v1.SubmitForfeitSigRequest
-	37, // 47: round.v1.RoundService.SubmitVTXOForfeitSigs:input_type -> round.v1.SubmitVTXOForfeitSigsRequest
-	38, // 48: round.v1.RoundService.QueryRoundStatus:input_type -> round.v1.QueryRoundStatusRequest
-	9,  // 49: round.v1.RoundService.JoinRound:output_type -> round.v1.ClientSuccessResp
-	9,  // 50: round.v1.RoundService.AcceptQuote:output_type -> round.v1.ClientSuccessResp
-	9,  // 51: round.v1.RoundService.RejectQuote:output_type -> round.v1.ClientSuccessResp
-	12, // 52: round.v1.RoundService.SubmitNonces:output_type -> round.v1.ClientVTXOAggNonces
-	13, // 53: round.v1.RoundService.SubmitPartialSigs:output_type -> round.v1.ClientVTXOAggSigs
-	11, // 54: round.v1.RoundService.SubmitForfeitSigs:output_type -> round.v1.ClientAwaitingInputSigsResp
-	9,  // 55: round.v1.RoundService.SubmitVTXOForfeitSigs:output_type -> round.v1.ClientSuccessResp
-	9,  // 56: round.v1.RoundService.QueryRoundStatus:output_type -> round.v1.ClientSuccessResp
-	49, // [49:57] is the sub-list for method output_type
-	41, // [41:49] is the sub-list for method input_type
-	41, // [41:41] is the sub-list for extension type_name
-	41, // [41:41] is the sub-list for extension extendee
-	0,  // [0:41] is the sub-list for field type_name
+	42, // 13: round.v1.ClientBatchInfo.asset_leaf_packages:type_name -> round.v1.ClientBatchInfo.AssetLeafPackagesEntry
+	43, // 14: round.v1.ClientVTXOAggNonces.agg_nonces:type_name -> round.v1.ClientVTXOAggNonces.AggNoncesEntry
+	44, // 15: round.v1.ClientVTXOAggSigs.agg_sigs:type_name -> round.v1.ClientVTXOAggSigs.AggSigsEntry
+	0,  // 16: round.v1.ClientRoundFailedResp.failure_code:type_name -> round.v1.RoundFailureCode
+	1,  // 17: round.v1.ClientRoundStatusReport.status:type_name -> round.v1.RoundLifecycleStatus
+	3,  // 18: round.v1.BoardingRequest.outpoint:type_name -> round.v1.Outpoint
+	3,  // 19: round.v1.ForfeitRequest.vtxo_outpoint:type_name -> round.v1.Outpoint
+	17, // 20: round.v1.JoinRoundRequest.boarding_requests:type_name -> round.v1.BoardingRequest
+	18, // 21: round.v1.JoinRoundRequest.vtxo_requests:type_name -> round.v1.VTXORequest
+	19, // 22: round.v1.JoinRoundRequest.forfeit_requests:type_name -> round.v1.ForfeitRequest
+	20, // 23: round.v1.JoinRoundRequest.leave_requests:type_name -> round.v1.LeaveRequest
+	21, // 24: round.v1.JoinRoundRequest.auth:type_name -> round.v1.JoinRoundAuth
+	24, // 25: round.v1.JoinRoundQuote.vtxo_quotes:type_name -> round.v1.VTXOQuote
+	25, // 26: round.v1.JoinRoundQuote.leave_quotes:type_name -> round.v1.LeaveQuote
+	23, // 27: round.v1.JoinRoundQuote.breakdown:type_name -> round.v1.FeeBreakdown
+	2,  // 28: round.v1.JoinRoundQuote.reject_reason:type_name -> round.v1.QuoteReason
+	45, // 29: round.v1.SubmitNoncesRequest.nonces:type_name -> round.v1.SubmitNoncesRequest.NoncesEntry
+	46, // 30: round.v1.SignerNonces.tx_nonces:type_name -> round.v1.SignerNonces.TxNoncesEntry
+	47, // 31: round.v1.SubmitPartialSigRequest.signatures:type_name -> round.v1.SubmitPartialSigRequest.SignaturesEntry
+	48, // 32: round.v1.SignerPartialSigs.tx_sigs:type_name -> round.v1.SignerPartialSigs.TxSigsEntry
+	3,  // 33: round.v1.BoardingInputSignature.outpoint:type_name -> round.v1.Outpoint
+	33, // 34: round.v1.SubmitForfeitSigRequest.signatures:type_name -> round.v1.BoardingInputSignature
+	3,  // 35: round.v1.ForfeitTxSig.vtxo_outpoint:type_name -> round.v1.Outpoint
+	35, // 36: round.v1.ForfeitTxSig.participant_sigs:type_name -> round.v1.ForfeitParticipantSig
+	36, // 37: round.v1.SubmitVTXOForfeitSigsRequest.forfeit_txs:type_name -> round.v1.ForfeitTxSig
+	6,  // 38: round.v1.ClientBatchInfo.VtxoTreePathsEntry.value:type_name -> round.v1.VTXOTree
+	7,  // 39: round.v1.ClientBatchInfo.ConnectorLeafMapEntry.value:type_name -> round.v1.ConnectorLeafInfo
+	30, // 40: round.v1.SubmitNoncesRequest.NoncesEntry.value:type_name -> round.v1.SignerNonces
+	32, // 41: round.v1.SubmitPartialSigRequest.SignaturesEntry.value:type_name -> round.v1.SignerPartialSigs
+	22, // 42: round.v1.RoundService.JoinRound:input_type -> round.v1.JoinRoundRequest
+	27, // 43: round.v1.RoundService.AcceptQuote:input_type -> round.v1.JoinRoundAccept
+	28, // 44: round.v1.RoundService.RejectQuote:input_type -> round.v1.JoinRoundReject
+	29, // 45: round.v1.RoundService.SubmitNonces:input_type -> round.v1.SubmitNoncesRequest
+	31, // 46: round.v1.RoundService.SubmitPartialSigs:input_type -> round.v1.SubmitPartialSigRequest
+	34, // 47: round.v1.RoundService.SubmitForfeitSigs:input_type -> round.v1.SubmitForfeitSigRequest
+	37, // 48: round.v1.RoundService.SubmitVTXOForfeitSigs:input_type -> round.v1.SubmitVTXOForfeitSigsRequest
+	38, // 49: round.v1.RoundService.QueryRoundStatus:input_type -> round.v1.QueryRoundStatusRequest
+	9,  // 50: round.v1.RoundService.JoinRound:output_type -> round.v1.ClientSuccessResp
+	9,  // 51: round.v1.RoundService.AcceptQuote:output_type -> round.v1.ClientSuccessResp
+	9,  // 52: round.v1.RoundService.RejectQuote:output_type -> round.v1.ClientSuccessResp
+	12, // 53: round.v1.RoundService.SubmitNonces:output_type -> round.v1.ClientVTXOAggNonces
+	13, // 54: round.v1.RoundService.SubmitPartialSigs:output_type -> round.v1.ClientVTXOAggSigs
+	11, // 55: round.v1.RoundService.SubmitForfeitSigs:output_type -> round.v1.ClientAwaitingInputSigsResp
+	9,  // 56: round.v1.RoundService.SubmitVTXOForfeitSigs:output_type -> round.v1.ClientSuccessResp
+	9,  // 57: round.v1.RoundService.QueryRoundStatus:output_type -> round.v1.ClientSuccessResp
+	50, // [50:58] is the sub-list for method output_type
+	42, // [42:50] is the sub-list for method input_type
+	42, // [42:42] is the sub-list for extension type_name
+	42, // [42:42] is the sub-list for extension extendee
+	0,  // [0:42] is the sub-list for field type_name
 }
 
 func init() { file_round_proto_init() }
@@ -3267,7 +3283,7 @@ func file_round_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_round_proto_rawDesc), len(file_round_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   45,
+			NumMessages:   46,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/roundpb/round.proto
+++ b/rpc/roundpb/round.proto
@@ -227,6 +227,10 @@ message ClientBatchInfo {
     // same value so both sides agree on how the round was conducted. Today
     // the only understood value is 1.
     uint32 flow_version = 10;
+
+    // asset_leaf_packages contains the sealed transfer package for each
+    // asset VTXO created for this client, keyed by VTXO outpoint.
+    map<string, bytes> asset_leaf_packages = 11;
 }
 
 // ClientAwaitingInputSigsResp notifies a client that the server is ready


### PR DESCRIPTION
## Summary

- carry sealed transfer packages keyed by each client asset leaf outpoint
- validate asset identity, amount, composed script, sealed package, and commitment root before signing
- use the validated tree path to derive each transaction’s Taproot signing tweak
- register and persist the composed output script for locally owned asset VTXOs
- isolate asset metadata for each extracted client path