### PR TITLE
ci: Add static code ownership policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# The core team can approve changes anywhere in the repository.
+* @bhandras @roasbeef @sputn1ck @darioAnongba
+
+# Taproot Assets changes can instead be approved by George. Keep the core team
+# on this rule so any core owner remains a valid fallback.
+/tapassets/ @GeorgeTsagk @bhandras @roasbeef @sputn1ck @darioAnongba
+
+# Documentation-only changes can instead be approved by the documentation bot.
+# Keep the core team on these rules as a fallback.
+/docs/ @litbot-9000 @bhandras @roasbeef @sputn1ck @darioAnongba
+README* @litbot-9000 @bhandras @roasbeef @sputn1ck @darioAnongba
+
+# Only the core team can change ownership rules or CI configuration.
+/.github/ @bhandras @roasbeef @sputn1ck @darioAnongba


### PR DESCRIPTION
## Summary

- make the core team the default owners for the repository
- allow George or a core owner to approve changes under `tapassets/`
- allow `litbot-9000` or a core owner to approve documentation and README changes
- keep `.github/`, including this policy and CI configuration, core-owned
- keep tests under human ownership

## Activation requirements

Before merging, grant `@GeorgeTsagk` write access so GitHub recognizes the `tapassets/` ownership entry. After merging, enable **Require review from Code Owners** in the default-branch ruleset. Existing required CI checks remain in force.