### PR TITLE
unroll: defer sweeps without fee estimates

### DIFF
--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -28,7 +28,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   `ChainSource`, `Wallet` (`SweepWallet`),
   `LegacyProofScanFloor` (earliest compatible commitment block for the
   configured supported public network; zero keeps block 1),
-  `MaxSweepFeeRateSatPerVByte`, `FraudCheckpointSafetyMargin int32`
+  `MaxSweepFeeRateSatPerVByte`, `SweepFeeRateFallbackSatPerVByte`
+  (explicit caller fallback; zero defers unless the exit policy declares an
+  emergency rate for a competing spend),
+  `FraudCheckpointSafetyMargin int32`
   (overrides the fraud-triggered unroll backstop margin in blocks;
   zero falls back to the default), `RegistryRef`.
 - `behavior` — actor behavior implementing `actor.TxBehavior[Msg, Resp,
@@ -62,6 +65,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   `VTXOStore`, `TxConfirmRef`, `ChainSource`, `Wallet`,
   optional `LedgerSink`, `MaxSweepFeeRateSatPerVByte`,
   `LegacyProofScanFloor` (forwarded to every child),
+  `SweepFeeRateFallbackSatPerVByte`,
   `ExitSpendPolicyResolver` (optional; reconstructs the exit spend policy
   from `(ExitPolicyKind, ExitPolicyRef)` after restart; nil means every child
   uses the standard VTXO timeout), and optional `VTXOExitObserver`
@@ -269,6 +273,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   `b.sweepTx` is already set; every retry converges on the same
   sweep txid/pkScript and avoids burning BIP32 addresses on fee-spike
   retries.
+- **Estimate before construction.** A fee-estimator error leaves the actor in
+  `AwaitingSweepBroadcast` without deriving an address or consuming a sweep
+  attempt. The next height retries estimation. An explicitly configured local
+  network fallback or a policy-owned emergency rate permits construction
+  without a fresh estimate; vHTLC policies use the latter because another
+  valid leaf can race either recovery action.
 - **Reissue fails hard on missing state.** The
   `ReissueInFlightTransactions` and `ReissueSweepConfirmation`
   outbox branches return errors on a missing proof node or nil

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -28,7 +28,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   `ChainSource`, `Wallet` (`SweepWallet`),
   `LegacyProofScanFloor` (earliest compatible commitment block for the
   configured supported public network; zero keeps block 1),
-  `MaxSweepFeeRateSatPerVByte`, `FraudCheckpointSafetyMargin int32`
+  `MaxSweepFeeRateSatPerVByte`, `SweepFeeRateFallbackSatPerVByte`
+  (explicit caller fallback; zero defers unless the exit policy declares an
+  emergency rate for a competing spend),
+  `FraudCheckpointSafetyMargin int32`
   (overrides the fraud-triggered unroll backstop margin in blocks;
   zero falls back to the default), `RegistryRef`.
 - `behavior` — actor behavior implementing `actor.TxBehavior[Msg, Resp,
@@ -62,6 +65,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   `VTXOStore`, `TxConfirmRef`, `ChainSource`, `Wallet`,
   optional `LedgerSink`, `MaxSweepFeeRateSatPerVByte`,
   `LegacyProofScanFloor` (forwarded to every child),
+  `SweepFeeRateFallbackSatPerVByte`,
   `ExitSpendPolicyResolver` (optional; reconstructs the exit spend policy
   from `(ExitPolicyKind, ExitPolicyRef)` after restart; nil means every child
   uses the standard VTXO timeout), and optional `VTXOExitObserver`
@@ -269,6 +273,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   `b.sweepTx` is already set; every retry converges on the same
   sweep txid/pkScript and avoids burning BIP32 addresses on fee-spike
   retries.
+- **Estimate before construction.** A fee-estimator error leaves the actor in
+  `AwaitingSweepBroadcast` without deriving an address or consuming a sweep
+  attempt. The next height retries estimation. An explicitly configured local
+  network fallback or a policy-owned emergency rate permits construction
+  without a fresh estimate; vHTLC policies use the latter because another
+  valid leaf can race either recovery action.
 - **Reissue fails hard on missing state.** The
   `ReissueInFlightTransactions` and `ReissueSweepConfirmation`
   outbox branches return errors on a missing proof node or nil

--- a/unroll/README.md
+++ b/unroll/README.md
@@ -137,6 +137,14 @@ same sweep tx is restored, so:
 - A crash between build and broadcast cannot cause a third sweep to
   emerge from the ashes.
 
+Sweep construction starts only after chainsource returns a usable fee
+estimate. A temporary estimator failure leaves the actor in
+`AwaitingSweepBroadcast` with no sweep transaction and no consumed retry
+attempt; the next height retries. Regtest and simnet callers may opt into an
+explicit fixed fallback rate. A race-sensitive exit policy may also declare an
+emergency rate; vHTLC claim and refund policies do this because another valid
+leaf can spend the same output after its timing conditions mature.
+
 ```mermaid
 sequenceDiagram
     participant FSM

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -63,6 +63,12 @@ type Config struct {
 	// MaxSweepFeeRateSatPerVByte clamps pathological fee estimates.
 	MaxSweepFeeRateSatPerVByte int64
 
+	// SweepFeeRateFallbackSatPerVByte is used only when fee estimation
+	// fails. Zero lets the exit policy choose whether to defer or use its
+	// own emergency rate. A positive value overrides the policy and is
+	// intended for controlled local networks.
+	SweepFeeRateFallbackSatPerVByte int64
+
 	// FraudCheckpointSafetyMargin overrides the recipient backstop
 	// margin (in blocks) for fraud-triggered unroll jobs. Zero falls
 	// back to defaultFraudCheckpointSafetyMargin. Plumbed onto the
@@ -476,10 +482,11 @@ func (b *behavior) driveEvent(ctx context.Context, ax actor.Exec[unrollTx],
 // transaction materializes from the checkpoint, txconfirm sees the same
 // txid it has been tracking, and the Ask resolves as a benign no-op.
 //
-// If buildSweepTx itself fails (fee estimation, signing, malformed
-// descriptor), we drive a SweepBuildFailedEvent through the FSM so the
-// retry budget is accounted for and we reach terminal Failed after
-// maxSweepAttempts.
+// A temporarily unavailable fee estimate defers construction until the next
+// height without consuming the retry budget. Other build failures (signing,
+// malformed descriptor, or an invalid estimate) drive a SweepBuildFailedEvent
+// through the FSM so the retry budget is accounted for and the job reaches
+// terminal Failed after maxSweepAttempts.
 func (b *behavior) startSweep(ctx context.Context,
 	ax actor.Exec[unrollTx]) error {
 
@@ -580,7 +587,8 @@ func (b *behavior) startSweep(ctx context.Context,
 
 		sweepTx, err := buildSweepTx(
 			ctx, b.cfg.Wallet, b.cfg.ChainSource, b.proof, b.desc,
-			b.cfg.MaxSweepFeeRateSatPerVByte, b.currentHeight(),
+			b.cfg.MaxSweepFeeRateSatPerVByte,
+			b.sweepFeeRateFallback(policy), b.currentHeight(),
 			policy,
 		)
 		if err != nil {
@@ -597,6 +605,24 @@ func (b *behavior) startSweep(ctx context.Context,
 						"target_outpoint",
 						b.cfg.TargetOutpoint.
 							String(),
+					),
+					slog.String("err", err.Error()),
+				)
+
+				return nil
+			}
+
+			// An estimator outage is not a failed sweep attempt: no
+			// transaction or wallet destination exists yet. Leave
+			// the planner in AwaitingSweepBroadcast so the next
+			// height asks for a fresh estimate.
+			var feeEstimateErr *sweepFeeEstimateUnavailableError
+			if errors.As(err, &feeEstimateErr) {
+				b.log.InfoS(ctx, "Deferring unroll exit spend: "+
+					"fee estimate unavailable",
+					slog.String(
+						"target_outpoint",
+						b.cfg.TargetOutpoint.String(),
 					),
 					slog.String("err", err.Error()),
 				)
@@ -660,6 +686,16 @@ func (b *behavior) startSweep(ctx context.Context,
 	}
 
 	return b.driveEvent(ctx, ax, &SweepBroadcastedEvent{Txid: sweepTxid})
+}
+
+// sweepFeeRateFallback prefers the daemon-level local-network fallback, then
+// lets a race-sensitive exit policy declare its own emergency rate.
+func (b *behavior) sweepFeeRateFallback(policy ExitSpendPolicy) int64 {
+	if b.cfg.SweepFeeRateFallbackSatPerVByte > 0 {
+		return b.cfg.SweepFeeRateFallbackSatPerVByte
+	}
+
+	return policy.FeeEstimateFallbackSatPerVByte()
 }
 
 // exitPolicyKind returns the durable policy kind for the current job.

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -419,6 +419,7 @@ type fakeChainSourceRef struct {
 	bestHeight  int32
 	feeRate     int64
 	feeErr      error
+	feeRequests int
 	blockRef    actor.TellOnlyRef[chainsource.BlockEpoch]
 	spendRefs   map[wire.OutPoint]spendEventRef
 	spendRegs   []wire.OutPoint
@@ -487,17 +488,22 @@ func (f *fakeChainSourceRef) Ask(_ context.Context,
 		)
 
 	case *chainsource.FeeEstimateRequest:
-		if f.feeErr != nil {
+		f.mu.Lock()
+		feeRate := f.feeRate
+		feeErr := f.feeErr
+		f.feeRequests++
+		f.mu.Unlock()
+
+		if feeErr != nil {
 			promise.Complete(
 				fn.Err[chainsource.ChainSourceResp](
-					f.feeErr,
+					feeErr,
 				),
 			)
 
 			return promise.Future()
 		}
 
-		feeRate := f.feeRate
 		if feeRate == 0 {
 			feeRate = 5
 		}
@@ -606,6 +612,23 @@ func (f *fakeChainSourceRef) Ask(_ context.Context,
 	return promise.Future()
 }
 
+// setFeeEstimate updates the estimator result returned by subsequent Asks.
+func (f *fakeChainSourceRef) setFeeEstimate(feeRate int64, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.feeRate = feeRate
+	f.feeErr = err
+}
+
+// feeRequestCount returns how many fee estimates the actor requested.
+func (f *fakeChainSourceRef) feeRequestCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.feeRequests
+}
+
 // confWatchCount returns the number of registered confirmation watches.
 func (f *fakeChainSourceRef) confWatchCount() int {
 	f.mu.Lock()
@@ -709,11 +732,20 @@ func (f *fakeChainSourceRef) removedTxSnapshot() []chainhash.Hash {
 }
 
 // fakeSweepWallet is a minimal signer plus wallet-destination test double.
-type fakeSweepWallet struct{}
+type fakeSweepWallet struct {
+	pkScriptRequests atomic.Int64
+}
 
 // NewWalletPkScript returns a deterministic destination script.
 func (w *fakeSweepWallet) NewWalletPkScript(context.Context) ([]byte, error) {
+	w.pkScriptRequests.Add(1)
+
 	return []byte{txscript.OP_TRUE}, nil
+}
+
+// pkScriptRequestCount returns how many destination scripts were derived.
+func (w *fakeSweepWallet) pkScriptRequestCount() int64 {
+	return w.pkScriptRequests.Load()
 }
 
 // SignOutputRaw returns a dummy schnorr signature.
@@ -3156,7 +3188,7 @@ func TestResumeReissuesSweepConfirmation(t *testing.T) {
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
 	sweepTx, err := buildSweepTx(
 		t.Context(), &fakeSweepWallet{}, &fakeChainSourceRef{}, proof,
-		desc, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
+		desc, 0, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
 	)
 	require.NoError(t, err)
 
@@ -3230,6 +3262,94 @@ func TestResumeReissuesSweepConfirmation(t *testing.T) {
 	}, testTimeout, 10*time.Millisecond)
 }
 
+// TestResumeRetriesDeferredSweepBuild verifies a checkpoint that has reached
+// sweep construction without persisting a transaction retries estimation on
+// restart instead of taking the persisted-sweep confirmation branch.
+func TestResumeRetriesDeferredSweepBuild(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	txconfirmRef := &fakeTxConfirmRef{}
+	store := newMemCheckpointStore()
+	chainSource := &fakeChainSourceRef{}
+	chainSource.setFeeEstimate(0, fmt.Errorf("estimator unavailable"))
+	wallet := &fakeSweepWallet{}
+
+	raw, err := encodeCheckpoint(&actorCheckpoint{
+		Version: checkpointVersion,
+		Height:  104,
+		Started: true,
+		Trigger: TriggerRestart,
+		State: unrollplan.State{
+			ConfirmedTxids: []chainhash.Hash{
+				proof.RootTxids()[0],
+				proof.TargetOutpoint().Hash,
+			},
+			TargetConfirmHeight: fn.Some[int32](102),
+		},
+	})
+	require.NoError(t, err)
+
+	err = store.SaveCheckpoint(t.Context(), actor.CheckpointParams{
+		ActorID:   "resume-deferred-sweep-test",
+		StateType: checkpointStateType,
+		StateData: raw,
+		Version:   checkpointVersion,
+	})
+	require.NoError(t, err)
+
+	cfg := Config{
+		TargetOutpoint: proof.TargetOutpoint(),
+		ActorID:        "resume-deferred-sweep-test",
+		DeliveryStore:  store,
+		ProofAssembler: &mockProofAssembler{
+			proof: proof,
+		},
+		VTXOStore: &mockVTXOStore{
+			desc: desc,
+		},
+		TxConfirmRef: txconfirmRef,
+		ChainSource:  chainSource,
+		Wallet:       wallet,
+		Log:          fn.Some(btclog.Disabled),
+	}
+	resumeBehavior := &behavior{cfg: cfg, log: btclog.Disabled}
+	err = resumeBehavior.restoreCheckpoint(t.Context())
+	require.NoError(t, err)
+
+	resumedActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
+		ID:          cfg.ActorID,
+		Behavior:    adaptTx(resumeBehavior),
+		MailboxSize: 64,
+	})
+	resumeBehavior.selfRef = resumedActor.TellRef()
+	resumedActor.Start()
+	t.Cleanup(resumedActor.Stop)
+
+	mustAsk(t, resumedActor.Ref(), &ResumeUnrollRequest{Height: 105})
+
+	stateResp, ok := mustAsk(
+		t, resumedActor.Ref(), &GetStateRequest{},
+	).(*GetStateResp)
+	require.True(t, ok)
+	require.Equal(t, PhaseSweepBroadcast, stateResp.Phase)
+	require.Equal(t, 1, chainSource.feeRequestCount())
+	require.Equal(t, int64(0), wallet.pkScriptRequestCount())
+	require.Equal(t, 0, txconfirmRef.requestCount())
+
+	checkpoint := mustDecodeCheckpoint(t, store, cfg.ActorID)
+	require.Nil(t, checkpoint.SweepTx)
+	require.Equal(t, 0, checkpoint.SweepAttempts)
+
+	chainSource.setFeeEstimate(7, nil)
+	mustAsk(t, resumedActor.Ref(), &HeightObservedMsg{Height: 106})
+
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() == 1
+	}, testTimeout, 10*time.Millisecond)
+	require.Equal(t, 2, chainSource.feeRequestCount())
+	require.Equal(t, int64(1), wallet.pkScriptRequestCount())
+}
+
 // TestBuildSweepTx verifies the copied sweep-construction helper works without
 // importing the legacy unroller package.
 func TestBuildSweepTx(t *testing.T) {
@@ -3238,7 +3358,7 @@ func TestBuildSweepTx(t *testing.T) {
 
 	sweepTx, err := buildSweepTx(
 		t.Context(), &fakeSweepWallet{}, &fakeChainSourceRef{}, proof,
-		desc, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
+		desc, 0, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
 	)
 	require.NoError(t, err)
 	require.Len(t, sweepTx.TxIn, 1)
@@ -3327,25 +3447,198 @@ func TestStandardExitSpendPolicyResolver(t *testing.T) {
 	require.Contains(t, err.Error(), "unknown exit policy kind")
 }
 
-// TestBuildSweepTxFallsBackWithoutFeeEstimate verifies the sweep builder uses
-// the regtest fallback fee when the backend has no estimate available yet.
-func TestBuildSweepTxFallsBackWithoutFeeEstimate(t *testing.T) {
+// TestBuildSweepTxUsesConfiguredFeeFallback verifies controlled regtest or
+// test callers can explicitly supply a fixed rate when the backend has no
+// estimate available yet.
+func TestBuildSweepTxUsesConfiguredFeeFallback(t *testing.T) {
 	proof := buildLinearProof(t)
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	const fallbackFeeRateSatPerVByte int64 = 2
 
 	sweepTx, err := buildSweepTx(
 		t.Context(), &fakeSweepWallet{}, &fakeChainSourceRef{
 			feeErr: fmt.Errorf("no fee estimates available"),
-		}, proof, desc, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
+		}, proof, desc, 0, fallbackFeeRateSatPerVByte, 110,
+		NewStandardVTXOExitSpendPolicy(desc),
 	)
 	require.NoError(t, err)
 
 	targetOutput, err := proof.TargetOutput()
 	require.NoError(t, err)
 
-	expectedFee := defaultSweepFallbackFeeRateSatPerVByte *
-		estimatedSweepVBytes
+	expectedFee := fallbackFeeRateSatPerVByte * estimatedSweepVBytes
 	require.Equal(t, targetOutput.Value-expectedFee, sweepTx.TxOut[0].Value)
+}
+
+// fallbackExitSpendPolicy models a policy whose spend competes with another
+// valid leaf and therefore must construct a transaction even when estimation
+// is temporarily unavailable.
+type fallbackExitSpendPolicy struct {
+	*StandardVTXOExitSpendPolicy
+}
+
+// Kind returns a non-standard durable policy identity.
+func (p *fallbackExitSpendPolicy) Kind() ExitPolicyKind {
+	return "test_race_sensitive"
+}
+
+// FeeEstimateFallbackSatPerVByte returns the policy-owned emergency rate.
+func (p *fallbackExitSpendPolicy) FeeEstimateFallbackSatPerVByte() int64 {
+	return 2
+}
+
+// fixedExitSpendPolicyResolver returns one policy for actor-boundary tests.
+type fixedExitSpendPolicyResolver struct {
+	policy ExitSpendPolicy
+}
+
+// ResolveExitSpendPolicy returns the configured policy.
+func (r *fixedExitSpendPolicyResolver) ResolveExitSpendPolicy(context.Context,
+	ExitSpendPolicyRequest) (ExitSpendPolicy, error) {
+
+	return r.policy, nil
+}
+
+// TestRaceSensitivePolicyUsesFeeEstimateFallback verifies a policy can opt
+// into an emergency rate when waiting would leave a competing spend path live.
+func TestRaceSensitivePolicyUsesFeeEstimateFallback(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, behavior, txconfirmRef, store := newActorHarness(
+		t, proof, desc,
+	)
+
+	standardPolicy := NewStandardVTXOExitSpendPolicy(desc)
+	policy := &fallbackExitSpendPolicy{standardPolicy}
+	behavior.cfg.ExitSpendPolicyResolver = &fixedExitSpendPolicyResolver{
+		policy: policy,
+	}
+	chainSource, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	chainSource.setFeeEstimate(0, fmt.Errorf("estimator unavailable"))
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:         100,
+		Trigger:        TriggerManual,
+		ExitPolicyKind: policy.Kind(),
+		ExitPolicyRef:  "race-sensitive-test",
+	})
+	txconfirmRef.emitConfirmed(t, 0, proof.RootTxids()[0], 101)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() == 2
+	}, testTimeout, 10*time.Millisecond)
+	txconfirmRef.emitConfirmed(t, 1, proof.TargetOutpoint().Hash, 102)
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: 104})
+
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() == 3
+	}, testTimeout, 10*time.Millisecond)
+	checkpoint := mustDecodeCheckpoint(t, store, "unroll-test")
+	require.NotNil(t, checkpoint.SweepTx)
+	require.Equal(t, 0, checkpoint.SweepAttempts)
+}
+
+// TestSweepDefersWhenFeeEstimateUnavailable verifies a transient estimator
+// outage leaves the exit non-terminal without deriving, persisting, or
+// submitting an anchorless sweep. A later height retries estimation and builds
+// exactly one sweep after the estimator recovers.
+func TestSweepDefersWhenFeeEstimateUnavailable(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, behavior, txconfirmRef, store := newActorHarness(
+		t, proof, desc,
+	)
+
+	chainSource, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	chainSource.setFeeEstimate(0, fmt.Errorf("estimator unavailable"))
+
+	wallet, ok := behavior.cfg.Wallet.(*fakeSweepWallet)
+	require.True(t, ok)
+
+	var logBuf bytes.Buffer
+	logger := btclog.NewSLogger(btclog.NewDefaultHandler(&logBuf))
+	logger.SetLevel(btclog.LevelInfo)
+	behavior.log = logger
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+	txconfirmRef.emitConfirmed(t, 0, proof.RootTxids()[0], 101)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() == 2
+	}, testTimeout, 10*time.Millisecond)
+	txconfirmRef.emitConfirmed(t, 1, proof.TargetOutpoint().Hash, 102)
+
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: 104})
+
+	stateResp, ok := mustAsk(
+		t, unrollActor.Ref(), &GetStateRequest{},
+	).(*GetStateResp)
+	require.True(t, ok)
+	require.Equal(t, PhaseSweepBroadcast, stateResp.Phase)
+	require.Equal(t, 2, txconfirmRef.requestCount())
+	require.Equal(t, 1, chainSource.feeRequestCount())
+	require.Equal(t, int64(0), wallet.pkScriptRequestCount())
+	require.Contains(
+		t, logBuf.String(),
+		"Deferring unroll exit spend: fee estimate unavailable",
+	)
+
+	checkpoint := mustDecodeCheckpoint(t, store, "unroll-test")
+	require.Nil(t, checkpoint.SweepTx)
+	require.Equal(t, 0, checkpoint.SweepAttempts)
+	require.Empty(t, checkpoint.Fail)
+
+	chainSource.setFeeEstimate(7, nil)
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: 105})
+
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() == 3
+	}, testTimeout, 10*time.Millisecond)
+	require.Equal(t, 2, chainSource.feeRequestCount())
+	require.Equal(t, int64(1), wallet.pkScriptRequestCount())
+
+	checkpoint = mustDecodeCheckpoint(t, store, "unroll-test")
+	require.NotNil(t, checkpoint.SweepTx)
+	require.Equal(t, 0, checkpoint.SweepAttempts)
+}
+
+// TestSweepBroadcastRetryReusesCachedTxWithoutFeeEstimate verifies estimator
+// availability no longer matters after a sweep is persisted. A txconfirm
+// failure consumes the existing retry budget and resubmits the same txid
+// without deriving a new destination or asking for a replacement fee.
+func TestSweepBroadcastRetryReusesCachedTxWithoutFeeEstimate(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, behavior, txconfirmRef, store := newActorHarness(
+		t, proof, desc,
+	)
+
+	chainSource, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	wallet, ok := behavior.cfg.Wallet.(*fakeSweepWallet)
+	require.True(t, ok)
+
+	sweepTxid := driveLinearToSweep(
+		t, unrollActor.Ref(), txconfirmRef, store, proof,
+	)
+	require.Equal(t, 1, chainSource.feeRequestCount())
+	require.Equal(t, int64(1), wallet.pkScriptRequestCount())
+
+	chainSource.setFeeEstimate(0, fmt.Errorf("estimator unavailable"))
+	txconfirmRef.emitFailed(t, 2, sweepTxid, "broadcast rejected")
+
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() == 4
+	}, testTimeout, 10*time.Millisecond)
+	require.Equal(t, sweepTxid, txconfirmRef.lastRequest(t).Tx.TxHash())
+	require.Equal(t, 1, chainSource.feeRequestCount())
+	require.Equal(t, int64(1), wallet.pkScriptRequestCount())
+
+	checkpoint := mustDecodeCheckpoint(t, store, "unroll-test")
+	require.Equal(t, 1, checkpoint.SweepAttempts)
 }
 
 // TestSweepConfirmationCompletesActor verifies that confirming the final sweep
@@ -4191,7 +4484,7 @@ func TestUnrollAdoptStagedSweepReusesPersisted(t *testing.T) {
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
 	sweepTx, err := buildSweepTx(
 		t.Context(), &fakeSweepWallet{}, &fakeChainSourceRef{}, proof,
-		desc, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
+		desc, 0, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
 	)
 	require.NoError(t, err)
 	sweepTxid := sweepTx.TxHash()

--- a/unroll/interfaces.go
+++ b/unroll/interfaces.go
@@ -119,6 +119,12 @@ type ExitSpendPolicy interface {
 	// non-final transaction that the mempool will reject.
 	RequiredLockTime() uint32
 
+	// FeeEstimateFallbackSatPerVByte returns the emergency fixed fee rate
+	// to use when estimation is unavailable, or zero to defer construction.
+	// A policy should return a positive value only when another valid spend
+	// path can race it and waiting is less safe than using a low fee.
+	FeeEstimateFallbackSatPerVByte() int64
+
 	// ValidateTarget verifies this policy can spend the materialized target
 	// output.
 	ValidateTarget(target *wire.TxOut) error

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -146,6 +146,11 @@ type RegistryConfig struct {
 	// MaxSweepFeeRateSatPerVByte clamps pathological fee estimates.
 	MaxSweepFeeRateSatPerVByte int64
 
+	// SweepFeeRateFallbackSatPerVByte is forwarded to child actors as an
+	// explicit estimator-error fallback. Zero lets each child's exit policy
+	// choose whether to defer or use its own emergency rate.
+	SweepFeeRateFallbackSatPerVByte int64
+
 	// ExitSpendPolicyResolver reconstructs the exit policy for each
 	// spawned child from the durable (ExitPolicyKind, ExitPolicyRef)
 	// identity persisted on the unroll job. If nil, every child uses
@@ -1485,16 +1490,18 @@ func (r *registryBehavior) validateResolverCoversRecords(
 // up a durable mailbox.
 func (r *registryBehavior) childConfig(target wire.OutPoint) Config {
 	return Config{
-		TargetOutpoint:              target,
-		DeliveryStore:               r.cfg.DeliveryStore,
-		ProofAssembler:              r.cfg.ProofAssembler,
-		VTXOStore:                   r.cfg.VTXOStore,
-		TxConfirmRef:                r.cfg.TxConfirmRef,
-		ChainSource:                 r.cfg.ChainSource,
-		Wallet:                      r.cfg.Wallet,
-		LedgerSink:                  r.cfg.LedgerSink,
-		Log:                         r.cfg.Log,
-		MaxSweepFeeRateSatPerVByte:  r.cfg.MaxSweepFeeRateSatPerVByte,
+		TargetOutpoint:             target,
+		DeliveryStore:              r.cfg.DeliveryStore,
+		ProofAssembler:             r.cfg.ProofAssembler,
+		VTXOStore:                  r.cfg.VTXOStore,
+		TxConfirmRef:               r.cfg.TxConfirmRef,
+		ChainSource:                r.cfg.ChainSource,
+		Wallet:                     r.cfg.Wallet,
+		LedgerSink:                 r.cfg.LedgerSink,
+		Log:                        r.cfg.Log,
+		MaxSweepFeeRateSatPerVByte: r.cfg.MaxSweepFeeRateSatPerVByte,
+		SweepFeeRateFallbackSatPerVByte: r.cfg.
+			SweepFeeRateFallbackSatPerVByte,
 		ExitSpendPolicyResolver:     r.cfg.ExitSpendPolicyResolver,
 		FraudCheckpointSafetyMargin: r.cfg.FraudCheckpointSafetyMargin,
 		LegacyProofScanFloor:        r.cfg.LegacyProofScanFloor,

--- a/unroll/registry_test.go
+++ b/unroll/registry_test.go
@@ -432,7 +432,9 @@ func newRegistryHarnessWithSpawn(t *testing.T,
 			Wallet:                     cfg.Wallet,
 			RegistryRef:                registryActor.TellRef(),
 			MaxSweepFeeRateSatPerVByte: maxFee,
-			ExitSpendPolicyResolver:    cfg.ExitSpendPolicyResolver,
+			SweepFeeRateFallbackSatPerVByte: cfg.
+				SweepFeeRateFallbackSatPerVByte,
+			ExitSpendPolicyResolver: cfg.ExitSpendPolicyResolver,
 		}
 		childBehavior := &behavior{
 			cfg: childCfg,
@@ -2020,10 +2022,12 @@ func (r *recordingExitSpendPolicyResolver) ResolveExitSpendPolicy(
 // kind (e.g. vhtlc_claim) fails closed at sweep time.
 func TestRegistryForwardsExitSpendPolicyResolver(t *testing.T) {
 	resolver := &recordingExitSpendPolicyResolver{}
+	const fallbackFeeRate int64 = 2
 
 	r := &registryBehavior{
 		cfg: RegistryConfig{
-			ExitSpendPolicyResolver: resolver,
+			ExitSpendPolicyResolver:         resolver,
+			SweepFeeRateFallbackSatPerVByte: fallbackFeeRate,
 		},
 	}
 
@@ -2035,6 +2039,9 @@ func TestRegistryForwardsExitSpendPolicyResolver(t *testing.T) {
 		childCfg.ExitSpendPolicyResolver,
 	)
 	require.Equal(t, target, childCfg.TargetOutpoint)
+	require.Equal(
+		t, fallbackFeeRate, childCfg.SweepFeeRateFallbackSatPerVByte,
+	)
 }
 
 // TestRegistryChildResolverDefaultsToNil documents the safe default: when

--- a/unroll/sweep.go
+++ b/unroll/sweep.go
@@ -22,13 +22,26 @@ const (
 	// timeout-path sweep spend.
 	estimatedSweepVBytes = 200
 
-	// defaultSweepFallbackFeeRateSatPerVByte is used when fee estimation is
-	// temporarily unavailable on regtest or a cold backend.
-	defaultSweepFallbackFeeRateSatPerVByte int64 = 2
-
 	// defaultMaxSweepFeeRateSatPerVByte clamps pathological fee estimates.
 	defaultMaxSweepFeeRateSatPerVByte int64 = 100
 )
+
+// sweepFeeEstimateUnavailableError marks a temporary estimator failure.
+// Callers must defer construction unless they explicitly supplied a fallback
+// rate, because an anchorless sweep cannot be fee-bumped later.
+type sweepFeeEstimateUnavailableError struct {
+	cause error
+}
+
+// Error describes the estimator failure that prevented sweep construction.
+func (e *sweepFeeEstimateUnavailableError) Error() string {
+	return fmt.Sprintf("sweep fee estimate unavailable: %v", e.cause)
+}
+
+// Unwrap exposes the original chainsource error for diagnostics.
+func (e *sweepFeeEstimateUnavailableError) Unwrap() error {
+	return e.cause
+}
 
 // StandardVTXOExitSpendPolicy builds the normal timeout-path sweep used by
 // standard Ark VTXOs.
@@ -95,6 +108,12 @@ func (p *StandardVTXOExitSpendPolicy) CSVDelay() uint32 {
 // RequiredLockTime returns zero. The standard timeout-path sweep has no
 // absolute locktime gate.
 func (p *StandardVTXOExitSpendPolicy) RequiredLockTime() uint32 {
+	return 0
+}
+
+// FeeEstimateFallbackSatPerVByte returns zero so an estimator outage defers a
+// standard timeout sweep. No competing spend path can claim that output.
+func (p *StandardVTXOExitSpendPolicy) FeeEstimateFallbackSatPerVByte() int64 {
 	return 0
 }
 
@@ -227,15 +246,18 @@ func (p *StandardVTXOExitSpendPolicy) BuildSpendTx(ctx context.Context,
 	return sweepTx, nil
 }
 
-// estimateSweepFeeRate asks chainsource for a 6-block fee estimate and
-// clamps it to a sane range.
+// estimateSweepFeeRate asks chainsource for a 6-block fee estimate and clamps
+// it to a sane range. An estimator error is classified as temporarily
+// unavailable unless fallbackFeeRate is positive. The explicit fallback is
+// intended for controlled tests and regtest environments where blocks can be
+// mined on demand; production callers leave it zero so they can retry later.
 //
 // Three failure modes are handled:
 //
-//   - Ask error (chainsource unavailable or estimator cold): fall back
-//     to a small fixed rate so regtest / fresh-sync daemons can still
-//     produce a plausible sweep. This fallback is clamped so it never
-//     exceeds maxFeeRate.
+//   - Ask error (chainsource unavailable or estimator cold): use a positive,
+//     explicitly configured fallback or return
+//     sweepFeeEstimateUnavailableError. A configured fallback is clamped so
+//     it never exceeds maxFeeRate.
 //
 //   - Non-positive estimate: reject with an error. A zero-rate sweep
 //     would be rejected by every node, so pretending is worse than
@@ -248,7 +270,7 @@ func (p *StandardVTXOExitSpendPolicy) BuildSpendTx(ctx context.Context,
 func estimateSweepFeeRate(ctx context.Context,
 	chainSource actor.ActorRef[
 		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
-	], maxFeeRate int64) (int64, error) {
+	], maxFeeRate, fallbackFeeRate int64) (int64, error) {
 
 	if maxFeeRate <= 0 {
 		maxFeeRate = defaultMaxSweepFeeRateSatPerVByte
@@ -258,7 +280,12 @@ func estimateSweepFeeRate(ctx context.Context,
 		ctx, &chainsource.FeeEstimateRequest{TargetConf: 6},
 	).Await(ctx).Unpack()
 	if err != nil {
-		fallbackFeeRate := defaultSweepFallbackFeeRateSatPerVByte
+		if fallbackFeeRate <= 0 {
+			return 0, &sweepFeeEstimateUnavailableError{
+				cause: err,
+			}
+		}
+
 		if fallbackFeeRate > maxFeeRate {
 			fallbackFeeRate = maxFeeRate
 		}
@@ -289,8 +316,8 @@ func buildSweepTx(ctx context.Context, wallet SweepWallet,
 	chainSource actor.ActorRef[
 		chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
 	], proof *recovery.Proof,
-	desc *vtxo.Descriptor, maxFeeRate int64, currentHeight int32,
-	policy ExitSpendPolicy) (*wire.MsgTx, error) {
+	desc *vtxo.Descriptor, maxFeeRate, fallbackFeeRate int64,
+	currentHeight int32, policy ExitSpendPolicy) (*wire.MsgTx, error) {
 
 	if wallet == nil {
 		return nil, fmt.Errorf("sweep wallet must be provided")
@@ -317,7 +344,9 @@ func buildSweepTx(ctx context.Context, wallet SweepWallet,
 		return nil, err
 	}
 
-	feeRate, err := estimateSweepFeeRate(ctx, chainSource, maxFeeRate)
+	feeRate, err := estimateSweepFeeRate(
+		ctx, chainSource, maxFeeRate, fallbackFeeRate,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("estimate fee: %w", err)
 	}

--- a/vhtlcrecovery/unrollpolicy/AGENTS.md
+++ b/vhtlcrecovery/unrollpolicy/AGENTS.md
@@ -52,6 +52,10 @@ parent package.
   `ExitSpendRequest.CurrentHeight` has not reached `RequiredLockTime`; the
   failure is signaled with `unroll.ErrExitSpendNotMatured` so the unroll FSM
   can defer broadcast instead of looping on a non-final transaction.
+- `FeeEstimateFallbackSatPerVByte` returns the historical 2 sat/vB emergency
+  rate. Both vHTLC recovery actions race another valid leaf after their timing
+  conditions mature, so attempting broadcast is safer than waiting for an
+  estimator indefinitely.
 - The wrapping VTXO descriptor's `RelativeExpiry` must be greater than or
   equal to the policy's `CSVDelay` for the leaf being spent. Violated invariant
   causes the unroll actor to fail fast.

--- a/vhtlcrecovery/unrollpolicy/CLAUDE.md
+++ b/vhtlcrecovery/unrollpolicy/CLAUDE.md
@@ -52,6 +52,10 @@ parent package.
   `ExitSpendRequest.CurrentHeight` has not reached `RequiredLockTime`; the
   failure is signaled with `unroll.ErrExitSpendNotMatured` so the unroll FSM
   can defer broadcast instead of looping on a non-final transaction.
+- `FeeEstimateFallbackSatPerVByte` returns the historical 2 sat/vB emergency
+  rate. Both vHTLC recovery actions race another valid leaf after their timing
+  conditions mature, so attempting broadcast is safer than waiting for an
+  estimator indefinitely.
 - The wrapping VTXO descriptor's `RelativeExpiry` must be greater than or
   equal to the policy's `CSVDelay` for the leaf being spent. Violated invariant
   causes the unroll actor to fail fast.

--- a/vhtlcrecovery/unrollpolicy/policy.go
+++ b/vhtlcrecovery/unrollpolicy/policy.go
@@ -24,6 +24,12 @@ const (
 	// before broadcast, so exact fee accounting can be refined in a later
 	// worker pass without changing restart safety.
 	estimatedVHTLCExitVBytes = 260
+
+	// fallbackVHTLCExitFeeRateSatPerVByte preserves a broadcast attempt
+	// when the estimator is unavailable. Both vHTLC recovery actions race
+	// another valid leaf after their timing conditions mature, so waiting
+	// is less safe than using the historical low-fee fallback.
+	fallbackVHTLCExitFeeRateSatPerVByte int64 = 2
 )
 
 // RecoveryJobLoader loads a durable recovery job by id.
@@ -323,6 +329,13 @@ func (p *VHTLCExitSpendPolicy) RequiredLockTime() uint32 {
 	}
 
 	return p.spendPath.RequiredLockTime
+}
+
+// FeeEstimateFallbackSatPerVByte returns the emergency rate used when the
+// estimator is unavailable. Both the receiver claim and sender refund actions
+// race another valid vHTLC leaf, so they must attempt broadcast once spendable.
+func (p *VHTLCExitSpendPolicy) FeeEstimateFallbackSatPerVByte() int64 {
+	return fallbackVHTLCExitFeeRateSatPerVByte
 }
 
 // ValidateTarget verifies the materialized output matches the vHTLC policy.

--- a/vhtlcrecovery/unrollpolicy/policy_test.go
+++ b/vhtlcrecovery/unrollpolicy/policy_test.go
@@ -187,6 +187,31 @@ func TestClaimExitSpendPolicyRequiredLockTimeZero(t *testing.T) {
 	require.Zero(t, policy.RequiredLockTime())
 }
 
+// TestVHTLCExitSpendPolicyDeclaresEmergencyFeeFallback verifies both recovery
+// actions retain a broadcast attempt when fee estimation is unavailable.
+func TestVHTLCExitSpendPolicyDeclaresEmergencyFeeFallback(t *testing.T) {
+	claimJob, preimage, _, _ := testPolicyJob(
+		t, vhtlcrecovery.ActionClaim,
+	)
+	claimPolicy, err := NewClaimExitSpendPolicy(claimJob, preimage)
+	require.NoError(t, err)
+
+	refundJob, _, _, _ := testPolicyJob(
+		t, vhtlcrecovery.ActionRefundWithoutReceiver,
+	)
+	refundPolicy, err := NewRefundWithoutReceiverExitSpendPolicy(
+		refundJob,
+	)
+	require.NoError(t, err)
+
+	require.Equal(
+		t, int64(2), claimPolicy.FeeEstimateFallbackSatPerVByte(),
+	)
+	require.Equal(
+		t, int64(2), refundPolicy.FeeEstimateFallbackSatPerVByte(),
+	)
+}
+
 // TestVHTLCExitSpendPolicyRejectsWrongTarget verifies the policy refuses to
 // spend a materialized output whose pkScript does not match the vHTLC recovered
 // from durable recovery columns.

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -250,6 +250,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   resolves them from the committed attempt.
 - `Unroll` / `GetUnrollStatus` return `codes.Unavailable` (not `Internal`)
   when the unroll subsystem refs are not yet set, so clients can retry.
+- `initUnrollSubsystem` configures a fixed 2 sat/vB exit-sweep fallback only
+  on regtest and simnet. Public networks pass zero, so a standard-policy
+  estimator outage leaves the actor waiting for the next height instead of
+  caching an anchorless sweep that cannot be fee-bumped. Race-sensitive
+  policies can still declare their own emergency fallback.
 - `Unroll` must set `ForceUnrollRequest.Trigger` explicitly to
   `actormsg.UnrollTriggerManual`. The zero value admits as
   `UnrollTriggerCriticalExpiry`, so omitting it records a hand-typed unroll as

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -250,6 +250,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   resolves them from the committed attempt.
 - `Unroll` / `GetUnrollStatus` return `codes.Unavailable` (not `Internal`)
   when the unroll subsystem refs are not yet set, so clients can retry.
+- `initUnrollSubsystem` configures a fixed 2 sat/vB exit-sweep fallback only
+  on regtest and simnet. Public networks pass zero, so a standard-policy
+  estimator outage leaves the actor waiting for the next height instead of
+  caching an anchorless sweep that cannot be fee-bumped. Race-sensitive
+  policies can still declare their own emergency fallback.
 - `Unroll` must set `ForceUnrollRequest.Trigger` explicitly to
   `actormsg.UnrollTriggerManual`. The zero value admits as
   `UnrollTriggerCriticalExpiry`, so omitting it records a hand-typed unroll as

--- a/waved/server.go
+++ b/waved/server.go
@@ -5893,6 +5893,8 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 		),
 		Log:                        fn.Some(s.subLogger("UNRL")),
 		MaxSweepFeeRateSatPerVByte: s.unrollMaxFeeRate(),
+		SweepFeeRateFallbackSatPerVByte: s.
+			unrollSweepFeeRateFallback(),
 		ExitSpendPolicyResolver: unrollpolicy.ExitSpendPolicyResolver{
 			Jobs:     recoveryStore,
 			Preimage: preimages,
@@ -6372,6 +6374,22 @@ func (s *Server) unrollMaxFeeRate() int64 {
 	if s.cfg != nil && s.cfg.Unroll != nil &&
 		s.cfg.Unroll.MaxFeeRateSatPerVByte > 0 {
 		return s.cfg.Unroll.MaxFeeRateSatPerVByte
+	}
+
+	return 0
+}
+
+// unrollSweepFeeRateFallback returns a fixed estimator-error fallback only on
+// regtest and simnet, where the caller controls block production and can safely
+// confirm a low-fee transaction. Public networks return zero so standard sweep
+// construction waits for a real estimate instead of caching an anchorless
+// transaction that cannot be fee-bumped.
+func (s *Server) unrollSweepFeeRateFallback() int64 {
+	const localFeeRateSatPerVByte int64 = 2
+
+	if s.cfg != nil && (s.cfg.Network == "regtest" ||
+		s.cfg.Network == "simnet") {
+		return localFeeRateSatPerVByte
 	}
 
 	return 0

--- a/waved/unroll_fee_fallback_test.go
+++ b/waved/unroll_fee_fallback_test.go
@@ -1,0 +1,31 @@
+package waved
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnrollSweepFeeRateFallbackRestrictsFixedRateToLocalNetworks verifies
+// public networks defer sweep construction when fee estimation fails, while
+// regtest and simnet keep an explicit fallback for controlled block production.
+func TestUnrollSweepFeeRateFallbackRestrictsFixedRateToLocalNetworks(
+	t *testing.T) {
+
+	require.Zero(t, (&Server{}).unrollSweepFeeRateFallback())
+	require.Zero(
+		t, (&Server{
+			cfg: &Config{Network: "mainnet"},
+		}).unrollSweepFeeRateFallback(),
+	)
+	require.Equal(
+		t, int64(2), (&Server{
+			cfg: &Config{Network: "regtest"},
+		}).unrollSweepFeeRateFallback(),
+	)
+	require.Equal(
+		t, int64(2), (&Server{
+			cfg: &Config{Network: "simnet"},
+		}).unrollSweepFeeRateFallback(),
+	)
+}


### PR DESCRIPTION
## The problem

A unilateral exit builds its final wallet sweep after the virtual transaction output (VTXO) and its proof transactions have confirmed. The client asks for a six-block fee estimate, then persists the signed transaction before handing it to the confirmation subsystem.

When fee estimation failed, the client silently used 2 satoshis per virtual byte (sat/vB). That value became part of the persisted, anchorless sweep. Every retry then reused the same transaction and transaction ID, as crash recovery requires, so a later estimator recovery could not repair the fee.

For example, the estimator can be unavailable while a backend starts even though the node currently requires more than 2 sat/vB. The client would pin a transaction that the backend rejects or that may remain pending after fees rise. The output stays wallet-owned, but the unilateral exit can fail or leave funds unavailable indefinitely.

## The fix

The sweep builder now returns a typed temporary error when fee estimation fails. For the standard timeout policy, the unroll actor keeps the job in `AwaitingSweepBroadcast` and waits for the next height without deriving a wallet address, building a transaction, or consuming a sweep attempt. A later successful estimate builds, persists, and submits one sweep.

Fee fallback is now explicit at two boundaries. Regtest and simnet use 2 sat/vB because the caller controls block production. Both vHTLC recovery policies also declare a 2 sat/vB emergency rate because their claim and refund leaves race another valid spend after the relevant timing conditions mature. Standard public-network sweeps wait for a real estimate.

```mermaid
flowchart TD
    A[Final sweep is ready] --> B{Sweep already persisted?}
    B -- Yes --> C[Resubmit the same txid]
    B -- No --> D{Fee estimate available?}
    D -- No --> G{Competing spend path?}
    G -- No --> E[Wait for the next height]
    G -- Yes --> F
    D -- Yes --> F[Build, persist, and submit once]
    E --> D
```

## Safety rule

Do not construct a standard anchorless exit sweep on a public network without a usable fee estimate. A race-sensitive policy may declare an emergency rate when waiting is less safe. Once any sweep is persisted, always reuse that exact transaction for broadcast retries and restart recovery.

## What does not change

- Positive estimates still use the existing maximum fee-rate cap.
- Invalid estimates, signing errors, and malformed proof data still consume the bounded sweep retry budget.
- A persisted sweep still survives restart and is reused under the same txid.
- A broadcast error still retries the cached sweep and never consults the estimator or derives another destination.

## Tests

- Estimator failure builds and submits no sweep, derives no address, consumes no attempt, and leaves the job non-terminal.
- A later height after estimator recovery builds and submits exactly one sweep.
- A later broadcast failure reuses the cached txid even if the estimator is unavailable again.
- An explicitly configured fallback still builds at the configured rate.
- Both vHTLC recovery actions declare the emergency fallback because another leaf can race them.
- Regtest and simnet select the local fixed fallback; public networks do not.
- Restart from a deferred sweep checkpoint retries estimation without taking the persisted-sweep branch.
- Existing persisted-sweep restart, staged-checkpoint reuse, and bounded broadcast-failure tests pass unchanged.

Validation:

- `make unit pkg=./unroll timeout=10m`
- `make unit pkg=./waved timeout=10m`
- `make unit pkg=./vhtlcrecovery/unrollpolicy timeout=10m`
- `make unit log='stdlog trace' pkg=./unroll case=TestRaceSensitivePolicyUsesFeeEstimateFallback timeout=5m`
- `make unit log='stdlog trace' pkg=./unroll case=TestResumeRetriesDeferredSweepBuild timeout=5m`
- `go test -race ./unroll -run '^(TestSweepDefersWhenFeeEstimateUnavailable|TestSweepBroadcastRetryReusesCachedTxWithoutFeeEstimate|TestRaceSensitivePolicyUsesFeeEstimateFallback|TestResumeRetriesDeferredSweepBuild)$' -count=1 -timeout=5m`
- `make lint-changed-local`
- `make tidy-module-check`
- `scripts/doc-check.sh`

## Compatibility and rollout

This changes no RPC, storage schema, or persisted transaction format. Existing cached sweeps keep their current transaction and retry behavior. New standard public-network sweeps defer only when the estimator returns an error. Race-sensitive vHTLC recovery retains the historical emergency rate. No coordinated rollout is required.

Fixes #1182.
