### PR TITLE
db: bound SQLite migration backup retention

### DIFF
--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -340,8 +340,17 @@ func TestSqliteMigrationBackup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now close and reopen the database. Since we're already at the latest
-	// version, no migration should run and no backup should be created.
+	// version, no migration should run. Leave a legacy backup beside the
+	// database to verify that the up-to-date path prunes backups left by an
+	// older release.
 	require.NoError(t, db.DB.Close())
+	legacyBackupPath := dbFileName + ".1234.backup"
+	require.NoError(
+		t,
+		os.WriteFile(
+			legacyBackupPath, []byte("legacy"), 0o600,
+		),
+	)
 
 	db2, err := NewSqliteStore(&SqliteConfig{
 		DatabaseFileName: dbFileName,
@@ -360,9 +369,9 @@ func TestSqliteMigrationBackup(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "regtest", chainName)
 
-	// Since we're already at the latest version, no backup should be
-	// created. This test verifies the backup logic works correctly by
-	// NOT creating a backup when unnecessary.
+	// Since we're already at the latest version, the old backup should be
+	// pruned and no new backup should be created.
+	require.NoFileExists(t, legacyBackupPath)
 	dbBackupFilePath := findDBBackupFilePath(t, dbFileName)
 	require.Empty(
 		t, dbBackupFilePath,

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -344,7 +344,7 @@ func TestSqliteMigrationBackup(t *testing.T) {
 	// database to verify that the up-to-date path prunes backups left by an
 	// older release.
 	require.NoError(t, db.DB.Close())
-	legacyBackupPath := dbFileName + ".1234.backup"
+	legacyBackupPath := dbFileName + ".1763079012000000000.backup"
 	require.NoError(
 		t,
 		os.WriteFile(

--- a/db/sqlite.go
+++ b/db/sqlite.go
@@ -296,25 +296,13 @@ func resolveSqliteSynchronous(value string) (string, error) {
 	}
 }
 
-// backupSqliteDatabase creates a backup of the given SQLite database. The
-// function uses the store's resolved logger for progress messages.
-func backupSqliteDatabase(srcDB *sql.DB, dbFullFilePath string,
-	backupLog btclog.Logger) error {
+// vacuumSqliteDatabase copies the source database to the given backup path.
+func vacuumSqliteDatabase(srcDB *sql.DB, dbFullFilePath,
+	backupFullFilePath string, backupLog btclog.Logger) error {
 
 	if srcDB == nil {
 		return fmt.Errorf("backup source database is nil")
 	}
-
-	// Create a database backup file full path from the given source
-	// database full file path.
-	//
-	// Get the current time and format it as a Unix timestamp in
-	// nanoseconds.
-	timestamp := time.Now().UnixNano()
-
-	// Add the timestamp to the backup name.
-	backupFullFilePath := fmt.Sprintf("%s.%d.backup", dbFullFilePath,
-		timestamp)
 
 	backupLog.InfoS(
 		context.Background(),
@@ -359,11 +347,11 @@ func (s *SqliteStore) backupAndMigrate(mig *migrate.Migrate,
 			"max_migration_version", maxMigrationVersion,
 		)
 
-		return nil
+		return pruneSqliteMigrationBackups(s.cfg.DatabaseFileName)
 	}
 
-	// At this point, we know that a database migration is necessary.
-	// Create a backup of the database before starting the migration.
+	// At this point, we know that a database migration is necessary. Create
+	// a backup of the database before starting the migration.
 	if !s.cfg.SkipMigrationDBBackup {
 		s.log.InfoS(
 			context.Background(),
@@ -371,8 +359,8 @@ func (s *SqliteStore) backupAndMigrate(mig *migrate.Migrate,
 				"migration(s))",
 		)
 
-		err := backupSqliteDatabase(
-			s.DB, s.cfg.DatabaseFileName, s.log,
+		err := prepareSqliteMigrationBackup(
+			s.DB, s.cfg.DatabaseFileName, currentDBVersion, s.log,
 		)
 		if err != nil {
 			return err
@@ -387,7 +375,12 @@ func (s *SqliteStore) backupAndMigrate(mig *migrate.Migrate,
 
 	s.log.InfoS(context.Background(), "Applying migrations to database")
 
-	return mig.Up()
+	err := mig.Up()
+	if err != nil {
+		return err
+	}
+
+	return pruneSqliteMigrationBackups(s.cfg.DatabaseFileName)
 }
 
 // ExecuteMigrations runs migrations for the sqlite database, depending on the

--- a/db/sqlite.go
+++ b/db/sqlite.go
@@ -255,6 +255,15 @@ func NewSqliteStore(cfg *SqliteConfig,
 				"actor-delivery migrations: %w", err)
 		}
 
+		err = pruneSqliteMigrationBackups(cfg.DatabaseFileName)
+		if err != nil {
+			storeLog.WarnS(
+				ctx,
+				"Unable to prune SQLite migration backups",
+				err,
+			)
+		}
+
 		storeLog.InfoS(
 			ctx, "All SQLite migrations completed successfully",
 		)
@@ -347,7 +356,7 @@ func (s *SqliteStore) backupAndMigrate(mig *migrate.Migrate,
 			"max_migration_version", maxMigrationVersion,
 		)
 
-		return pruneSqliteMigrationBackups(s.cfg.DatabaseFileName)
+		return nil
 	}
 
 	// At this point, we know that a database migration is necessary. Create
@@ -375,12 +384,7 @@ func (s *SqliteStore) backupAndMigrate(mig *migrate.Migrate,
 
 	s.log.InfoS(context.Background(), "Applying migrations to database")
 
-	err := mig.Up()
-	if err != nil {
-		return err
-	}
-
-	return pruneSqliteMigrationBackups(s.cfg.DatabaseFileName)
+	return mig.Up()
 }
 
 // ExecuteMigrations runs migrations for the sqlite database, depending on the

--- a/db/sqlite_backup_native.go
+++ b/db/sqlite_backup_native.go
@@ -1,0 +1,146 @@
+//go:build !js || !wasm
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/btcsuite/btclog/v2"
+)
+
+// sqliteMigrationBackupPath returns the stable backup path for a source schema
+// version.
+func sqliteMigrationBackupPath(dbFullFilePath string,
+	currentDBVersion int) string {
+
+	return fmt.Sprintf("%s.v%d.backup", dbFullFilePath, currentDBVersion)
+}
+
+// prepareSqliteMigrationBackup creates one reusable backup for the current
+// source schema version.
+func prepareSqliteMigrationBackup(srcDB *sql.DB, dbFullFilePath string,
+	currentDBVersion int, backupLog btclog.Logger) error {
+
+	backupPath := sqliteMigrationBackupPath(
+		dbFullFilePath, currentDBVersion,
+	)
+	info, err := os.Stat(backupPath)
+	switch {
+	case err == nil && info.Mode().IsRegular():
+		backupLog.InfoS(
+			context.Background(),
+			"Reusing database backup for pending migration",
+			slog.String("backup", backupPath),
+			slog.Int("current_db_version", currentDBVersion),
+		)
+
+		return nil
+
+	case err == nil:
+		return fmt.Errorf("migration backup path is not a regular "+
+			"file: %s", backupPath)
+
+	case !errors.Is(err, os.ErrNotExist):
+		return fmt.Errorf("inspect migration backup %s: %w", backupPath,
+			err)
+	}
+
+	// VACUUM INTO leaves its destination behind when it fails. A stable
+	// staging path makes an interrupted copy replaceable on the next start
+	// without accumulating partial files.
+	stagingPath := backupPath + ".tmp"
+	err = os.Remove(stagingPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove incomplete migration backup %s: %w",
+			stagingPath, err)
+	}
+
+	err = vacuumSqliteDatabase(
+		srcDB, dbFullFilePath, stagingPath, backupLog,
+	)
+	if err != nil {
+		_ = os.Remove(stagingPath)
+
+		return fmt.Errorf("create migration backup: %w", err)
+	}
+
+	err = os.Rename(stagingPath, backupPath)
+	if err != nil {
+		_ = os.Remove(stagingPath)
+
+		return fmt.Errorf("publish migration backup: %w", err)
+	}
+
+	return nil
+}
+
+// pruneSqliteMigrationBackups removes completed and interrupted migration
+// backups owned by the database package.
+func pruneSqliteMigrationBackups(dbFullFilePath string) error {
+	dir := filepath.Dir(dbFullFilePath)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("list migration backups: %w", err)
+	}
+
+	dbFileName := filepath.Base(dbFullFilePath)
+	var pruneErr error
+	for _, entry := range entries {
+		if entry.IsDir() ||
+			!isSqliteMigrationBackup(dbFileName, entry.Name()) {
+
+			continue
+		}
+
+		backupPath := filepath.Join(dir, entry.Name())
+		err := os.Remove(backupPath)
+		if err != nil {
+			pruneErr = errors.Join(
+				pruneErr, fmt.Errorf("remove migration "+
+					"backup %s: %w", backupPath, err),
+			)
+		}
+	}
+
+	return pruneErr
+}
+
+// isSqliteMigrationBackup reports whether a file name matches a timestamped
+// legacy backup or a version-keyed backup created by this package.
+func isSqliteMigrationBackup(dbFileName, candidate string) bool {
+	prefix := dbFileName + "."
+	if !strings.HasPrefix(candidate, prefix) {
+		return false
+	}
+
+	identifier := strings.TrimPrefix(candidate, prefix)
+	isStaging := strings.HasSuffix(identifier, ".backup.tmp")
+	if isStaging {
+		identifier = strings.TrimSuffix(identifier, ".tmp")
+	}
+
+	identifier, found := strings.CutSuffix(identifier, ".backup")
+	if !found {
+		return false
+	}
+
+	isVersioned := strings.HasPrefix(identifier, "v")
+	if isStaging && !isVersioned {
+		return false
+	}
+	if isVersioned {
+		identifier = strings.TrimPrefix(identifier, "v")
+	}
+
+	value, err := strconv.ParseInt(identifier, 10, 64)
+
+	return err == nil && strconv.FormatInt(value, 10) == identifier
+}

--- a/db/sqlite_backup_native.go
+++ b/db/sqlite_backup_native.go
@@ -16,6 +16,8 @@ import (
 	"github.com/btcsuite/btclog/v2"
 )
 
+const legacySqliteBackupTimestampLength = 19
+
 // sqliteMigrationBackupPath returns the stable backup path for a source schema
 // version.
 func sqliteMigrationBackupPath(dbFullFilePath string,
@@ -138,6 +140,8 @@ func isSqliteMigrationBackup(dbFileName, candidate string) bool {
 	}
 	if isVersioned {
 		identifier = strings.TrimPrefix(identifier, "v")
+	} else if len(identifier) != legacySqliteBackupTimestampLength {
+		return false
 	}
 
 	value, err := strconv.ParseInt(identifier, 10, 64)

--- a/db/sqlite_backup_native_test.go
+++ b/db/sqlite_backup_native_test.go
@@ -1,0 +1,166 @@
+//go:build !js || !wasm
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/db/sqlc"
+	"github.com/stretchr/testify/require"
+)
+
+// newSqliteStoreWithoutMigrations opens a SQLite store without applying its
+// schema migrations.
+func newSqliteStoreWithoutMigrations(t *testing.T,
+	dbFileName string) *SqliteStore {
+
+	t.Helper()
+
+	store, err := NewSqliteStore(&SqliteConfig{
+		DatabaseFileName: dbFileName,
+		SkipMigrations:   true,
+	}, btclog.Disabled)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.DB.Close())
+	})
+
+	return store
+}
+
+// queryChainName opens a SQLite database and returns the selected chain name.
+func queryChainName(t *testing.T, dbFileName string, id int) string {
+	t.Helper()
+
+	result, err := OpenSQLiteDatabase(SQLiteOpenConfig{
+		DatabaseFileName: dbFileName,
+		MaxOpenConns:     1,
+		MaxIdleConns:     1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, result.DB.Close())
+	})
+
+	var chainName string
+	err = result.DB.QueryRowContext(
+		t.Context(),
+		`SELECT chain_name FROM chain_info WHERE id = ?`, id,
+	).Scan(&chainName)
+	require.NoError(t, err)
+
+	return chainName
+}
+
+// TestSqliteMigrationBackupReuse verifies that an interrupted migration reuses
+// the complete backup for its source schema version instead of copying the
+// database again.
+func TestSqliteMigrationBackupReuse(t *testing.T) {
+	dbFileName := filepath.Join(t.TempDir(), "test.db")
+	store := newSqliteStoreWithoutMigrations(t, dbFileName)
+	require.NoError(t, store.ExecuteMigrations(TargetVersion(1)))
+
+	_, err := store.ExecContext(t.Context(), `
+		INSERT INTO chain_info (id, chain_name, genesis_hash)
+		VALUES (1, 'before', X'00')
+	`)
+	require.NoError(t, err)
+
+	backupPath := sqliteMigrationBackupPath(dbFileName, 1)
+	stagingPath := backupPath + ".tmp"
+	require.NoError(t, os.WriteFile(stagingPath, []byte("partial"), 0o600))
+
+	err = prepareSqliteMigrationBackup(
+		store.DB, dbFileName, 1, btclog.Disabled,
+	)
+	require.NoError(t, err)
+	require.NoFileExists(t, stagingPath)
+	require.Equal(t, "before", queryChainName(t, backupPath, 1))
+
+	_, err = store.ExecContext(
+		t.Context(),
+		`UPDATE chain_info SET chain_name = 'after' WHERE id = 1`,
+	)
+	require.NoError(t, err)
+
+	err = prepareSqliteMigrationBackup(
+		store.DB, dbFileName, 1, btclog.Disabled,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "before", queryChainName(t, backupPath, 1))
+}
+
+// TestSqliteMigrationBackupPrunedAfterSuccess verifies that a completed
+// migration removes version-keyed backups, interrupted staging files, and
+// timestamped backups created by older versions.
+func TestSqliteMigrationBackupPrunedAfterSuccess(t *testing.T) {
+	dbFileName := filepath.Join(t.TempDir(), "test.db")
+	store := newSqliteStoreWithoutMigrations(t, dbFileName)
+	require.NoError(t, store.ExecuteMigrations(TargetVersion(17)))
+
+	legacyPath := fmt.Sprintf("%s.%d.backup", dbFileName, 1234)
+	stagingPath := sqliteMigrationBackupPath(dbFileName, 16) + ".tmp"
+	manualPath := dbFileName + ".manual.backup"
+	preservedPaths := []string{
+		manualPath,
+		dbFileName + ".+1234.backup",
+		dbFileName + ".001234.backup",
+		dbFileName + ".1234.backup.tmp",
+	}
+	for _, path := range append(
+		[]string{legacyPath, stagingPath}, preservedPaths...,
+	) {
+		require.NoError(t, os.WriteFile(path, []byte("test"), 0o600))
+	}
+
+	require.NoError(t, store.ExecuteMigrations(store.backupAndMigrate))
+
+	var version int
+	err := store.QueryRow(
+		`SELECT version FROM schema_migrations`,
+	).Scan(&version)
+	require.NoError(t, err)
+	require.Equal(t, int(LatestMigrationVersion), version)
+
+	require.NoFileExists(t, legacyPath)
+	require.NoFileExists(t, stagingPath)
+	require.NoFileExists(t, sqliteMigrationBackupPath(dbFileName, 17))
+	for _, path := range preservedPaths {
+		require.FileExists(t, path)
+	}
+}
+
+// TestSqliteMigrationBackupRetainedAfterFailure verifies that a failed
+// migration keeps its pre-migration backup available for recovery.
+func TestSqliteMigrationBackupRetainedAfterFailure(t *testing.T) {
+	dbFileName := filepath.Join(t.TempDir(), "test.db")
+	store := newSqliteStoreWithoutMigrations(t, dbFileName)
+	require.NoError(t, store.ExecuteMigrations(TargetVersion(17)))
+
+	testErr := errors.New("post-migration check failed")
+	checks := map[uint]postMigrationCheck{
+		18: func(_ context.Context, _ sqlc.Querier) error {
+			return testErr
+		},
+	}
+
+	err := store.ExecuteMigrations(
+		store.backupAndMigrate,
+		WithPostStepCallbacks(
+			makePostStepCallbacks(store, btclog.Disabled, checks),
+		),
+	)
+	require.ErrorIs(t, err, testErr)
+
+	backupPath := sqliteMigrationBackupPath(dbFileName, 17)
+	require.FileExists(t, backupPath)
+	info, err := os.Stat(backupPath)
+	require.NoError(t, err)
+	require.Positive(t, info.Size())
+}

--- a/db/sqlite_backup_native_test.go
+++ b/db/sqlite_backup_native_test.go
@@ -103,12 +103,16 @@ func TestSqliteMigrationBackupPrunedAfterSuccess(t *testing.T) {
 	dbFileName := filepath.Join(t.TempDir(), "test.db")
 	store := newSqliteStoreWithoutMigrations(t, dbFileName)
 	require.NoError(t, store.ExecuteMigrations(TargetVersion(17)))
+	require.NoError(t, store.DB.Close())
 
-	legacyPath := fmt.Sprintf("%s.%d.backup", dbFileName, 1234)
+	legacyPath := fmt.Sprintf("%s.%d.backup", dbFileName,
+		int64(1763079012000000000))
 	stagingPath := sqliteMigrationBackupPath(dbFileName, 16) + ".tmp"
 	manualPath := dbFileName + ".manual.backup"
 	preservedPaths := []string{
 		manualPath,
+		dbFileName + ".1234.backup",
+		dbFileName + ".20260904.backup",
 		dbFileName + ".+1234.backup",
 		dbFileName + ".001234.backup",
 		dbFileName + ".1234.backup.tmp",
@@ -119,10 +123,16 @@ func TestSqliteMigrationBackupPrunedAfterSuccess(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("test"), 0o600))
 	}
 
-	require.NoError(t, store.ExecuteMigrations(store.backupAndMigrate))
+	store, err := NewSqliteStore(&SqliteConfig{
+		DatabaseFileName: dbFileName,
+	}, btclog.Disabled)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.DB.Close())
+	})
 
 	var version int
-	err := store.QueryRow(
+	err = store.QueryRow(
 		`SELECT version FROM schema_migrations`,
 	).Scan(&version)
 	require.NoError(t, err)
@@ -134,6 +144,39 @@ func TestSqliteMigrationBackupPrunedAfterSuccess(t *testing.T) {
 	for _, path := range preservedPaths {
 		require.FileExists(t, path)
 	}
+}
+
+// TestSqliteMigrationBackupRetainedAfterActorMigrationFailure verifies that a
+// main-schema backup remains available until actor-delivery migrations also
+// complete.
+func TestSqliteMigrationBackupRetainedAfterActorMigrationFailure(t *testing.T) {
+	dbFileName := filepath.Join(t.TempDir(), "test.db")
+	store := newSqliteStoreWithoutMigrations(t, dbFileName)
+	require.NoError(t, store.ExecuteMigrations(TargetVersion(17)))
+
+	_, err := store.ExecContext(t.Context(), `
+		CREATE TABLE actor_delivery_schema_migrations (
+			version INTEGER NOT NULL,
+			dirty BOOLEAN NOT NULL
+		);
+		INSERT INTO actor_delivery_schema_migrations (version, dirty)
+		VALUES (1, TRUE);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, store.DB.Close())
+
+	backupPath := sqliteMigrationBackupPath(dbFileName, 17)
+	for range 2 {
+		_, err = NewSqliteStore(&SqliteConfig{
+			DatabaseFileName: dbFileName,
+		}, btclog.Disabled)
+		require.ErrorContains(t, err, "database is in a dirty state")
+		require.FileExists(t, backupPath)
+	}
+
+	info, err := os.Stat(backupPath)
+	require.NoError(t, err)
+	require.Positive(t, info.Size())
 }
 
 // TestSqliteMigrationBackupRetainedAfterFailure verifies that a failed

--- a/db/sqlite_backup_wasm.go
+++ b/db/sqlite_backup_wasm.go
@@ -1,0 +1,30 @@
+//go:build js && wasm
+
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+)
+
+// prepareSqliteMigrationBackup creates a migration backup in the active SQLite
+// virtual file system.
+func prepareSqliteMigrationBackup(srcDB *sql.DB, dbFullFilePath string, _ int,
+	backupLog btclog.Logger) error {
+
+	backupPath := fmt.Sprintf("%s.%d.backup", dbFullFilePath,
+		time.Now().UnixNano())
+
+	return vacuumSqliteDatabase(
+		srcDB, dbFullFilePath, backupPath, backupLog,
+	)
+}
+
+// pruneSqliteMigrationBackups is a no-op because the browser SQLite virtual
+// file system does not expose file removal through database/sql.
+func pruneSqliteMigrationBackups(string) error {
+	return nil
+}


### PR DESCRIPTION
In this PR, we bound the native SQLite backups that waved creates before
schema migrations. Each source schema version now has one stable rollback
copy, so a restart can reuse the same snapshot instead of adding another full
database copy.

The backup first lands at a deterministic staging path and moves into place
only after `VACUUM INTO` succeeds. An interrupted copy therefore replaces the
same staging file on the next start. A failed migration keeps the stable
backup, including a failure in the actor-delivery migration suite after the
main schema has advanced.

Once both SQLite migration suites succeed, we remove version-keyed snapshots,
interrupted staging files, and the 19-digit Unix-nanosecond backups emitted by
older releases. Cleanup failures produce a warning without blocking startup.
The already-current startup path runs the same cleanup, which lets existing
deployments shed stale copies without waiting for another migration.

The browser WebAssembly path keeps its existing virtual-file-system behavior
because its `database/sql` driver does not expose file removal. The reported
standalone waved path uses the bounded native implementation.

## Testing

- `go test ./db -count=1`
- `go test -race ./db -run 'TestSqliteMigrationBackup' -count=1`
- `make lint-changed-local`
- `make build`
- `make tidy-module-check`
- `make check-migration-version`
- `make commitmsg-lint range='origin/main..HEAD'`
- `GOOS=js GOARCH=wasm go test -c ./db`

Closes #1251.
