### PR TITLE
unroll: use public-network proof scan floors

### DIFF
--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -26,9 +26,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `Config` — per-actor wiring. Notable: `TargetOutpoint`, `ActorID`,
   `DeliveryStore`, `ProofAssembler`, `VTXOStore`, `TxConfirmRef`,
   `ChainSource`, `Wallet` (`SweepWallet`),
-  `LegacyProofScanFloor` (earliest compatible commitment block for a known
-  operator; zero keeps block 1), `LegacyProofScanOperatorKey` (the matching
-  operator identity; nil or mismatch keeps block 1),
+  `LegacyProofScanFloor` (earliest compatible commitment block for the
+  configured supported public network; zero keeps block 1),
   `MaxSweepFeeRateSatPerVByte`, `FraudCheckpointSafetyMargin int32`
   (overrides the fraud-triggered unroll backstop margin in blocks;
   zero falls back to the default), `RegistryRef`.
@@ -62,8 +61,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `RegistryConfig` — `Store`, `DeliveryStore`, `ProofAssembler`,
   `VTXOStore`, `TxConfirmRef`, `ChainSource`, `Wallet`,
   optional `LedgerSink`, `MaxSweepFeeRateSatPerVByte`,
-  `LegacyProofScanFloor` and `LegacyProofScanOperatorKey` (forwarded to every
-  child),
+  `LegacyProofScanFloor` (forwarded to every child),
   `ExitSpendPolicyResolver` (optional; reconstructs the exit spend policy
   from `(ExitPolicyKind, ExitPolicyRef)` after restart; nil means every child
   uses the standard VTXO timeout), and optional `VTXOExitObserver`
@@ -181,29 +179,23 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   has a known (>0) height. A single unknown fragment returns 0 because a min
   over only known fragments would not bound its ancestor. Nothing in a VTXO's
   proof graph confirms before its commitment tx, so complete heights provide
-  a tight, provable floor. Without complete heights, `CreatedHeight` decides.
-  A single-fragment target created less than one lookback ago uses
-  `proofNodeHeightHint(currentHeight)` =
-  `max(1, currentHeight - proofNodeHeightHintLookback)` (10000 blocks) to
-  bound the neutrino rescan (wavelength#884). A configured operator deployment
-  floor may raise that fallback only when the target descriptor's stored
-  operator key matches `LegacyProofScanOperatorKey`. Every other legacy target
-  uses that matching deployment floor: an age of at least one lookback (that
-  bound can skip an earlier proof ancestor), an unknown `CreatedHeight`
-  (nothing proves the target is recent), or multiple ancestry fragments (one
-  scalar creation height cannot prove every contributing commitment is
-  recent). A missing or mismatched operator key, zero, block 1, or a floor
-  above the current tip safely resolves to block 1. This prevents a current
-  endpoint from imposing its deployment history on VTXOs from an older
-  operator.
+  a tight, provable floor. Without complete heights, the configured public
+  network's deployment floor applies. This floor is independent of endpoint
+  and operator identity because no compatible operator existed on mainnet,
+  testnet3, testnet4, or signet before the chosen network floor.
+  `CreatedHeight` cannot safely narrow the scan because an OOR target can be
+  created long after its commitment ancestor confirmed, and the descriptor
+  carries no maximum bound on that gap. Regtest, simnet, unknown networks,
+  zero, block 1, or a floor above the current tip safely resolves to block 1.
   Direct proof confirmations and their backup proof-output spend watches use
   the same floor. The fallback scan can be expensive but cannot silently stall
   the exit. One process-local
-  `proofNodeFloorAlertDeduper` is
-  shared by every child of an unroll registry, so this fallback emits one
-  warning per registry and process lifetime. Each affected target keeps Debug
-  evidence. A restart creates a new deduper and warns again if the condition
-  persists. Once the daemon is ready, waved attempts a bounded repair from
+  `proofNodeFloorAlertDeduper` is shared by every child of an unroll registry,
+  so block-1 fallback emits one Warning per registry and process lifetime.
+  Bounded deployment-floor fallback emits one Info per affected target. Each
+  affected target also keeps Debug evidence. A restart creates a new deduper
+  and warns again if the condition persists.
+  Once the daemon is ready, waved attempts a bounded repair from
   authenticated indexed ancestry. Indexed heights must be no greater than the
   local chain tip and, for single-fragment ancestry, the VTXO's known creation
   height. Existing jobs retain the safe fallback; successful repairs apply to

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -26,9 +26,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `Config` — per-actor wiring. Notable: `TargetOutpoint`, `ActorID`,
   `DeliveryStore`, `ProofAssembler`, `VTXOStore`, `TxConfirmRef`,
   `ChainSource`, `Wallet` (`SweepWallet`),
-  `LegacyProofScanFloor` (earliest compatible commitment block for a known
-  operator; zero keeps block 1), `LegacyProofScanOperatorKey` (the matching
-  operator identity; nil or mismatch keeps block 1),
+  `LegacyProofScanFloor` (earliest compatible commitment block for the
+  configured supported public network; zero keeps block 1),
   `MaxSweepFeeRateSatPerVByte`, `FraudCheckpointSafetyMargin int32`
   (overrides the fraud-triggered unroll backstop margin in blocks;
   zero falls back to the default), `RegistryRef`.
@@ -62,8 +61,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - `RegistryConfig` — `Store`, `DeliveryStore`, `ProofAssembler`,
   `VTXOStore`, `TxConfirmRef`, `ChainSource`, `Wallet`,
   optional `LedgerSink`, `MaxSweepFeeRateSatPerVByte`,
-  `LegacyProofScanFloor` and `LegacyProofScanOperatorKey` (forwarded to every
-  child),
+  `LegacyProofScanFloor` (forwarded to every child),
   `ExitSpendPolicyResolver` (optional; reconstructs the exit spend policy
   from `(ExitPolicyKind, ExitPolicyRef)` after restart; nil means every child
   uses the standard VTXO timeout), and optional `VTXOExitObserver`
@@ -181,29 +179,23 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   has a known (>0) height. A single unknown fragment returns 0 because a min
   over only known fragments would not bound its ancestor. Nothing in a VTXO's
   proof graph confirms before its commitment tx, so complete heights provide
-  a tight, provable floor. Without complete heights, `CreatedHeight` decides.
-  A single-fragment target created less than one lookback ago uses
-  `proofNodeHeightHint(currentHeight)` =
-  `max(1, currentHeight - proofNodeHeightHintLookback)` (10000 blocks) to
-  bound the neutrino rescan (wavelength#884). A configured operator deployment
-  floor may raise that fallback only when the target descriptor's stored
-  operator key matches `LegacyProofScanOperatorKey`. Every other legacy target
-  uses that matching deployment floor: an age of at least one lookback (that
-  bound can skip an earlier proof ancestor), an unknown `CreatedHeight`
-  (nothing proves the target is recent), or multiple ancestry fragments (one
-  scalar creation height cannot prove every contributing commitment is
-  recent). A missing or mismatched operator key, zero, block 1, or a floor
-  above the current tip safely resolves to block 1. This prevents a current
-  endpoint from imposing its deployment history on VTXOs from an older
-  operator.
+  a tight, provable floor. Without complete heights, the configured public
+  network's deployment floor applies. This floor is independent of endpoint
+  and operator identity because no compatible operator existed on mainnet,
+  testnet3, testnet4, or signet before the chosen network floor.
+  `CreatedHeight` cannot safely narrow the scan because an OOR target can be
+  created long after its commitment ancestor confirmed, and the descriptor
+  carries no maximum bound on that gap. Regtest, simnet, unknown networks,
+  zero, block 1, or a floor above the current tip safely resolves to block 1.
   Direct proof confirmations and their backup proof-output spend watches use
   the same floor. The fallback scan can be expensive but cannot silently stall
   the exit. One process-local
-  `proofNodeFloorAlertDeduper` is
-  shared by every child of an unroll registry, so this fallback emits one
-  warning per registry and process lifetime. Each affected target keeps Debug
-  evidence. A restart creates a new deduper and warns again if the condition
-  persists. Once the daemon is ready, waved attempts a bounded repair from
+  `proofNodeFloorAlertDeduper` is shared by every child of an unroll registry,
+  so block-1 fallback emits one Warning per registry and process lifetime.
+  Bounded deployment-floor fallback emits one Info per affected target. Each
+  affected target also keeps Debug evidence. A restart creates a new deduper
+  and warns again if the condition persists.
+  Once the daemon is ready, waved attempts a bounded repair from
   authenticated indexed ancestry. Indexed heights must be no greater than the
   local chain tip and, for single-fragment ancestry, the VTXO's known creation
   height. Existing jobs retain the safe fallback; successful repairs apply to

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
@@ -70,18 +69,12 @@ type Config struct {
 	// FSM Environment.
 	FraudCheckpointSafetyMargin int32
 
-	// LegacyProofScanFloor is the earliest block at which the configured
-	// operator could have created a compatible commitment transaction. It
-	// bounds proof scans for legacy descriptors whose exact commitment
-	// height is unavailable. Zero, one, or a value above the current tip
-	// falls back to block 1.
+	// LegacyProofScanFloor is the earliest block at which a supported
+	// deployment on the configured public network could have created a
+	// compatible commitment transaction. It bounds proof scans for legacy
+	// descriptors whose exact commitment height is unavailable. Zero, one,
+	// or a value above the current tip falls back to block 1.
 	LegacyProofScanFloor uint32
-
-	// LegacyProofScanOperatorKey identifies the operator whose deployment
-	// history justifies LegacyProofScanFloor. The fallback floor applies
-	// only when the target descriptor carries this same key. A nil or
-	// mismatched key falls back to block 1.
-	LegacyProofScanOperatorKey *btcec.PublicKey
 
 	// RegistryRef receives terminal notifications from this actor when set.
 	RegistryRef actor.TellOnlyRef[RegistryMsg]
@@ -752,33 +745,6 @@ func safeTxOutPkScript(tx *wire.MsgTx, index uint32) ([]byte, error) {
 	return append([]byte(nil), tx.TxOut[index].PkScript...), nil
 }
 
-// proofNodeHeightHintLookback is the number of blocks below the actor's
-// current best height used as the confirmation-watch FALLBACK floor for
-// proof-graph transactions when no commitment height is known and a recent
-// single-fragment target proves that bounded scan is safe. A block-1 floor
-// forces neutrino's notifier to rescan every block from tip to block 1 (one
-// GetCFilter per block) when the watched tx never confirms, which is expensive
-// (wavelength#884). Older and less provable legacy targets use the separate
-// operator-bound fallback in proofNodeConfHeightHint.
-//
-// The lookback MUST comfortably exceed the maximum batch lifetime plus the
-// worst-case tree-depth + CSV exit window, because proof roots and
-// intermediate OOR checkpoint ancestors can confirm well before the target
-// descriptor's CreatedHeight — using the creation height as the floor would
-// miss an ancestor that already confirmed. A generous operator-configured max
-// batch lifetime is on the order of one month (~4320 blocks at 144
-// blocks/day); 10000 blocks (~10 weeks) is a safe multiple for a target whose
-// creation height proves it is inside that window.
-//
-// The primary, tight floor is the commitment-tx confirmation height carried
-// per fragment on Descriptor.Ancestry[i].CommitmentHeight: nothing in a
-// VTXO's proof graph can confirm before its commitment tx, so min() across
-// fragments is a provable lower bound for every proof ancestor. When that
-// height is unknown (zero), behavior.proofNodeConfHeightHint decides whether
-// this bounded lookback is provable or whether the target needs the matching
-// operator deployment floor or block 1.
-const proofNodeHeightHintLookback uint32 = 10000
-
 // removeAbandonedBroadcastTimeout bounds each best-effort wallet RemoveTx RPC
 // issued on the terminal-failure cleanup path. lnd's RemoveTransaction is a
 // fast local wallet mutation, so 30s is generous headroom for a heavily loaded
@@ -786,36 +752,14 @@ const proofNodeHeightHintLookback uint32 = 10000
 // the detached cleanup goroutine indefinitely (wavelength#609).
 const removeAbandonedBroadcastTimeout = 30 * time.Second
 
-// proofNodeHeightHint returns the earliest safe confirmation height hint for
-// proof-graph transactions given the actor's current best height. Roots and
-// intermediate OOR checkpoint ancestors can confirm before the target
-// descriptor's CreatedHeight, so proof watches must not use the target
-// creation height as a lower bound; instead we floor at a bounded lookback
-// below the current height (never below block 1). See
-// proofNodeHeightHintLookback for the sizing rationale. Callers that hold a
-// Descriptor should route through behavior.proofNodeConfHeightHint instead, so
-// the age-exceeds-lookback breadcrumb fires.
-func proofNodeHeightHint(currentHeight uint32) uint32 {
-	if currentHeight <= proofNodeHeightHintLookback {
-		return 1
-	}
-
-	return currentHeight - proofNodeHeightHintLookback
-}
-
-// legacyProofScanFloor returns the configured operator deployment floor when
-// it is usable at the current chain tip and belongs to the operator that
-// created the target. A missing or mismatched key, absent floor, or future
-// floor falls back to block 1. An endpoint migration therefore cannot apply
-// the new operator's deployment history to an older operator's VTXO.
+// legacyProofScanFloor returns the configured public-network deployment floor
+// when it is usable at the current chain tip. Supported public-network floors
+// are independent of operator identity: no compatible deployment existed on
+// those networks before the configured floor. Local and unknown networks set
+// the floor to 1.
 func (b *behavior) legacyProofScanFloor(currentHeight uint32) uint32 {
 	floor := b.cfg.LegacyProofScanFloor
 	if floor <= 1 || floor > currentHeight {
-		return 1
-	}
-	if b.desc == nil || b.desc.OperatorKey == nil ||
-		b.cfg.LegacyProofScanOperatorKey == nil ||
-		!b.desc.OperatorKey.IsEqual(b.cfg.LegacyProofScanOperatorKey) {
 		return 1
 	}
 
@@ -859,16 +803,11 @@ func (b *behavior) commitmentHeightFloor() int32 {
 // proofNodeConfHeightHint returns the confirmation-watch height floor for one
 // proof-graph node. When the target descriptor carries a known commitment
 // height it uses min(commitment height) across fragments as a tight, provable
-// floor (clamped to at least block 1). Otherwise it falls back to the bounded
-// lookback below the current height and leaves a breadcrumb when the target
-// VTXO is old enough that the fallback floor may have risen above a proof
-// ancestor's real confirmation height. On the fallback path the lookback keeps
-// the floor below every ancestor only while the VTXO's age (in blocks) stays
-// within proofNodeHeightHintLookback and its ancestry has one fragment. A
-// multi-fragment descriptor's scalar CreatedHeight cannot prove every
-// contributing commitment is recent. Past either boundary, legacy descriptors
-// fall back to the deployment floor for their matching operator key. A missing
-// or mismatched key, or an absent, invalid, or future floor becomes block 1.
+// floor (clamped to at least block 1). Otherwise it uses the configured
+// public-network deployment floor. CreatedHeight is not a safe substitute: an
+// OOR target can be created long after its commitment ancestor confirmed, and
+// the descriptor carries no maximum bound on that gap. Local and unknown
+// networks, and an absent, invalid, or future deployment floor, use block 1.
 // The wider scan is expensive but cannot skip an already-confirmed ancestor
 // and silently stall the exit.
 func (b *behavior) proofNodeConfHeightHint(ctx context.Context,
@@ -886,33 +825,19 @@ func (b *behavior) proofNodeConfHeightHint(ctx context.Context,
 		return uint32(floor)
 	}
 
-	// Fallback path: no commitment height is known. A recent target can use
-	// the fixed lookback safely. An older target must scan from the
-	// earliest block where the configured operator could have created a
-	// compatible commitment, because the bounded floor may already be above
-	// an ancestor's real confirmation height.
+	// Fallback path: no commitment height is known. Scan from the earliest
+	// block where a supported deployment on this public network could have
+	// created a compatible commitment. CreatedHeight cannot narrow this
+	// floor because an OOR descendant may have been created arbitrarily
+	// later than its on-chain commitment ancestor.
 	//
-	// currentHeightHint returns 0 only for an uninitialized job (no height
-	// observed yet), and proofNodeHeightHint(0) is the genesis floor (1) —
-	// the very rescan-to-genesis behaviour #884 fixes. That is not
-	// reachable on the real path: a proof watch is registered only while
-	// handling a Start/Resume/HeightUpdated event, all of which set
-	// b.pending.Height first, so currentHeightHint is non-zero here in
-	// practice.
+	// currentHeightHint returns 0 only for an uninitialized job. That is
+	// not reachable on the real path: a proof watch is registered only
+	// while handling a Start/Resume/HeightUpdated event, all of which set
+	// b.pending.Height first.
 	currentHeight := b.currentHeightHint()
-	hint := proofNodeHeightHint(currentHeight)
 	legacyFloor := b.legacyProofScanFloor(currentHeight)
-	if legacyFloor > hint {
-		hint = legacyFloor
-	}
 
-	// CreatedHeight is our proxy for deciding whether the bounded fallback
-	// is still sound. An unknown creation height cannot prove the target is
-	// recent. Nor can one scalar creation height prove every contributing
-	// commitment in a multi-fragment ancestry is recent. Once the known age
-	// reaches the lookback, use the operator deployment floor. This can
-	// make neutrino replay many compact filters, but a slow exit is
-	// preferable to one that silently misses a confirmed ancestor.
 	createdHeight := int32(0)
 	ancestryFragments := 0
 	if b.desc != nil {
@@ -923,45 +848,15 @@ func (b *behavior) proofNodeConfHeightHint(ctx context.Context,
 	if createdHeight > 0 {
 		age = int64(currentHeight) - int64(createdHeight)
 	}
-	if createdHeight <= 0 || ancestryFragments > 1 ||
-		age >= int64(proofNodeHeightHintLookback) {
+	if b.proofNodeFloorWarned {
+		return legacyFloor
+	}
 
-		if b.proofNodeFloorWarned {
-			return legacyFloor
-		}
-
-		b.proofNodeFloorWarned = true
-		firstAlert := b.cfg.proofNodeFloorAlerts == nil ||
-			b.cfg.proofNodeFloorAlerts.first()
-		if firstAlert {
-			b.log.WarnS(ctx, "Legacy proof commitment height "+
-				"unavailable; using safe fallback floor",
-				nil,
-				slog.String(
-					"target_outpoint",
-					b.cfg.TargetOutpoint.String(),
-				),
-				slog.String("proof_txid", txid.String()),
-				slog.Int64("vtxo_age_blocks", age),
-				slog.Uint64(
-					"lookback", uint64(
-						proofNodeHeightHintLookback,
-					),
-				),
-				slog.Uint64(
-					"height_hint", uint64(legacyFloor),
-				),
-				slog.Int64(
-					"created_height", int64(createdHeight),
-				),
-				slog.Int(
-					"ancestry_fragment_count",
-					ancestryFragments,
-				),
-			)
-		}
-
-		b.log.DebugS(ctx, "Legacy proof fallback-scan target",
+	b.proofNodeFloorWarned = true
+	firstAlert := legacyFloor > 1 || b.cfg.proofNodeFloorAlerts == nil ||
+		b.cfg.proofNodeFloorAlerts.first()
+	if firstAlert {
+		attrs := []any{
 			slog.String(
 				"target_outpoint",
 				b.cfg.TargetOutpoint.String(),
@@ -969,20 +864,47 @@ func (b *behavior) proofNodeConfHeightHint(ctx context.Context,
 			slog.String("proof_txid", txid.String()),
 			slog.Int64("vtxo_age_blocks", age),
 			slog.Uint64(
-				"lookback", uint64(proofNodeHeightHintLookback),
+				"configured_floor",
+				uint64(b.cfg.LegacyProofScanFloor),
+			),
+			slog.Uint64(
+				"current_height", uint64(currentHeight),
 			),
 			slog.Uint64("height_hint", uint64(legacyFloor)),
 			slog.Int64(
-				"created_height",
-				int64(createdHeight),
+				"created_height", int64(createdHeight),
 			),
-			slog.Int("ancestry_fragment_count", ancestryFragments),
-		)
-
-		return legacyFloor
+			slog.Int(
+				"ancestry_fragment_count", ancestryFragments,
+			),
+		}
+		msg := "Legacy proof commitment height unavailable; " +
+			"using safe fallback floor"
+		if legacyFloor == 1 {
+			b.log.WarnS(ctx, msg, nil, attrs...)
+		} else {
+			b.log.InfoS(ctx, msg, attrs...)
+		}
 	}
 
-	return hint
+	b.log.DebugS(ctx, "Legacy proof fallback-scan target",
+		slog.String(
+			"target_outpoint", b.cfg.TargetOutpoint.String(),
+		),
+		slog.String("proof_txid", txid.String()),
+		slog.Int64("vtxo_age_blocks", age),
+		slog.Uint64(
+			"configured_floor", uint64(
+				b.cfg.LegacyProofScanFloor,
+			),
+		),
+		slog.Uint64("current_height", uint64(currentHeight)),
+		slog.Uint64("height_hint", uint64(legacyFloor)),
+		slog.Int64("created_height", int64(createdHeight)),
+		slog.Int("ancestry_fragment_count", ancestryFragments),
+	)
+
+	return legacyFloor
 }
 
 // ensureNodeConfirmed hands one ready proof-graph node to txconfirm and

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -1665,56 +1665,6 @@ func TestStartUnrollSubmitsInitialFrontier(t *testing.T) {
 	require.NotNil(t, checkpoint)
 }
 
-// TestProofNodeHeightHintBoundedBelowTip verifies that at a realistic mainnet
-// height the proof-node confirmation watch is floored a bounded lookback below
-// the current tip, not at genesis (block 1). A genesis floor makes neutrino
-// rescan every block to block 1 for a tx that never confirms
-// (wavelength#884); the bounded floor caps the rescan window while staying
-// low enough that a proof ancestor confirming before the target's creation
-// height is still covered.
-func TestProofNodeHeightHintBoundedBelowTip(t *testing.T) {
-	proof := buildLinearProof(t)
-	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
-	unrollActor, _, txconfirmRef, _ := newActorHarness(t, proof, desc)
-
-	// A mainnet-scale height comfortably above the lookback so the floor
-	// is (height - lookback), not the genesis clamp.
-	const startHeight uint32 = 850_000
-	desc.CreatedHeight = int32(startHeight - 100)
-
-	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
-		Height:  int32(startHeight),
-		Trigger: TriggerManual,
-	})
-
-	require.Equal(t, 1, txconfirmRef.requestCount())
-	hint := txconfirmRef.lastRequest(t).HeightHint
-
-	// The hint must not be the genesis floor, and must be exactly the
-	// bounded lookback below the observed height.
-	require.Greater(t, hint, uint32(1))
-	require.Equal(t, startHeight-proofNodeHeightHintLookback, hint)
-}
-
-// TestProofNodeHeightHintClampsToGenesis verifies the helper never returns a
-// height below block 1, even when the current height is at or below the
-// configured lookback window.
-func TestProofNodeHeightHintClampsToGenesis(t *testing.T) {
-	require.Equal(t, uint32(1), proofNodeHeightHint(0))
-	require.Equal(t, uint32(1), proofNodeHeightHint(1))
-	require.Equal(
-		t, uint32(1), proofNodeHeightHint(proofNodeHeightHintLookback),
-	)
-	require.Equal(
-		t, uint32(1),
-		proofNodeHeightHint(proofNodeHeightHintLookback-1),
-	)
-	require.Equal(
-		t, uint32(2),
-		proofNodeHeightHint(proofNodeHeightHintLookback+2),
-	)
-}
-
 // TestCommitmentHeightFloor verifies the commitment-height floor helper: it
 // returns the smallest height only when every fragment carries a known
 // positive height, and returns 0 (defer to the fallback floor) when any
@@ -1841,7 +1791,6 @@ func TestProofNodeHeightHintUsesCommitmentHeight(t *testing.T) {
 	// Exact local ancestry remains authoritative even when it predates the
 	// configured fallback floor.
 	behavior.cfg.LegacyProofScanFloor = 750_000
-	behavior.cfg.LegacyProofScanOperatorKey = desc.OperatorKey
 
 	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
 		Height:  int32(startHeight),
@@ -1853,17 +1802,18 @@ func TestProofNodeHeightHintUsesCommitmentHeight(t *testing.T) {
 
 	// The tight commitment floor is used, not the lookback floor.
 	require.Equal(t, uint32(lowHeight), hint)
-	require.NotEqual(t, startHeight-proofNodeHeightHintLookback, hint)
 }
 
-// TestProofNodeHeightHintFallsBackForRecentVTXO verifies that a recent target
-// with no commitment height can safely use the bounded lookback floor.
-func TestProofNodeHeightHintFallsBackForRecentVTXO(t *testing.T) {
+// TestProofNodeHeightHintUsesGenesisForRecentLegacyVTXO verifies that a recent
+// CreatedHeight cannot narrow a missing commitment-height floor. An OOR target
+// may be recent even when its single commitment ancestor is much older.
+func TestProofNodeHeightHintUsesGenesisForRecentLegacyVTXO(t *testing.T) {
 	proof := buildLinearProof(t)
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
 
-	// A single ancestry fragment with an unknown commitment height can use
-	// the recent target's creation height to justify the lookback.
+	// One fragment does not prove the ancestor is recent. The same fragment
+	// can back an OOR descendant created long after the commitment
+	// confirmed.
 	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
 
 	const startHeight uint32 = 850_000
@@ -1879,7 +1829,7 @@ func TestProofNodeHeightHintFallsBackForRecentVTXO(t *testing.T) {
 	require.Equal(t, 1, txconfirmRef.requestCount())
 	hint := txconfirmRef.lastRequest(t).HeightHint
 
-	require.Equal(t, startHeight-proofNodeHeightHintLookback, hint)
+	require.Equal(t, uint32(1), hint)
 }
 
 // TestProofNodeHeightHintUsesGenesisForOldLegacyVTXO verifies that an old
@@ -1925,7 +1875,6 @@ func TestProofNodeHeightHintUsesConfiguredFloorForOldLegacyVTXO(t *testing.T) {
 	)
 	const deploymentFloor uint32 = 800_000
 	behavior.cfg.LegacyProofScanFloor = deploymentFloor
-	behavior.cfg.LegacyProofScanOperatorKey = desc.OperatorKey
 
 	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
 		Height:  850_000,
@@ -1947,9 +1896,9 @@ func TestProofNodeHeightHintUsesConfiguredFloorForOldLegacyVTXO(t *testing.T) {
 	)
 }
 
-// TestProofNodeHeightHintUsesConfiguredFloorForRecentLegacyVTXO verifies the
-// configured deployment floor also prevents a recent fallback scan from
-// starting earlier than the operator could have created commitments.
+// TestProofNodeHeightHintUsesConfiguredFloorForRecentLegacyVTXO verifies a
+// recent target with unknown commitment height uses the deployment floor even
+// when the former tip-relative lookback would have selected a later height.
 func TestProofNodeHeightHintUsesConfiguredFloorForRecentLegacyVTXO(
 	t *testing.T) {
 
@@ -1961,9 +1910,8 @@ func TestProofNodeHeightHintUsesConfiguredFloorForRecentLegacyVTXO(
 	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
 		t, proof, desc,
 	)
-	const deploymentFloor uint32 = 845_000
+	const deploymentFloor uint32 = 800_000
 	behavior.cfg.LegacyProofScanFloor = deploymentFloor
-	behavior.cfg.LegacyProofScanOperatorKey = desc.OperatorKey
 
 	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
 		Height:  850_000,
@@ -1975,12 +1923,36 @@ func TestProofNodeHeightHintUsesConfiguredFloorForRecentLegacyVTXO(
 	)
 }
 
-// TestProofNodeHeightHintRejectsConfiguredFloorForAnotherOperator verifies an
-// endpoint migration cannot apply the current operator's deployment floor to
-// a legacy VTXO created by a different operator.
-func TestProofNodeHeightHintRejectsConfiguredFloorForAnotherOperator(
+// TestProofNodeHeightHintUsesConfiguredFloorWithoutOperatorIdentity verifies
+// the supported public-network floor does not depend on descriptor operator
+// identity.
+func TestProofNodeHeightHintUsesConfiguredFloorWithoutOperatorIdentity(
 	t *testing.T) {
 
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 1
+	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
+	desc.OperatorKey = nil
+
+	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
+		t, proof, desc,
+	)
+	behavior.cfg.LegacyProofScanFloor = 800_000
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  850_000,
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(
+		t, uint32(800_000), txconfirmRef.lastRequest(t).HeightHint,
+	)
+}
+
+// TestProofNodeHeightHintUsesConfiguredFloorForAnyOperator verifies an
+// operator rotation does not collapse a supported public network to block 1.
+func TestProofNodeHeightHintUsesConfiguredFloorForAnyOperator(t *testing.T) {
 	proof := buildLinearProof(t)
 	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
 	desc.CreatedHeight = 1
@@ -1989,17 +1961,19 @@ func TestProofNodeHeightHintRejectsConfiguredFloorForAnotherOperator(
 	unrollActor, behavior, txconfirmRef, _ := newActorHarness(
 		t, proof, desc,
 	)
-	currentOperator, err := btcec.NewPrivateKey()
+	otherOperator, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
+	desc.OperatorKey = otherOperator.PubKey()
 	behavior.cfg.LegacyProofScanFloor = 800_000
-	behavior.cfg.LegacyProofScanOperatorKey = currentOperator.PubKey()
 
 	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
 		Height:  850_000,
 		Trigger: TriggerManual,
 	})
 
-	require.Equal(t, uint32(1), txconfirmRef.lastRequest(t).HeightHint)
+	require.Equal(
+		t, uint32(800_000), txconfirmRef.lastRequest(t).HeightHint,
+	)
 	chainRef, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
 	require.True(t, ok)
 	rootOutpoint := wire.OutPoint{
@@ -2007,7 +1981,8 @@ func TestProofNodeHeightHintRejectsConfiguredFloorForAnotherOperator(
 		Index: 0,
 	}
 	require.Equal(
-		t, uint32(1), chainRef.spendRequest(t, rootOutpoint).HeightHint,
+		t, uint32(800_000),
+		chainRef.spendRequest(t, rootOutpoint).HeightHint,
 	)
 }
 
@@ -2023,26 +1998,7 @@ func TestProofNodeHeightHintRejectsConfiguredFloorAboveTip(t *testing.T) {
 		t, proof, desc,
 	)
 	behavior.cfg.LegacyProofScanFloor = 900_000
-	behavior.cfg.LegacyProofScanOperatorKey = desc.OperatorKey
 
-	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
-		Height:  850_000,
-		Trigger: TriggerManual,
-	})
-
-	require.Equal(t, uint32(1), txconfirmRef.lastRequest(t).HeightHint)
-}
-
-// TestProofNodeHeightHintUsesGenesisWhenCreatedHeightUnknown verifies that an
-// absent creation height cannot be treated as evidence that a legacy target is
-// recent enough for the bounded floor.
-func TestProofNodeHeightHintUsesGenesisWhenCreatedHeightUnknown(t *testing.T) {
-	proof := buildLinearProof(t)
-	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
-	desc.CreatedHeight = 0
-	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
-
-	unrollActor, _, txconfirmRef, _ := newActorHarness(t, proof, desc)
 	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
 		Height:  850_000,
 		Trigger: TriggerManual,
@@ -2113,6 +2069,38 @@ func TestProofNodeHeightHintWarnsOncePerActor(t *testing.T) {
 			),
 		),
 	)
+	require.Contains(t, buf.String(), "[WRN]")
+}
+
+// TestProofNodeHeightHintLogsBoundedFallbackAtInfo verifies a configured,
+// network deployment floor is routine compatibility handling, not an operator
+// warning.
+func TestProofNodeHeightHintLogsBoundedFallbackAtInfo(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	desc.CreatedHeight = 1
+	desc.Ancestry = []vtxo.Ancestry{{CommitmentHeight: 0}}
+
+	var buf bytes.Buffer
+	logger := btclog.NewSLogger(btclog.NewDefaultHandler(&buf))
+	logger.SetLevel(btclog.LevelInfo)
+
+	unrollActor, behavior, _, _ := newActorHarness(t, proof, desc)
+	behavior.log = logger
+	behavior.cfg.LegacyProofScanFloor = 800_000
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  850_000,
+		Trigger: TriggerManual,
+	})
+
+	require.Contains(
+		t, buf.String(),
+		"Legacy proof commitment height unavailable; using safe "+
+			"fallback floor",
+	)
+	require.Contains(t, buf.String(), "[INF]")
+	require.NotContains(t, buf.String(), "[WRN]")
 }
 
 // TestFraudTriggerDefersReadyCheckpoint verifies fraud-triggered recovery

--- a/unroll/proof_floor_alert.go
+++ b/unroll/proof_floor_alert.go
@@ -4,10 +4,10 @@ import (
 	"sync"
 )
 
-// proofNodeFloorAlertDeduper limits the legacy fallback-scan warning to one
-// alert per unroll registry and process lifetime. The alert reports the shared
-// compatibility condition; per-target Debug logs retain the affected
-// outpoints without repeating an operator warning for every proof transaction.
+// proofNodeFloorAlertDeduper limits the legacy block-1 fallback warning to one
+// per unroll registry and process lifetime. Per-target Debug logs retain the
+// affected outpoints without repeating the warning for every proof
+// transaction.
 type proofNodeFloorAlertDeduper struct {
 	mu     sync.Mutex
 	warned bool

--- a/unroll/proof_floor_alert_test.go
+++ b/unroll/proof_floor_alert_test.go
@@ -1,12 +1,15 @@
 package unroll
 
 import (
+	"bytes"
 	"sync"
 	"sync/atomic"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,12 +40,9 @@ func TestProofNodeFloorAlertDeduper(t *testing.T) {
 
 	// Exercise the production registry constructor and spawn seam. Two real
 	// children must receive the same registry-lifetime deduper.
-	operatorPriv, err := btcec.NewPrivateKey()
-	require.NoError(t, err)
 	registry := NewUnrollRegistryActor(RegistryConfig{
-		DeliveryStore:              newMemCheckpointStore(),
-		LegacyProofScanFloor:       123,
-		LegacyProofScanOperatorKey: operatorPriv.PubKey(),
+		DeliveryStore:        newMemCheckpointStore(),
+		LegacyProofScanFloor: 1,
 	})
 	t.Cleanup(registry.Stop)
 	require.NotNil(t, registry.behavior.proofNodeFloorAlerts)
@@ -71,19 +71,42 @@ func TestProofNodeFloorAlertDeduper(t *testing.T) {
 		secondChild.behavior.cfg.proofNodeFloorAlerts,
 	)
 	require.Equal(
-		t, uint32(123), firstChild.behavior.cfg.LegacyProofScanFloor,
+		t, uint32(1), firstChild.behavior.cfg.LegacyProofScanFloor,
 	)
 	require.Equal(
-		t, uint32(123), secondChild.behavior.cfg.LegacyProofScanFloor,
+		t, uint32(1), secondChild.behavior.cfg.LegacyProofScanFloor,
 	)
-	require.True(
-		t, operatorPriv.PubKey().IsEqual(
-			firstChild.behavior.cfg.LegacyProofScanOperatorKey,
+	// Drive both spawned behaviors through the real warning site. The
+	// registry-wide deduper must allow only the first child to warn.
+	var buf bytes.Buffer
+	logger := btclog.NewSLogger(btclog.NewDefaultHandler(&buf))
+	logger.SetLevel(btclog.LevelInfo)
+	for _, child := range []*VTXOUnrollActor{firstChild, secondChild} {
+		child.behavior.desc = &vtxo.Descriptor{
+			CreatedHeight: 850_000,
+			Ancestry: []vtxo.Ancestry{{
+				CommitmentHeight: 0,
+			}},
+		}
+		child.behavior.pending = &actorCheckpoint{Height: 850_100}
+		child.behavior.log = logger
+		proofTxid := chainhash.Hash{
+			byte(child.behavior.cfg.TargetOutpoint.Index),
+		}
+		child.behavior.proofNodeConfHeightHint(
+			t.Context(), proofTxid,
+		)
+	}
+
+	require.Equal(
+		t, 1,
+		bytes.Count(
+			buf.Bytes(), []byte(
+				"Legacy proof commitment height "+
+					"unavailable; using safe fallback "+
+					"floor",
+			),
 		),
 	)
-	require.True(
-		t, operatorPriv.PubKey().IsEqual(
-			secondChild.behavior.cfg.LegacyProofScanOperatorKey,
-		),
-	)
+	require.Contains(t, buf.String(), "[WRN]")
 }

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
@@ -166,16 +165,11 @@ type RegistryConfig struct {
 	// FSM Environment.
 	FraudCheckpointSafetyMargin int32
 
-	// LegacyProofScanFloor is the earliest block where the configured
-	// operator could have created a compatible commitment transaction.
-	// It is forwarded to every child unroll actor. Zero preserves the
-	// block-1 fallback.
+	// LegacyProofScanFloor is the earliest block where a supported
+	// deployment on the configured public network could have created a
+	// compatible commitment transaction. It is forwarded to every child
+	// unroll actor. Zero preserves the block-1 fallback.
 	LegacyProofScanFloor uint32
-
-	// LegacyProofScanOperatorKey identifies the operator whose deployment
-	// history justifies LegacyProofScanFloor. It is forwarded to every
-	// child unroll actor. A nil key preserves the block-1 fallback.
-	LegacyProofScanOperatorKey *btcec.PublicKey
 
 	// VTXOExitObserver, when set, receives an ExitOutcomeNotification each
 	// time a child unroll job reaches a terminal phase: a clean failure
@@ -1504,7 +1498,6 @@ func (r *registryBehavior) childConfig(target wire.OutPoint) Config {
 		ExitSpendPolicyResolver:     r.cfg.ExitSpendPolicyResolver,
 		FraudCheckpointSafetyMargin: r.cfg.FraudCheckpointSafetyMargin,
 		LegacyProofScanFloor:        r.cfg.LegacyProofScanFloor,
-		LegacyProofScanOperatorKey:  r.cfg.LegacyProofScanOperatorKey,
 		RegistryRef:                 r.selfRef,
 		proofNodeFloorAlerts:        r.proofNodeFloorAlerts,
 	}

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -116,11 +116,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   lightning-infra#3749.
   Changing a default here changes where an existing user's daemon dials on
   restart; treat it as a deployment change, not a constant tweak. The same
-  table anchors legacy proof scans at a rounded floor below each canonical
-  operator's first supported deployment. The floor applies only when the
-  VTXO's stored operator key matches the key negotiated from that endpoint.
-  An explicit custom operator or key mismatch keeps block 1 because the
-  relevant deployment history is unknown.
+  table anchors legacy proof scans at a rounded floor below the first
+  supported deployment on each public network. No compatible operator existed
+  on mainnet, testnet3, testnet4, or signet before the chosen floor, so the
+  floor is independent of endpoint and operator identity. Regtest, simnet, and
+  unknown networks keep block 1.
 - All sub-stores share the single `s.clk` clock assigned in `NewServer`; new
   code must not call `clock.NewDefaultClock()` directly, use `s.clk`.
 - Actor startup order in `startWalletDependentActors`: VTXO manager, then
@@ -142,13 +142,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   above that tip and, for single-fragment ancestry, a candidate above the
   VTXO's known creation height. A per-target failure does not stop later
   repairs; failures produce one non-fatal Info summary. The unroll registry
-  owns the single process-level warning if an affected target needs the safe
-  fallback scan. Canonical Lightning Labs endpoints use the network's
-  deployment floor only for descriptors whose stored operator key matches the
-  negotiated endpoint key. Custom operators, operator-key mismatches, regtest,
-  simnet, unknown networks, and a configured floor above the current tip use
-  block 1. Existing unroll jobs keep that fallback for this process, while
-  successful repairs apply to later admissions and restarts.
+  owns the single process-level Warning for block-1 fallback; bounded
+  deployment-floor fallback logs one Info per affected target. Mainnet,
+  testnet3, testnet4, and signet use their network floor for every operator.
+  Regtest, simnet, unknown networks, and a configured floor above the current
+  tip use block 1. Existing unroll jobs keep that fallback for this process,
+  while successful repairs apply to later admissions and restarts.
 - `initUnrollSubsystem` boot ordering is policy-preserving.
   `recoverySvc.RestoreNonTerminal` (in-flight vHTLC recovery jobs, each
   carrying its durable exit policy) runs **before** the chain resolver is

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -116,11 +116,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   lightning-infra#3749.
   Changing a default here changes where an existing user's daemon dials on
   restart; treat it as a deployment change, not a constant tweak. The same
-  table anchors legacy proof scans at a rounded floor below each canonical
-  operator's first supported deployment. The floor applies only when the
-  VTXO's stored operator key matches the key negotiated from that endpoint.
-  An explicit custom operator or key mismatch keeps block 1 because the
-  relevant deployment history is unknown.
+  table anchors legacy proof scans at a rounded floor below the first
+  supported deployment on each public network. No compatible operator existed
+  on mainnet, testnet3, testnet4, or signet before the chosen floor, so the
+  floor is independent of endpoint and operator identity. Regtest, simnet, and
+  unknown networks keep block 1.
 - All sub-stores share the single `s.clk` clock assigned in `NewServer`; new
   code must not call `clock.NewDefaultClock()` directly, use `s.clk`.
 - Actor startup order in `startWalletDependentActors`: VTXO manager, then
@@ -142,13 +142,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   above that tip and, for single-fragment ancestry, a candidate above the
   VTXO's known creation height. A per-target failure does not stop later
   repairs; failures produce one non-fatal Info summary. The unroll registry
-  owns the single process-level warning if an affected target needs the safe
-  fallback scan. Canonical Lightning Labs endpoints use the network's
-  deployment floor only for descriptors whose stored operator key matches the
-  negotiated endpoint key. Custom operators, operator-key mismatches, regtest,
-  simnet, unknown networks, and a configured floor above the current tip use
-  block 1. Existing unroll jobs keep that fallback for this process, while
-  successful repairs apply to later admissions and restarts.
+  owns the single process-level Warning for block-1 fallback; bounded
+  deployment-floor fallback logs one Info per affected target. Mainnet,
+  testnet3, testnet4, and signet use their network floor for every operator.
+  Regtest, simnet, unknown networks, and a configured floor above the current
+  tip use block 1. Existing unroll jobs keep that fallback for this process,
+  while successful repairs apply to later admissions and restarts.
 - `initUnrollSubsystem` boot ordering is policy-preserving.
   `recoverySvc.RestoreNonTerminal` (in-flight vHTLC recovery jobs, each
   carrying its durable exit policy) runs **before** the chain resolver is

--- a/waved/config.go
+++ b/waved/config.go
@@ -145,11 +145,10 @@ const (
 		"lightning.finance"
 
 	// The legacy proof scan floors are rounded well below the first
-	// supported operator deployment on each public network. They are used
-	// only with the canonical Lightning Labs operator endpoint. The extra
+	// supported deployment on each public network. No compatible Ark
+	// operator existed on these networks before the floors. The extra
 	// margin covers incomplete deployment history and operator database
-	// resets while still avoiding a scan of chain history in which that
-	// operator could not have created VTXOs.
+	// resets while avoiding scans of earlier chain history.
 	defaultMainnetLegacyProofScanFloor uint32 = 950_000
 	testnet3LegacyProofScanFloor       uint32 = 4_940_000
 	testnet4LegacyProofScanFloor       uint32 = 140_000
@@ -1582,21 +1581,13 @@ func (c *Config) ArkServerAddress() string {
 	return defaults.ark.forTransport(c.Server.Transport)
 }
 
-// legacyProofScanFloor returns the earliest block where the configured Ark
-// operator could have created a compatible commitment. The deployment-backed
-// floors apply only to the canonical Lightning Labs endpoints. A custom or
-// unknown operator retains block 1 because its deployment history is unknown.
+// legacyProofScanFloor returns the earliest block where a supported deployment
+// could have created a compatible commitment on the configured public network.
+// The floor is network-wide and independent of operator identity because no
+// compatible deployment existed before it. Local and unknown networks use
+// block 1.
 func (c *Config) legacyProofScanFloor() uint32 {
-	if c == nil || c.Server == nil {
-		return 1
-	}
-
-	defaults, ok := defaultNetworkEndpoints(c.Network)
-	if !ok {
-		return 1
-	}
-	canonical := defaults.ark.forTransport(c.Server.Transport)
-	if canonical == "" || c.ArkServerAddress() != canonical {
+	if c == nil {
 		return 1
 	}
 

--- a/waved/config_network_test.go
+++ b/waved/config_network_test.go
@@ -406,9 +406,9 @@ func TestConfigEndpointDefaultsPreserveOverrides(t *testing.T) {
 	require.Equal(t, "localhost:11030", cfg.SwapServerAddress())
 }
 
-// TestLegacyProofScanFloor verifies deployment-backed floors apply only to
-// the canonical operator for each public network. Custom operators retain the
-// block-1 fallback because their earliest compatible commitment is unknown.
+// TestLegacyProofScanFloor verifies deployment-backed floors apply to every
+// operator on each supported public network. No compatible operator existed
+// before these floors. Local and unknown networks retain block 1.
 func TestLegacyProofScanFloor(t *testing.T) {
 	t.Parallel()
 
@@ -471,7 +471,7 @@ func TestLegacyProofScanFloor(t *testing.T) {
 			name:    "custom public operator",
 			network: "testnet",
 			host:    "ark.example.com:443",
-			want:    1,
+			want:    testnet3LegacyProofScanFloor,
 		},
 		{
 			name:    "explicit canonical operator",
@@ -511,6 +511,10 @@ func TestLegacyProofScanFloor(t *testing.T) {
 	}
 
 	require.Equal(t, uint32(1), (*Config)(nil).legacyProofScanFloor())
+	require.Equal(
+		t, defaultMainnetLegacyProofScanFloor,
+		(&Config{Network: "mainnet"}).legacyProofScanFloor(),
+	)
 }
 
 // TestNetworkToChainParams verifies network strings map to their exact btcd

--- a/waved/server.go
+++ b/waved/server.go
@@ -5866,12 +5866,6 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 	}
 	s.proofAssembler = proofAssembler
 	legacyProofScanFloor := s.cfg.legacyProofScanFloor()
-	var legacyProofScanOperatorKey *btcec.PublicKey
-	if legacyProofScanFloor > 1 {
-		if terms := s.loadOperatorTerms(); terms != nil {
-			legacyProofScanOperatorKey = terms.PubKey
-		}
-	}
 
 	// Adapt the VTXO manager ref into a tell-only exit observer so the
 	// unroll registry can report each job's terminal outcome back to the
@@ -5903,9 +5897,8 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 			Jobs:     recoveryStore,
 			Preimage: preimages,
 		},
-		VTXOExitObserver:           exitObserver,
-		LegacyProofScanFloor:       legacyProofScanFloor,
-		LegacyProofScanOperatorKey: legacyProofScanOperatorKey,
+		VTXOExitObserver:     exitObserver,
+		LegacyProofScanFloor: legacyProofScanFloor,
 	})
 	s.unrollRegistry = registry
 	s.unrollRegistryRef = fn.Some(registry.Ref())


### PR DESCRIPTION
## Problem

A unilateral exit watches every transaction in its proof graph. Each watch needs a starting height that is early enough to include an already-confirmed ancestor.

When every ancestry fragment has an authenticated commitment height, the minimum of those heights is the tightest safe floor. Legacy descriptors can lack one or more heights.

The old fallback used a 10,000-block lookback derived from the target's `CreatedHeight`. That is unsafe for out-of-round descendants. A target can be created long after its commitment ancestor confirmed, so the lookback can start too late and silently stall the exit.

## Fix

- Keep the minimum authenticated commitment height as the primary floor when every fragment has one.
- Otherwise use the fixed supported-deployment floor for the configured public network:
  - mainnet: `950000`
  - testnet3: `4940000`
  - testnet4: `140000`
  - signet: `300000`
- Use block 1 only for regtest, simnet, unknown networks, invalid floors, or floors above the current tip.
- Remove endpoint and operator-key checks. The public-network floor is independent of endpoint, key parity, rotation, or missing descriptor key material.
- Pass the same floor to direct confirmation and backup-spend watches.
- Emit one process-level Warning for block-1 fallback. Log bounded public-network fallback at Info per affected target. Keep per-target Debug evidence.

## Safety rule

The confirmation floor must not be later than a proof ancestor's possible confirmation height.

Exact complete ancestry proves the primary floor. Database evidence establishes that no compatible operator existed on mainnet, testnet3, testnet4, or signet before the chosen floor. That makes each constant a network-wide supported-deployment floor, not endpoint provenance.

`CreatedHeight` remains diagnostic only. It does not establish an ancestry lower bound.

## Tests

- Exact complete ancestry wins even when it predates the network floor.
- Recent, old, and multi-fragment legacy targets ignore `CreatedHeight`.
- Missing and changed operator keys still use the public-network floor.
- Custom endpoints on supported public networks use the same floor.
- Regtest, simnet, and unknown networks use block 1.
- A future configured floor uses block 1.
- Direct confirmation and backup-spend watches receive the same floor.
- Registry-wide Warning deduplication and Info severity are covered.

## Verification

- `go test ./unroll ./waved`
- `make unit timeout=15m`
- `make unit-race pkg=unroll timeout=15m`
- `make fmt-changed-check base=origin/main`
- `make lint-changed-local base=origin/main`
- `make doc-check`
- `make tidy-module-check`
- `make commitmsg-lint range=origin/main..HEAD`
- `git diff --check origin/main..HEAD`

## Compatibility and rollout

This is a code-only change. It adds no schema, wire, proof, or descriptor migration. No coordinated rollout is required. The `backport-v0.1.x-branch` label will create the release-branch backport after merge.
