### PR TITLE
waved: bound standalone log file growth

### DIFF
--- a/cmd/waved/log_test.go
+++ b/cmd/waved/log_test.go
@@ -5,11 +5,15 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/lightninglabs/wavelength/waved"
+	lndbuild "github.com/lightningnetwork/lnd/build"
 	"github.com/stretchr/testify/require"
 )
+
+const testLogFileSize = 1000 * 1024
 
 var errStdoutWrite = errors.New("stdout write failed")
 
@@ -114,4 +118,56 @@ func TestConfigureDaemonLogWriterKeepsInjectedWriter(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, logFile)
 	require.Same(t, &injected, cfg.LogWriter)
+}
+
+// TestConfigureDaemonLogWriterRotatesFile verifies standalone daemon logs do
+// not grow one persistent file without bound.
+func TestConfigureDaemonLogWriterRotatesFile(t *testing.T) {
+	t.Parallel()
+
+	logDir := t.TempDir()
+	cfg := waved.DefaultConfig()
+	cfg.LogDirPath = logDir
+	stdout := &bytes.Buffer{}
+	logConfig := lndbuild.DefaultLogConfig().File
+	require.Equal(
+		t, lndbuild.DefaultMaxLogFileSize, logConfig.MaxLogFileSize,
+	)
+	require.Equal(t, lndbuild.DefaultMaxLogFiles, logConfig.MaxLogFiles)
+	require.Equal(t, lndbuild.Gzip, logConfig.Compressor)
+	logConfig.MaxLogFileSize = 1
+
+	closer, err := configureDaemonLogWriterWithConfig(
+		cfg, stdout, 1, logConfig.MaxLogFiles,
+	)
+	require.NoError(t, err)
+
+	logLine := []byte(strings.Repeat("a", testLogFileSize/2-1) + "\n")
+	start := make(chan struct{})
+	writeErrs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			_, err := cfg.LogWriter.Write(logLine)
+			writeErrs <- err
+		}()
+	}
+	close(start)
+
+	for range 2 {
+		require.NoError(t, <-writeErrs)
+	}
+	require.NoError(t, closer.Close())
+
+	backupFiles, err := filepath.Glob(filepath.Join(logDir, "waved.log.*"))
+	require.NoError(t, err)
+	require.Equal(
+		t, []string{
+			filepath.Join(logDir, "waved.log.1.gz"),
+		}, backupFiles,
+	)
+
+	activeInfo, err := os.Stat(filepath.Join(logDir, daemonLogFileName))
+	require.NoError(t, err)
+	require.Zero(t, activeInfo.Size())
 }

--- a/cmd/waved/main.go
+++ b/cmd/waved/main.go
@@ -9,10 +9,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
+	"github.com/jrick/logrotate/rotator"
 	"github.com/lightninglabs/wavelength/build"
 	"github.com/lightninglabs/wavelength/chainbackends/bitcoindrpc"
 	"github.com/lightninglabs/wavelength/waved"
+	lndbuild "github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/signal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -26,6 +29,12 @@ type bestEffortWriter struct {
 	w io.Writer
 }
 
+type serializedLogWriter struct {
+	mu     sync.Mutex
+	writer io.Writer
+	closer io.Closer
+}
+
 // Write forwards the bytes when a sink is configured and always reports a
 // successful full write so optional log mirroring cannot stop the daemon.
 func (b bestEffortWriter) Write(p []byte) (int, error) {
@@ -34,6 +43,22 @@ func (b bestEffortWriter) Write(p []byte) (int, error) {
 	}
 
 	return len(p), nil
+}
+
+// Write serializes access to all configured log sinks.
+func (s *serializedLogWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.writer.Write(p)
+}
+
+// Close waits for any active write before closing the log rotator.
+func (s *serializedLogWriter) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.closer.Close()
 }
 
 // main executes the waved command and reports startup or runtime failures to
@@ -676,29 +701,46 @@ func run(cfg *waved.Config) error {
 // stdout and a persistent log file. Embedders that provide LogWriter keep full
 // control of the sink.
 func configureDaemonLogWriter(cfg *waved.Config,
-	stdout io.Writer) (*os.File, error) {
+	stdout io.Writer) (io.Closer, error) {
+
+	logConfig := lndbuild.DefaultLogConfig().File
+
+	return configureDaemonLogWriterWithConfig(
+		cfg, stdout, logConfig.MaxLogFileSize, logConfig.MaxLogFiles,
+	)
+}
+
+// configureDaemonLogWriterWithConfig configures standalone logging with the
+// supplied rotation limits.
+func configureDaemonLogWriterWithConfig(cfg *waved.Config, stdout io.Writer,
+	maxLogFileSize, maxLogFiles int) (io.Closer, error) {
 
 	if cfg.LogWriter != nil {
 		return nil, nil
 	}
 
-	logDir := cfg.LogDir()
-	if err := os.MkdirAll(logDir, 0o700); err != nil {
-		return nil, fmt.Errorf("create log directory %q: %w", logDir,
-			err)
+	logFilePath := filepath.Join(cfg.LogDir(), daemonLogFileName)
+	if err := os.MkdirAll(filepath.Dir(logFilePath), 0700); err != nil {
+		return nil, fmt.Errorf("create log directory: %w", err)
 	}
 
-	logFilePath := filepath.Join(logDir, daemonLogFileName)
-	logFile, err := os.OpenFile( //nolint:gosec // G304: operator log path.
-		logFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600,
+	// Match lnd's rotation setup. The lnd setting is expressed in MB while
+	// the rotator accepts a threshold in KB and enables gzip by default.
+	logRotator, err := rotator.New(
+		logFilePath, int64(maxLogFileSize)*1024, false, maxLogFiles,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("open log file %q: %w", logFilePath, err)
+		return nil, fmt.Errorf("initialize log rotator %q: %w",
+			logFilePath, err)
 	}
 
-	cfg.LogWriter = io.MultiWriter(bestEffortWriter{stdout}, logFile)
+	logWriter := &serializedLogWriter{
+		writer: io.MultiWriter(bestEffortWriter{stdout}, logRotator),
+		closer: logRotator,
+	}
+	cfg.LogWriter = logWriter
 
-	return logFile, nil
+	return logWriter, nil
 }
 
 // registerBitcoindFlags registers optional direct bitcoind package relay

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jessevdk/go-flags v1.6.1 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
-	github.com/jrick/logrotate v1.1.2 // indirect
+	github.com/jrick/logrotate v1.1.2
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kkdai/bstream v1.0.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect


### PR DESCRIPTION
In this PR, we replace standalone `waved`'s raw append-only log file
with the same `jrick/logrotate` implementation and defaults used by lnd.
The active `waved.log` rotates at lnd's configured 20 MB threshold, and
normal operation retains ten gzip-compressed backups. This closes #1252.

Wavelength's subsystem loggers share the same sink, while the rotator
supports only one writer at a time. A shared mutex therefore serializes
each complete stdout-and-file write and prevents shutdown from closing the
rotator during an active write. Stdout failures remain best-effort, and
embedded callers that provide `Config.LogWriter` retain full ownership of
their sink.

`github.com/jrick/logrotate` was already present transitively through lnd;
this PR only classifies it as a direct dependency. The existing indirect
`lumberjack.v2` dependency is unchanged and remains required by etcd through
lnd's kvdb stack.

The active-file limit is synchronous. Backup compression is asynchronous,
so sustained rotation that outruns gzip can temporarily exceed the normal
ten-backup target inherited from lnd.

## Verification

```text
go test ./cmd/waved
go test -race ./cmd/waved -run TestConfigureDaemonLogWriter -count=20
make lint-changed-local
make ast-lint
make tidy-module-check
make commitmsg-lint range="origin/main..HEAD"
```
