### PR TITLE
wallet: Derive fresh signing keys for refreshes

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1740,14 +1740,17 @@ func (a *Ark) handleRefreshVTXOs(ctx context.Context,
 			PolicyTemplate: policyTemplate,
 			Amount:         vtxo.Amount,
 			OwnerKey:       vtxo.ClientKey,
-			SigningKey:     vtxo.ClientKey,
+			// Leave SigningKey empty. Round registration derives a
+			// fresh locator-backed key for the MuSig2 tree. Reusing
+			// an old owner descriptor breaks when legacy VTXOs
+			// retain the pubkey but not its LND key locator.
+
 			// Refresh output: the new VTXO is funded by the
-			// client's own forfeited VTXO (not by wallet or
-			// an external party). Origin drives the ledger
-			// emission to SourceRoundRefresh so the
-			// VTXOReceived credit cancels the paired VTXOSent
-			// debit on transfers_out, leaving only the
-			// operator fee as the net vtxo_balance change.
+			// client's own forfeited VTXO (not by wallet or an
+			// external party). Origin drives the ledger emission to
+			// SourceRoundRefresh so the VTXOReceived credit cancels
+			// the paired VTXOSent debit on transfers_out, leaving
+			// only the operator fee as the net vtxo_balance change.
 			Origin: types.VTXOOriginRoundRefresh,
 		})
 	}

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -595,16 +595,23 @@ func testVTXOReader(descs map[wire.OutPoint]*VTXODescriptor) VTXOReader {
 }
 
 // TestRefreshReservesBeforeRoundRegistration verifies that the wallet
-// reserves forfeit inputs through the VTXO manager before sending
-// RegisterIntentMsg to the round actor.
+// reserves forfeit inputs before round registration, preserves the long-lived
+// owner key, and leaves the ephemeral signing key for the round to derive.
 func TestRefreshReservesBeforeRoundRegistration(t *testing.T) {
 	t.Parallel()
+
+	ownerPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	ownerKey := keychain.KeyDescriptor{
+		PubKey: ownerPriv.PubKey(),
+	}
 
 	op := testOutpoint(0)
 	vtxoDescs := map[wire.OutPoint]*VTXODescriptor{
 		op: {
-			Outpoint: op,
-			Amount:   50000,
+			Outpoint:  op,
+			Amount:    50000,
+			ClientKey: ownerKey,
 			PkScript: []byte{
 				0x51,
 				0x20,
@@ -640,6 +647,11 @@ func TestRefreshReservesBeforeRoundRegistration(t *testing.T) {
 
 	// Round should have received the intent.
 	require.Equal(t, 1, roundActor.registerCalls)
+	require.NotNil(t, roundActor.capturedIntent)
+	require.Len(t, roundActor.capturedIntent.VTXOs, 1)
+	request := roundActor.capturedIntent.VTXOs[0]
+	require.Equal(t, ownerKey, request.OwnerKey)
+	require.Nil(t, request.SigningKey.PubKey)
 }
 
 // TestCustomRefreshActivatesSignerWithoutLiveReservation verifies that the


### PR DESCRIPTION
## Summary

- stop reusing a VTXO owner descriptor as the round's MuSig2 tree key
- let round registration derive a fresh locator-backed signing key
- keep the long-lived owner descriptor unchanged on the replacement VTXO

Fixes #1255.

## Why

Testnet produced 16 refresh failures across seven owner pubkeys in 30 days.
The affected VTXOs could sign their join-auth inputs, but MuSig2 session
creation failed with `signing key is not found in key set`.

Normal refresh composition copied `vtxo.ClientKey` into both `OwnerKey` and
`SigningKey`. Legacy VTXOs can retain a usable owner pubkey without its LND key
locator. Join authentication can sign by pubkey. LND's MuSig2 session API uses
the locator, so the copied descriptor selected the wrong local key and aborted
the round.

`ensureVTXOSigningKeys` already derives a fresh `VTXOSigningKeyFamily` key when
`SigningKey` is empty. Normal refreshes now use that path. Other round
producers that intentionally supply a signing descriptor remain unchanged.

## Safety

- The owner key and output policy do not change.
- The old owner key still signs the forfeit input through the VTXO actor.
- The fresh key signs only the new round's MuSig2 tree, matching its documented
  ephemeral role.
- Failed rounds already release their forfeit reservations.

## Validation

- `make unit pkg=wallet case=TestRefreshReservesBeforeRoundRegistration`
- `make unit pkg=wallet`
- `go test -race -tags='dev nolog' ./wallet`
- `make lint-changed-local`
- `make commitmsg-lint range='origin/main..HEAD'`
