### PR TITLE
oor: validate incoming checkpoint witnesses

### DIFF
--- a/oor/incoming_adapter_test.go
+++ b/oor/incoming_adapter_test.go
@@ -1,8 +1,11 @@
 package oor
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,4 +32,120 @@ func TestIsIncomingResolveCorrelationID(t *testing.T) {
 			incomingResolveCorrelationPrefix,
 		),
 	)
+}
+
+// TestIncomingTransferEventFromResponseAcceptsValidCheckpointWitness proves
+// full receiver validation preserves the normal finalized OOR package path.
+func TestIncomingTransferEventFromResponseAcceptsValidCheckpointWitness(
+	t *testing.T) {
+
+	t.Parallel()
+
+	resp, sessionID, _, recipientEventID := buildIncomingResolveResponse(t)
+
+	event, err := IncomingTransferEventFromResponse(
+		sessionID, recipientEventID, resp,
+	)
+	require.NoError(t, err)
+	require.Equal(t, sessionID, event.SessionID)
+}
+
+// TestIncomingTransferEventFromResponseRejectsInvalidCheckpointWitness proves
+// receiver admission executes checkpoint witnesses before the resolved package
+// can enter the durable receive state machine. A correctly sized garbage
+// key-spend signature satisfies structural validation but cannot spend the
+// checkpoint's exact VTXO prevout.
+func TestIncomingTransferEventFromResponseRejectsInvalidCheckpointWitness(
+	t *testing.T) {
+
+	t.Parallel()
+
+	resp, sessionID, _, recipientEventID := buildIncomingResolveResponse(t)
+	checkpoint, err := psbtutil.Parse(resp.Events[0].CheckpointPsbts[0])
+	require.NoError(t, err)
+
+	checkpoint.Inputs[0].FinalScriptWitness = nil
+	checkpoint.Inputs[0].TaprootScriptSpendSig = nil
+	checkpoint.Inputs[0].TaprootKeySpendSig = bytes.Repeat(
+		[]byte{0x01}, 64,
+	)
+	resp.Events[0].CheckpointPsbts[0], err = psbtutil.Serialize(checkpoint)
+	require.NoError(t, err)
+
+	_, err = IncomingTransferEventFromResponse(
+		sessionID, recipientEventID, resp,
+	)
+	require.ErrorContains(t, err, "script validation failed")
+}
+
+// TestIncomingTransferEventFromResponseRejectsWrongCheckpointPrevout proves
+// signature validation commits to the exact witness UTXO value supplied for
+// the checkpoint input. Replacing that prevout after signing invalidates the
+// package before receiver admission.
+func TestIncomingTransferEventFromResponseRejectsWrongCheckpointPrevout(
+	t *testing.T) {
+
+	t.Parallel()
+
+	resp, sessionID, _, recipientEventID := buildIncomingResolveResponse(t)
+	checkpoint, err := psbtutil.Parse(resp.Events[0].CheckpointPsbts[0])
+	require.NoError(t, err)
+	require.NotNil(t, checkpoint.Inputs[0].WitnessUtxo)
+
+	checkpoint.Inputs[0].WitnessUtxo.Value++
+	resp.Events[0].CheckpointPsbts[0], err = psbtutil.Serialize(checkpoint)
+	require.NoError(t, err)
+
+	_, err = IncomingTransferEventFromResponse(
+		sessionID, recipientEventID, resp,
+	)
+	require.ErrorContains(t, err, "script validation failed")
+}
+
+// TestIncomingTransferEventFromResponseRejectsInvalidControlBlock proves the
+// receiver binds the revealed collaborative leaf and control block to the
+// checkpoint's exact taproot prevout before accepting the package.
+func TestIncomingTransferEventFromResponseRejectsInvalidControlBlock(
+	t *testing.T) {
+
+	t.Parallel()
+
+	resp, sessionID, _, recipientEventID := buildIncomingResolveResponse(t)
+	checkpoint, err := psbtutil.Parse(resp.Events[0].CheckpointPsbts[0])
+	require.NoError(t, err)
+	require.NotEmpty(t, checkpoint.Inputs[0].TaprootLeafScript)
+	require.NotEmpty(
+		t, checkpoint.Inputs[0].TaprootLeafScript[0].ControlBlock,
+	)
+
+	checkpoint.Inputs[0].TaprootLeafScript[0].ControlBlock[0] ^= 0x01
+	resp.Events[0].CheckpointPsbts[0], err = psbtutil.Serialize(checkpoint)
+	require.NoError(t, err)
+
+	_, err = IncomingTransferEventFromResponse(
+		sessionID, recipientEventID, resp,
+	)
+	require.ErrorContains(t, err, "script validation failed")
+}
+
+// TestValidateIncomingPackageGraphAcceptsReorderedCheckpoints proves receiver
+// validation matches checkpoints to canonical Ark inputs by transaction ID,
+// not by attacker-controlled package order.
+func TestValidateIncomingPackageGraphAcceptsReorderedCheckpoints(t *testing.T) {
+	t.Parallel()
+
+	ark, checkpoints, _, _, _, _ :=
+		buildTestIncomingMaterializationMultiInput(t)
+	require.Len(t, checkpoints, 2)
+
+	reordered := []*psbt.Packet{checkpoints[1], checkpoints[0]}
+	root := packageArtifactForValidation(
+		SessionID(
+			ark.UnsignedTx.TxHash(),
+		),
+		ark,
+		reordered,
+	)
+
+	require.NoError(t, validateIncomingPackageGraph(root, nil))
 }

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -192,16 +192,15 @@ func (h *LocalPersistenceOutboxHandler) validateMaterializeIncoming(
 		return fmt.Errorf("incoming recipients must be provided")
 	}
 
-	if h.PackageStore != nil {
-		root := packageArtifactForValidation(
-			msg.SessionID, msg.ArkPSBT, msg.FinalCheckpointPSBTs,
-		)
-		err := validateIncomingPackageGraph(
-			root, msg.AncestorPackages,
-		)
-		if err != nil {
-			return err
-		}
+	// Revalidate on every materialization attempt. A restored snapshot or
+	// replayed actor message must not bypass the ingress check, even when
+	// the optional OOR package store is disabled.
+	root := packageArtifactForValidation(
+		msg.SessionID, msg.ArkPSBT, msg.FinalCheckpointPSBTs,
+	)
+	err := validateIncomingPackageGraph(root, msg.AncestorPackages)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/oor/local_persistence_handler_test.go
+++ b/oor/local_persistence_handler_test.go
@@ -19,6 +19,7 @@ import (
 	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
 	libtypes "github.com/lightninglabs/wavelength/lib/types"
 	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
@@ -374,6 +375,50 @@ func TestLocalPersistenceOutboxHandlerRejectsInvalidAncestorPackage(
 	require.Zero(t, packageStore.packageCalls)
 }
 
+// TestLocalPersistenceOutboxHandlerRejectsInvalidCheckpointWitness proves a
+// restored or replayed materialization request reruns script validation before
+// writing either a VTXO or package artifact. The check remains mandatory when
+// the optional package store is disabled.
+func TestLocalPersistenceOutboxHandlerRejectsInvalidCheckpointWitness(
+	t *testing.T) {
+
+	t.Parallel()
+
+	arkPSBT, finalCheckpoints, recipients, _, _, operatorKey :=
+		buildTestIncomingMaterialization(t)
+	finalCheckpoints[0].Inputs[0].TaprootScriptSpendSig = nil
+	finalCheckpoints[0].Inputs[0].TaprootKeySpendSig = make([]byte, 64)
+
+	store := newTestVTXOStore()
+	handler := &LocalPersistenceOutboxHandler{
+		Store:       store,
+		OperatorKey: operatorKey,
+		ExitDelay:   10,
+		NotifyIncomingVTXOs: func(_ context.Context,
+			_ []*vtxo.Descriptor) error {
+
+			return nil
+		},
+		ResolveIncomingClientKey: func(_ context.Context,
+			_ ArkRecipientOutput) (keychain.KeyDescriptor, error) {
+
+			return keychain.KeyDescriptor{}, nil
+		},
+	}
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+	req := &MaterializeIncomingVTXOsRequest{
+		SessionID:            sessionID,
+		ArkPSBT:              arkPSBT,
+		FinalCheckpointPSBTs: finalCheckpoints,
+		Recipients:           recipients,
+	}
+
+	events, err := handler.Handle(t.Context(), sessionID, req)
+	require.ErrorContains(t, err, "script validation failed")
+	require.Empty(t, events)
+	require.Empty(t, store.records)
+}
+
 // TestValidateIncomingPackageGraphRejectsUnconsumedAncestor asserts valid but
 // unrelated ancestor packages must not be accepted as recovery ancestors.
 func TestValidateIncomingPackageGraphRejectsUnconsumedAncestor(t *testing.T) {
@@ -412,31 +457,46 @@ func TestValidateIncomingPackageGraphRejectsUnconsumedAncestor(t *testing.T) {
 func TestValidateIncomingPackageGraphAcceptsConnectedAncestor(t *testing.T) {
 	t.Parallel()
 
-	ancestorArk, ancestorCheckpoints, _, _, _, _ :=
-		buildTestIncomingMaterialization(t)
-	rootArk, rootCheckpoints, _, _, _, _ :=
-		buildTestIncomingMaterialization(t)
-	rootArk, rootCheckpoints = reparentTestIncomingPackage(
-		t, rootArk, rootCheckpoints, ancestorArk,
-	)
-
-	root := packageArtifactForValidation(
-		SessionID(
-			rootArk.UnsignedTx.TxHash(),
-		),
-		rootArk,
-		rootCheckpoints,
-	)
-	ancestor := packageArtifactForValidation(
-		SessionID(
-			ancestorArk.UnsignedTx.TxHash(),
-		),
-		ancestorArk,
-		ancestorCheckpoints,
-	)
+	root, ancestor := buildSignedTestIncomingPackageChain(t)
 
 	err := validateIncomingPackageGraph(root, []PackageArtifact{ancestor})
 	require.NoError(t, err)
+}
+
+// TestValidateIncomingPackageGraphRejectsAncestorWitnessUtxoMismatch proves a
+// checkpoint cannot bind its valid signature to a fabricated witness UTXO
+// while claiming to spend a different output from a supplied ancestor.
+func TestValidateIncomingPackageGraphRejectsAncestorWitnessUtxoMismatch(
+	t *testing.T) {
+
+	t.Parallel()
+
+	root, ancestor := buildSignedTestIncomingPackageChainWithChildAmount(
+		t, 9_999,
+	)
+
+	err := validateIncomingPackageGraph(root, []PackageArtifact{ancestor})
+	require.ErrorContains(
+		t, err, "is not consumed by incoming package chain",
+	)
+}
+
+// TestValidateIncomingPackageGraphRejectsInvalidAncestorWitness proves every
+// supplied recovery ancestor executes its checkpoint witness before the graph
+// can be accepted. A valid root cannot hide an unspendable earlier hop.
+func TestValidateIncomingPackageGraphRejectsInvalidAncestorWitness(
+	t *testing.T) {
+
+	t.Parallel()
+
+	root, ancestor := buildSignedTestIncomingPackageChain(t)
+	input := &ancestor.FinalCheckpointPSBTs[0].Inputs[0]
+	require.NotEmpty(t, input.TaprootScriptSpendSig)
+	require.NotEmpty(t, input.TaprootScriptSpendSig[0].Signature)
+	input.TaprootScriptSpendSig[0].Signature[0] ^= 0x01
+
+	err := validateIncomingPackageGraph(root, []PackageArtifact{ancestor})
+	require.ErrorContains(t, err, "script validation failed")
 }
 
 // TestValidateIncomingPackageGraphRejectsDuplicateAncestor asserts valid
@@ -444,28 +504,7 @@ func TestValidateIncomingPackageGraphAcceptsConnectedAncestor(t *testing.T) {
 func TestValidateIncomingPackageGraphRejectsDuplicateAncestor(t *testing.T) {
 	t.Parallel()
 
-	ancestorArk, ancestorCheckpoints, _, _, _, _ :=
-		buildTestIncomingMaterialization(t)
-	rootArk, rootCheckpoints, _, _, _, _ :=
-		buildTestIncomingMaterialization(t)
-	rootArk, rootCheckpoints = reparentTestIncomingPackage(
-		t, rootArk, rootCheckpoints, ancestorArk,
-	)
-
-	root := packageArtifactForValidation(
-		SessionID(
-			rootArk.UnsignedTx.TxHash(),
-		),
-		rootArk,
-		rootCheckpoints,
-	)
-	ancestor := packageArtifactForValidation(
-		SessionID(
-			ancestorArk.UnsignedTx.TxHash(),
-		),
-		ancestorArk,
-		ancestorCheckpoints,
-	)
+	root, ancestor := buildSignedTestIncomingPackageChain(t)
 
 	err := validateIncomingPackageGraph(
 		root, []PackageArtifact{ancestor, ancestor},
@@ -556,8 +595,8 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncomingSkipsNotOwned(
 
 	ctx := t.Context()
 
-	arkPSBT, _, recipients, parentCommitment, recipientKey, operatorKey :=
-		buildTestIncomingMaterialization(t)
+	arkPSBT, finalCheckpoints, recipients, parentCommitment, recipientKey,
+		operatorKey := buildTestIncomingMaterialization(t)
 
 	anchorIndex := uint32(len(arkPSBT.UnsignedTx.TxOut) - 1)
 	recipients = append(recipients, ArkRecipientOutput{
@@ -620,9 +659,10 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncomingSkipsNotOwned(
 	}
 
 	req := &MaterializeIncomingVTXOsRequest{
-		SessionID:  sessionID,
-		ArkPSBT:    arkPSBT,
-		Recipients: recipients,
+		SessionID:            sessionID,
+		ArkPSBT:              arkPSBT,
+		FinalCheckpointPSBTs: finalCheckpoints,
+		Recipients:           recipients,
 	}
 	events, err := handler.Handle(ctx, sessionID, req)
 	require.NoError(t, err)
@@ -647,7 +687,7 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncomingRequiresOwned(
 
 	ctx := t.Context()
 
-	arkPSBT, _, recipients, _, _, operatorKey :=
+	arkPSBT, finalCheckpoints, recipients, _, _, operatorKey :=
 		buildTestIncomingMaterialization(t)
 	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
 	store := newTestVTXOStore()
@@ -688,9 +728,10 @@ func TestLocalPersistenceOutboxHandlerMaterializeIncomingRequiresOwned(
 	}
 
 	req := &MaterializeIncomingVTXOsRequest{
-		SessionID:  sessionID,
-		ArkPSBT:    arkPSBT,
-		Recipients: recipients,
+		SessionID:            sessionID,
+		ArkPSBT:              arkPSBT,
+		FinalCheckpointPSBTs: finalCheckpoints,
+		Recipients:           recipients,
 	}
 	events, err := handler.Handle(ctx, sessionID, req)
 	require.Error(t, err)
@@ -1019,124 +1060,182 @@ func buildTestIncomingMaterialization(t *testing.T) (*psbt.Packet,
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	policy := arkscript.CheckpointPolicy{
-		OperatorKey: operatorKey.PubKey(),
-		CSVDelay:    10,
-	}
+	inputOwnerKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
 
 	recipientKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
 	inputValue := btcutil.Amount(10000)
-	inputs := []oortx.CheckpointInput{
-		{
-			SpentVTXO: oortx.SpentVTXORef{
-				Outpoint: wire.OutPoint{
-					Hash: [32]byte{
-						0x11,
-					},
-					Index: 0,
-				},
-				Output: &wire.TxOut{
-					Value: int64(inputValue),
-					PkScript: newTestTaprootPkScript(
-						t, operatorKey.PubKey(),
-					),
-				},
-			},
-			OwnerLeafScript: []byte{
-				0x51,
-			},
+	spentOutpoint := wire.OutPoint{
+		Hash: [32]byte{
+			0x11,
 		},
+		Index: 0,
 	}
 
+	arkPSBT, checkpoints, recipients := buildSignedTestIncomingPackage(
+		t, operatorKey, inputOwnerKey, spentOutpoint, inputValue,
+		recipientKey,
+	)
+
+	return arkPSBT, checkpoints, recipients, spentOutpoint.Hash,
+		recipientKey, operatorKey.PubKey()
+}
+
+// buildSignedTestIncomingPackage constructs an incoming package whose
+// checkpoint spends one real VTXO collaborative leaf. The helper keeps
+// materialization tests on the same cryptographic path as receiver admission.
+func buildSignedTestIncomingPackage(t *testing.T,
+	operatorKey, inputOwnerKey *btcec.PrivateKey,
+	spentOutpoint wire.OutPoint, amount btcutil.Amount,
+	recipientKey *btcec.PrivateKey) (*psbt.Packet, []*psbt.Packet,
+	[]ArkRecipientOutput) {
+
+	t.Helper()
+
+	checkpoint, tapTree := buildSignedTestIncomingCheckpoint(
+		t, operatorKey, inputOwnerKey, spentOutpoint, amount,
+	)
+
 	vtxoTapKey, err := arkscript.VTXOTapKey(
-		recipientKey.PubKey(), policy.OperatorKey, 10,
+		recipientKey.PubKey(), operatorKey.PubKey(), 10,
 	)
 	require.NoError(t, err)
 
 	recipientPkScript, err := txscript.PayToTaprootScript(vtxoTapKey)
 	require.NoError(t, err)
 
-	outputs := []oortx.RecipientOutput{
-		{
-			PkScript: recipientPkScript,
-			Value:    inputValue,
-		},
-	}
-
-	cp, err := oortx.BuildCheckpointPSBT(policy, inputs[0])
-	require.NoError(t, err)
-	cp.PSBT.Inputs[0].FinalScriptWitness = []byte{0x01, 0x51}
-
-	arkPSBT, err := oortx.BuildArkPSBT(
-		[]oortx.CheckpointOutput{
-			{
-				Txid:           cp.PSBT.UnsignedTx.TxHash(),
-				Output:         cp.PSBT.UnsignedTx.TxOut[0],
-				TapTreeEncoded: cp.TapTreeEncoded,
-			},
-		},
-		outputs,
-	)
+	arkPSBT, err := oortx.BuildArkPSBT([]oortx.CheckpointOutput{{
+		Txid:           checkpoint.UnsignedTx.TxHash(),
+		Output:         checkpoint.UnsignedTx.TxOut[0],
+		TapTreeEncoded: tapTree,
+	}}, []oortx.RecipientOutput{{
+		PkScript: recipientPkScript,
+		Value:    amount,
+	}})
 	require.NoError(t, err)
 
 	recipients, err := ExtractArkRecipients(arkPSBT)
 	require.NoError(t, err)
 
-	return arkPSBT, []*psbt.Packet{cp.PSBT}, recipients,
-		inputs[0].SpentVTXO.Outpoint.Hash, recipientKey,
-		operatorKey.PubKey()
+	return arkPSBT, []*psbt.Packet{checkpoint}, recipients
 }
 
-// reparentTestIncomingPackage rewrites the test package's checkpoint input to
-// spend output zero of parentArk, then rebuilds the Ark transaction so its
-// session ID follows the new checkpoint txid.
-func reparentTestIncomingPackage(t *testing.T, arkPSBT *psbt.Packet,
-	checkpoints []*psbt.Packet,
-	parentArk *psbt.Packet) (*psbt.Packet, []*psbt.Packet) {
+// buildSignedTestIncomingCheckpoint constructs and fully signs one checkpoint
+// against the exact VTXO prevout supplied to receiver validation.
+func buildSignedTestIncomingCheckpoint(t *testing.T,
+	operatorKey, inputOwnerKey *btcec.PrivateKey,
+	spentOutpoint wire.OutPoint, amount btcutil.Amount) (*psbt.Packet,
+	[]byte) {
 
 	t.Helper()
 
-	require.Len(t, checkpoints, 1)
-	require.NotNil(t, parentArk)
-	require.NotNil(t, parentArk.UnsignedTx)
-	require.NotEmpty(t, parentArk.UnsignedTx.TxOut)
-
-	checkpoint := checkpoints[0]
-	require.NotNil(t, checkpoint)
-	require.NotNil(t, checkpoint.UnsignedTx)
-	require.NotEmpty(t, checkpoint.UnsignedTx.TxIn)
-	require.NotEmpty(t, checkpoint.UnsignedTx.TxOut)
-
-	parentTxid := parentArk.UnsignedTx.TxHash()
-	checkpoint.UnsignedTx.TxIn[0].PreviousOutPoint = wire.OutPoint{
-		Hash:  parentTxid,
-		Index: 0,
+	transferInput := newTestTransferInput(
+		t, inputOwnerKey, operatorKey.PubKey(), spentOutpoint, amount,
+	)
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    transferInput.VTXO.RelativeExpiry,
 	}
-	checkpoint.Inputs[0].WitnessUtxo = parentArk.UnsignedTx.TxOut[0]
-
-	recipients, err := ExtractArkRecipients(arkPSBT)
-	require.NoError(t, err)
-
-	outputs := make([]oortx.RecipientOutput, 0, len(recipients))
-	for i := range recipients {
-		outputs = append(outputs, oortx.RecipientOutput{
-			PkScript: recipients[i].PkScript,
-			Value:    recipients[i].Value,
-		})
-	}
-
-	arkPSBT, err = oortx.BuildArkPSBT(
-		[]oortx.CheckpointOutput{{
-			Txid:   checkpoint.UnsignedTx.TxHash(),
-			Output: checkpoint.UnsignedTx.TxOut[0],
-		}},
-		outputs,
+	checkpoint, err := oortx.BuildCheckpointPSBT(
+		policy, oortx.CheckpointInput{
+			SpentVTXO: oortx.SpentVTXORef{
+				Outpoint: transferInput.VTXO.Outpoint,
+				Output: &wire.TxOut{
+					Value: int64(
+						transferInput.VTXO.Amount,
+					),
+					PkScript: transferInput.VTXO.PkScript,
+				},
+			},
+			OwnerLeafScript: transferInput.OwnerLeafScript,
+		},
 	)
 	require.NoError(t, err)
 
-	return arkPSBT, checkpoints
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
+	ownerSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{inputOwnerKey}, nil,
+	)
+	checkpoints := []*psbt.Packet{checkpoint.PSBT}
+	inputs := []TransferInput{transferInput}
+
+	err = coSignCheckpointPSBTsForTest(
+		operatorSigner, inputs, checkpoints,
+	)
+	require.NoError(t, err)
+	err = SignCheckpointPSBTs(ownerSigner, inputs, checkpoints)
+	require.NoError(t, err)
+
+	return checkpoint.PSBT, checkpoint.TapTreeEncoded
+}
+
+// buildSignedTestIncomingPackageChain constructs two finalized packages where
+// the child checkpoint spends the parent's recipient VTXO. It exercises the
+// same ancestor graph and script checks used for chained recovery material.
+func buildSignedTestIncomingPackageChain(t *testing.T) (PackageArtifact,
+	PackageArtifact) {
+
+	t.Helper()
+
+	return buildSignedTestIncomingPackageChainWithChildAmount(t, 10_000)
+}
+
+// buildSignedTestIncomingPackageChainWithChildAmount constructs a signed
+// parent and child while allowing the child to self-declare a different input
+// value from the parent's real output.
+func buildSignedTestIncomingPackageChainWithChildAmount(t *testing.T,
+	childAmount btcutil.Amount) (PackageArtifact, PackageArtifact) {
+
+	t.Helper()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	parentInputOwner, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	childInputOwner, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	childRecipient, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const parentAmount = btcutil.Amount(10_000)
+	parentArk, parentCheckpoints, parentRecipients :=
+		buildSignedTestIncomingPackage(
+			t, operatorKey, parentInputOwner, wire.OutPoint{
+				Hash:  chainhash.Hash{0x31},
+				Index: 0,
+			}, parentAmount, childInputOwner,
+		)
+
+	childArk, childCheckpoints, _ := buildSignedTestIncomingPackage(
+		t, operatorKey, childInputOwner, wire.OutPoint{
+			Hash:  parentArk.UnsignedTx.TxHash(),
+			Index: parentRecipients[0].OutputIndex,
+		}, childAmount, childRecipient,
+	)
+
+	parent := packageArtifactForValidation(
+		SessionID(
+			parentArk.UnsignedTx.TxHash(),
+		),
+		parentArk,
+		parentCheckpoints,
+	)
+	child := packageArtifactForValidation(
+		SessionID(
+			childArk.UnsignedTx.TxHash(),
+		),
+		childArk,
+		childCheckpoints,
+	)
+
+	return child, parent
 }
 
 // buildTestIncomingMaterializationMultiInput is the two-checkpoint
@@ -1159,51 +1258,32 @@ func buildTestIncomingMaterializationMultiInput(t *testing.T) (*psbt.Packet,
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	policy := arkscript.CheckpointPolicy{
-		OperatorKey: operatorKey.PubKey(),
-		CSVDelay:    10,
-	}
-
 	recipientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	inputOwnerA, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	inputOwnerB, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
 	// Two independent checkpoint inputs anchored to distinct
 	// upstream Ark txids so the produced Ark tx has two inputs,
 	// each contributable by a different ancestry fragment.
 	inputAmt := btcutil.Amount(5_000)
-	makeInput := func(seed byte) oortx.CheckpointInput {
-		return oortx.CheckpointInput{
-			SpentVTXO: oortx.SpentVTXORef{
-				Outpoint: wire.OutPoint{
-					Hash: [32]byte{
-						seed,
-					},
-					Index: 0,
-				},
-				Output: &wire.TxOut{
-					Value: int64(inputAmt),
-					PkScript: newTestTaprootPkScript(
-						t, operatorKey.PubKey(),
-					),
-				},
-			},
-			OwnerLeafScript: []byte{
-				0x51,
-			},
-		}
-	}
-	inputs := []oortx.CheckpointInput{
-		makeInput(0x11), makeInput(0x22),
-	}
-
-	cp0, err := oortx.BuildCheckpointPSBT(policy, inputs[0])
-	require.NoError(t, err)
-
-	cp1, err := oortx.BuildCheckpointPSBT(policy, inputs[1])
-	require.NoError(t, err)
+	cp0, tapTree0 := buildSignedTestIncomingCheckpoint(
+		t, operatorKey, inputOwnerA, wire.OutPoint{
+			Hash:  chainhash.Hash{0x11},
+			Index: 0,
+		}, inputAmt,
+	)
+	cp1, tapTree1 := buildSignedTestIncomingCheckpoint(
+		t, operatorKey, inputOwnerB, wire.OutPoint{
+			Hash:  chainhash.Hash{0x22},
+			Index: 0,
+		}, inputAmt,
+	)
 
 	vtxoTapKey, err := arkscript.VTXOTapKey(
-		recipientKey.PubKey(), policy.OperatorKey, 10,
+		recipientKey.PubKey(), operatorKey.PubKey(), 10,
 	)
 	require.NoError(t, err)
 
@@ -1220,14 +1300,14 @@ func buildTestIncomingMaterializationMultiInput(t *testing.T) (*psbt.Packet,
 	arkPSBT, err := oortx.BuildArkPSBT(
 		[]oortx.CheckpointOutput{
 			{
-				Txid:           cp0.PSBT.UnsignedTx.TxHash(),
-				Output:         cp0.PSBT.UnsignedTx.TxOut[0],
-				TapTreeEncoded: cp0.TapTreeEncoded,
+				Txid:           cp0.UnsignedTx.TxHash(),
+				Output:         cp0.UnsignedTx.TxOut[0],
+				TapTreeEncoded: tapTree0,
 			},
 			{
-				Txid:           cp1.PSBT.UnsignedTx.TxHash(),
-				Output:         cp1.PSBT.UnsignedTx.TxOut[0],
-				TapTreeEncoded: cp1.TapTreeEncoded,
+				Txid:           cp1.UnsignedTx.TxHash(),
+				Output:         cp1.UnsignedTx.TxOut[0],
+				TapTreeEncoded: tapTree1,
 			},
 		},
 		outputs,
@@ -1245,11 +1325,11 @@ func buildTestIncomingMaterializationMultiInput(t *testing.T) (*psbt.Packet,
 	// across the per-fragment cross-check; it does not interpret
 	// the commitment txid itself.
 	commits := [2]chainhash.Hash{
-		cp0.PSBT.UnsignedTx.TxHash(),
-		cp1.PSBT.UnsignedTx.TxHash(),
+		cp0.UnsignedTx.TxHash(),
+		cp1.UnsignedTx.TxHash(),
 	}
 
-	return arkPSBT, []*psbt.Packet{cp0.PSBT, cp1.PSBT}, recipients,
+	return arkPSBT, []*psbt.Packet{cp0, cp1}, recipients,
 		commits, recipientKey, operatorKey.PubKey()
 }
 

--- a/oor/package_validation.go
+++ b/oor/package_validation.go
@@ -1,6 +1,7 @@
 package oor
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/btcsuite/btcd/psbt/v2"
@@ -8,8 +9,10 @@ import (
 	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
 )
 
-// validateIncomingPackage validates the finalized OOR package shape before
-// any untrusted incoming artifact is persisted for future recovery.
+// validateIncomingPackage executes every finalized checkpoint spend before any
+// untrusted incoming artifact enters the receive state machine or recovery
+// store. Structural validation alone accepts correctly sized garbage
+// signatures, which would defer failure until unilateral exit.
 func validateIncomingPackage(label string, sessionID SessionID,
 	ark *psbt.Packet, checkpoints []*psbt.Packet) error {
 
@@ -27,7 +30,7 @@ func validateIncomingPackage(label string, sessionID SessionID,
 			label)
 	}
 
-	err := oortx.ValidateFinalizePackage(ark, checkpoints)
+	err := oortx.ValidateFinalizePackageSigned(ark, checkpoints)
 	if err != nil {
 		return fmt.Errorf("%s finalize package invalid: %w", label, err)
 	}
@@ -105,7 +108,7 @@ func walkPackageAncestors(pkg PackageArtifact,
 		}
 
 		// Finalized OOR checkpoints are single-input collab spends.
-		// oortx.ValidateFinalizePackage enforces that invariant
+		// oortx.ValidateFinalizePackageSigned enforces that invariant
 		// before this graph walk, so TxIn[0] is the only ancestry
 		// edge to follow.
 		prevOut := checkpoint.UnsignedTx.TxIn[0].PreviousOutPoint
@@ -115,7 +118,10 @@ func walkPackageAncestors(pkg PackageArtifact,
 			continue
 		}
 
-		if !validAncestorOutput(ancestor.ArkPSBT, prevOut.Index) {
+		if !validAncestorOutput(
+			ancestor.ArkPSBT, checkpoint, prevOut.Index,
+		) {
+
 			continue
 		}
 
@@ -128,10 +134,14 @@ func walkPackageAncestors(pkg PackageArtifact,
 	}
 }
 
-// validAncestorOutput reports whether an ancestor checkpoint input references a
-// real non-anchor Ark output in the referenced ancestor package.
-func validAncestorOutput(ark *psbt.Packet, outputIndex uint32) bool {
-	if ark == nil || ark.UnsignedTx == nil {
+// validAncestorOutput reports whether a checkpoint input's declared witness
+// UTXO equals the real non-anchor Ark output in the referenced ancestor.
+func validAncestorOutput(ark, checkpoint *psbt.Packet,
+	outputIndex uint32) bool {
+
+	if ark == nil || ark.UnsignedTx == nil || checkpoint == nil ||
+		len(checkpoint.Inputs) != 1 ||
+		checkpoint.Inputs[0].WitnessUtxo == nil {
 		return false
 	}
 
@@ -140,7 +150,15 @@ func validAncestorOutput(ark *psbt.Packet, outputIndex uint32) bool {
 		return false
 	}
 
-	return !arktx.IsAnchorOutput(tx.TxOut[outputIndex])
+	ancestorOutput := tx.TxOut[outputIndex]
+	if ancestorOutput == nil || arktx.IsAnchorOutput(ancestorOutput) {
+		return false
+	}
+
+	witnessUtxo := checkpoint.Inputs[0].WitnessUtxo
+
+	return ancestorOutput.Value == witnessUtxo.Value &&
+		bytes.Equal(ancestorOutput.PkScript, witnessUtxo.PkScript)
 }
 
 // packageArtifactForValidation projects package fields into the common

--- a/systest/oor_vtxo_manager_test.go
+++ b/systest/oor_vtxo_manager_test.go
@@ -21,13 +21,16 @@ import (
 	"github.com/lightninglabs/wavelength/db/actordelivery"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/lib/tree"
+	libtx "github.com/lightninglabs/wavelength/lib/tx"
 	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
 	"github.com/lightninglabs/wavelength/lib/types"
 	"github.com/lightninglabs/wavelength/lndbackend"
 	"github.com/lightninglabs/wavelength/oor"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
@@ -466,28 +469,18 @@ func buildSystemTestIncomingMaterialization(t *testing.T) (*psbt.Packet,
 
 	recipientKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
+	inputOwnerKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
 
 	inputValue := btcutil.Amount(10000)
+	checkpointInput, checkpoint := buildSystemTestSignedCheckpoint(
+		t, policy, operatorKey, inputOwnerKey, wire.OutPoint{
+			Hash:  [32]byte{0x11},
+			Index: 0,
+		}, inputValue,
+	)
 	inputs := []oortx.CheckpointInput{
-		{
-			SpentVTXO: oortx.SpentVTXORef{
-				Outpoint: wire.OutPoint{
-					Hash: [32]byte{
-						0x11,
-					},
-					Index: 0,
-				},
-				Output: &wire.TxOut{
-					Value: int64(inputValue),
-					PkScript: systemTestTaprootPkScript(
-						t, operatorKey.PubKey(),
-					),
-				},
-			},
-			OwnerLeafScript: []byte{
-				0x51,
-			},
-		},
+		checkpointInput,
 	}
 
 	vtxoTapKey, err := arkscript.VTXOTapKey(
@@ -505,8 +498,6 @@ func buildSystemTestIncomingMaterialization(t *testing.T) (*psbt.Packet,
 		},
 	}
 
-	checkpoint, err := oortx.BuildCheckpointPSBT(policy, inputs[0])
-	require.NoError(t, err)
 	checkpointTxHash := checkpoint.PSBT.UnsignedTx.TxHash()
 	checkpointTxOut := checkpoint.PSBT.UnsignedTx.TxOut[0]
 
@@ -582,33 +573,22 @@ func buildSystemTestChangeMaterialization(t *testing.T) (*psbt.Packet,
 
 	changeKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
+	inputOwnerKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
 
 	const (
 		externalValue btcutil.Amount = 6_000
 		changeValue   btcutil.Amount = 4_000
 	)
 	inputValue := externalValue + changeValue
-
+	checkpointInput, checkpoint := buildSystemTestSignedCheckpoint(
+		t, policy, operatorKey, inputOwnerKey, wire.OutPoint{
+			Hash:  [32]byte{0x22},
+			Index: 0,
+		}, inputValue,
+	)
 	inputs := []oortx.CheckpointInput{
-		{
-			SpentVTXO: oortx.SpentVTXORef{
-				Outpoint: wire.OutPoint{
-					Hash: [32]byte{
-						0x22,
-					},
-					Index: 0,
-				},
-				Output: &wire.TxOut{
-					Value: int64(inputValue),
-					PkScript: systemTestTaprootPkScript(
-						t, operatorKey.PubKey(),
-					),
-				},
-			},
-			OwnerLeafScript: []byte{
-				0x51,
-			},
-		},
+		checkpointInput,
 	}
 
 	externalPkScript := systemTestVTXOPkScript(
@@ -629,8 +609,6 @@ func buildSystemTestChangeMaterialization(t *testing.T) (*psbt.Packet,
 		},
 	}
 
-	checkpoint, err := oortx.BuildCheckpointPSBT(policy, inputs[0])
-	require.NoError(t, err)
 	checkpointTxHash := checkpoint.PSBT.UnsignedTx.TxHash()
 	checkpointTxOut := checkpoint.PSBT.UnsignedTx.TxOut[0]
 
@@ -695,6 +673,117 @@ func buildSystemTestChangeMaterialization(t *testing.T) (*psbt.Packet,
 		changeRecipient, metadata, changeKey, operatorKey.PubKey()
 }
 
+// buildSystemTestSignedCheckpoint constructs a checkpoint with both
+// collaborative-path signatures so system tests exercise the production
+// incoming-package validation boundary.
+func buildSystemTestSignedCheckpoint(t *testing.T,
+	policy arkscript.CheckpointPolicy,
+	operatorKey, inputOwnerKey *btcec.PrivateKey,
+	spentOutpoint wire.OutPoint, amount btcutil.Amount) (
+	oortx.CheckpointInput, *oortx.CheckpointArtifact) {
+
+	t.Helper()
+
+	inputTapScript, err := arkscript.VTXOTapScript(
+		inputOwnerKey.PubKey(), operatorKey.PubKey(), policy.CSVDelay,
+	)
+	require.NoError(t, err)
+
+	inputTapKey, err := arkscript.VTXOTapKey(
+		inputOwnerKey.PubKey(), operatorKey.PubKey(), policy.CSVDelay,
+	)
+	require.NoError(t, err)
+
+	inputPkScript, err := txscript.PayToTaprootScript(inputTapKey)
+	require.NoError(t, err)
+
+	ownerLeaf, err := arkscript.MultiSigCollabTapLeaf(
+		inputOwnerKey.PubKey(), operatorKey.PubKey(),
+	)
+	require.NoError(t, err)
+
+	checkpointInput := oortx.CheckpointInput{
+		SpentVTXO: oortx.SpentVTXORef{
+			Outpoint: spentOutpoint,
+			Output: &wire.TxOut{
+				Value:    int64(amount),
+				PkScript: inputPkScript,
+			},
+		},
+		OwnerLeafScript: ownerLeaf.Script,
+	}
+	checkpoint, err := oortx.BuildCheckpointPSBT(
+		policy, checkpointInput,
+	)
+	require.NoError(t, err)
+
+	transferInput := oor.TransferInput{
+		VTXO: &vtxo.Descriptor{
+			Outpoint: spentOutpoint,
+			Amount:   amount,
+			PkScript: inputPkScript,
+			ClientKey: keychain.KeyDescriptor{
+				PubKey: inputOwnerKey.PubKey(),
+			},
+			OperatorKey:    operatorKey.PubKey(),
+			TapScript:      inputTapScript,
+			RelativeExpiry: policy.CSVDelay,
+		},
+		OwnerLeafScript: ownerLeaf.Script,
+	}
+
+	prevOut := checkpoint.PSBT.Inputs[0].WitnessUtxo
+	require.NotNil(t, prevOut)
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		prevOut.PkScript, prevOut.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(
+		checkpoint.PSBT.UnsignedTx, prevFetcher,
+	)
+	signDesc, spendInfo, err := libtx.NewVTXOCollabSignDescriptor(
+		&libtx.VTXOSpendContext{
+			Outpoint:  spentOutpoint,
+			Output:    prevOut,
+			TapScript: inputTapScript,
+		}, keychain.KeyDescriptor{
+			PubKey: operatorKey.PubKey(),
+		}, 0, sigHashes, prevFetcher,
+	)
+	require.NoError(t, err)
+
+	operatorSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{operatorKey}, nil,
+	)
+	operatorSig, err := operatorSigner.SignOutputRaw(
+		checkpoint.PSBT.UnsignedTx, signDesc,
+	)
+	require.NoError(t, err)
+
+	err = psbtutil.AddTapLeafScript(
+		&checkpoint.PSBT.Inputs[0], spendInfo,
+	)
+	require.NoError(t, err)
+	err = psbtutil.AddTaprootScriptSpendSig(
+		&checkpoint.PSBT.Inputs[0], operatorKey.PubKey(),
+		spendInfo.WitnessScript, operatorSig.Serialize(),
+		signDesc.HashType,
+	)
+	require.NoError(t, err)
+
+	ownerSigner := input.NewMockSigner(
+		[]*btcec.PrivateKey{inputOwnerKey}, nil,
+	)
+	err = oor.SignCheckpointPSBTs(
+		ownerSigner, []oor.TransferInput{transferInput},
+		[]*psbt.Packet{checkpoint.PSBT},
+	)
+	require.NoError(t, err)
+
+	return checkpointInput, checkpoint
+}
+
+// systemTestVTXOPkScript derives the standard VTXO output script used by
+// incoming-materialization fixtures.
 func systemTestVTXOPkScript(t *testing.T,
 	clientKey, operatorKey *btcec.PublicKey, exitDelay uint32) []byte {
 
@@ -706,17 +795,6 @@ func systemTestVTXOPkScript(t *testing.T,
 	require.NoError(t, err)
 
 	pkScript, err := txscript.PayToTaprootScript(vtxoTapKey)
-	require.NoError(t, err)
-
-	return pkScript
-}
-
-// systemTestTaprootPkScript returns a valid P2TR pkScript for systest
-// fixtures.
-func systemTestTaprootPkScript(t *testing.T, key *btcec.PublicKey) []byte {
-	t.Helper()
-
-	pkScript, err := txscript.PayToTaprootScript(key)
 	require.NoError(t, err)
 
 	return pkScript


### PR DESCRIPTION
## Problem

Incoming OOR package admission checked transaction shape and witness presence,
but did not execute finalized checkpoint scripts. A counterparty could send a
correctly sized invalid signature. The receiver would accept and persist the
package, then discover the invalid recovery path only during unilateral exit.

## Fix

- Run the existing full finalized-package validator before an incoming package
  enters the receive state machine.
- Run the same validation before materialization so restored or replayed work
  cannot bypass the ingress check.
- Keep checkpoint matching transaction-ID based. Package ordering remains
  irrelevant.
- Replace synthetic receive fixtures with valid collaborative Taproot
  signatures.

The validation executes each checkpoint against its exact witness UTXO,
control block, sighash, and signature. Supplied ancestor edges also require the
checkpoint's witness UTXO to equal the real referenced Ark output. The change
does not alter package construction, fees, state transitions, or the wire
format.

## Tests

- Valid incoming finalized package.
- Correctly sized invalid key-spend signature.
- Wrong checkpoint prevout after signing.
- Invalid Taproot control block.
- Invalid ancestor checkpoint witness.
- Fully signed child with a fabricated ancestor witness UTXO.
- Reordered checkpoint set.
- Restored or replayed materialization with the optional package store disabled.
- Existing connected and duplicate ancestor graph cases.
- PostgreSQL and SQLite OOR materialization system tests use real finalized
  checkpoint signatures.
- `make unit pkg=./oor timeout=10m`
- `make unit pkg=./lib/tx/oor timeout=5m`
- `go test -race -tags='dev nolog' ./oor -count=1 -timeout=15m`
- Focused PostgreSQL and SQLite OOR materialization system tests.
- `make lint-changed-local`
- `make tidy-module-check`
