### PR TITLE
ledger: Namespace operation idempotency keys

### DIFF
--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -64,8 +64,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   before the first transport enqueue and remains authoritative after the
   mutable session row becomes terminal or changes direction.
 - `LedgerStoreDB` — implements `ledger.LedgerStore`. Wraps
-  `sqlc.InsertClientLedgerEntry` (ON CONFLICT DO NOTHING for replay
-  idempotency). Joins the outer actor transaction via
+  `sqlc.InsertClientLedgerEntry` (ON CONFLICT DO NOTHING followed by an exact
+  winner-payload comparison, so contradictory key reuse fails). Joins the
+  outer actor transaction via
   `actor.TxFromContext`. Read API:
   `GetAccountBalance`/`GetTotalOperatorFeesPaid`/`ListLedgerEntries[…]`/
   `CountLedgerEntries`/`ListAccounts`.
@@ -356,6 +357,11 @@ when adding one.
   duplicate send but cannot recover recipient outpoints. If legacy failed and
   non-failed rows reused one key, the non-failed row wins deterministically.
   The down migration only drops the new table.
+- `000019_ledger_idempotency_domains` — rewrites legacy 36-byte refresh-send
+  and unilateral-exit keys into versioned operation-and-leg domains. Its Go
+  post-step detects the old refresh/exit collision and reconstructs the
+  missing net exit-send row from the surviving refresh-send and exit-fee rows,
+  repairing the overstated VTXO balance atomically with the key rewrite.
 
 ## Deep Docs
 

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -64,8 +64,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   before the first transport enqueue and remains authoritative after the
   mutable session row becomes terminal or changes direction.
 - `LedgerStoreDB` — implements `ledger.LedgerStore`. Wraps
-  `sqlc.InsertClientLedgerEntry` (ON CONFLICT DO NOTHING for replay
-  idempotency). Joins the outer actor transaction via
+  `sqlc.InsertClientLedgerEntry` (ON CONFLICT DO NOTHING followed by an exact
+  winner-payload comparison, so contradictory key reuse fails). Joins the
+  outer actor transaction via
   `actor.TxFromContext`. Read API:
   `GetAccountBalance`/`GetTotalOperatorFeesPaid`/`ListLedgerEntries[…]`/
   `CountLedgerEntries`/`ListAccounts`.
@@ -356,6 +357,11 @@ when adding one.
   duplicate send but cannot recover recipient outpoints. If legacy failed and
   non-failed rows reused one key, the non-failed row wins deterministically.
   The down migration only drops the new table.
+- `000019_ledger_idempotency_domains` — rewrites legacy 36-byte refresh-send
+  and unilateral-exit keys into versioned operation-and-leg domains. Its Go
+  post-step detects the old refresh/exit collision and reconstructs the
+  missing net exit-send row from the surviving refresh-send and exit-fee rows,
+  repairing the overstated VTXO balance atomically with the key rewrite.
 
 ## Deep Docs
 

--- a/db/ledger_store.go
+++ b/db/ledger_store.go
@@ -1,8 +1,11 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/google/uuid"
@@ -48,41 +51,161 @@ func NewLedgerStoreDB(store *Store) *LedgerStoreDB {
 // TransactionExecutor.ExecTx joins that outer tx rather than opening
 // a fresh one, so multiple invocations from within a single actor
 // handler commit atomically alongside the mailbox ack. The underlying
-// InsertClientLedgerEntry query uses ON CONFLICT DO NOTHING against
-// the partial unique indexes on round_id, session_id, and
-// idempotency_key so redelivery of an already-persisted message
-// silently dedupes instead of raising a constraint violation.
+// InsertClientLedgerEntry query uses ON CONFLICT DO NOTHING against the
+// partial unique indexes on round_id, session_id, and idempotency_key. The
+// winning row is then compared with the requested payload: an identical replay
+// succeeds, while a conflicting reuse returns ledger.ErrIdempotencyConflict.
 func (s *LedgerStoreDB) InsertLedgerEntry(ctx context.Context,
 	entry ledger.LedgerEntry) error {
 
 	return s.ExecTx(
 		ctx, WriteTxOption(),
 		func(qtx *sqlc.Queries) error {
-			return qtx.InsertClientLedgerEntry(
-				ctx, sqlc.InsertClientLedgerEntryParams{
-					DebitAccount:  entry.DebitAccount,
-					CreditAccount: entry.CreditAccount,
-					AmountSat:     entry.AmountSat,
-					RoundID:       entry.RoundID,
-					RoundUuid: roundUUIDText(
-						entry.RoundID,
-					),
-					SessionID:      entry.SessionID,
-					EventType:      entry.EventType,
-					Description:    entry.Description,
-					CreatedAt:      entry.CreatedAt,
-					IdempotencyKey: entry.IdempotencyKey,
-					ChainTxid:      entry.ChainTxid,
-					ChainVout: sqlInt32Ptr(
-						entry.ChainVout,
-					),
-					ConfirmationHeight: sqlInt32Ptr(
-						entry.ConfirmationHeight,
-					),
-				},
-			)
+			params := sqlc.InsertClientLedgerEntryParams{
+				DebitAccount:  entry.DebitAccount,
+				CreditAccount: entry.CreditAccount,
+				AmountSat:     entry.AmountSat,
+				RoundID:       entry.RoundID,
+				RoundUuid: roundUUIDText(
+					entry.RoundID,
+				),
+				SessionID:      entry.SessionID,
+				EventType:      entry.EventType,
+				Description:    entry.Description,
+				CreatedAt:      entry.CreatedAt,
+				IdempotencyKey: entry.IdempotencyKey,
+				ChainTxid:      entry.ChainTxid,
+				ChainVout: sqlInt32Ptr(
+					entry.ChainVout,
+				),
+				ConfirmationHeight: sqlInt32Ptr(
+					entry.ConfirmationHeight,
+				),
+			}
+
+			if err := qtx.InsertClientLedgerEntry(
+				ctx, params,
+			); err != nil {
+				return err
+			}
+
+			return verifyLedgerEntryReplay(ctx, qtx, params)
 		},
 	)
+}
+
+// verifyLedgerEntryReplay proves every applicable unique identity resolves to
+// the same payload that was requested. InsertClientLedgerEntry deliberately
+// suppresses unique violations, so reading the winner is what distinguishes a
+// harmless at-least-once replay from contradictory accounting data.
+func verifyLedgerEntryReplay(ctx context.Context, q *sqlc.Queries,
+	want sqlc.InsertClientLedgerEntryParams) error {
+
+	// Some audit-style ledger rows intentionally have no natural replay
+	// identity. They are not covered by any partial unique index, so a
+	// successful insert has no winner to compare and retains the historical
+	// append-only behavior.
+	hasIdentity := len(want.IdempotencyKey) > 0 ||
+		len(want.SessionID) > 0 || len(want.RoundID) > 0
+	if !hasIdentity {
+		return nil
+	}
+
+	var winners []sqlc.LedgerEntry
+	appendWinner := func(row sqlc.LedgerEntry, err error) error {
+		switch {
+		case err == nil:
+			winners = append(winners, row)
+
+			return nil
+
+		case errors.Is(err, sql.ErrNoRows):
+			return nil
+
+		default:
+			return err
+		}
+	}
+
+	if len(want.IdempotencyKey) > 0 {
+		row, err := q.GetClientLedgerEntryByIdempotencyKey(
+			ctx, sqlc.GetClientLedgerEntryByIdempotencyKeyParams{
+				IdempotencyKey: want.IdempotencyKey,
+				EventType:      want.EventType,
+				DebitAccount:   want.DebitAccount,
+				CreditAccount:  want.CreditAccount,
+			},
+		)
+		if err := appendWinner(row, err); err != nil {
+			return err
+		}
+	}
+
+	if len(want.SessionID) > 0 {
+		row, err := q.GetClientLedgerEntryBySessionID(
+			ctx, sqlc.GetClientLedgerEntryBySessionIDParams{
+				SessionID:     want.SessionID,
+				EventType:     want.EventType,
+				DebitAccount:  want.DebitAccount,
+				CreditAccount: want.CreditAccount,
+			},
+		)
+		if err := appendWinner(row, err); err != nil {
+			return err
+		}
+	}
+
+	if len(want.RoundID) > 0 && len(want.IdempotencyKey) == 0 {
+		row, err := q.GetClientLedgerEntryByRoundID(
+			ctx, sqlc.GetClientLedgerEntryByRoundIDParams{
+				RoundID:       want.RoundID,
+				EventType:     want.EventType,
+				DebitAccount:  want.DebitAccount,
+				CreditAccount: want.CreditAccount,
+			},
+		)
+		if err := appendWinner(row, err); err != nil {
+			return err
+		}
+	}
+
+	if len(winners) == 0 {
+		return fmt.Errorf("%w: no row for ledger identity",
+			ledger.ErrIdempotencyConflict)
+	}
+
+	for _, winner := range winners {
+		if ledgerPayloadEqual(winner, want) {
+			continue
+		}
+
+		return fmt.Errorf("%w: event=%s debit=%s credit=%s",
+			ledger.ErrIdempotencyConflict, want.EventType,
+			want.DebitAccount, want.CreditAccount)
+	}
+
+	return nil
+}
+
+// ledgerPayloadEqual compares the durable accounting payload while ignoring
+// CreatedAt. The same message can be retried after the wall clock advances;
+// every field that changes money, provenance, or user-visible description must
+// still match exactly.
+func ledgerPayloadEqual(got sqlc.LedgerEntry,
+	want sqlc.InsertClientLedgerEntryParams) bool {
+
+	return got.DebitAccount == want.DebitAccount &&
+		got.CreditAccount == want.CreditAccount &&
+		got.AmountSat == want.AmountSat &&
+		bytes.Equal(got.RoundID, want.RoundID) &&
+		bytes.Equal(got.SessionID, want.SessionID) &&
+		bytes.Equal(got.IdempotencyKey, want.IdempotencyKey) &&
+		got.EventType == want.EventType &&
+		got.Description == want.Description &&
+		bytes.Equal(got.ChainTxid, want.ChainTxid) &&
+		got.ChainVout == want.ChainVout &&
+		got.ConfirmationHeight == want.ConfirmationHeight &&
+		got.RoundUuid == want.RoundUuid
 }
 
 // roundUUIDText mirrors a raw 16-byte ledger round_id into the canonical
@@ -123,7 +246,7 @@ func sqlInt32Ptr(v *int32) sql.NullInt32 {
 func (s *LedgerStoreDB) GetConfirmedExitCost(ctx context.Context,
 	outpoint wire.OutPoint) (int64, error) {
 
-	key := ledger.ExitIdempotencyKey(outpoint.Hash, outpoint.Index)
+	key := ledger.ExitFeeIdempotencyKey(outpoint.Hash, outpoint.Index)
 
 	var cost int64
 	err := s.ExecTx(

--- a/db/ledger_store_test.go
+++ b/db/ledger_store_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"fmt"
 	"testing"
 	"time"
@@ -280,8 +281,8 @@ func TestLedgerStoreInsertStampsRoundUUID(t *testing.T) {
 
 // TestLedgerStoreGetConfirmedExitCost proves the exit-cost lookup returns
 // exactly the onchain_fee_paid leg keyed by the exited VTXO's outpoint: the
-// send leg sharing the same idempotency key and a fee leg for a different
-// outpoint contribute nothing, and an unknown outpoint reads zero.
+// separately namespaced send leg and a fee leg for a different outpoint
+// contribute nothing, and an unknown outpoint reads zero.
 func TestLedgerStoreGetConfirmedExitCost(t *testing.T) {
 	t.Parallel()
 
@@ -299,9 +300,15 @@ func TestLedgerStoreGetConfirmedExitCost(t *testing.T) {
 		entry := makeLedgerEntry(
 			debit, credit, amount, eventType, nil, 1_000,
 		)
-		entry.IdempotencyKey = ledger.ExitIdempotencyKey(
-			op.Hash, op.Index,
-		)
+		if eventType == ledger.EventOnchainFeePaid {
+			entry.IdempotencyKey = ledger.ExitFeeIdempotencyKey(
+				op.Hash, op.Index,
+			)
+		} else {
+			entry.IdempotencyKey = ledger.ExitSendIdempotencyKey(
+				op.Hash, op.Index,
+			)
+		}
 		require.NoError(t, store.InsertLedgerEntry(ctx, entry))
 	}
 
@@ -320,6 +327,195 @@ func TestLedgerStoreGetConfirmedExitCost(t *testing.T) {
 	cost, err = store.GetConfirmedExitCost(ctx, unknown)
 	require.NoError(t, err)
 	require.Zero(t, cost)
+}
+
+// TestLedgerStoreReplayRejectsConflictingPayloads verifies all three ledger
+// identity classes accept an identical retry after time advances but reject a
+// different amount under the same key. The original row remains authoritative
+// in every case.
+func TestLedgerStoreReplayRejectsConflictingPayloads(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		apply func(*ledger.LedgerEntry)
+	}{
+		{
+			name: "idempotency key",
+			apply: func(entry *ledger.LedgerEntry) {
+				entry.IdempotencyKey = testBytes(48, 0x11)
+			},
+		},
+		{
+			name: "session id",
+			apply: func(entry *ledger.LedgerEntry) {
+				entry.SessionID = testBytes(32, 0x22)
+			},
+		},
+		{
+			name: "round id",
+			apply: func(entry *ledger.LedgerEntry) {
+				entry.RoundID = testBytes(16, 0x33)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			store := newLedgerStoreForTest(t)
+			entry := makeLedgerEntry(
+				ledger.AccountTransfersOut,
+				ledger.AccountVTXOBalance, 50_000,
+				ledger.EventVTXOSent, nil, 1_000,
+			)
+			test.apply(&entry)
+
+			require.NoError(t, store.InsertLedgerEntry(ctx, entry))
+
+			replay := entry
+			replay.CreatedAt++
+			require.NoError(t, store.InsertLedgerEntry(ctx, replay))
+
+			conflict := replay
+			conflict.AmountSat++
+			err := store.InsertLedgerEntry(ctx, conflict)
+			require.ErrorIs(t, err, ledger.ErrIdempotencyConflict)
+
+			count, err := store.CountLedgerEntries(ctx)
+			require.NoError(t, err)
+			require.Equal(t, int64(1), count)
+		})
+	}
+}
+
+// TestLedgerIdempotencyMigrationRepairsRefreshExitCollision verifies the
+// version-19 post-step recognizes the surviving legacy shape, separates the
+// refresh and exit domains, and restores the missing net exit-send row.
+func TestLedgerIdempotencyMigrationRepairsRefreshExitCollision(t *testing.T) {
+	ctx := t.Context()
+	database := NewTestDBWithVersion(t, 18)
+
+	var hash [32]byte
+	copy(hash[:], testBytes(32, 0x41))
+	const index = uint32(7)
+	legacyKey := make([]byte, 36)
+	copy(legacyKey, hash[:])
+	binary.BigEndian.PutUint32(legacyKey[32:], index)
+
+	roundID := uuid.New()
+	roundUUID := sql.NullString{
+		String: roundID.String(),
+		Valid:  true,
+	}
+	insert := func(params sqlc.InsertClientLedgerEntryParams) {
+		require.NoError(
+			t, database.InsertClientLedgerEntry(ctx, params),
+		)
+	}
+
+	insert(sqlc.InsertClientLedgerEntryParams{
+		DebitAccount:   ledger.AccountVTXOBalance,
+		CreditAccount:  ledger.AccountTransfersOut,
+		AmountSat:      50_000,
+		RoundID:        roundID[:],
+		IdempotencyKey: legacyKey,
+		EventType:      ledger.EventVTXOReceived,
+		Description:    "replacement VTXO received",
+		CreatedAt:      100,
+		RoundUuid:      roundUUID,
+	})
+	insert(sqlc.InsertClientLedgerEntryParams{
+		DebitAccount:   ledger.AccountTransfersOut,
+		CreditAccount:  ledger.AccountVTXOBalance,
+		AmountSat:      50_000,
+		RoundID:        roundID[:],
+		IdempotencyKey: legacyKey,
+		EventType:      ledger.EventVTXOSent,
+		Description:    fmt.Sprintf("VTXO sent in round %x", roundID),
+		CreatedAt:      100,
+		RoundUuid:      roundUUID,
+	})
+	insert(sqlc.InsertClientLedgerEntryParams{
+		DebitAccount:   ledger.AccountOnchainFees,
+		CreditAccount:  ledger.AccountVTXOBalance,
+		AmountSat:      2_000,
+		IdempotencyKey: legacyKey,
+		EventType:      ledger.EventOnchainFeePaid,
+		Description: fmt.Sprintf(
+			"exit cost for %x:%d at height %d", hash, index, 800,
+		),
+		CreatedAt: 200,
+	})
+
+	before, err := database.GetClientAccountBalance(
+		ctx, ledger.AccountVTXOBalance,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(-2_000), before)
+
+	require.NoError(
+		t,
+		database.ExecuteMigrations(
+			TargetLatest,
+			WithPostStepCallbacks(
+				makePostStepCallbacks(
+					database, btclog.Disabled,
+					postMigrationChecks,
+				),
+			),
+		),
+	)
+
+	after, err := database.GetClientAccountBalance(
+		ctx, ledger.AccountVTXOBalance,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(-50_000), after)
+
+	rows, err := database.ListClientLedgerEntries(
+		ctx, sqlc.ListClientLedgerEntriesParams{
+			Limit: 10,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 4)
+
+	keys := make(map[string]sqlc.LedgerEntry)
+	for _, row := range rows {
+		keys[string(row.IdempotencyKey)] = row
+	}
+
+	refreshKey := ledger.RefreshSendIdempotencyKey(hash, index)
+	exitSendKey := ledger.ExitSendIdempotencyKey(hash, index)
+	exitFeeKey := ledger.ExitFeeIdempotencyKey(hash, index)
+	require.Equal(t, int64(50_000), keys[string(refreshKey)].AmountSat)
+	require.Equal(t, int64(48_000), keys[string(exitSendKey)].AmountSat)
+	require.Equal(t, int64(2_000), keys[string(exitFeeKey)].AmountSat)
+	for _, key := range [][]byte{exitSendKey, exitFeeKey} {
+		row := keys[string(key)]
+		require.Equal(t, hash[:], row.ChainTxid)
+		require.True(t, row.ChainVout.Valid)
+		require.Equal(t, int32(index), row.ChainVout.Int32)
+	}
+	require.Contains(
+		t, keys[string(exitSendKey)].Description,
+		"unilateral exit net value",
+	)
+
+	// The receive side is not part of the conflicting send identity and
+	// keeps its existing key. Re-running reconciliation is a no-op.
+	require.Equal(
+		t, ledger.EventVTXOReceived, keys[string(legacyKey)].EventType,
+	)
+	require.NoError(
+		t, reconcileLedgerIdempotencyKeys(ctx, database.Queries),
+	)
+	count, err := database.CountClientLedgerEntries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), count)
 }
 
 // TestBackfillLedgerRoundUUIDs proves the migration-15 post-step converts

--- a/db/ledger_store_test.go
+++ b/db/ledger_store_test.go
@@ -439,6 +439,16 @@ func TestLedgerIdempotencyMigrationRepairsRefreshExitCollision(t *testing.T) {
 		RoundUuid:      roundUUID,
 	})
 	insert(sqlc.InsertClientLedgerEntryParams{
+		DebitAccount:  ledger.AccountFeesPaid,
+		CreditAccount: ledger.AccountVTXOBalance,
+		AmountSat:     750,
+		RoundID:       roundID[:],
+		EventType:     ledger.EventRefreshFeePaid,
+		Description:   "refresh operator fee",
+		CreatedAt:     100,
+		RoundUuid:     roundUUID,
+	})
+	insert(sqlc.InsertClientLedgerEntryParams{
 		DebitAccount:   ledger.AccountOnchainFees,
 		CreditAccount:  ledger.AccountVTXOBalance,
 		AmountSat:      2_000,
@@ -454,7 +464,7 @@ func TestLedgerIdempotencyMigrationRepairsRefreshExitCollision(t *testing.T) {
 		ctx, ledger.AccountVTXOBalance,
 	)
 	require.NoError(t, err)
-	require.Equal(t, int64(-2_000), before)
+	require.Equal(t, int64(-2_750), before)
 
 	require.NoError(
 		t,
@@ -481,7 +491,7 @@ func TestLedgerIdempotencyMigrationRepairsRefreshExitCollision(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Len(t, rows, 4)
+	require.Len(t, rows, 5)
 
 	keys := make(map[string]sqlc.LedgerEntry)
 	for _, row := range rows {
@@ -492,13 +502,15 @@ func TestLedgerIdempotencyMigrationRepairsRefreshExitCollision(t *testing.T) {
 	exitSendKey := ledger.ExitSendIdempotencyKey(hash, index)
 	exitFeeKey := ledger.ExitFeeIdempotencyKey(hash, index)
 	require.Equal(t, int64(50_000), keys[string(refreshKey)].AmountSat)
-	require.Equal(t, int64(48_000), keys[string(exitSendKey)].AmountSat)
+	require.Equal(t, int64(47_250), keys[string(exitSendKey)].AmountSat)
 	require.Equal(t, int64(2_000), keys[string(exitFeeKey)].AmountSat)
 	for _, key := range [][]byte{exitSendKey, exitFeeKey} {
 		row := keys[string(key)]
 		require.Equal(t, hash[:], row.ChainTxid)
 		require.True(t, row.ChainVout.Valid)
 		require.Equal(t, int32(index), row.ChainVout.Int32)
+		require.True(t, row.ConfirmationHeight.Valid)
+		require.Equal(t, int32(800), row.ConfirmationHeight.Int32)
 	}
 	require.Contains(
 		t, keys[string(exitSendKey)].Description,
@@ -515,7 +527,124 @@ func TestLedgerIdempotencyMigrationRepairsRefreshExitCollision(t *testing.T) {
 	)
 	count, err := database.CountClientLedgerEntries(ctx)
 	require.NoError(t, err)
-	require.Equal(t, int64(4), count)
+	require.Equal(t, int64(5), count)
+
+	history, err := database.ListTransactionHistory(
+		ctx, sqlc.ListTransactionHistoryParams{
+			TypeFilter: "sweep",
+			FromUnixS:  int64(0),
+			ToUnixS:    int64(0),
+			PageLimit:  10,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, history, 2)
+
+	var exitSend sqlc.ListTransactionHistoryRow
+	for _, row := range history {
+		if row.Subtype == ledger.EventVTXOSent {
+			exitSend = row
+			break
+		}
+	}
+	require.Equal(t, int64(47_250), exitSend.AmountSat)
+	require.Equal(t, int64(2_000), exitSend.FeeSat)
+	require.Equal(t, "confirmed", exitSend.Status)
+	require.Equal(t, int32(800), exitSend.ConfirmationHeight)
+}
+
+// TestLedgerIdempotencyMigrationSkipsUnknownExitShape verifies an unfamiliar
+// legacy description does not strand the database at a dirty migration while
+// the unambiguous identity-domain rewrites still complete.
+func TestLedgerIdempotencyMigrationSkipsUnknownExitShape(t *testing.T) {
+	ctx := t.Context()
+	database := NewTestDBWithVersion(t, 18)
+
+	hash := testHash32(0x62)
+	const index = uint32(3)
+	legacyKey := make([]byte, legacyLedgerOutpointKeyLen)
+	copy(legacyKey, hash[:])
+	binary.BigEndian.PutUint32(legacyKey[32:], index)
+
+	roundID := uuid.New()
+	insert := func(params sqlc.InsertClientLedgerEntryParams) {
+		require.NoError(
+			t, database.InsertClientLedgerEntry(ctx, params),
+		)
+	}
+	insert(sqlc.InsertClientLedgerEntryParams{
+		DebitAccount:   ledger.AccountVTXOBalance,
+		CreditAccount:  ledger.AccountTransfersOut,
+		AmountSat:      25_000,
+		RoundID:        roundID[:],
+		IdempotencyKey: legacyKey,
+		EventType:      ledger.EventVTXOReceived,
+		Description:    "legacy refresh receive",
+		CreatedAt:      100,
+	})
+	insert(sqlc.InsertClientLedgerEntryParams{
+		DebitAccount:   ledger.AccountTransfersOut,
+		CreditAccount:  ledger.AccountVTXOBalance,
+		AmountSat:      25_000,
+		RoundID:        roundID[:],
+		IdempotencyKey: legacyKey,
+		EventType:      ledger.EventVTXOSent,
+		Description:    "legacy refresh send",
+		CreatedAt:      100,
+	})
+	insert(sqlc.InsertClientLedgerEntryParams{
+		DebitAccount:   ledger.AccountOnchainFees,
+		CreditAccount:  ledger.AccountVTXOBalance,
+		AmountSat:      1_000,
+		IdempotencyKey: legacyKey,
+		EventType:      ledger.EventOnchainFeePaid,
+		Description:    "unrecognized historical exit cost",
+		CreatedAt:      200,
+	})
+
+	require.NoError(
+		t,
+		database.ExecuteMigrations(
+			TargetLatest,
+			WithPostStepCallbacks(
+				makePostStepCallbacks(
+					database, btclog.Disabled,
+					postMigrationChecks,
+				),
+			),
+		),
+	)
+
+	rows, err := database.ListClientLedgerEntries(
+		ctx, sqlc.ListClientLedgerEntriesParams{
+			Limit: 10,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+
+	keys := make(map[string]sqlc.LedgerEntry, len(rows))
+	for _, row := range rows {
+		keys[string(row.IdempotencyKey)] = row
+	}
+	require.Contains(
+		t, keys,
+		string(
+			ledger.RefreshSendIdempotencyKey(hash, index),
+		),
+	)
+	require.Contains(
+		t, keys,
+		string(
+			ledger.ExitFeeIdempotencyKey(hash, index),
+		),
+	)
+	require.NotContains(
+		t, keys,
+		string(
+			ledger.ExitSendIdempotencyKey(hash, index),
+		),
+	)
 }
 
 // TestBackfillLedgerRoundUUIDs proves the migration-15 post-step converts

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 18
+	LatestMigrationVersion uint = 19
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/post_migration_checks.go
+++ b/db/post_migration_checks.go
@@ -3,7 +3,9 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/btcsuite/btclog/v2"
@@ -11,6 +13,7 @@ import (
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/google/uuid"
 	"github.com/lightninglabs/wavelength/db/sqlc"
+	"github.com/lightninglabs/wavelength/ledger"
 )
 
 // postMigrationCheck is a function type for a function that performs a
@@ -27,8 +30,218 @@ var (
 		// raw round_id BLOB; the string conversion itself is only
 		// expressible in Go.
 		15: backfillLedgerRoundUUIDs,
+
+		// Migration 19 replaces ambiguous outpoint-only refresh and
+		// exit keys with versioned operation-and-leg identities. It
+		// also repairs the missing exit send row left by the legacy
+		// collision.
+		19: reconcileLedgerIdempotencyKeys,
 	}
 )
+
+const legacyLedgerOutpointKeyLen = 36
+
+type legacyLedgerGroup struct {
+	refreshSend *sqlc.LedgerEntry
+	exitSend    *sqlc.LedgerEntry
+	exitFee     *sqlc.LedgerEntry
+}
+
+// reconcileLedgerIdempotencyKeys rewrites legacy refresh and unilateral-exit
+// identities into separate versioned domains. When the old shared identity
+// suppressed an exit send, the surviving refresh send and exit fee contain
+// enough information to reconstruct the missing net-value leg exactly.
+func reconcileLedgerIdempotencyKeys(ctx context.Context, q sqlc.Querier) error {
+	rows, err := q.ListLegacyOutpointLedgerEntries(ctx)
+	if err != nil {
+		return fmt.Errorf("list legacy ledger identities: %w", err)
+	}
+
+	groups := make(map[string]*legacyLedgerGroup)
+	orderedGroups := make([]*legacyLedgerGroup, 0)
+	for i := range rows {
+		row := rows[i]
+		group := groups[string(row.IdempotencyKey)]
+		if group == nil {
+			group = &legacyLedgerGroup{}
+			groups[string(row.IdempotencyKey)] = group
+			orderedGroups = append(orderedGroups, group)
+		}
+
+		switch {
+		case row.EventType == ledger.EventVTXOSent &&
+			len(row.RoundID) > 0:
+
+			if group.refreshSend != nil {
+				return fmt.Errorf("duplicate legacy refresh " +
+					"send identity")
+			}
+			group.refreshSend = &row
+
+		case row.EventType == ledger.EventVTXOSent:
+			if group.exitSend != nil {
+				return fmt.Errorf("duplicate legacy exit " +
+					"send identity")
+			}
+			group.exitSend = &row
+
+		case row.EventType == ledger.EventOnchainFeePaid:
+			if group.exitFee != nil {
+				return fmt.Errorf("duplicate legacy exit fee " +
+					"identity")
+			}
+			group.exitFee = &row
+		}
+	}
+
+	for _, group := range orderedGroups {
+		for _, row := range []*sqlc.LedgerEntry{
+			group.refreshSend, group.exitSend, group.exitFee,
+		} {
+			if row == nil {
+				continue
+			}
+
+			hash, index, err := decodeLegacyLedgerOutpoint(
+				row.IdempotencyKey,
+			)
+			if err != nil {
+				return err
+			}
+
+			var newKey []byte
+			switch {
+			case row == group.refreshSend:
+				newKey = ledger.RefreshSendIdempotencyKey(
+					hash, index,
+				)
+
+			case row == group.exitSend:
+				newKey = ledger.ExitSendIdempotencyKey(
+					hash, index,
+				)
+
+			case row == group.exitFee:
+				newKey = ledger.ExitFeeIdempotencyKey(
+					hash, index,
+				)
+			}
+
+			updated, err := rewriteLegacyLedgerIdentity(
+				ctx, q, row, newKey, hash, index,
+				row == group.refreshSend,
+			)
+			if err != nil {
+				return fmt.Errorf("rewrite ledger identity "+
+					"%d: %w", row.EntryID, err)
+			}
+			if updated != 1 {
+				return fmt.Errorf("rewrite ledger identity "+
+					"%d: updated %d rows", row.EntryID,
+					updated)
+			}
+		}
+
+		if group.refreshSend == nil || group.exitFee == nil ||
+			group.exitSend != nil {
+
+			continue
+		}
+
+		if group.exitFee.AmountSat >= group.refreshSend.AmountSat {
+			return fmt.Errorf("legacy exit fee %d is not below "+
+				"VTXO amount %d", group.exitFee.AmountSat,
+				group.refreshSend.AmountSat)
+		}
+
+		hash, index, err := decodeLegacyLedgerOutpoint(
+			group.exitFee.IdempotencyKey,
+		)
+		if err != nil {
+			return err
+		}
+
+		const feeDescriptionPrefix = "exit cost for "
+		if !strings.HasPrefix(
+			group.exitFee.Description, feeDescriptionPrefix,
+		) {
+			return fmt.Errorf("legacy exit fee %d has unknown "+
+				"description", group.exitFee.EntryID)
+		}
+		description := "unilateral exit net value for " +
+			strings.TrimPrefix(
+				group.exitFee.Description, feeDescriptionPrefix,
+			)
+
+		chainVout := int32(index)
+		err = q.InsertClientLedgerEntry(
+			ctx, sqlc.InsertClientLedgerEntryParams{
+				DebitAccount:  ledger.AccountTransfersOut,
+				CreditAccount: ledger.AccountVTXOBalance,
+				AmountSat: group.refreshSend.AmountSat -
+					group.exitFee.AmountSat,
+				IdempotencyKey: ledger.ExitSendIdempotencyKey(
+					hash, index,
+				),
+				EventType:   ledger.EventVTXOSent,
+				Description: description,
+				CreatedAt:   group.exitFee.CreatedAt,
+				ChainTxid:   hash[:],
+				ChainVout:   sqlInt32Ptr(&chainVout),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("repair missing exit send: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// rewriteLegacyLedgerIdentity applies the namespaced key and adds structured
+// outpoint metadata to unilateral-exit rows. Refresh sends keep their existing
+// chain metadata because their paired receive already identifies the output.
+func rewriteLegacyLedgerIdentity(ctx context.Context, q sqlc.Querier,
+	row *sqlc.LedgerEntry, newKey []byte, hash [32]byte, index uint32,
+	refresh bool) (int64, error) {
+
+	if refresh {
+		return q.UpdateLedgerEntryIdempotencyKey(
+			ctx, sqlc.UpdateLedgerEntryIdempotencyKeyParams{
+				NewKey:  newKey,
+				EntryID: row.EntryID,
+				OldKey:  row.IdempotencyKey,
+			},
+		)
+	}
+
+	chainVout := int32(index)
+
+	return q.UpdateLegacyExitLedgerEntry(
+		ctx, sqlc.UpdateLegacyExitLedgerEntryParams{
+			NewKey:    newKey,
+			ChainTxid: hash[:],
+			ChainVout: sqlInt32Ptr(&chainVout),
+			EntryID:   row.EntryID,
+			OldKey:    row.IdempotencyKey,
+		},
+	)
+}
+
+// decodeLegacyLedgerOutpoint decodes the old 32-byte hash plus big-endian
+// uint32 output-index identity.
+func decodeLegacyLedgerOutpoint(key []byte) ([32]byte, uint32, error) {
+	var hash [32]byte
+	if len(key) != legacyLedgerOutpointKeyLen {
+		return hash, 0, fmt.Errorf("legacy ledger key has length %d",
+			len(key))
+	}
+
+	copy(hash[:], key[:32])
+	index := binary.BigEndian.Uint32(key[32:])
+
+	return hash, index, nil
+}
 
 // backfillLedgerRoundUUIDs mirrors every distinct raw 16-byte round_id in
 // ledger_entries into the round_uuid TEXT column added by migration 15, using

--- a/db/post_migration_checks.go
+++ b/db/post_migration_checks.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/binary"
 	"fmt"
+	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/google/uuid"
+	"github.com/lightninglabs/wavelength/build"
 	"github.com/lightninglabs/wavelength/db/sqlc"
 	"github.com/lightninglabs/wavelength/ledger"
 )
@@ -60,7 +63,7 @@ func reconcileLedgerIdempotencyKeys(ctx context.Context, q sqlc.Querier) error {
 	groups := make(map[string]*legacyLedgerGroup)
 	orderedGroups := make([]*legacyLedgerGroup, 0)
 	for i := range rows {
-		row := rows[i]
+		row := &rows[i]
 		group := groups[string(row.IdempotencyKey)]
 		if group == nil {
 			group = &legacyLedgerGroup{}
@@ -76,25 +79,39 @@ func reconcileLedgerIdempotencyKeys(ctx context.Context, q sqlc.Querier) error {
 				return fmt.Errorf("duplicate legacy refresh " +
 					"send identity")
 			}
-			group.refreshSend = &row
+			group.refreshSend = row
 
 		case row.EventType == ledger.EventVTXOSent:
 			if group.exitSend != nil {
 				return fmt.Errorf("duplicate legacy exit " +
 					"send identity")
 			}
-			group.exitSend = &row
+			group.exitSend = row
 
 		case row.EventType == ledger.EventOnchainFeePaid:
 			if group.exitFee != nil {
 				return fmt.Errorf("duplicate legacy exit fee " +
 					"identity")
 			}
-			group.exitFee = &row
+			group.exitFee = row
 		}
 	}
 
 	for _, group := range orderedGroups {
+		var (
+			exitDescription    string
+			confirmationHeight *int32
+		)
+		if group.exitFee != nil {
+			description, height, ok := legacyExitMetadata(
+				group.exitFee.Description,
+			)
+			if ok {
+				exitDescription = description
+				confirmationHeight = &height
+			}
+		}
+
 		for _, row := range []*sqlc.LedgerEntry{
 			group.refreshSend, group.exitSend, group.exitFee,
 		} {
@@ -129,7 +146,7 @@ func reconcileLedgerIdempotencyKeys(ctx context.Context, q sqlc.Querier) error {
 
 			updated, err := rewriteLegacyLedgerIdentity(
 				ctx, q, row, newKey, hash, index,
-				row == group.refreshSend,
+				row == group.refreshSend, confirmationHeight,
 			)
 			if err != nil {
 				return fmt.Errorf("rewrite ledger identity "+
@@ -148,10 +165,13 @@ func reconcileLedgerIdempotencyKeys(ctx context.Context, q sqlc.Querier) error {
 			continue
 		}
 
-		if group.exitFee.AmountSat >= group.refreshSend.AmountSat {
-			return fmt.Errorf("legacy exit fee %d is not below "+
-				"VTXO amount %d", group.exitFee.AmountSat,
-				group.refreshSend.AmountSat)
+		if confirmationHeight == nil {
+			logSkippedLegacyExitRepair(
+				ctx, group.exitFee.EntryID,
+				"unrecognized fee description",
+			)
+
+			continue
 		}
 
 		hash, index, err := decodeLegacyLedgerOutpoint(
@@ -161,33 +181,44 @@ func reconcileLedgerIdempotencyKeys(ctx context.Context, q sqlc.Querier) error {
 			return err
 		}
 
-		const feeDescriptionPrefix = "exit cost for "
-		if !strings.HasPrefix(
-			group.exitFee.Description, feeDescriptionPrefix,
-		) {
-			return fmt.Errorf("legacy exit fee %d has unknown "+
-				"description", group.exitFee.EntryID)
+		refreshFeeSat, err := q.GetRefreshFeePaidByRoundID(
+			ctx, group.refreshSend.RoundID,
+		)
+		if err != nil {
+			return fmt.Errorf("load legacy refresh fee: %w", err)
 		}
-		description := "unilateral exit net value for " +
-			strings.TrimPrefix(
-				group.exitFee.Description, feeDescriptionPrefix,
+
+		grossAmount := group.refreshSend.AmountSat
+		if refreshFeeSat >= grossAmount || group.exitFee.AmountSat >=
+			grossAmount-refreshFeeSat {
+
+			logSkippedLegacyExitRepair(
+				ctx, group.exitFee.EntryID,
+				"fees consume the full VTXO value",
 			)
+
+			continue
+		}
+		netAmount := grossAmount - refreshFeeSat -
+			group.exitFee.AmountSat
 
 		chainVout := int32(index)
 		err = q.InsertClientLedgerEntry(
 			ctx, sqlc.InsertClientLedgerEntryParams{
 				DebitAccount:  ledger.AccountTransfersOut,
 				CreditAccount: ledger.AccountVTXOBalance,
-				AmountSat: group.refreshSend.AmountSat -
-					group.exitFee.AmountSat,
+				AmountSat:     netAmount,
 				IdempotencyKey: ledger.ExitSendIdempotencyKey(
 					hash, index,
 				),
 				EventType:   ledger.EventVTXOSent,
-				Description: description,
+				Description: exitDescription,
 				CreatedAt:   group.exitFee.CreatedAt,
 				ChainTxid:   hash[:],
 				ChainVout:   sqlInt32Ptr(&chainVout),
+				ConfirmationHeight: sqlInt32Ptr(
+					confirmationHeight,
+				),
 			},
 		)
 		if err != nil {
@@ -198,12 +229,53 @@ func reconcileLedgerIdempotencyKeys(ctx context.Context, q sqlc.Querier) error {
 	return nil
 }
 
+// legacyExitMetadata parses the exit-completion height embedded by the old
+// ledger writer and derives the corresponding send-leg description.
+func legacyExitMetadata(description string) (string, int32, bool) {
+	const (
+		feeDescriptionPrefix = "exit cost for "
+		heightMarker         = " at height "
+	)
+
+	if !strings.HasPrefix(description, feeDescriptionPrefix) {
+		return "", 0, false
+	}
+
+	exitTarget := strings.TrimPrefix(description, feeDescriptionPrefix)
+	heightIndex := strings.LastIndex(exitTarget, heightMarker)
+	if heightIndex < 0 {
+		return "", 0, false
+	}
+
+	heightValue := exitTarget[heightIndex+len(heightMarker):]
+	height, err := strconv.ParseUint(heightValue, 10, 31)
+	if err != nil || height == 0 {
+		return "", 0, false
+	}
+
+	return "unilateral exit net value for " + exitTarget,
+		int32(height), true
+}
+
+// logSkippedLegacyExitRepair records an unreconstructible historical row
+// without aborting the migration or guessing at accounting data.
+func logSkippedLegacyExitRepair(ctx context.Context, entryID int64,
+	reason string) {
+
+	build.LoggerFromContext(ctx).InfoS(
+		ctx,
+		"Skipping legacy exit ledger repair",
+		slog.Int64("entry_id", entryID),
+		slog.String("reason", reason),
+	)
+}
+
 // rewriteLegacyLedgerIdentity applies the namespaced key and adds structured
 // outpoint metadata to unilateral-exit rows. Refresh sends keep their existing
 // chain metadata because their paired receive already identifies the output.
 func rewriteLegacyLedgerIdentity(ctx context.Context, q sqlc.Querier,
 	row *sqlc.LedgerEntry, newKey []byte, hash [32]byte, index uint32,
-	refresh bool) (int64, error) {
+	refresh bool, confirmationHeight *int32) (int64, error) {
 
 	if refresh {
 		return q.UpdateLedgerEntryIdempotencyKey(
@@ -219,11 +291,12 @@ func rewriteLegacyLedgerIdentity(ctx context.Context, q sqlc.Querier,
 
 	return q.UpdateLegacyExitLedgerEntry(
 		ctx, sqlc.UpdateLegacyExitLedgerEntryParams{
-			NewKey:    newKey,
-			ChainTxid: hash[:],
-			ChainVout: sqlInt32Ptr(&chainVout),
-			EntryID:   row.EntryID,
-			OldKey:    row.IdempotencyKey,
+			NewKey:             newKey,
+			ChainTxid:          hash[:],
+			ChainVout:          sqlInt32Ptr(&chainVout),
+			ConfirmationHeight: sqlInt32Ptr(confirmationHeight),
+			EntryID:            row.EntryID,
+			OldKey:             row.IdempotencyKey,
 		},
 	)
 }
@@ -304,7 +377,7 @@ func makePostStepCallbacks(db DatabaseBackend, log btclog.Logger,
 	checks map[uint]postMigrationCheck) map[uint]migrate.PostStepCallback {
 
 	var (
-		ctx  = context.Background()
+		ctx  = build.ContextWithLogger(context.Background(), log)
 		txDB = NewTransactionExecutor(
 			db, func(tx *sql.Tx) sqlc.Querier {
 				return db.WithTx(tx)

--- a/db/sqlc/fee_accounting.sql.go
+++ b/db/sqlc/fee_accounting.sql.go
@@ -59,6 +59,145 @@ func (q *Queries) GetClientAccountBalance(ctx context.Context, accountID string)
 	return balance, err
 }
 
+const GetClientLedgerEntryByIdempotencyKey = `-- name: GetClientLedgerEntryByIdempotencyKey :one
+SELECT entry_id, debit_account, credit_account, amount_sat,
+       round_id, session_id, idempotency_key,
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height, round_uuid
+FROM ledger_entries
+WHERE idempotency_key = $1
+  AND event_type = $2
+  AND debit_account = $3
+  AND credit_account = $4
+`
+
+type GetClientLedgerEntryByIdempotencyKeyParams struct {
+	IdempotencyKey []byte
+	EventType      string
+	DebitAccount   string
+	CreditAccount  string
+}
+
+func (q *Queries) GetClientLedgerEntryByIdempotencyKey(ctx context.Context, arg GetClientLedgerEntryByIdempotencyKeyParams) (LedgerEntry, error) {
+	row := q.db.QueryRowContext(ctx, GetClientLedgerEntryByIdempotencyKey,
+		arg.IdempotencyKey,
+		arg.EventType,
+		arg.DebitAccount,
+		arg.CreditAccount,
+	)
+	var i LedgerEntry
+	err := row.Scan(
+		&i.EntryID,
+		&i.DebitAccount,
+		&i.CreditAccount,
+		&i.AmountSat,
+		&i.RoundID,
+		&i.SessionID,
+		&i.IdempotencyKey,
+		&i.EventType,
+		&i.Description,
+		&i.CreatedAt,
+		&i.ChainTxid,
+		&i.ChainVout,
+		&i.ConfirmationHeight,
+		&i.RoundUuid,
+	)
+	return i, err
+}
+
+const GetClientLedgerEntryByRoundID = `-- name: GetClientLedgerEntryByRoundID :one
+SELECT entry_id, debit_account, credit_account, amount_sat,
+       round_id, session_id, idempotency_key,
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height, round_uuid
+FROM ledger_entries
+WHERE round_id = $1
+  AND idempotency_key IS NULL
+  AND event_type = $2
+  AND debit_account = $3
+  AND credit_account = $4
+`
+
+type GetClientLedgerEntryByRoundIDParams struct {
+	RoundID       []byte
+	EventType     string
+	DebitAccount  string
+	CreditAccount string
+}
+
+func (q *Queries) GetClientLedgerEntryByRoundID(ctx context.Context, arg GetClientLedgerEntryByRoundIDParams) (LedgerEntry, error) {
+	row := q.db.QueryRowContext(ctx, GetClientLedgerEntryByRoundID,
+		arg.RoundID,
+		arg.EventType,
+		arg.DebitAccount,
+		arg.CreditAccount,
+	)
+	var i LedgerEntry
+	err := row.Scan(
+		&i.EntryID,
+		&i.DebitAccount,
+		&i.CreditAccount,
+		&i.AmountSat,
+		&i.RoundID,
+		&i.SessionID,
+		&i.IdempotencyKey,
+		&i.EventType,
+		&i.Description,
+		&i.CreatedAt,
+		&i.ChainTxid,
+		&i.ChainVout,
+		&i.ConfirmationHeight,
+		&i.RoundUuid,
+	)
+	return i, err
+}
+
+const GetClientLedgerEntryBySessionID = `-- name: GetClientLedgerEntryBySessionID :one
+SELECT entry_id, debit_account, credit_account, amount_sat,
+       round_id, session_id, idempotency_key,
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height, round_uuid
+FROM ledger_entries
+WHERE session_id = $1
+  AND event_type = $2
+  AND debit_account = $3
+  AND credit_account = $4
+`
+
+type GetClientLedgerEntryBySessionIDParams struct {
+	SessionID     []byte
+	EventType     string
+	DebitAccount  string
+	CreditAccount string
+}
+
+func (q *Queries) GetClientLedgerEntryBySessionID(ctx context.Context, arg GetClientLedgerEntryBySessionIDParams) (LedgerEntry, error) {
+	row := q.db.QueryRowContext(ctx, GetClientLedgerEntryBySessionID,
+		arg.SessionID,
+		arg.EventType,
+		arg.DebitAccount,
+		arg.CreditAccount,
+	)
+	var i LedgerEntry
+	err := row.Scan(
+		&i.EntryID,
+		&i.DebitAccount,
+		&i.CreditAccount,
+		&i.AmountSat,
+		&i.RoundID,
+		&i.SessionID,
+		&i.IdempotencyKey,
+		&i.EventType,
+		&i.Description,
+		&i.CreatedAt,
+		&i.ChainTxid,
+		&i.ChainVout,
+		&i.ConfirmationHeight,
+		&i.RoundUuid,
+	)
+	return i, err
+}
+
 const GetClientLedgerStats = `-- name: GetClientLedgerStats :one
 SELECT CAST(COUNT(*) AS BIGINT) AS entry_count,
        CAST(COALESCE(MIN(created_at), 0) AS BIGINT) AS first_created_at,
@@ -88,8 +227,8 @@ WHERE event_type = 'onchain_fee_paid'
 
 // GetConfirmedExitCost returns the confirmed on-chain cost of a unilateral
 // exit: the onchain_fee_paid leg the ledger booked after the exit's final
-// sweep confirmed, keyed by the exit's outpoint-derived idempotency key
-// (ledger.ExitIdempotencyKey). Zero when the exit has not confirmed (or
+// sweep confirmed, keyed by the exit's fee-leg identity
+// (ledger.ExitFeeIdempotencyKey). Zero when the exit has not confirmed (or
 // predates exit-cost accounting).
 func (q *Queries) GetConfirmedExitCost(ctx context.Context, idempotencyKey []byte) (int64, error) {
 	row := q.db.QueryRowContext(ctx, GetConfirmedExitCost, idempotencyKey)
@@ -151,13 +290,11 @@ type InsertClientLedgerEntryParams struct {
 // every partial unique index on ledger_entries:
 //   - idx_client_ledger_idempotent_round covers per-round events
 //   - idx_client_ledger_idempotent_session covers per-OOR-session events
-//   - idx_client_ledger_idempotent_key covers outpoint-keyed events
-//     (unilateral exit send leg + fee leg share the same key)
+//   - idx_client_ledger_idempotent_key covers operation-and-leg-scoped events
 //
 // A redelivered durable-actor message that reprocesses an entry
-// already persisted in a committed tx becomes a silent no-op
-// instead of surfacing a constraint violation that would drive
-// an infinite nack-and-retry loop on a permanent condition.
+// already persisted in a committed tx becomes a no-op. The adapter reads the
+// winning row and rejects a replay whose accounting payload differs.
 func (q *Queries) InsertClientLedgerEntry(ctx context.Context, arg InsertClientLedgerEntryParams) error {
 	_, err := q.db.ExecContext(ctx, InsertClientLedgerEntry,
 		arg.DebitAccount,
@@ -441,6 +578,85 @@ func (q *Queries) ListLedgerRoundIDsMissingUuid(ctx context.Context) ([][]byte, 
 	return items, nil
 }
 
+const ListLegacyOutpointLedgerEntries = `-- name: ListLegacyOutpointLedgerEntries :many
+SELECT entry_id, debit_account, credit_account, amount_sat,
+       round_id, session_id, idempotency_key,
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height, round_uuid
+FROM ledger_entries
+WHERE LENGTH(idempotency_key) = 36
+  AND (
+      (
+          event_type = 'vtxo_sent'
+          AND debit_account = 'transfers_out'
+          AND credit_account = 'vtxo_balance'
+          AND session_id IS NULL
+          AND (
+              round_id IS NULL
+              OR EXISTS (
+                  SELECT 1
+                  FROM ledger_entries AS received
+                  WHERE received.idempotency_key =
+                            ledger_entries.idempotency_key
+                    AND received.event_type = 'vtxo_received'
+                    AND received.debit_account = 'vtxo_balance'
+                    AND received.credit_account = 'transfers_out'
+                    AND received.round_id = ledger_entries.round_id
+              )
+          )
+      )
+      OR (
+          event_type = 'onchain_fee_paid'
+          AND debit_account = 'onchain_fees'
+          AND credit_account = 'vtxo_balance'
+          AND round_id IS NULL
+          AND session_id IS NULL
+      )
+  )
+ORDER BY entry_id
+`
+
+// Migration 19 rewrites only the legacy 36-byte outpoint identities used by
+// refresh sends and unilateral-exit legs. Other event types may also carry
+// 36-byte natural keys, so the account/event shapes are part of the filter.
+func (q *Queries) ListLegacyOutpointLedgerEntries(ctx context.Context) ([]LedgerEntry, error) {
+	rows, err := q.db.QueryContext(ctx, ListLegacyOutpointLedgerEntries)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []LedgerEntry
+	for rows.Next() {
+		var i LedgerEntry
+		if err := rows.Scan(
+			&i.EntryID,
+			&i.DebitAccount,
+			&i.CreditAccount,
+			&i.AmountSat,
+			&i.RoundID,
+			&i.SessionID,
+			&i.IdempotencyKey,
+			&i.EventType,
+			&i.Description,
+			&i.CreatedAt,
+			&i.ChainTxid,
+			&i.ChainVout,
+			&i.ConfirmationHeight,
+			&i.RoundUuid,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListTransactionHistory = `-- name: ListTransactionHistory :many
 SELECT source, entry_id, txid, transaction_type, subtype,
        amount_sat, fee_sat, created_at, status, description,
@@ -462,6 +678,12 @@ FROM (
                WHEN le.event_type IN (
                    'boarding_fee_paid', 'wallet_utxo_created'
                ) THEN 'boarding'
+               WHEN le.event_type = 'vtxo_sent'
+                    AND le.round_id IS NULL
+                    AND le.session_id IS NULL
+                    AND le.chain_txid IS NOT NULL
+                    AND le.chain_vout IS NOT NULL
+               THEN 'sweep'
                WHEN le.event_type IN (
                    'onchain_fee_paid', 'boarding_sweep_fee_paid'
                ) THEN 'sweep'
@@ -477,6 +699,11 @@ FROM (
            END AS fee_sat,
            le.created_at,
            CASE
+               WHEN le.event_type = 'vtxo_sent'
+                    AND le.round_id IS NULL
+                    AND le.session_id IS NULL
+                    AND le.confirmation_height IS NOT NULL
+               THEN 'confirmed'
                WHEN le.event_type = 'wallet_utxo_created'
                     AND boarding_round.confirmed
                THEN 'confirmed'
@@ -756,4 +983,56 @@ func (q *Queries) ListTransactionHistory(ctx context.Context, arg ListTransactio
 		return nil, err
 	}
 	return items, nil
+}
+
+const UpdateLedgerEntryIdempotencyKey = `-- name: UpdateLedgerEntryIdempotencyKey :execrows
+UPDATE ledger_entries
+SET idempotency_key = $1
+WHERE entry_id = $2
+  AND idempotency_key = $3
+`
+
+type UpdateLedgerEntryIdempotencyKeyParams struct {
+	NewKey  []byte
+	EntryID int64
+	OldKey  []byte
+}
+
+func (q *Queries) UpdateLedgerEntryIdempotencyKey(ctx context.Context, arg UpdateLedgerEntryIdempotencyKeyParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, UpdateLedgerEntryIdempotencyKey, arg.NewKey, arg.EntryID, arg.OldKey)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const UpdateLegacyExitLedgerEntry = `-- name: UpdateLegacyExitLedgerEntry :execrows
+UPDATE ledger_entries
+SET idempotency_key = $1,
+    chain_txid = COALESCE(chain_txid, $2),
+    chain_vout = COALESCE(chain_vout, $3)
+WHERE entry_id = $4
+  AND idempotency_key = $5
+`
+
+type UpdateLegacyExitLedgerEntryParams struct {
+	NewKey    []byte
+	ChainTxid []byte
+	ChainVout sql.NullInt32
+	EntryID   int64
+	OldKey    []byte
+}
+
+func (q *Queries) UpdateLegacyExitLedgerEntry(ctx context.Context, arg UpdateLegacyExitLedgerEntryParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, UpdateLegacyExitLedgerEntry,
+		arg.NewKey,
+		arg.ChainTxid,
+		arg.ChainVout,
+		arg.EntryID,
+		arg.OldKey,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }

--- a/db/sqlc/fee_accounting.sql.go
+++ b/db/sqlc/fee_accounting.sql.go
@@ -237,6 +237,24 @@ func (q *Queries) GetConfirmedExitCost(ctx context.Context, idempotencyKey []byt
 	return exit_cost_sat, err
 }
 
+const GetRefreshFeePaidByRoundID = `-- name: GetRefreshFeePaidByRoundID :one
+SELECT CAST(COALESCE(SUM(amount_sat), 0) AS BIGINT) AS refresh_fee_sat
+FROM ledger_entries
+WHERE round_id = $1
+  AND event_type = 'refresh_fee_paid'
+  AND debit_account = 'fees_paid'
+  AND credit_account = 'vtxo_balance'
+`
+
+// GetRefreshFeePaidByRoundID returns the operator fee carved out of VTXO
+// value in a refresh round. Zero when the round had no operator fee.
+func (q *Queries) GetRefreshFeePaidByRoundID(ctx context.Context, roundID []byte) (int64, error) {
+	row := q.db.QueryRowContext(ctx, GetRefreshFeePaidByRoundID, roundID)
+	var refresh_fee_sat int64
+	err := row.Scan(&refresh_fee_sat)
+	return refresh_fee_sat, err
+}
+
 const GetTotalOperatorFeesPaid = `-- name: GetTotalOperatorFeesPaid :one
 SELECT CAST(COALESCE(SUM(amount_sat), 0) AS BIGINT) AS total_fees
 FROM ledger_entries
@@ -692,6 +710,22 @@ FROM (
            le.event_type AS subtype,
            le.amount_sat,
            CASE
+               WHEN le.event_type = 'vtxo_sent'
+                    AND le.round_id IS NULL
+                    AND le.session_id IS NULL
+                    AND le.chain_txid IS NOT NULL
+                    AND le.chain_vout IS NOT NULL
+               THEN CAST(COALESCE((
+                   SELECT SUM(exit_fee.amount_sat)
+                   FROM ledger_entries AS exit_fee
+                   WHERE exit_fee.event_type = 'onchain_fee_paid'
+                     AND exit_fee.debit_account = 'onchain_fees'
+                     AND exit_fee.credit_account = 'vtxo_balance'
+                     AND exit_fee.round_id IS NULL
+                     AND exit_fee.session_id IS NULL
+                     AND exit_fee.chain_txid = le.chain_txid
+                     AND exit_fee.chain_vout = le.chain_vout
+               ), 0) AS BIGINT)
                WHEN le.event_type = 'wallet_utxo_created'
                     AND boarding_round.fee_sat > 0
                THEN boarding_round.fee_sat
@@ -1010,17 +1044,21 @@ const UpdateLegacyExitLedgerEntry = `-- name: UpdateLegacyExitLedgerEntry :execr
 UPDATE ledger_entries
 SET idempotency_key = $1,
     chain_txid = COALESCE(chain_txid, $2),
-    chain_vout = COALESCE(chain_vout, $3)
-WHERE entry_id = $4
-  AND idempotency_key = $5
+    chain_vout = COALESCE(chain_vout, $3),
+    confirmation_height = COALESCE(
+        confirmation_height, $4
+    )
+WHERE entry_id = $5
+  AND idempotency_key = $6
 `
 
 type UpdateLegacyExitLedgerEntryParams struct {
-	NewKey    []byte
-	ChainTxid []byte
-	ChainVout sql.NullInt32
-	EntryID   int64
-	OldKey    []byte
+	NewKey             []byte
+	ChainTxid          []byte
+	ChainVout          sql.NullInt32
+	ConfirmationHeight sql.NullInt32
+	EntryID            int64
+	OldKey             []byte
 }
 
 func (q *Queries) UpdateLegacyExitLedgerEntry(ctx context.Context, arg UpdateLegacyExitLedgerEntryParams) (int64, error) {
@@ -1028,6 +1066,7 @@ func (q *Queries) UpdateLegacyExitLedgerEntry(ctx context.Context, arg UpdateLeg
 		arg.NewKey,
 		arg.ChainTxid,
 		arg.ChainVout,
+		arg.ConfirmationHeight,
 		arg.EntryID,
 		arg.OldKey,
 	)

--- a/db/sqlc/migrations/000019_ledger_idempotency_domains.down.sql
+++ b/db/sqlc/migrations/000019_ledger_idempotency_domains.down.sql
@@ -1,0 +1,3 @@
+-- Reversing the key rewrite would recreate the collision this migration
+-- repairs. A schema downgrade therefore leaves the corrected rows intact.
+SELECT 1;

--- a/db/sqlc/migrations/000019_ledger_idempotency_domains.up.sql
+++ b/db/sqlc/migrations/000019_ledger_idempotency_domains.up.sql
@@ -1,0 +1,4 @@
+-- Ledger key reconciliation is implemented as the version-19 Go post-step.
+-- The operation prefixes contain binary outpoint payloads, and deriving them
+-- in Go keeps the rewrite byte-identical across SQLite and PostgreSQL.
+SELECT 1;

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -97,14 +97,17 @@ type Querier interface {
 	GetBoardingSweepByInput(ctx context.Context, arg GetBoardingSweepByInputParams) (BoardingSweep, error)
 	GetChainInfo(ctx context.Context, chainName string) (ChainInfo, error)
 	GetClientAccountBalance(ctx context.Context, accountID string) (int64, error)
+	GetClientLedgerEntryByIdempotencyKey(ctx context.Context, arg GetClientLedgerEntryByIdempotencyKeyParams) (LedgerEntry, error)
+	GetClientLedgerEntryByRoundID(ctx context.Context, arg GetClientLedgerEntryByRoundIDParams) (LedgerEntry, error)
+	GetClientLedgerEntryBySessionID(ctx context.Context, arg GetClientLedgerEntryBySessionIDParams) (LedgerEntry, error)
 	GetClientLedgerStats(ctx context.Context) (GetClientLedgerStatsRow, error)
 	GetClientTreeByTxid(ctx context.Context, txid []byte) (RoundClientTree, error)
 	GetClientTreeTxidInfo(ctx context.Context, txid []byte) (ClientTreeTxid, error)
 	GetClientTreeTxids(ctx context.Context, arg GetClientTreeTxidsParams) ([]GetClientTreeTxidsRow, error)
 	// GetConfirmedExitCost returns the confirmed on-chain cost of a unilateral
 	// exit: the onchain_fee_paid leg the ledger booked after the exit's final
-	// sweep confirmed, keyed by the exit's outpoint-derived idempotency key
-	// (ledger.ExitIdempotencyKey). Zero when the exit has not confirmed (or
+	// sweep confirmed, keyed by the exit's fee-leg identity
+	// (ledger.ExitFeeIdempotencyKey). Zero when the exit has not confirmed (or
 	// predates exit-cost accounting).
 	GetConfirmedExitCost(ctx context.Context, idempotencyKey []byte) (int64, error)
 	GetCreditOperation(ctx context.Context, opID string) (CreditOperation, error)
@@ -164,12 +167,10 @@ type Querier interface {
 	// every partial unique index on ledger_entries:
 	//   - idx_client_ledger_idempotent_round covers per-round events
 	//   - idx_client_ledger_idempotent_session covers per-OOR-session events
-	//   - idx_client_ledger_idempotent_key covers outpoint-keyed events
-	//     (unilateral exit send leg + fee leg share the same key)
+	//   - idx_client_ledger_idempotent_key covers operation-and-leg-scoped events
 	// A redelivered durable-actor message that reprocesses an entry
-	// already persisted in a committed tx becomes a silent no-op
-	// instead of surfacing a constraint violation that would drive
-	// an infinite nack-and-retry loop on a permanent condition.
+	// already persisted in a committed tx becomes a no-op. The adapter reads the
+	// winning row and rejects a replay whose accounting payload differs.
 	InsertClientLedgerEntry(ctx context.Context, arg InsertClientLedgerEntryParams) error
 	// Client tree txids queries.
 	InsertClientTreeTxid(ctx context.Context, arg InsertClientTreeTxidParams) error
@@ -245,6 +246,10 @@ type Querier interface {
 	// SQLite and Postgres, so the migration-015 post-step performs it in Go and
 	// writes the result back via BackfillLedgerRoundUuid.
 	ListLedgerRoundIDsMissingUuid(ctx context.Context) ([][]byte, error)
+	// Migration 19 rewrites only the legacy 36-byte outpoint identities used by
+	// refresh sends and unilateral-exit legs. Other event types may also carry
+	// 36-byte natural keys, so the account/event shapes are part of the filter.
+	ListLegacyOutpointLedgerEntries(ctx context.Context) ([]LedgerEntry, error)
 	// ListLiveVTXOAncestryPaths returns every ancestry row whose parent VTXO
 	// is non-terminal, mirroring the filter on ListLiveVTXOs. Used as a
 	// single batched companion query so descriptor materialization across
@@ -409,6 +414,8 @@ type Querier interface {
 	SumBoardingIntentAmountsByStatus(ctx context.Context, status string) (interface{}, error)
 	SumUnspentVTXOAmounts(ctx context.Context) (interface{}, error)
 	UpdateBoardingIntentStatus(ctx context.Context, arg UpdateBoardingIntentStatusParams) error
+	UpdateLedgerEntryIdempotencyKey(ctx context.Context, arg UpdateLedgerEntryIdempotencyKeyParams) (int64, error)
+	UpdateLegacyExitLedgerEntry(ctx context.Context, arg UpdateLegacyExitLedgerEntryParams) (int64, error)
 	UpdateRoundBoardingIntentSignature(ctx context.Context, arg UpdateRoundBoardingIntentSignatureParams) error
 	UpdateRoundStatus(ctx context.Context, arg UpdateRoundStatusParams) error
 	// UpdateVTXOAncestryCommitmentHeight fills one legacy zero commitment height

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -130,6 +130,9 @@ type Querier interface {
 	// Fetch one intent header by id, exposing the terminal-failure columns so
 	// callers (and tests) can assert send-failure state without raw SQL.
 	GetPendingIntentByID(ctx context.Context, intentID []byte) (GetPendingIntentByIDRow, error)
+	// GetRefreshFeePaidByRoundID returns the operator fee carved out of VTXO
+	// value in a refresh round. Zero when the round had no operator fee.
+	GetRefreshFeePaidByRoundID(ctx context.Context, roundID []byte) (int64, error)
 	GetRound(ctx context.Context, roundID string) (Round, error)
 	GetRoundBoardingIntents(ctx context.Context, roundID string) ([]RoundBoardingIntent, error)
 	GetRoundByCommitmentTxid(ctx context.Context, commitmentTxid []byte) (Round, error)

--- a/db/sqlc/queries/fee_accounting.sql
+++ b/db/sqlc/queries/fee_accounting.sql
@@ -10,12 +10,10 @@
 -- every partial unique index on ledger_entries:
 --   - idx_client_ledger_idempotent_round covers per-round events
 --   - idx_client_ledger_idempotent_session covers per-OOR-session events
---   - idx_client_ledger_idempotent_key covers outpoint-keyed events
---     (unilateral exit send leg + fee leg share the same key)
+--   - idx_client_ledger_idempotent_key covers operation-and-leg-scoped events
 -- A redelivered durable-actor message that reprocesses an entry
--- already persisted in a committed tx becomes a silent no-op
--- instead of surfacing a constraint violation that would drive
--- an infinite nack-and-retry loop on a permanent condition.
+-- already persisted in a committed tx becomes a no-op. The adapter reads the
+-- winning row and rejects a replay whose accounting payload differs.
 INSERT INTO ledger_entries (
     debit_account, credit_account, amount_sat,
     round_id, session_id, idempotency_key,
@@ -24,6 +22,40 @@ INSERT INTO ledger_entries (
     round_uuid
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 ON CONFLICT DO NOTHING;
+
+-- name: GetClientLedgerEntryByIdempotencyKey :one
+SELECT entry_id, debit_account, credit_account, amount_sat,
+       round_id, session_id, idempotency_key,
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height, round_uuid
+FROM ledger_entries
+WHERE idempotency_key = $1
+  AND event_type = $2
+  AND debit_account = $3
+  AND credit_account = $4;
+
+-- name: GetClientLedgerEntryBySessionID :one
+SELECT entry_id, debit_account, credit_account, amount_sat,
+       round_id, session_id, idempotency_key,
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height, round_uuid
+FROM ledger_entries
+WHERE session_id = $1
+  AND event_type = $2
+  AND debit_account = $3
+  AND credit_account = $4;
+
+-- name: GetClientLedgerEntryByRoundID :one
+SELECT entry_id, debit_account, credit_account, amount_sat,
+       round_id, session_id, idempotency_key,
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height, round_uuid
+FROM ledger_entries
+WHERE round_id = $1
+  AND idempotency_key IS NULL
+  AND event_type = $2
+  AND debit_account = $3
+  AND credit_account = $4;
 
 -- name: ListClientLedgerEntries :many
 SELECT entry_id, debit_account, credit_account, amount_sat,
@@ -69,6 +101,12 @@ FROM (
                WHEN le.event_type IN (
                    'boarding_fee_paid', 'wallet_utxo_created'
                ) THEN 'boarding'
+               WHEN le.event_type = 'vtxo_sent'
+                    AND le.round_id IS NULL
+                    AND le.session_id IS NULL
+                    AND le.chain_txid IS NOT NULL
+                    AND le.chain_vout IS NOT NULL
+               THEN 'sweep'
                WHEN le.event_type IN (
                    'onchain_fee_paid', 'boarding_sweep_fee_paid'
                ) THEN 'sweep'
@@ -84,6 +122,11 @@ FROM (
            END AS fee_sat,
            le.created_at,
            CASE
+               WHEN le.event_type = 'vtxo_sent'
+                    AND le.round_id IS NULL
+                    AND le.session_id IS NULL
+                    AND le.confirmation_height IS NOT NULL
+               THEN 'confirmed'
                WHEN le.event_type = 'wallet_utxo_created'
                     AND boarding_round.confirmed
                THEN 'confirmed'
@@ -344,8 +387,8 @@ FROM ledger_entries;
 -- name: GetConfirmedExitCost :one
 -- GetConfirmedExitCost returns the confirmed on-chain cost of a unilateral
 -- exit: the onchain_fee_paid leg the ledger booked after the exit's final
--- sweep confirmed, keyed by the exit's outpoint-derived idempotency key
--- (ledger.ExitIdempotencyKey). Zero when the exit has not confirmed (or
+-- sweep confirmed, keyed by the exit's fee-leg identity
+-- (ledger.ExitFeeIdempotencyKey). Zero when the exit has not confirmed (or
 -- predates exit-cost accounting).
 SELECT CAST(COALESCE(SUM(amount_sat), 0) AS BIGINT) AS exit_cost_sat
 FROM ledger_entries
@@ -372,3 +415,57 @@ UPDATE ledger_entries
 SET round_uuid = $1
 WHERE round_id = $2
   AND round_uuid IS NULL;
+
+-- name: ListLegacyOutpointLedgerEntries :many
+-- Migration 19 rewrites only the legacy 36-byte outpoint identities used by
+-- refresh sends and unilateral-exit legs. Other event types may also carry
+-- 36-byte natural keys, so the account/event shapes are part of the filter.
+SELECT entry_id, debit_account, credit_account, amount_sat,
+       round_id, session_id, idempotency_key,
+       event_type, description, created_at,
+       chain_txid, chain_vout, confirmation_height, round_uuid
+FROM ledger_entries
+WHERE LENGTH(idempotency_key) = 36
+  AND (
+      (
+          event_type = 'vtxo_sent'
+          AND debit_account = 'transfers_out'
+          AND credit_account = 'vtxo_balance'
+          AND session_id IS NULL
+          AND (
+              round_id IS NULL
+              OR EXISTS (
+                  SELECT 1
+                  FROM ledger_entries AS received
+                  WHERE received.idempotency_key =
+                            ledger_entries.idempotency_key
+                    AND received.event_type = 'vtxo_received'
+                    AND received.debit_account = 'vtxo_balance'
+                    AND received.credit_account = 'transfers_out'
+                    AND received.round_id = ledger_entries.round_id
+              )
+          )
+      )
+      OR (
+          event_type = 'onchain_fee_paid'
+          AND debit_account = 'onchain_fees'
+          AND credit_account = 'vtxo_balance'
+          AND round_id IS NULL
+          AND session_id IS NULL
+      )
+  )
+ORDER BY entry_id;
+
+-- name: UpdateLedgerEntryIdempotencyKey :execrows
+UPDATE ledger_entries
+SET idempotency_key = sqlc.arg(new_key)
+WHERE entry_id = sqlc.arg(entry_id)
+  AND idempotency_key = sqlc.arg(old_key);
+
+-- name: UpdateLegacyExitLedgerEntry :execrows
+UPDATE ledger_entries
+SET idempotency_key = sqlc.arg(new_key),
+    chain_txid = COALESCE(chain_txid, sqlc.arg(chain_txid)),
+    chain_vout = COALESCE(chain_vout, sqlc.arg(chain_vout))
+WHERE entry_id = sqlc.arg(entry_id)
+  AND idempotency_key = sqlc.arg(old_key);

--- a/db/sqlc/queries/fee_accounting.sql
+++ b/db/sqlc/queries/fee_accounting.sql
@@ -115,6 +115,22 @@ FROM (
            le.event_type AS subtype,
            le.amount_sat,
            CASE
+               WHEN le.event_type = 'vtxo_sent'
+                    AND le.round_id IS NULL
+                    AND le.session_id IS NULL
+                    AND le.chain_txid IS NOT NULL
+                    AND le.chain_vout IS NOT NULL
+               THEN CAST(COALESCE((
+                   SELECT SUM(exit_fee.amount_sat)
+                   FROM ledger_entries AS exit_fee
+                   WHERE exit_fee.event_type = 'onchain_fee_paid'
+                     AND exit_fee.debit_account = 'onchain_fees'
+                     AND exit_fee.credit_account = 'vtxo_balance'
+                     AND exit_fee.round_id IS NULL
+                     AND exit_fee.session_id IS NULL
+                     AND exit_fee.chain_txid = le.chain_txid
+                     AND exit_fee.chain_vout = le.chain_vout
+               ), 0) AS BIGINT)
                WHEN le.event_type = 'wallet_utxo_created'
                     AND boarding_round.fee_sat > 0
                THEN boarding_round.fee_sat
@@ -395,6 +411,16 @@ FROM ledger_entries
 WHERE event_type = 'onchain_fee_paid'
   AND idempotency_key = $1;
 
+-- name: GetRefreshFeePaidByRoundID :one
+-- GetRefreshFeePaidByRoundID returns the operator fee carved out of VTXO
+-- value in a refresh round. Zero when the round had no operator fee.
+SELECT CAST(COALESCE(SUM(amount_sat), 0) AS BIGINT) AS refresh_fee_sat
+FROM ledger_entries
+WHERE round_id = $1
+  AND event_type = 'refresh_fee_paid'
+  AND debit_account = 'fees_paid'
+  AND credit_account = 'vtxo_balance';
+
 -- name: ListLedgerRoundIDsMissingUuid :many
 -- ListLedgerRoundIDsMissingUuid returns the distinct raw round_id BLOBs that
 -- have not yet been mirrored into the round_uuid TEXT column. The BLOB-to-UUID
@@ -466,6 +492,9 @@ WHERE entry_id = sqlc.arg(entry_id)
 UPDATE ledger_entries
 SET idempotency_key = sqlc.arg(new_key),
     chain_txid = COALESCE(chain_txid, sqlc.arg(chain_txid)),
-    chain_vout = COALESCE(chain_vout, sqlc.arg(chain_vout))
+    chain_vout = COALESCE(chain_vout, sqlc.arg(chain_vout)),
+    confirmation_height = COALESCE(
+        confirmation_height, sqlc.arg(confirmation_height)
+    )
 WHERE entry_id = sqlc.arg(entry_id)
   AND idempotency_key = sqlc.arg(old_key);

--- a/internal/actortest/ledger_e2e_test.go
+++ b/internal/actortest/ledger_e2e_test.go
@@ -97,8 +97,8 @@ func tryCount(store *db.LedgerStoreDB) (int64, bool) {
 
 // TestLedgerActorExitCostCommitsBothLegs drives a real ExitCostMsg through the
 // durable mailbox and asserts the two legs (send + fee) are booked atomically
-// in one fenced Commit, and that a replay is idempotent (the shared
-// outpoint-keyed legs dedup, so no double-booking through the real stack).
+// in one fenced Commit, and that a replay is idempotent (each separately
+// namespaced outpoint-keyed leg dedups through the real stack).
 func TestLedgerActorExitCostCommitsBothLegs(t *testing.T) {
 	t.Parallel()
 
@@ -131,9 +131,9 @@ func TestLedgerActorExitCostCommitsBothLegs(t *testing.T) {
 	requireBalance(t, store, ledger.AccountOnchainFees, msg.ExitCostSat)
 	requireBalance(t, store, ledger.AccountVTXOBalance, -msg.AmountSat)
 
-	// Replaying the same event is a no-op: both legs share the
-	// outpoint-derived idempotency key and dedup via ON CONFLICT DO
-	// NOTHING, so the row count never grows past two.
+	// Replaying the same event is a no-op: the separately namespaced
+	// outpoint identities dedup via ON CONFLICT DO NOTHING, so the row
+	// count never grows past two.
 	require.NoError(t, ledgerActor.Ref().Tell(t.Context(), msg))
 	require.Never(t, func() bool {
 		n, ok := tryCount(store)

--- a/ledger/AGENTS.md
+++ b/ledger/AGENTS.md
@@ -62,10 +62,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/ledger.<
   The db adapter additionally mirrors a 16-byte `RoundID` into the
   `round_uuid` TEXT column (migration 000015) so ledger rows join
   against `rounds.round_id` / `vtxos.forfeit_round_id` in portable SQL.
-- `exitIdempotencyKey(hash, index)` / `walletUTXOIdempotencyKey` —
-  derive 36-byte `outpoint_hash || outpoint_index` dedup keys
-  distinct from round-keyed and session-keyed entries (separate
-  `idx_client_ledger_idempotent_key` partial unique index).
+- `RefreshSendIdempotencyKey` / `ExitSendIdempotencyKey` /
+  `ExitFeeIdempotencyKey` — derive versioned operation-and-leg keys over the
+  36-byte `outpoint_hash || outpoint_index` identity. Refresh and exit sends
+  for the same VTXO therefore cannot collide in
+  `idx_client_ledger_idempotent_key`.
 - `UTXOAuditStore` / `UTXOAuditEntry` — UTXO audit log persistence
   (outpoint, amount, event, block height, classification). Implemented
   by `db.UTXOAuditStoreDB`.
@@ -194,11 +195,13 @@ or balance reconciliation. Required emission pairs:
 - UTXO audit inserts are idempotent on
   `(outpoint_hash, outpoint_index, event)` via
   `ON CONFLICT DO NOTHING`.
-- **Replay safety**: `InsertClientLedgerEntry` uses
-  `ON CONFLICT DO NOTHING` against every partial unique index
-  (`idx_client_ledger_idempotent_round`, `_session`, `_key`). Crash
-  atomicity for multi-leg events (ExitCost) comes from the durable
-  actor's outer tx: handlers run inside
+- **Replay safety**: `InsertClientLedgerEntry` uses `ON CONFLICT DO NOTHING`
+  against every partial unique index (`idx_client_ledger_idempotent_round`,
+  `_session`, `_key`), then reads the winner and accepts it only when the
+  accounting payload matches (the retry timestamp is ignored). Conflicting
+  reuse returns
+  `ErrIdempotencyConflict`. Crash atomicity for multi-leg events (ExitCost)
+  comes from the durable actor's outer tx: handlers run inside
   `TxAwareDeliveryStore.ExecTx`; `db.TransactionExecutor.ExecTx`
   joins via `actor.TxFromContext` so two `InsertLedgerEntry` calls
   commit atomically with the mailbox ack.

--- a/ledger/AGENTS.md
+++ b/ledger/AGENTS.md
@@ -99,7 +99,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/ledger.<
 - `ExitCostMsg` — unilateral exit as two ledger entries: send leg
   (`transfers_out` ⇐⇒ `vtxo_balance` net-of-fee) + fee leg
   (`onchain_fees` ⇐⇒ `vtxo_balance` miner fee). Wallet-side movement
-  is covered separately by the `wallet_utxo_log` audit trail.
+  is covered separately by the `wallet_utxo_log` audit trail. Both rows
+  retain the exited VTXO outpoint as their stable chain identity, while
+  `ConfirmationHeight` is the final sweep height that completed the exit.
 - `UTXOCreatedMsg` — wallet UTXO confirmations with classification.
   `handleUTXOCreated` writes TWO rows: `wallet_utxo_log` audit row
   AND a ledger row keyed by an outpoint-derived idempotency key.
@@ -173,7 +175,9 @@ or balance reconciliation. Required emission pairs:
 - Every ledger entry is double-entry: debit and credit must differ.
 - Handlers reject non-positive `AmountSat` with `ErrInvalidMessage`
   so a malformed TLV dead-letters cleanly instead of hitting
-  `CHECK (amount_sat > 0)` and driving infinite nack-retry.
+  `CHECK (amount_sat > 0)`. The ledger retry policy immediately
+  dead-letters `ErrInvalidMessage` and `ErrIdempotencyConflict`; transient
+  storage and runtime failures retain the durable actor's bounded backoff.
 - Unknown fee types and VTXO sources error out (no silent
   misclassification). Use the exported `FeeType*`/`Source*`/
   `Classification*` constants, not string literals.

--- a/ledger/CLAUDE.md
+++ b/ledger/CLAUDE.md
@@ -62,10 +62,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/ledger.<
   The db adapter additionally mirrors a 16-byte `RoundID` into the
   `round_uuid` TEXT column (migration 000015) so ledger rows join
   against `rounds.round_id` / `vtxos.forfeit_round_id` in portable SQL.
-- `exitIdempotencyKey(hash, index)` / `walletUTXOIdempotencyKey` —
-  derive 36-byte `outpoint_hash || outpoint_index` dedup keys
-  distinct from round-keyed and session-keyed entries (separate
-  `idx_client_ledger_idempotent_key` partial unique index).
+- `RefreshSendIdempotencyKey` / `ExitSendIdempotencyKey` /
+  `ExitFeeIdempotencyKey` — derive versioned operation-and-leg keys over the
+  36-byte `outpoint_hash || outpoint_index` identity. Refresh and exit sends
+  for the same VTXO therefore cannot collide in
+  `idx_client_ledger_idempotent_key`.
 - `UTXOAuditStore` / `UTXOAuditEntry` — UTXO audit log persistence
   (outpoint, amount, event, block height, classification). Implemented
   by `db.UTXOAuditStoreDB`.
@@ -194,11 +195,13 @@ or balance reconciliation. Required emission pairs:
 - UTXO audit inserts are idempotent on
   `(outpoint_hash, outpoint_index, event)` via
   `ON CONFLICT DO NOTHING`.
-- **Replay safety**: `InsertClientLedgerEntry` uses
-  `ON CONFLICT DO NOTHING` against every partial unique index
-  (`idx_client_ledger_idempotent_round`, `_session`, `_key`). Crash
-  atomicity for multi-leg events (ExitCost) comes from the durable
-  actor's outer tx: handlers run inside
+- **Replay safety**: `InsertClientLedgerEntry` uses `ON CONFLICT DO NOTHING`
+  against every partial unique index (`idx_client_ledger_idempotent_round`,
+  `_session`, `_key`), then reads the winner and accepts it only when the
+  accounting payload matches (the retry timestamp is ignored). Conflicting
+  reuse returns
+  `ErrIdempotencyConflict`. Crash atomicity for multi-leg events (ExitCost)
+  comes from the durable actor's outer tx: handlers run inside
   `TxAwareDeliveryStore.ExecTx`; `db.TransactionExecutor.ExecTx`
   joins via `actor.TxFromContext` so two `InsertLedgerEntry` calls
   commit atomically with the mailbox ack.

--- a/ledger/CLAUDE.md
+++ b/ledger/CLAUDE.md
@@ -99,7 +99,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/ledger.<
 - `ExitCostMsg` — unilateral exit as two ledger entries: send leg
   (`transfers_out` ⇐⇒ `vtxo_balance` net-of-fee) + fee leg
   (`onchain_fees` ⇐⇒ `vtxo_balance` miner fee). Wallet-side movement
-  is covered separately by the `wallet_utxo_log` audit trail.
+  is covered separately by the `wallet_utxo_log` audit trail. Both rows
+  retain the exited VTXO outpoint as their stable chain identity, while
+  `ConfirmationHeight` is the final sweep height that completed the exit.
 - `UTXOCreatedMsg` — wallet UTXO confirmations with classification.
   `handleUTXOCreated` writes TWO rows: `wallet_utxo_log` audit row
   AND a ledger row keyed by an outpoint-derived idempotency key.
@@ -173,7 +175,9 @@ or balance reconciliation. Required emission pairs:
 - Every ledger entry is double-entry: debit and credit must differ.
 - Handlers reject non-positive `AmountSat` with `ErrInvalidMessage`
   so a malformed TLV dead-letters cleanly instead of hitting
-  `CHECK (amount_sat > 0)` and driving infinite nack-retry.
+  `CHECK (amount_sat > 0)`. The ledger retry policy immediately
+  dead-letters `ErrInvalidMessage` and `ErrIdempotencyConflict`; transient
+  storage and runtime failures retain the durable actor's bounded backoff.
 - Unknown fee types and VTXO sources error out (no silent
   misclassification). Use the exported `FeeType*`/`Source*`/
   `Classification*` constants, not string literals.

--- a/ledger/actor.go
+++ b/ledger/actor.go
@@ -19,7 +19,15 @@ import (
 // failures that don't wrap this sentinel are logged at warn
 // level because they're external triggers (DB locked, I/O, etc.)
 // and should not page on their own.
-var ErrInvalidMessage = errors.New("ledger: invalid message")
+var (
+	ErrInvalidMessage = errors.New("ledger: invalid message")
+
+	// ErrIdempotencyConflict is returned when an existing ledger identity
+	// is replayed with a different accounting payload. Treating that case
+	// as a successful duplicate would hide a lost or contradictory ledger
+	// leg.
+	ErrIdempotencyConflict = errors.New("ledger: idempotency conflict")
+)
 
 const (
 	// defaultActorID is the durable mailbox identifier for the
@@ -211,10 +219,10 @@ type LedgerStore interface {
 	// InsertLedgerEntry persists a single ledger leg. The call
 	// joins any outer actor transaction present in ctx so that
 	// multiple invocations within one handler commit atomically
-	// with the mailbox ack. Conflicts on the idempotency partial
-	// unique indexes (round_id / session_id / idempotency_key)
-	// are swallowed via ON CONFLICT DO NOTHING so redelivery of
-	// a partially-processed message is a silent no-op.
+	// with the mailbox ack. Conflicts on the idempotency partial unique
+	// indexes (round_id / session_id / idempotency_key) succeed only when
+	// the existing payload is identical. A different payload returns
+	// ErrIdempotencyConflict.
 	InsertLedgerEntry(
 		ctx context.Context, entry LedgerEntry,
 	) error

--- a/ledger/actor.go
+++ b/ledger/actor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
@@ -196,9 +197,11 @@ type LedgerEntry struct {
 	// Nil means this ledger entry is not tied to a concrete output.
 	ChainVout *int32
 
-	// ConfirmationHeight optionally records the block height that
-	// confirmed the on-chain transaction. Nil means the height is
-	// unknown or the ledger entry has no chain transaction.
+	// ConfirmationHeight optionally records the relevant confirmation
+	// height. For unilateral-exit rows, ChainTxid and ChainVout identify
+	// the exited VTXO while this field records the final sweep height that
+	// completed the exit. Nil means the height is unknown or the ledger
+	// entry has no chain transaction.
 	ConfirmationHeight *int32
 }
 
@@ -392,6 +395,7 @@ func (a *LedgerActor) Start(ctx context.Context) error {
 	](
 		a.actorID, a, a.bindStores, a.cfg.DeliveryStore, codec,
 	)
+	durableCfg.TellRetryPolicy = ledgerTellRetryPolicy
 	durable, err := actor.NewDurableActor(durableCfg).Unpack()
 	if err != nil {
 		return fmt.Errorf("build ledger durable actor: %w", err)
@@ -420,6 +424,18 @@ func (a *LedgerActor) Start(ctx context.Context) error {
 	)
 
 	return nil
+}
+
+// ledgerTellRetryPolicy immediately dead-letters permanent caller and
+// accounting-identity failures while retaining the default transient retry
+// behavior for storage and runtime errors.
+func ledgerTellRetryPolicy(err error, attempts int) (bool, time.Duration) {
+	if errors.Is(err, ErrInvalidMessage) ||
+		errors.Is(err, ErrIdempotencyConflict) {
+		return false, 0
+	}
+
+	return actor.DefaultTellRetryPolicy(err, attempts)
 }
 
 // Stop stops the durable ledger actor.

--- a/ledger/actor_test.go
+++ b/ledger/actor_test.go
@@ -1,0 +1,36 @@
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLedgerTellRetryPolicy verifies permanent ledger failures are not
+// retried while transient failures retain the durable actor's default policy.
+func TestLedgerTellRetryPolicy(t *testing.T) {
+	t.Parallel()
+
+	permanentErrors := []error{
+		ErrInvalidMessage,
+		fmt.Errorf("wrapped: %w", ErrInvalidMessage),
+		ErrIdempotencyConflict,
+		fmt.Errorf("wrapped: %w", ErrIdempotencyConflict),
+	}
+	for _, testErr := range permanentErrors {
+		retry, delay := ledgerTellRetryPolicy(testErr, 0)
+		require.False(t, retry)
+		require.Zero(t, delay)
+	}
+
+	transientErr := errors.New("storage unavailable")
+	wantRetry, wantDelay := actor.DefaultTellRetryPolicy(transientErr, 2)
+	gotRetry, gotDelay := ledgerTellRetryPolicy(transientErr, 2)
+	require.Equal(t, wantRetry, gotRetry)
+	require.Equal(t, wantDelay, gotDelay)
+	require.Equal(t, 4*time.Second, gotDelay)
+}

--- a/ledger/handlers.go
+++ b/ledger/handlers.go
@@ -348,7 +348,7 @@ func (a *LedgerActor) handleVTXOSent(ctx context.Context, msg *VTXOSentMsg,
 		idempotencyKey = msg.IdempotencyKey
 
 	case !msg.Outpoint.Hash.IsEqual(&zeroHash):
-		idempotencyKey = walletUTXOIdempotencyKey(
+		idempotencyKey = refreshSendIdempotencyKey(
 			msg.Outpoint.Hash, msg.Outpoint.Index,
 		)
 	}
@@ -392,10 +392,10 @@ var zeroHash chainhash.Hash
 // a possibly-successful first insert) rolls back. Redelivery of
 // a committed message cannot happen because Ack/MarkProcessed
 // land in the same tx; defensive protection against out-of-band
-// replays is provided by the shared outpoint-derived
-// IdempotencyKey on both legs, which hits the partial unique
-// index idx_client_ledger_idempotent_key and is swallowed by the
-// adapter's ON CONFLICT DO NOTHING.
+// replays is provided by separate, versioned operation-and-leg
+// identities. Both hit the partial unique index
+// idx_client_ledger_idempotent_key; the adapter accepts an
+// identical winner and rejects a conflicting payload.
 //
 // On-chain wallet-side balance movement is intentionally not booked
 // here: this handler records the VTXO-funded exit value and confirmed
@@ -441,9 +441,12 @@ func (a *LedgerActor) handleExitCost(ctx context.Context, msg *ExitCostMsg,
 
 	now := a.clk.Now().Unix()
 	netAmount := msg.AmountSat - msg.ExitCostSat
-	idempotencyKey := exitIdempotencyKey(
+	chainVout := int32(msg.OutpointIndex)
+	confirmationHeight := int32(msg.BlockHeight)
+	sendKey := exitSendIdempotencyKey(
 		msg.OutpointHash, msg.OutpointIndex,
 	)
+	feeKey := exitFeeIdempotencyKey(msg.OutpointHash, msg.OutpointIndex)
 
 	sendLeg := LedgerEntry{
 		DebitAccount:  AccountTransfersOut,
@@ -456,8 +459,11 @@ func (a *LedgerActor) handleExitCost(ctx context.Context, msg *ExitCostMsg,
 			msg.OutpointHash, msg.OutpointIndex,
 			msg.BlockHeight,
 		),
-		CreatedAt:      now,
-		IdempotencyKey: idempotencyKey,
+		CreatedAt:          now,
+		IdempotencyKey:     sendKey,
+		ChainTxid:          msg.OutpointHash[:],
+		ChainVout:          &chainVout,
+		ConfirmationHeight: &confirmationHeight,
 	}
 
 	feeLeg := LedgerEntry{
@@ -471,18 +477,19 @@ func (a *LedgerActor) handleExitCost(ctx context.Context, msg *ExitCostMsg,
 			msg.OutpointIndex,
 			msg.BlockHeight,
 		),
-		CreatedAt:      now,
-		IdempotencyKey: idempotencyKey,
+		CreatedAt:          now,
+		IdempotencyKey:     feeKey,
+		ChainTxid:          msg.OutpointHash[:],
+		ChainVout:          &chainVout,
+		ConfirmationHeight: &confirmationHeight,
 	}
 
 	// Book the send leg and the fee leg via two InsertLedgerEntry
 	// calls inside ONE Commit. Both join the same lease-fenced writer
 	// transaction, so a crash or error between them rolls back both
 	// writes and the mailbox ack together -- no partial-write window.
-	// The shared outpoint-derived IdempotencyKey makes an out-of-band
-	// replay resolve to a silent no-op via the partial unique index
-	// idx_client_ledger_idempotent_key and the ON CONFLICT DO NOTHING
-	// clause on the insert query.
+	// The separately namespaced outpoint identities make an out-of-band
+	// replay resolve to the same two rows via the partial unique index.
 	return a.commit(ctx, ax, errMsg, func(ctx context.Context,
 		q ledgerTx) error {
 
@@ -498,13 +505,19 @@ func (a *LedgerActor) handleExitCost(ctx context.Context, msg *ExitCostMsg,
 	})
 }
 
-// exitIdempotencyKey derives the outpoint-scoped dedup key used on
-// ExitCost ledger entries. Packing hash (32 bytes) and index (4
-// bytes) into a single BLOB lets both exit legs share a key and
-// share the idempotency index, while staying distinct across
-// outpoints that only differ in the index (same tx, different
-// output).
-func exitIdempotencyKey(hash [32]byte, index uint32) []byte {
+const ledgerIdempotencyVersion = "ledger:v1:"
+
+const (
+	operationRoundRefresh   = "round_refresh"
+	operationUnilateralExit = "unilateral_exit"
+	legSend                 = "send"
+	legFee                  = "fee"
+)
+
+// outpointIdempotencyPayload returns the stable natural identity shared by
+// outpoint-scoped operations. Refresh and exit handlers always store it under
+// a versioned operation-and-leg prefix.
+func outpointIdempotencyPayload(hash [32]byte, index uint32) []byte {
 	out := make([]byte, 32+4)
 	copy(out[:32], hash[:])
 	out[32] = byte(index >> 24)
@@ -515,12 +528,63 @@ func exitIdempotencyKey(hash [32]byte, index uint32) []byte {
 	return out
 }
 
-// ExitIdempotencyKey exposes the exit-leg dedup key derivation to read-side
-// consumers: the unilateral exit send and fee legs booked by handleExitCost
-// share this outpoint-derived key, so a store can look up the confirmed exit
-// cost for a given VTXO outpoint without text-parsing descriptions.
+// ledgerIdempotencyKey scopes a natural identity by a versioned business
+// operation and ledger leg. The textual prefix is stable and human-readable
+// while the payload remains opaque binary data.
+func ledgerIdempotencyKey(operation, leg string, payload []byte) []byte {
+	prefix := ledgerIdempotencyVersion + operation + ":" + leg + ":"
+	key := make([]byte, 0, len(prefix)+len(payload))
+	key = append(key, prefix...)
+
+	return append(key, payload...)
+}
+
+// refreshSendIdempotencyKey derives the identity of the synthetic send leg
+// paired with a replacement VTXO created by a refresh round.
+func refreshSendIdempotencyKey(hash [32]byte, index uint32) []byte {
+	return ledgerIdempotencyKey(
+		operationRoundRefresh, legSend,
+		outpointIdempotencyPayload(hash, index),
+	)
+}
+
+// RefreshSendIdempotencyKey exposes refresh-send key derivation to migration
+// code that rewrites legacy outpoint-only ledger identities.
+func RefreshSendIdempotencyKey(hash [32]byte, index uint32) []byte {
+	return refreshSendIdempotencyKey(hash, index)
+}
+
+// exitSendIdempotencyKey derives the unilateral exit's net-value send leg.
+func exitSendIdempotencyKey(hash [32]byte, index uint32) []byte {
+	return ledgerIdempotencyKey(
+		operationUnilateralExit, legSend,
+		outpointIdempotencyPayload(hash, index),
+	)
+}
+
+// ExitSendIdempotencyKey exposes exit-send key derivation to migration code.
+func ExitSendIdempotencyKey(hash [32]byte, index uint32) []byte {
+	return exitSendIdempotencyKey(hash, index)
+}
+
+// exitFeeIdempotencyKey derives the unilateral exit's on-chain fee leg.
+func exitFeeIdempotencyKey(hash [32]byte, index uint32) []byte {
+	return ledgerIdempotencyKey(
+		operationUnilateralExit, legFee,
+		outpointIdempotencyPayload(hash, index),
+	)
+}
+
+// ExitFeeIdempotencyKey exposes the fee-leg identity to read-side consumers
+// and migration code.
+func ExitFeeIdempotencyKey(hash [32]byte, index uint32) []byte {
+	return exitFeeIdempotencyKey(hash, index)
+}
+
+// ExitIdempotencyKey returns the unilateral exit fee identity used by the
+// confirmed-cost read path.
 func ExitIdempotencyKey(hash [32]byte, index uint32) []byte {
-	return exitIdempotencyKey(hash, index)
+	return exitFeeIdempotencyKey(hash, index)
 }
 
 // handleUTXOCreated records a new wallet UTXO in two places:
@@ -643,14 +707,7 @@ func (a *LedgerActor) handleUTXOCreated(ctx context.Context,
 // change to one scheme (e.g. collision domain split) doesn't
 // silently affect the other.
 func walletUTXOIdempotencyKey(hash [32]byte, index uint32) []byte {
-	out := make([]byte, 32+4)
-	copy(out[:32], hash[:])
-	out[32] = byte(index >> 24)
-	out[33] = byte(index >> 16)
-	out[34] = byte(index >> 8)
-	out[35] = byte(index)
-
-	return out
+	return outpointIdempotencyPayload(hash, index)
 }
 
 // handleUTXOSpent records a spent wallet UTXO in the audit log.

--- a/ledger/handlers.go
+++ b/ledger/handlers.go
@@ -448,6 +448,10 @@ func (a *LedgerActor) handleExitCost(ctx context.Context, msg *ExitCostMsg,
 	)
 	feeKey := exitFeeIdempotencyKey(msg.OutpointHash, msg.OutpointIndex)
 
+	// The exited VTXO outpoint is the stable identity shared by both
+	// accounting legs. ConfirmationHeight intentionally records the final
+	// sweep height that completed the exit, not a confirmation of that
+	// outpoint transaction.
 	sendLeg := LedgerEntry{
 		DebitAccount:  AccountTransfersOut,
 		CreditAccount: AccountVTXOBalance,

--- a/ledger/handlers_test.go
+++ b/ledger/handlers_test.go
@@ -892,14 +892,11 @@ func (d *dedupLedgerStore) getEntries() []LedgerEntry {
 	return append([]LedgerEntry{}, d.entries...)
 }
 
-// TestHandleExitCostWritesBothLegsWithSharedKey verifies that
-// handleExitCost emits the send leg and the fee leg with the
-// correct account sides and that both carry the same
-// outpoint-derived IdempotencyKey. The durable actor's outer tx
-// provides crash atomicity for the two writes; the shared
-// idempotency key is what makes an out-of-band replay safe via
-// idx_client_ledger_idempotent_key + ON CONFLICT DO NOTHING.
-func TestHandleExitCostWritesBothLegsWithSharedKey(t *testing.T) {
+// TestHandleExitCostNamespacesBothLegs verifies that handleExitCost emits the
+// send and fee entries under distinct operation-and-leg identities. Both keys
+// retain the same outpoint payload, while the namespace prevents either leg
+// from colliding with a refresh send for that outpoint.
+func TestHandleExitCostNamespacesBothLegs(t *testing.T) {
 	t.Parallel()
 
 	a, store := newTestActor(t)
@@ -937,13 +934,22 @@ func TestHandleExitCostWritesBothLegsWithSharedKey(t *testing.T) {
 	require.Equal(t, int64(3_500), entries[1].AmountSat)
 	require.Equal(t, EventOnchainFeePaid, entries[1].EventType)
 
-	// Both legs must carry the same outpoint-scoped
-	// IdempotencyKey so the partial unique index
-	// idx_client_ledger_idempotent_key dedups a replay.
-	key := exitIdempotencyKey(msg.OutpointHash, msg.OutpointIndex)
-	require.Equal(t, key, entries[0].IdempotencyKey)
-	require.Equal(t, key, entries[1].IdempotencyKey)
-	require.Len(t, key, 36)
+	sendKey := exitSendIdempotencyKey(
+		msg.OutpointHash, msg.OutpointIndex,
+	)
+	feeKey := exitFeeIdempotencyKey(msg.OutpointHash, msg.OutpointIndex)
+	require.Equal(t, sendKey, entries[0].IdempotencyKey)
+	require.Equal(t, feeKey, entries[1].IdempotencyKey)
+	require.NotEqual(t, sendKey, feeKey)
+	require.Contains(t, string(sendKey), "ledger:v1:unilateral_exit:send:")
+	require.Contains(t, string(feeKey), "ledger:v1:unilateral_exit:fee:")
+	for _, entry := range entries {
+		require.Equal(t, msg.OutpointHash[:], entry.ChainTxid)
+		require.Equal(t, int32(msg.OutpointIndex), *entry.ChainVout)
+		require.Equal(
+			t, int32(msg.BlockHeight), *entry.ConfirmationHeight,
+		)
+	}
 }
 
 // TestHandleExitCostReplayIsIdempotent simulates an at-least-once
@@ -952,7 +958,7 @@ func TestHandleExitCostWritesBothLegsWithSharedKey(t *testing.T) {
 // four. This validates the combined contract of:
 //
 //   - two handleExitCost invocations produce four insert calls
-//   - the shared outpoint-derived IdempotencyKey puts every
+//   - each namespaced outpoint-derived IdempotencyKey puts its
 //     leg under the partial unique index
 //     idx_client_ledger_idempotent_key
 //   - ON CONFLICT DO NOTHING at the DB adapter layer turns the
@@ -1007,22 +1013,37 @@ func TestHandleExitCostReplayIsIdempotent(t *testing.T) {
 	)
 }
 
-// TestExitIdempotencyKeyDistinguishesOutputs confirms the key
-// derivation distinguishes outputs that share a txid but differ
-// in the output index -- the scenario where two exit legs on the
-// same tx must not collide in the unique index.
-func TestExitIdempotencyKeyDistinguishesOutputs(t *testing.T) {
+// TestExitFeeIdempotencyKeyDistinguishesOutputs confirms two exited VTXOs that
+// share a transaction hash but differ in output index receive distinct fee-leg
+// identities.
+func TestExitFeeIdempotencyKeyDistinguishesOutputs(t *testing.T) {
 	t.Parallel()
 
 	hash := [32]byte{0xde, 0xad}
 
-	k0 := exitIdempotencyKey(hash, 0)
-	k1 := exitIdempotencyKey(hash, 1)
-	kMax := exitIdempotencyKey(hash, 1<<31)
+	k0 := exitFeeIdempotencyKey(hash, 0)
+	k1 := exitFeeIdempotencyKey(hash, 1)
+	kMax := exitFeeIdempotencyKey(hash, 1<<31)
 
 	require.NotEqual(t, k0, k1)
 	require.NotEqual(t, k1, kMax)
 	require.NotEqual(t, k0, kMax)
+}
+
+// TestLedgerIdempotencyKeysSeparateOperations confirms the exact collision
+// domain that refresh and unilateral-exit sends share at the database index is
+// split before either row reaches persistence.
+func TestLedgerIdempotencyKeysSeparateOperations(t *testing.T) {
+	t.Parallel()
+
+	hash := [32]byte{0xde, 0xad}
+	refresh := refreshSendIdempotencyKey(hash, 7)
+	exitSend := exitSendIdempotencyKey(hash, 7)
+	exitFee := exitFeeIdempotencyKey(hash, 7)
+
+	require.NotEqual(t, refresh, exitSend)
+	require.NotEqual(t, refresh, exitFee)
+	require.NotEqual(t, exitSend, exitFee)
 }
 
 // TestHandleExitCostInvalidAmounts verifies non-positive inputs

--- a/ledger/messages.go
+++ b/ledger/messages.go
@@ -651,9 +651,9 @@ func (m *VTXOSentMsg) Decode(r io.Reader) error {
 	return nil
 }
 
-// ExitCostMsg is sent when the client pays an on-chain exit
-// cost (e.g. unilateral exit). The ledger actor records the
-// on-chain fee expense.
+// ExitCostMsg is sent after a unilateral exit's final sweep confirms. The
+// ledger actor records the exited VTXO as the stable chain subject and books
+// both its net value and the final on-chain fee expense.
 type ExitCostMsg struct {
 	actor.BaseMessage
 
@@ -671,8 +671,8 @@ type ExitCostMsg struct {
 	// ExitCostSat is the on-chain fee cost of the exit.
 	ExitCostSat int64
 
-	// BlockHeight is the block height at which the exit was
-	// confirmed.
+	// BlockHeight is the height of the final sweep confirmation that
+	// completed the exit. It does not confirm OutpointHash itself.
 	BlockHeight uint32
 }
 


### PR DESCRIPTION
## Summary

- give each ledger operation and accounting leg a versioned identity
- preserve identical retry idempotency while rejecting mismatched replays
- reconcile legacy key collisions and reconstruct missing exit sends
- record structured exit provenance for history and replay checks

## Testing

- `make fmt-changed`
- `make lint-changed-local`
- `go test ./ledger ./db ./internal/actortest ./round ./unroll -count=1`
- `go mod tidy -diff` across the root and tools modules
