### PR TITLE
docs: nightly doc-gardening sweep 2026-09-04

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,7 @@ package may import from a higher layer.
 | [`vhtlcrecovery`](vhtlcrecovery/) | Durable control-plane types for vHTLC on-chain recovery jobs (action, state, script parameters, swap linkage) |
 | [`credit`](credit/) | Client-side credit subsystem: supervisor/per-operation-actor pair driving fault-tolerant sub-floor pay, credit-receive, and redeem flows against the authoritative server ledger |
 | [`coinselect`](coinselect/) | Single coin-type-agnostic coin-selection algorithm shared across wallet backends |
+| [`tapassets`](tapassets/) | Taproot Assets adapter: seals tap-sdk custom-anchor transitions into a caller-funded Ark batch output and materializes an asset-carrying VTXO tree beneath it. Journal-backed; not yet wired into `waved` |
 
 ### Layer 2: Infrastructure (Chain, Storage, Messaging)
 
@@ -144,6 +145,11 @@ waved (orchestrator)
 └── db              │
     └── (SQLite | PostgreSQL)
 ```
+
+`tapassets` is deliberately absent from this tree: it depends on `lib/tree`,
+`lib/arkscript`, and `lib/tx/psbtutil`, but nothing in the daemon imports it
+yet. It is a self-contained Taproot Assets adapter reached only through its own
+exported surface.
 
 ## Architectural Patterns
 

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -12,6 +12,12 @@ message interfaces, and core Ark types.
 - `Tree` — Root node plus batch outpoint/output (encapsulates VTXO Merkle tree).
 - `Node` — Individual tree node with children and outputs.
 - `LeafDescriptor` — VTXO or connector output to include in tree construction.
+- `AssetTreeContext` — Side-table of per-tree asset state (subtree amounts,
+  per-input signing tweaks, sealed transfer packages, leaf asset roots), kept
+  out of `Node` so the Bitcoin tree stays asset-agnostic. `nil` on
+  Bitcoin-only trees.
+- `BatchOutputSpec` — Batch output plus the taproot material (`InternalKey`,
+  `SweepLeaf`, BIP-371 tap tree) needed to commit an asset root to it.
 
 ### lib/arkscript
 - `Node` — Sealed AST interface for tapscript spending conditions (Multisig, CSV, Condition, etc.).
@@ -43,6 +49,10 @@ message interfaces, and core Ark types.
 - `VTXOActorServiceKey()`, `VTXOManagerServiceKey()`, `RoundActorServiceKey()` — Deterministic actor lookup.
 - `TriggerBoardMsg`, `RegisterIntentMsg` — Cross-package messages from wallet→round.
 - `SelectAndReserveSpendRequest`, `ReserveForfeitRequest`, etc. — VTXO manager admission types.
+- `SelectedVTXO.ReserveEpoch` / `ReleaseSpendRequest.ReserveEpochs` — Monotonic
+  reservation epoch echoed to a spend and presented back on release, so the
+  manager can refuse a stale release whose reservation was superseded. Zero (or
+  an absent map entry) releases unconditionally.
 
 ### lib/recovery
 - `Proof` — Immutable unilateral-exit recovery graph for one target outpoint.

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -12,6 +12,12 @@ message interfaces, and core Ark types.
 - `Tree` — Root node plus batch outpoint/output (encapsulates VTXO Merkle tree).
 - `Node` — Individual tree node with children and outputs.
 - `LeafDescriptor` — VTXO or connector output to include in tree construction.
+- `AssetTreeContext` — Side-table of per-tree asset state (subtree amounts,
+  per-input signing tweaks, sealed transfer packages, leaf asset roots), kept
+  out of `Node` so the Bitcoin tree stays asset-agnostic. `nil` on
+  Bitcoin-only trees.
+- `BatchOutputSpec` — Batch output plus the taproot material (`InternalKey`,
+  `SweepLeaf`, BIP-371 tap tree) needed to commit an asset root to it.
 
 ### lib/arkscript
 - `Node` — Sealed AST interface for tapscript spending conditions (Multisig, CSV, Condition, etc.).
@@ -43,6 +49,10 @@ message interfaces, and core Ark types.
 - `VTXOActorServiceKey()`, `VTXOManagerServiceKey()`, `RoundActorServiceKey()` — Deterministic actor lookup.
 - `TriggerBoardMsg`, `RegisterIntentMsg` — Cross-package messages from wallet→round.
 - `SelectAndReserveSpendRequest`, `ReserveForfeitRequest`, etc. — VTXO manager admission types.
+- `SelectedVTXO.ReserveEpoch` / `ReleaseSpendRequest.ReserveEpochs` — Monotonic
+  reservation epoch echoed to a spend and presented back on release, so the
+  manager can refuse a stale release whose reservation was superseded. Zero (or
+  an absent map entry) releases unconditionally.
 
 ### lib/recovery
 - `Proof` — Immutable unilateral-exit recovery graph for one target outpoint.

--- a/lib/actormsg/AGENTS.md
+++ b/lib/actormsg/AGENTS.md
@@ -15,7 +15,7 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - `SelectAndReserveSpendRequest` / `SelectAndReserveSpendResponse` — Ask-message to select and lock VTXOs for OOR spend.
 - `SelectAndReserveForfeitRequest` / `SelectAndReserveForfeitResponse` — Ask-message to atomically select and reserve VTXOs for cooperative forfeit (directed sends). Combines coin selection and PendingForfeit reservation in one step to close a race window.
 - `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
-- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
+- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages. `ReleaseSpendRequest.ReserveEpochs` optionally names, per outpoint, the reservation epoch the releasing owner held.
 - `ForceUnrollRequest` / `ForceUnrollResponse` — Ask-message that routes an operator or chain-resolver unroll trigger through the VTXO manager into the per-VTXO FSM. `ForceUnrollRequest.Trigger` (a `UnrollTrigger`) names *why* the coin is exiting, and `ForceUnrollRequest.ExitPolicy` (an `fn.Option[ExitPolicy]`) names *which* exit-spend policy the target unrolls under, so a single admission path carries manual, critical-expiry, fraud, and vHTLC-recovery intent through to the unroll registry. `ForceUnrollResponse.Accepted` is true when the request caused a state transition; when false, `Reason` distinguishes `"no such vtxo"` from `"already terminal"` so callers don't misread a silent self-loop as success.
 - `UnrollTrigger` — String-typed enum naming why a unilateral exit was started (`UnrollTriggerCriticalExpiry` is the empty-string zero value and preserves the historical critical-expiry admission, `UnrollTriggerManual`, `UnrollTriggerFraudSpend`). It mirrors the unroll package's `StartTrigger` so `vtxo` and `actormsg` can thread the trigger through `ForceUnroll` without importing `unroll` (which would form a cycle); the waved chain resolver bridge converts it back at the seam.
 - `ExitPolicyKind` / `ExitPolicyRef` / `ExitPolicy` — Durable exit-spend policy identity for a forced exit. `ExitPolicyKind` is a string-typed enum of the non-standard policies that ride `ForceUnroll` (`ExitPolicyVHTLCClaim`, `ExitPolicyVHTLCRefundWithoutReceiver`), with `Valid()` true only for those two vHTLC kinds; `ExitPolicyRef` is the policy-specific durable reference (e.g. a vHTLC recovery job id), kept a distinct type so `Kind` and `Ref` can't be transposed; `ExitPolicy` bundles the pair as one identity validated at the registry admission boundary. A `None` `ExitPolicy` selects the standard VTXO timeout policy.
@@ -25,7 +25,7 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
   (`true` for directed sends) or parks in `PendingRoundAssembly` for
   batching (`false` for refresh/leave flows).
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
-- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
+- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript, `ReserveEpoch`).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.
 
 ## Relationships
@@ -38,6 +38,12 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - All cross-boundary actor messages must implement the appropriate marker interface (`RoundReceivable`, `VTXOManagerMsg`, etc.) for type-safe actor routing.
 - Service key names are constants (`RoundActorServiceKeyName`, `VTXOManagerServiceKeyName`) shared across the codebase for consistent actor discovery.
 - `SelectedVTXO` intentionally duplicates minimal VTXO info to avoid `wallet` importing `vtxo.Descriptor`.
+- The reservation epoch is a **spend-only** identity. `SelectedVTXO.ReserveEpoch`
+  is zero for reservations that are not spend reservations (e.g. forfeit
+  inputs), and an absent `ReleaseSpendRequest.ReserveEpochs` entry — or a nil
+  map — releases unconditionally, which is what keeps a manual unlock and any
+  pre-epoch caller working. Only a *mismatched* non-zero pair is refused; see
+  `vtxo.Manager.handleReleaseSpend`.
 
 ## Deep Docs
 

--- a/lib/actormsg/CLAUDE.md
+++ b/lib/actormsg/CLAUDE.md
@@ -15,7 +15,7 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - `SelectAndReserveSpendRequest` / `SelectAndReserveSpendResponse` — Ask-message to select and lock VTXOs for OOR spend.
 - `SelectAndReserveForfeitRequest` / `SelectAndReserveForfeitResponse` — Ask-message to atomically select and reserve VTXOs for cooperative forfeit (directed sends). Combines coin selection and PendingForfeit reservation in one step to close a race window.
 - `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
-- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
+- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages. `ReleaseSpendRequest.ReserveEpochs` optionally names, per outpoint, the reservation epoch the releasing owner held.
 - `ForceUnrollRequest` / `ForceUnrollResponse` — Ask-message that routes an operator or chain-resolver unroll trigger through the VTXO manager into the per-VTXO FSM. `ForceUnrollRequest.Trigger` (a `UnrollTrigger`) names *why* the coin is exiting, and `ForceUnrollRequest.ExitPolicy` (an `fn.Option[ExitPolicy]`) names *which* exit-spend policy the target unrolls under, so a single admission path carries manual, critical-expiry, fraud, and vHTLC-recovery intent through to the unroll registry. `ForceUnrollResponse.Accepted` is true when the request caused a state transition; when false, `Reason` distinguishes `"no such vtxo"` from `"already terminal"` so callers don't misread a silent self-loop as success.
 - `UnrollTrigger` — String-typed enum naming why a unilateral exit was started (`UnrollTriggerCriticalExpiry` is the empty-string zero value and preserves the historical critical-expiry admission, `UnrollTriggerManual`, `UnrollTriggerFraudSpend`). It mirrors the unroll package's `StartTrigger` so `vtxo` and `actormsg` can thread the trigger through `ForceUnroll` without importing `unroll` (which would form a cycle); the waved chain resolver bridge converts it back at the seam.
 - `ExitPolicyKind` / `ExitPolicyRef` / `ExitPolicy` — Durable exit-spend policy identity for a forced exit. `ExitPolicyKind` is a string-typed enum of the non-standard policies that ride `ForceUnroll` (`ExitPolicyVHTLCClaim`, `ExitPolicyVHTLCRefundWithoutReceiver`), with `Valid()` true only for those two vHTLC kinds; `ExitPolicyRef` is the policy-specific durable reference (e.g. a vHTLC recovery job id), kept a distinct type so `Kind` and `Ref` can't be transposed; `ExitPolicy` bundles the pair as one identity validated at the registry admission boundary. A `None` `ExitPolicy` selects the standard VTXO timeout policy.
@@ -25,7 +25,7 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
   (`true` for directed sends) or parks in `PendingRoundAssembly` for
   batching (`false` for refresh/leave flows).
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
-- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
+- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript, `ReserveEpoch`).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.
 
 ## Relationships
@@ -38,6 +38,12 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - All cross-boundary actor messages must implement the appropriate marker interface (`RoundReceivable`, `VTXOManagerMsg`, etc.) for type-safe actor routing.
 - Service key names are constants (`RoundActorServiceKeyName`, `VTXOManagerServiceKeyName`) shared across the codebase for consistent actor discovery.
 - `SelectedVTXO` intentionally duplicates minimal VTXO info to avoid `wallet` importing `vtxo.Descriptor`.
+- The reservation epoch is a **spend-only** identity. `SelectedVTXO.ReserveEpoch`
+  is zero for reservations that are not spend reservations (e.g. forfeit
+  inputs), and an absent `ReleaseSpendRequest.ReserveEpochs` entry — or a nil
+  map — releases unconditionally, which is what keeps a manual unlock and any
+  pre-epoch caller working. Only a *mismatched* non-zero pair is refused; see
+  `vtxo.Manager.handleReleaseSpend`.
 
 ## Deep Docs
 

--- a/lib/tree/AGENTS.md
+++ b/lib/tree/AGENTS.md
@@ -10,11 +10,14 @@ descriptors through branch nodes to the batch output.
 
 - `Tree` — Complete VTXO or connector tree: root outpoint, root output, node hierarchy, and traversal helpers. `Verify` checks structure plus value flow; `ValidateValueConservation` exposes the funding check separately for callers that have already bound `BatchOutput` to an authoritative prevout. Built via `BuildVTXOTree` or `BuildConnectorTree`.
 - `Node` — Single tree node representing a transaction in the tree (branch or leaf).
-- `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay.
+- `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay, and optional `AssetAmount` for asset trees.
 - `VTXODescriptor` — Interface for VTXO metadata needed by tree construction (amount, cosigners, owner key).
 - `ConnectorDescriptor` — Describes a connector output for forfeit transaction construction.
-- `Structure` — Intermediate tree layout built by `BuildStructure` before materialization.
+- `Structure` — Intermediate tree layout built by `BuildStructure` before materialization; carries an `AssetContext` when any leaf declared an `AssetAmount`.
 - `StructureConfig` — Configuration for tree building (radix, partition weight function).
+- `AssetTreeContext` — Side-table of per-tree asset state, kept out of `Node` so the Bitcoin tree stays asset-agnostic: subtree asset amounts, per-input taproot signing tweaks, sealed transfer packages, leaf asset commitment roots, and the tree's asset ref. `nil` on Bitcoin-only trees; `IsEmpty` reports a context carrying no asset data.
+- `BatchOutputSpec` / `BuildBatchOutputSpec` — Batch output plus the taproot material needed to commit an asset root to it (untweaked `InternalKey`, `SweepLeaf`, BIP-371 `TapTreeBytes`). `BuildBatchOutput` is the output-only wrapper.
+- `ComputeInternalKey` — Untweaked MuSig2 cosigner aggregate, used when the taproot tweak comes from somewhere other than the sweep root.
 - `SignerSession` — MuSig2 signing session for tree transactions, wrapping `input.MuSig2Signer`.
 - `Materializer` / `BTCMaterializer` — Interface and implementation for materializing tree nodes into actual Bitcoin transactions.
 - `TreeAssembler` — Two-pass builder (`BuildStructure` then `Materialize`) driven by `TreeConfig`.
@@ -23,7 +26,7 @@ descriptors through branch nodes to the batch output.
 ## Relationships
 
 - **Depends on**: `lib/arkscript` (taproot script construction, policy templates, `SpendInfo`).
-- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization).
+- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization), `tapassets` (asset tree materialization drives `BuildStructure`/`Materialize` and populates `AssetTreeContext`).
 
 ## Invariants
 
@@ -42,6 +45,19 @@ descriptors through branch nodes to the batch output.
   all outputs and recurses only into retained children. The traversal rejects
   cycles and nodes shared by multiple parents. `Node.Verify` checks only
   parent-child outpoint topology and is not a trust-boundary validator.
+- Cosigner slices are copied before every MuSig2 aggregation and before every
+  signer session: `musig2.AggregateKeys` and local signers sort their input in
+  place, so passing `Node.CoSigners` directly would silently reorder a node's
+  canonical cosigner set.
+- Asset trees sign under a **per-node** taproot tweak, not the shared sweep
+  tapscript root: `NewTreeSignerSession` switches to `AssetContext`'s tweak
+  lookup whenever the tree carries an asset context, and fails the session if
+  any node has no recorded tweak. Bitcoin-only trees keep using
+  `SweepTapscriptRoot` for every node.
+- `AssetTreeContext` indexes asset amounts by *both* node pointer and input
+  outpoint. Path extraction clones nodes but preserves their inputs, so the
+  outpoint index is what keeps extracted paths readable; the context itself is
+  shared by pointer with every extracted sub-tree.
 - **Cache-aliasing invariant**: a `*Tree` is effectively immutable once published from
   a builder or resolver. Multiple downstream consumers may share the same `*Tree`
   pointer through caches and ancestry-fragment slices. Silently mutating a shared

--- a/lib/tree/CLAUDE.md
+++ b/lib/tree/CLAUDE.md
@@ -10,11 +10,14 @@ descriptors through branch nodes to the batch output.
 
 - `Tree` — Complete VTXO or connector tree: root outpoint, root output, node hierarchy, and traversal helpers. `Verify` checks structure plus value flow; `ValidateValueConservation` exposes the funding check separately for callers that have already bound `BatchOutput` to an authoritative prevout. Built via `BuildVTXOTree` or `BuildConnectorTree`.
 - `Node` — Single tree node representing a transaction in the tree (branch or leaf).
-- `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay.
+- `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay, and optional `AssetAmount` for asset trees.
 - `VTXODescriptor` — Interface for VTXO metadata needed by tree construction (amount, cosigners, owner key).
 - `ConnectorDescriptor` — Describes a connector output for forfeit transaction construction.
-- `Structure` — Intermediate tree layout built by `BuildStructure` before materialization.
+- `Structure` — Intermediate tree layout built by `BuildStructure` before materialization; carries an `AssetContext` when any leaf declared an `AssetAmount`.
 - `StructureConfig` — Configuration for tree building (radix, partition weight function).
+- `AssetTreeContext` — Side-table of per-tree asset state, kept out of `Node` so the Bitcoin tree stays asset-agnostic: subtree asset amounts, per-input taproot signing tweaks, sealed transfer packages, leaf asset commitment roots, and the tree's asset ref. `nil` on Bitcoin-only trees; `IsEmpty` reports a context carrying no asset data.
+- `BatchOutputSpec` / `BuildBatchOutputSpec` — Batch output plus the taproot material needed to commit an asset root to it (untweaked `InternalKey`, `SweepLeaf`, BIP-371 `TapTreeBytes`). `BuildBatchOutput` is the output-only wrapper.
+- `ComputeInternalKey` — Untweaked MuSig2 cosigner aggregate, used when the taproot tweak comes from somewhere other than the sweep root.
 - `SignerSession` — MuSig2 signing session for tree transactions, wrapping `input.MuSig2Signer`.
 - `Materializer` / `BTCMaterializer` — Interface and implementation for materializing tree nodes into actual Bitcoin transactions.
 - `TreeAssembler` — Two-pass builder (`BuildStructure` then `Materialize`) driven by `TreeConfig`.
@@ -23,7 +26,7 @@ descriptors through branch nodes to the batch output.
 ## Relationships
 
 - **Depends on**: `lib/arkscript` (taproot script construction, policy templates, `SpendInfo`).
-- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization).
+- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization), `tapassets` (asset tree materialization drives `BuildStructure`/`Materialize` and populates `AssetTreeContext`).
 
 ## Invariants
 
@@ -42,6 +45,19 @@ descriptors through branch nodes to the batch output.
   all outputs and recurses only into retained children. The traversal rejects
   cycles and nodes shared by multiple parents. `Node.Verify` checks only
   parent-child outpoint topology and is not a trust-boundary validator.
+- Cosigner slices are copied before every MuSig2 aggregation and before every
+  signer session: `musig2.AggregateKeys` and local signers sort their input in
+  place, so passing `Node.CoSigners` directly would silently reorder a node's
+  canonical cosigner set.
+- Asset trees sign under a **per-node** taproot tweak, not the shared sweep
+  tapscript root: `NewTreeSignerSession` switches to `AssetContext`'s tweak
+  lookup whenever the tree carries an asset context, and fails the session if
+  any node has no recorded tweak. Bitcoin-only trees keep using
+  `SweepTapscriptRoot` for every node.
+- `AssetTreeContext` indexes asset amounts by *both* node pointer and input
+  outpoint. Path extraction clones nodes but preserves their inputs, so the
+  outpoint index is what keeps extracted paths readable; the context itself is
+  shared by pointer with every extracted sub-tree.
 - **Cache-aliasing invariant**: a `*Tree` is effectively immutable once published from
   a builder or resolver. Multiple downstream consumers may share the same `*Tree`
   pointer through caches and ancestry-fragment slices. Silently mutating a shared

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -79,6 +79,23 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
   `IncomingSnapshot.Version = 1`); restore rejects a zero version. Outgoing
   v5 adds the `FirstRejectUnixNanos` record (bounded transient submit-reject
   retry window); a pre-v5 snapshot decodes it to 0 (a fresh window).
+- Transfer-input records grow by appending TLV types in ascending order, which
+  keeps the encoded stream canonical without bumping the direction version:
+  `transferInputReserveEpochRecordType` (18) is the newest and is always
+  written, so an input encoded before the field decodes to a zero epoch.
+- **Input releases name the reservation they held.** `TransferInput.ReserveEpoch`
+  carries the monotonic epoch the VTXO manager stamped at
+  `SelectAndReserveSpendResponse` time, and it persists into
+  `TransferInputSnapshot`. `ReleaseInputsRequest.ReserveEpochs` is an
+  in-memory side channel — `ToProto` does not serialize it, because the
+  request is never a persisted transport message. `prePONRReserveEpochs`
+  rebuilds the map from the state's durable `TransferInputs` every time the FSM
+  re-enters the non-retryable failure transition, so a release replayed after a
+  rolled-back commit still presents the epoch it actually held and the manager
+  refuses it if a newer session has since re-reserved the coin. Inputs with a
+  zero epoch (a pre-upgrade snapshot) are omitted from the map entirely and so
+  release unconditionally, preserving the old behaviour. `SpendReleaser` takes
+  the epoch map alongside the outpoints.
 - `StartTransferRequest.IdempotencyKey` dedup reads
   `oor_dispatch_attempts`, not the mutable session row. The table has one row
   per caller key and one caller key per deterministic session id. Once the

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -79,6 +79,23 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
   `IncomingSnapshot.Version = 1`); restore rejects a zero version. Outgoing
   v5 adds the `FirstRejectUnixNanos` record (bounded transient submit-reject
   retry window); a pre-v5 snapshot decodes it to 0 (a fresh window).
+- Transfer-input records grow by appending TLV types in ascending order, which
+  keeps the encoded stream canonical without bumping the direction version:
+  `transferInputReserveEpochRecordType` (18) is the newest and is always
+  written, so an input encoded before the field decodes to a zero epoch.
+- **Input releases name the reservation they held.** `TransferInput.ReserveEpoch`
+  carries the monotonic epoch the VTXO manager stamped at
+  `SelectAndReserveSpendResponse` time, and it persists into
+  `TransferInputSnapshot`. `ReleaseInputsRequest.ReserveEpochs` is an
+  in-memory side channel — `ToProto` does not serialize it, because the
+  request is never a persisted transport message. `prePONRReserveEpochs`
+  rebuilds the map from the state's durable `TransferInputs` every time the FSM
+  re-enters the non-retryable failure transition, so a release replayed after a
+  rolled-back commit still presents the epoch it actually held and the manager
+  refuses it if a newer session has since re-reserved the coin. Inputs with a
+  zero epoch (a pre-upgrade snapshot) are omitted from the map entirely and so
+  release unconditionally, preserving the old behaviour. `SpendReleaser` takes
+  the epoch map alongside the outpoints.
 - `StartTransferRequest.IdempotencyKey` dedup reads
   `oor_dispatch_attempts`, not the mutable session row. The table has one row
   per caller key and one caller key per deterministic session id. Once the

--- a/tapassets/AGENTS.md
+++ b/tapassets/AGENTS.md
@@ -1,0 +1,115 @@
+# tapassets
+
+## Purpose
+
+Adapts the external tap-sdk custom-anchor transition API to Ark's batch output
+and VTXO tree shapes. It moves confirmed Taproot Asset states into a single
+caller-funded batch output, then materializes an asset-carrying VTXO tree
+beneath that output so every tree transaction also commits one Taproot Asset
+transition.
+
+## Key Types
+
+- `BatchAnchorCommitter` — Serialized, journal-backed committer for one asset
+  batch output. `DeriveScript` computes the output script *before* Bitcoin
+  funding, `Commit` seals the asset transition against the funded anchor PSBT,
+  and `Publish` records the finalized transaction in tapd.
+- `BatchAnchorRequest` / `BatchAnchorSource` / `BatchAnchorChange` — The
+  requested asset amount, the confirmed asset inputs that fund it, and the
+  optional surplus output returned to the operator's tapd wallet.
+  `DeriveBatchAnchorChange` derives the change output's wallet keys.
+- `BatchAnchorScript` — Pre-funding derivation of the batch output: composed
+  `PkScript`, untweaked cosigner `InternalKey`, `SigningTweak`, `AssetRoot`,
+  and `ChangePkScript`.
+- `BatchAnchorCommit` — Sealed transfer package, tapd-signed anchor PSBT, the
+  echoed script derivation, and the `TreeRootAssetSource` that feeds tree
+  materialization.
+- `BuildAssetTree` / `AssetTreeRequest` / `TreeMaterializerConfig` — Builds an
+  asset VTXO tree below a batch output, committing one custom-anchor transition
+  per node and returning a `lib/tree.Tree` with a populated `AssetContext`.
+- `TreeRootAssetSource` / `TreeRootAssetInput` — The asset states held by the
+  batch output that the tree root spends, plus that output's taproot tweak and
+  P2TR script.
+- `TreeLeafAnchor` / `StandardVTXOLeafAnchor` — A leaf's policy taproot
+  material (uncomposed pkScript, internal key, canonical tap leaves), which the
+  materializer composes with the leaf's asset commitment root.
+- `Store` / `ErrStoreNotFound` — Durable key/value journal for sealed
+  transition packages. Implementations must replace each value atomically.
+- `ErrReconciliationRequired` — `Publish` could not determine whether tapd
+  accepted the transfer; the outcome must be checked before any retry.
+
+## Relationships
+
+- **Depends on**: `lib/tree` (`Node`, `Tree`, `AssetTreeContext`,
+  `BuildStructure`/`Materialize`, `ComputeInternalKey`, per-node signing
+  tweaks), `lib/arkscript` (leaf policy compilation and taproot spend info),
+  `lib/tx/psbtutil` (anchor PSBT parse/encode), and the external
+  `github.com/lightninglabs/tap-sdk` custom-anchor API.
+- **Depended on by**: nothing yet. The package is a self-contained adapter and
+  is not wired into `waved`, `round`, or any actor. Treat the exported surface
+  as the intended integration point, not a live dependency.
+- **Sends**: no actor messages. Every call is a direct, synchronous SDK call.
+- **Receives**: no actor messages.
+
+## Invariants
+
+- **Derive before funding, then re-derive after committing.** `DeriveScript`
+  produces the batch output script before the Bitcoin transaction is funded.
+  `Commit` fails if the committed taproot merkle root, asset root, or composed
+  pkScript diverges from that pre-funding derivation. This is what makes it
+  safe to fund and sign Bitcoin before the asset commitment exists.
+- **Commits are journaled by request digest.** `commitDurably` keys each tapd
+  mutation under a domain-separated SHA-256 digest of the JSON-encoded
+  `CustomAnchorRequest` (`wavelength/asset-batch-request/v0` for batch anchors,
+  `wavelength/asset-tree-request/v0` for tree nodes). A replay decodes the
+  stored sealed package instead of re-committing. Reusing a journal key with a
+  *different* request is refused rather than overwritten.
+- **The journal write survives caller cancellation.** After tapd accepts a
+  commit, the package is stored on a context detached with
+  `context.WithoutCancel` under a 5-second timeout, so a cancelled caller
+  cannot lose a completed tapd mutation.
+- `BatchAnchorCommitter.Commit` holds its mutex across the journal read and the
+  tapd mutation, keeping the check and the mutation in one critical section.
+- **Ark broadcasts, tapd only records.** Commits set
+  `SkipAnchorTxBroadcast`/`ExternalBroadcast`, so the SDK never broadcasts the
+  anchor transaction. `Publish` verifies the finalized PSBT and records it.
+- `Publish` joins `ErrReconciliationRequired` when the SDK reports
+  `OutcomeUnknown`: publication may have succeeded, so a blind retry is unsafe.
+- Batch anchors must commit in `CustomAnchorFundingCallerFundedExact` mode with
+  `CustomAssetScriptOPTrue` outputs, and the committed anchor PSBT's txid must
+  equal the funded transaction's txid.
+- **Output indexes must be final before deriving a request with change.** The
+  change output's derivation binds to its position in the anchor transaction.
+- **Tree transactions are zero fee.** The batch output value must equal the sum
+  of the leaf carrier amounts; leaf asset amounts must sum to
+  `AssetTreeRequest.AssetAmount`, which must in turn equal the sum of
+  `TreeMaterializerConfig.Root.Inputs` amounts. Every leaf needs a non-zero
+  asset amount and a cosigner that appears exactly once; `Radix` must be >= 2.
+- The batch output must be P2TR, the root signing tweak exactly 32 bytes, and
+  `Digest` non-zero — `Digest` also domain-scopes the deterministic OP_TRUE
+  asset script keys, so distinct trees never reuse a script key.
+- **Every node's key is bound to the output it spends.** `boundFinalKey`
+  recomputes the cosigner aggregate, applies the parent's asset-committing
+  tweak, and fails unless the result reproduces the spent pkScript byte for
+  byte. A node is never signed against a key that does not open its parent.
+- Per-node commits validate that inputs match their requested sources one to
+  one, that outputs conserve each issuance's amount exactly
+  (`validateIssuanceConservation`), and that the committed transaction is
+  byte-identical to the node template.
+- **Proof capacity is checked before materialization.**
+  `validateTreeProofCapacity` rejects a tree whose depth would push any root
+  input's proof past `AssetProofPathMaxDepth` or `AssetProofPathMaxSize`.
+- `treePathVerifier` splits verification by depth: steps below the input's base
+  depth delegate to that input's own verifier, while appended tree steps must
+  match the expected previous outpoint, anchor outpoint, anchor transaction
+  bytes, and input outpoint set exactly.
+- `MuSig2` cosigner slices are copied before aggregation and before signing;
+  `musig2.AggregateKeys` and local signers sort their input in place.
+
+## Deep Docs
+
+- [lib/tree/CLAUDE.md](../lib/tree/CLAUDE.md) — Tree structure, materialization
+  interface, and `AssetTreeContext`.
+- [lib/arkscript/CLAUDE.md](../lib/arkscript/CLAUDE.md) — Policy compilation
+  and taproot spend info.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/tapassets/CLAUDE.md
+++ b/tapassets/CLAUDE.md
@@ -1,0 +1,115 @@
+# tapassets
+
+## Purpose
+
+Adapts the external tap-sdk custom-anchor transition API to Ark's batch output
+and VTXO tree shapes. It moves confirmed Taproot Asset states into a single
+caller-funded batch output, then materializes an asset-carrying VTXO tree
+beneath that output so every tree transaction also commits one Taproot Asset
+transition.
+
+## Key Types
+
+- `BatchAnchorCommitter` — Serialized, journal-backed committer for one asset
+  batch output. `DeriveScript` computes the output script *before* Bitcoin
+  funding, `Commit` seals the asset transition against the funded anchor PSBT,
+  and `Publish` records the finalized transaction in tapd.
+- `BatchAnchorRequest` / `BatchAnchorSource` / `BatchAnchorChange` — The
+  requested asset amount, the confirmed asset inputs that fund it, and the
+  optional surplus output returned to the operator's tapd wallet.
+  `DeriveBatchAnchorChange` derives the change output's wallet keys.
+- `BatchAnchorScript` — Pre-funding derivation of the batch output: composed
+  `PkScript`, untweaked cosigner `InternalKey`, `SigningTweak`, `AssetRoot`,
+  and `ChangePkScript`.
+- `BatchAnchorCommit` — Sealed transfer package, tapd-signed anchor PSBT, the
+  echoed script derivation, and the `TreeRootAssetSource` that feeds tree
+  materialization.
+- `BuildAssetTree` / `AssetTreeRequest` / `TreeMaterializerConfig` — Builds an
+  asset VTXO tree below a batch output, committing one custom-anchor transition
+  per node and returning a `lib/tree.Tree` with a populated `AssetContext`.
+- `TreeRootAssetSource` / `TreeRootAssetInput` — The asset states held by the
+  batch output that the tree root spends, plus that output's taproot tweak and
+  P2TR script.
+- `TreeLeafAnchor` / `StandardVTXOLeafAnchor` — A leaf's policy taproot
+  material (uncomposed pkScript, internal key, canonical tap leaves), which the
+  materializer composes with the leaf's asset commitment root.
+- `Store` / `ErrStoreNotFound` — Durable key/value journal for sealed
+  transition packages. Implementations must replace each value atomically.
+- `ErrReconciliationRequired` — `Publish` could not determine whether tapd
+  accepted the transfer; the outcome must be checked before any retry.
+
+## Relationships
+
+- **Depends on**: `lib/tree` (`Node`, `Tree`, `AssetTreeContext`,
+  `BuildStructure`/`Materialize`, `ComputeInternalKey`, per-node signing
+  tweaks), `lib/arkscript` (leaf policy compilation and taproot spend info),
+  `lib/tx/psbtutil` (anchor PSBT parse/encode), and the external
+  `github.com/lightninglabs/tap-sdk` custom-anchor API.
+- **Depended on by**: nothing yet. The package is a self-contained adapter and
+  is not wired into `waved`, `round`, or any actor. Treat the exported surface
+  as the intended integration point, not a live dependency.
+- **Sends**: no actor messages. Every call is a direct, synchronous SDK call.
+- **Receives**: no actor messages.
+
+## Invariants
+
+- **Derive before funding, then re-derive after committing.** `DeriveScript`
+  produces the batch output script before the Bitcoin transaction is funded.
+  `Commit` fails if the committed taproot merkle root, asset root, or composed
+  pkScript diverges from that pre-funding derivation. This is what makes it
+  safe to fund and sign Bitcoin before the asset commitment exists.
+- **Commits are journaled by request digest.** `commitDurably` keys each tapd
+  mutation under a domain-separated SHA-256 digest of the JSON-encoded
+  `CustomAnchorRequest` (`wavelength/asset-batch-request/v0` for batch anchors,
+  `wavelength/asset-tree-request/v0` for tree nodes). A replay decodes the
+  stored sealed package instead of re-committing. Reusing a journal key with a
+  *different* request is refused rather than overwritten.
+- **The journal write survives caller cancellation.** After tapd accepts a
+  commit, the package is stored on a context detached with
+  `context.WithoutCancel` under a 5-second timeout, so a cancelled caller
+  cannot lose a completed tapd mutation.
+- `BatchAnchorCommitter.Commit` holds its mutex across the journal read and the
+  tapd mutation, keeping the check and the mutation in one critical section.
+- **Ark broadcasts, tapd only records.** Commits set
+  `SkipAnchorTxBroadcast`/`ExternalBroadcast`, so the SDK never broadcasts the
+  anchor transaction. `Publish` verifies the finalized PSBT and records it.
+- `Publish` joins `ErrReconciliationRequired` when the SDK reports
+  `OutcomeUnknown`: publication may have succeeded, so a blind retry is unsafe.
+- Batch anchors must commit in `CustomAnchorFundingCallerFundedExact` mode with
+  `CustomAssetScriptOPTrue` outputs, and the committed anchor PSBT's txid must
+  equal the funded transaction's txid.
+- **Output indexes must be final before deriving a request with change.** The
+  change output's derivation binds to its position in the anchor transaction.
+- **Tree transactions are zero fee.** The batch output value must equal the sum
+  of the leaf carrier amounts; leaf asset amounts must sum to
+  `AssetTreeRequest.AssetAmount`, which must in turn equal the sum of
+  `TreeMaterializerConfig.Root.Inputs` amounts. Every leaf needs a non-zero
+  asset amount and a cosigner that appears exactly once; `Radix` must be >= 2.
+- The batch output must be P2TR, the root signing tweak exactly 32 bytes, and
+  `Digest` non-zero — `Digest` also domain-scopes the deterministic OP_TRUE
+  asset script keys, so distinct trees never reuse a script key.
+- **Every node's key is bound to the output it spends.** `boundFinalKey`
+  recomputes the cosigner aggregate, applies the parent's asset-committing
+  tweak, and fails unless the result reproduces the spent pkScript byte for
+  byte. A node is never signed against a key that does not open its parent.
+- Per-node commits validate that inputs match their requested sources one to
+  one, that outputs conserve each issuance's amount exactly
+  (`validateIssuanceConservation`), and that the committed transaction is
+  byte-identical to the node template.
+- **Proof capacity is checked before materialization.**
+  `validateTreeProofCapacity` rejects a tree whose depth would push any root
+  input's proof past `AssetProofPathMaxDepth` or `AssetProofPathMaxSize`.
+- `treePathVerifier` splits verification by depth: steps below the input's base
+  depth delegate to that input's own verifier, while appended tree steps must
+  match the expected previous outpoint, anchor outpoint, anchor transaction
+  bytes, and input outpoint set exactly.
+- `MuSig2` cosigner slices are copied before aggregation and before signing;
+  `musig2.AggregateKeys` and local signers sort their input in place.
+
+## Deep Docs
+
+- [lib/tree/CLAUDE.md](../lib/tree/CLAUDE.md) — Tree structure, materialization
+  interface, and `AssetTreeContext`.
+- [lib/arkscript/CLAUDE.md](../lib/arkscript/CLAUDE.md) — Policy compilation
+  and taproot spend info.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -164,6 +164,23 @@ when the local wallet owns the receive script.
   actors from. Coin selection is already `VTXOStatusLive`-scoped via
   `ListSelectionCandidatesByStatus`, so it excludes them by construction.
 - VTXO actor state is the single source of truth for availability.
+- **Spend reservations are epoch-stamped, and releases are epoch-guarded.**
+  `markReserved` returns a monotonic epoch that `selectAndReserveVTXOs` echoes
+  back in `SelectedVTXO.ReserveEpoch`; the owning spend persists it and
+  presents it again in `ReleaseSpendRequest.ReserveEpochs`.
+  `handleReleaseSpend` refuses a release **only** when a live in-memory
+  reservation names a *different* non-zero epoch — that means the reservation
+  was superseded, and honouring the stale release would return a coin the newer
+  owner is already spending to the live set. Three cases deliberately release
+  anyway: a zero caller epoch ("unknown" — a pre-upgrade snapshot or a manual
+  unlock), a zero *current* mark, and no live reservation at all (the manager
+  restarted and never repopulated this coin, so refusing would strand it in
+  `Spending` forever).
+- The orphan-reservation sweep re-marks with `markReservedUnknown` (epoch 0),
+  **not** a fresh epoch. The epoch counter restarts at 0 on boot, so a fresh
+  mark could never match what a resumed session persisted and its later release
+  would be wrongly refused. Admission only tests presence (`isReserved`), so
+  the sweep does not need a real epoch.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
 - `ExpiryConfig.MaxPaymentCLTV` reserves a total Lightning CLTV window above

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -164,6 +164,23 @@ when the local wallet owns the receive script.
   actors from. Coin selection is already `VTXOStatusLive`-scoped via
   `ListSelectionCandidatesByStatus`, so it excludes them by construction.
 - VTXO actor state is the single source of truth for availability.
+- **Spend reservations are epoch-stamped, and releases are epoch-guarded.**
+  `markReserved` returns a monotonic epoch that `selectAndReserveVTXOs` echoes
+  back in `SelectedVTXO.ReserveEpoch`; the owning spend persists it and
+  presents it again in `ReleaseSpendRequest.ReserveEpochs`.
+  `handleReleaseSpend` refuses a release **only** when a live in-memory
+  reservation names a *different* non-zero epoch — that means the reservation
+  was superseded, and honouring the stale release would return a coin the newer
+  owner is already spending to the live set. Three cases deliberately release
+  anyway: a zero caller epoch ("unknown" — a pre-upgrade snapshot or a manual
+  unlock), a zero *current* mark, and no live reservation at all (the manager
+  restarted and never repopulated this coin, so refusing would strand it in
+  `Spending` forever).
+- The orphan-reservation sweep re-marks with `markReservedUnknown` (epoch 0),
+  **not** a fresh epoch. The epoch counter restarts at 0 on boot, so a fresh
+  mark could never match what a resumed session persisted and its later release
+  would be wrongly refused. Admission only tests presence (`isReserved`), so
+  the sweep does not need a real epoch.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
 - `ExpiryConfig.MaxPaymentCLTV` reserves a total Lightning CLTV window above

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -20,7 +20,7 @@ refresh, leave, OOR spend, and directed send flows.
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
-- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
+- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript, `ReserveEpoch`). Breaks the vtxo → round → wallet import cycle. `handleSelectAndLockVTXOs` copies the manager's `ReserveEpoch` through verbatim so the OOR transfer that spends the coin can name the reservation on release; dropping it would silently downgrade every release to unconditional.
 - `CreateBoardingAddressRequest` / `CreateBoardingAddressResponse` — Ask-request for deriving new address.
 - `BlockEpochNotification` — Tell-message from chain source triggering UTXO polling.
 - `BoardingUtxoConfirmedEvent` — Tell-message sent when a VTXO confirms.

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -20,7 +20,7 @@ refresh, leave, OOR spend, and directed send flows.
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
-- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
+- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript, `ReserveEpoch`). Breaks the vtxo → round → wallet import cycle. `handleSelectAndLockVTXOs` copies the manager's `ReserveEpoch` through verbatim so the OOR transfer that spends the coin can name the reservation on release; dropping it would silently downgrade every release to unconditional.
 - `CreateBoardingAddressRequest` / `CreateBoardingAddressResponse` — Ask-request for deriving new address.
 - `BlockEpochNotification` — Tell-message from chain source triggering UTXO polling.
 - `BoardingUtxoConfirmedEvent` — Tell-message sent when a VTXO confirms.


### PR DESCRIPTION
Nightly documentation-graph sweep: adds `tapassets` per-package docs and
refreshes the asset-tree and spend-reservation-epoch invariants across
`lib/tree`, `lib`, `lib/actormsg`, `vtxo`, `oor`, and `wallet`.

Please review the updated CLAUDE.md/AGENTS.md and ARCHITECTURE.md diffs.

Note: the workflow run URL could not be recorded — the run identifier
environment variables were not readable in this run.
