### PR TITLE
unroll: Reissue staged work after route errors

### DIFF
--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -195,6 +195,13 @@ type behavior struct {
 	// so a policy-gated sweep is not reported as imminent. None until the
 	// sweep phase resolves the policy.
 	requiredLockTime fn.Option[uint32]
+
+	// routeRetryPending records that the current FSM state was durably
+	// staged before an outbox effect failed. The next turn replays the
+	// checkpoint's in-flight work through ResumeEvent before applying its
+	// own message. This is in-memory only because process restart already
+	// enters through ResumeUnrollRequest.
+	routeRetryPending bool
 }
 
 // unrollTx is the transaction-scoped store handed to the unroll behavior inside
@@ -265,12 +272,20 @@ func (b *behavior) Receive(ctx context.Context, msg Msg,
 	// Run the FSM pipeline. Every checkpoint write inside is a short,
 	// lock-releasing Stage and the slow txconfirm IO runs with no writer
 	// transaction held; dispatch never commits.
+	if b.routeRetryPending {
+		if err := b.reissueStagedRoute(ctx, ax); err != nil {
+			return fn.Err[Resp](err)
+		}
+	}
+
 	res := b.dispatch(ctx, ax, msg)
 	if res.IsErr() {
 
-		// The behavior did not commit, so the framework nacks the
-		// message; it is redelivered and replayed against the durably
-		// Staged state.
+		// The behavior did not commit. Durable Tells are nacked for
+		// redelivery; Asks return the error to their caller. If route
+		// IO failed after Stage, routeRetryPending makes the next live
+		// turn reissue the checkpoint's in-flight work before it
+		// applies its own message.
 		return res
 	}
 
@@ -281,8 +296,26 @@ func (b *behavior) Receive(ctx context.Context, msg Msg,
 	if err := b.commitAck(ctx, ax); err != nil {
 		return fn.Err[Resp](err)
 	}
+	b.routeRetryPending = false
 
 	return res
+}
+
+// reissueStagedRoute replays every outbox effect implied by the current staged
+// checkpoint. A failed route has already advanced the FSM state, so applying
+// the original event again cannot rediscover work now classified as in-flight;
+// ResumeEvent is the explicit reissue path for that state.
+func (b *behavior) reissueStagedRoute(ctx context.Context,
+	ax actor.Exec[unrollTx]) error {
+
+	state, err := b.currentState()
+	if err != nil {
+		return err
+	}
+
+	return b.driveEvent(ctx, ax, &ResumeEvent{
+		Height: stateHeight(state),
+	})
 }
 
 // dispatch maps one durable message onto the FSM event surface and runs the
@@ -401,10 +434,12 @@ func (b *behavior) handleEvent(ctx context.Context, ax actor.Exec[unrollTx],
 //     so the txconfirm IO that follows never holds it. If the process
 //     crashes between the Stage and the outbox routing, restart restores
 //     the exact same state that was in memory and re-emits the outbox via
-//     the reissue path, so no work is lost and no work is duplicated
-//     beyond what txconfirm's txid-keyed dedup already collapses. The
-//     message itself is acked only once, by the single lease-fenced Commit
-//     in Receive after the whole (possibly recursive) pipeline settles.
+//     the reissue path. A live route failure arms the same reissue path for
+//     the next turn before the original event is reapplied. No work is lost
+//     and no work is duplicated beyond what txconfirm's txid-keyed dedup
+//     already collapses. The message itself is acked only once, by the
+//     single lease-fenced Commit in Receive after the whole (possibly
+//     recursive) pipeline settles.
 //
 //  3. Route: interpret each OutboxEvent as a real IO effect — submit
 //     ready proof nodes to txconfirm, re-arm in-flight subscriptions,
@@ -440,6 +475,8 @@ func (b *behavior) driveEvent(ctx context.Context, ax actor.Exec[unrollTx],
 	}
 
 	if err := b.routeOutbox(ctx, ax, outbox); err != nil {
+		b.routeRetryPending = true
+
 		return err
 	}
 

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,12 +23,15 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/lightninglabs/wavelength/chainsource"
+	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/db/actordelivery"
 	"github.com/lightninglabs/wavelength/ledger"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/lib/recovery"
 	"github.com/lightninglabs/wavelength/txconfirm"
 	"github.com/lightninglabs/wavelength/unrollplan"
 	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -74,6 +78,7 @@ func (m *mockVTXOStore) ListLiveVTXOs(context.Context) ([]*vtxo.Descriptor,
 	return nil, nil
 }
 
+// ListRecoverableVTXOs is unused in these tests.
 func (m *mockVTXOStore) ListRecoverableVTXOs(context.Context) (
 	[]*vtxo.Descriptor, error) {
 
@@ -101,6 +106,7 @@ func (m *mockVTXOStore) UpdateVTXOStatus(context.Context, wire.OutPoint,
 	return nil
 }
 
+// UpdateVTXOStatusReleasingReservation is unused in these tests.
 func (m *mockVTXOStore) UpdateVTXOStatusReleasingReservation(context.Context,
 	wire.OutPoint, vtxo.VTXOStatus) error {
 
@@ -141,6 +147,7 @@ type fakeTxConfirmRef struct {
 	responseStates map[chainhash.Hash]txconfirm.TxState
 	confirmHeights map[chainhash.Hash]int32
 	failureReasons map[chainhash.Hash]string
+	askFailures    map[chainhash.Hash]int
 
 	// onAsk, when set, is invoked with each EnsureConfirmedReq as it is
 	// recorded (outside the store lock). Tests use it to assert ordering
@@ -186,8 +193,13 @@ func (f *fakeTxConfirmRef) Ask(_ context.Context,
 
 	f.mu.Lock()
 	f.requests = append(f.requests, req)
-	state := f.responseStates[req.Tx.TxHash()]
-	height := f.confirmHeights[req.Tx.TxHash()]
+	txid := req.Tx.TxHash()
+	state := f.responseStates[txid]
+	height := f.confirmHeights[txid]
+	failures := f.askFailures[txid]
+	if failures > 0 {
+		f.askFailures[txid] = failures - 1
+	}
 	onAsk := f.onAsk
 	f.mu.Unlock()
 
@@ -196,6 +208,16 @@ func (f *fakeTxConfirmRef) Ask(_ context.Context,
 	// exact moment the unroll actor is doing its txconfirm IO.
 	if onAsk != nil {
 		onAsk(req)
+	}
+	if failures > 0 {
+		promise.Complete(
+			fn.Err[txconfirm.Resp](
+				fmt.Errorf("injected txconfirm ask "+
+					"failure for %s", txid),
+			),
+		)
+
+		return promise.Future()
 	}
 
 	if state == 0 {
@@ -234,6 +256,19 @@ func (f *fakeTxConfirmRef) Ask(_ context.Context,
 	)
 
 	return promise.Future()
+}
+
+// failNextAsks configures the next count asks for txid to fail before the
+// normal response logic runs.
+func (f *fakeTxConfirmRef) failNextAsks(txid chainhash.Hash, count int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.askFailures == nil {
+		f.askFailures = make(map[chainhash.Hash]int)
+	}
+
+	f.askFailures[txid] = count
 }
 
 // lastRequest returns the latest txconfirm request.
@@ -2961,6 +2996,78 @@ func TestConfirmedNodesAdvanceToSweep(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, PhaseSweepConfirmation, stateResp.Phase)
 	require.NotNil(t, stateResp.SweepTxid)
+}
+
+// TestUnrollTellRetryReissuesStagedInFlight verifies that a durable chain
+// notification replay reissues work which was staged as in-flight before a
+// transient txconfirm Ask failure.
+func TestUnrollTellRetryReissuesStagedInFlight(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	txconfirmRef := &fakeTxConfirmRef{}
+	targetTxid := proof.TargetOutpoint().Hash
+	txconfirmRef.failNextAsks(targetTxid, 1)
+
+	sqlDB := db.NewTestDB(t)
+	deliveryStore, err := actordelivery.NewTxAwareDeliveryStoreFromDB(
+		sqlDB.DB, sqlDB.Backend(), clock.NewDefaultClock(),
+		btclog.Disabled,
+	)
+	require.NoError(t, err)
+
+	const actorID = "unroll-tell-retry"
+	unrollActor, err := NewVTXOUnrollActor(Config{
+		TargetOutpoint: proof.TargetOutpoint(),
+		ActorID:        actorID,
+		DeliveryStore:  deliveryStore,
+		ProofAssembler: &mockProofAssembler{proof: proof},
+		VTXOStore:      &mockVTXOStore{desc: desc},
+		TxConfirmRef:   txconfirmRef,
+		ChainSource:    &fakeChainSourceRef{},
+		Wallet:         &fakeSweepWallet{},
+		Log:            fn.Some(btclog.Disabled),
+	})
+	require.NoError(t, err)
+	t.Cleanup(unrollActor.Stop)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+	rootTxid := proof.RootTxids()[0]
+	require.Equal(t, 1, txconfirmRef.requestCountForTxid(rootTxid))
+
+	// The root notification is a durable Tell. It stages the target as
+	// in-flight, then the injected txconfirm Ask failure nacks the Tell.
+	txconfirmRef.emitConfirmedByTxid(t, rootTxid, 101)
+
+	// Redelivery must explicitly reissue the staged in-flight target.
+	// Merely applying the root confirmation again is idempotent and emits
+	// no work.
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(targetTxid) == 2
+	}, 6*time.Second, 20*time.Millisecond)
+
+	txconfirmRef.emitConfirmed(t, 2, targetTxid, 102)
+	require.Eventually(t, func() bool {
+		checkpoint, loadErr := deliveryStore.LoadCheckpoint(
+			t.Context(), actorID,
+		)
+		if loadErr != nil || checkpoint == nil {
+			return false
+		}
+
+		decoded, decodeErr := decodeCheckpoint(checkpoint.StateData)
+		if decodeErr != nil {
+			return false
+		}
+
+		return slices.Contains(decoded.State.ConfirmedTxids, targetTxid)
+	}, testTimeout, 10*time.Millisecond)
+
+	require.Equal(t, 1, txconfirmRef.requestCountForTxid(rootTxid))
+	require.Equal(t, 2, txconfirmRef.requestCountForTxid(targetTxid))
+	require.Equal(t, 3, txconfirmRef.requestCount())
 }
 
 // TestResumeReissuesInflightWork verifies that resume reattaches the actor to


### PR DESCRIPTION
## Summary

Fixes #1268.

Reissue staged unroll work after a live outbox route failure. This prevents a transient txconfirm error from leaving a proof transaction recorded as in flight without an active txconfirm subscription.

## Problem

Unroll stages its next planner state before routing actor-boundary IO. A confirmation notification can therefore:

1. unblock the next proof transaction;
2. stage that transaction in `InFlightTxids`;
3. fail while asking txconfirm to ensure it;
4. nack and redeliver the durable notification.

Reapplying the notification is idempotent. The planner sees the child transaction as already in flight and emits no second ensure request. The notification then commits, and recovery waits for a daemon restart because only `ResumeEvent` reissues the in-flight set.

## Fix

When route IO fails after Stage, the behavior records an in-memory pending reissue. The next actor turn drives the existing `ResumeEvent` path before applying its own message. The marker clears only after the turn commits.

Restart behavior stays unchanged. The marker does not need persistence because restored actors already enter through `ResumeUnrollRequest`. Repeated ensure requests keep the same txid and use txconfirm's existing deduplication boundary.

## Test

`TestUnrollTellRetryReissuesStagedInFlight` uses the real SQLite durable mailbox:

- start a linear unroll and ensure the root once;
- confirm the root through a durable txconfirm notification;
- fail the newly unblocked target ensure once;
- let the same actor process redeliver the notification;
- assert the same target txid is reissued exactly once;
- confirm it and assert the durable checkpoint records confirmation;
- assert the root was not resubmitted and no distinct work was created.

Local validation:

- `go test ./unroll -count=3`
- `go test -race ./unroll -run '^TestUnrollTellRetryReissuesStagedInFlight$' -count=3`
- `make fmt-changed`
- `make lint-changed-local`
- `make commitmsg-lint range=origin/main..HEAD`
- Go documentation audit for both changed Go files

## Relationship to #1243

This fixes a pre-existing unroll replay gap and has no code dependency on #1243. #1243 makes transient txconfirm setup failures surface as request errors, which is one way to reach this existing path.
