### PR TITLE
waved: apply leave admission filter to sweep-all onchain sends

### DIFF
--- a/waved/rpc_leave_admission.go
+++ b/waved/rpc_leave_admission.go
@@ -116,3 +116,77 @@ func (r *RPCServer) admitLeaveTargets(ctx context.Context,
 
 	return admitted, skipped, nil
 }
+
+// sweepAllTargets enumerates the VTXOs a sweep_all SendOnChain can forfeit.
+// It is the sweep-all counterpart of the selection=all branch in LeaveVTXOs
+// and applies the same admission check, because the two RPCs share the
+// failure it guards against: ListLiveVTXOs returns every non-terminal VTXO,
+// PendingForfeit and Forfeiting included, and the wallet reserves the sweep
+// set strictly, so one coin sitting in an unconfirmed round (an automatic
+// refresh that fired moments earlier, say) would otherwise fail the whole
+// sweep with the VTXO manager's raw reservation error.
+//
+// An empty admitted set is reported as FailedPrecondition and distinguishes
+// "nothing to sweep" from "everything is committed to a round", since the
+// second resolves on its own once that round confirms and the first does
+// not.
+func (r *RPCServer) sweepAllTargets(ctx context.Context) ([]wire.OutPoint,
+	error) {
+
+	if r.server.vtxoStore == nil {
+		return nil, status.Errorf(codes.Internal, "vtxo store not "+
+			"initialized")
+	}
+
+	liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list live VTXOs: %v",
+			err)
+	}
+	if len(liveVTXOs) == 0 {
+		return nil, status.Errorf(codes.FailedPrecondition, "no live "+
+			"VTXOs to sweep")
+	}
+
+	// ListLiveVTXOs already returned hydrated descriptors, so the
+	// admission check runs on those rather than re-reading each row
+	// through admitLeaveTargets; on a large wallet that round trip is
+	// one extra transaction plus an ancestry query per coin.
+	var skipped int
+	admitted := make([]wire.OutPoint, 0, len(liveVTXOs))
+	for _, desc := range liveVTXOs {
+		admitErr := vtxo.CheckForfeitAdmission(desc)
+		if admitErr == nil {
+			admitted = append(admitted, desc.Outpoint)
+
+			continue
+		}
+
+		skipped++
+
+		// The admission error names what holds the coin, so the
+		// line says which coin was left out of the sweep and what
+		// has to resolve before a retry can include it.
+		r.server.log.InfoS(ctx, "Skipping sweep-all target: not "+
+			"admissible for forfeit",
+			slog.String("outpoint", desc.Outpoint.String()),
+			slog.String("status", desc.Status.String()),
+			slog.String("reason", admitErr.Error()),
+		)
+	}
+
+	if skipped > 0 {
+		r.server.log.InfoS(ctx, "Sweep-all targets skipped",
+			slog.Int("skipped_count", skipped),
+			slog.Int("remaining_count", len(admitted)),
+		)
+	}
+
+	if len(admitted) == 0 {
+		return nil, status.Errorf(codes.FailedPrecondition, "no "+
+			"sweepable VTXOs: %d skipped (committed to a round or "+
+			"spend-reserved); retry once they resolve", skipped)
+	}
+
+	return admitted, nil
+}

--- a/waved/rpc_leave_admission_test.go
+++ b/waved/rpc_leave_admission_test.go
@@ -193,3 +193,51 @@ func TestLeaveVTXOsDryRunRejectsCommitted(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 }
+
+// TestSweepAllTargetsSkipsCommitted asserts a sweep_all SendOnChain drops the
+// VTXOs it cannot forfeit rather than failing the whole sweep. This is the
+// SendOnChain twin of TestAdmitLeaveTargetsAllSkipsCommitted: a VTXO the
+// automatic refresh had just committed to a round sank an otherwise valid
+// "exit my whole balance" request with the manager's raw reservation error.
+func TestSweepAllTargetsSkipsCommitted(t *testing.T) {
+	t.Parallel()
+
+	r, store := newLeaveAdmissionServer(t)
+
+	live := saveVTXOWithStatus(t, store, 0x41, vtxo.VTXOStatusLive)
+	saveVTXOWithStatus(t, store, 0x42, vtxo.VTXOStatusForfeiting)
+	saveVTXOWithStatus(t, store, 0x43, vtxo.VTXOStatusPendingForfeit)
+
+	targets, err := r.sweepAllTargets(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []wire.OutPoint{live.Outpoint}, targets)
+}
+
+// TestSweepAllTargetsAllCommitted asserts that a wallet whose every coin is
+// committed to a round answers FailedPrecondition rather than "no live VTXOs":
+// the caller should retry once the rounds confirm, not conclude the wallet is
+// empty.
+func TestSweepAllTargetsAllCommitted(t *testing.T) {
+	t.Parallel()
+
+	r, store := newLeaveAdmissionServer(t)
+	saveVTXOWithStatus(t, store, 0x51, vtxo.VTXOStatusForfeiting)
+
+	_, err := r.sweepAllTargets(t.Context())
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.Contains(t, err.Error(), "skipped (committed to a round")
+}
+
+// TestSweepAllTargetsEmptyWallet keeps the pre-existing empty-wallet answer
+// distinct from the all-committed one.
+func TestSweepAllTargetsEmptyWallet(t *testing.T) {
+	t.Parallel()
+
+	r, _ := newLeaveAdmissionServer(t)
+
+	_, err := r.sweepAllTargets(t.Context())
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.Contains(t, err.Error(), "no live VTXOs to sweep")
+}

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -2636,29 +2636,17 @@ func (r *RPCServer) SendOnChain(ctx context.Context,
 			"terms: %v", err)
 	}
 
-	// For sweep_all, enumerate live VTXOs up front. We do this at
-	// the RPC layer (not in the wallet actor) so the dry_run path
-	// can echo the planned outpoint set without reserving anything,
-	// and so the wallet does not need its own live-set listing seam.
+	// For sweep_all, enumerate the sweepable VTXOs up front. We do
+	// this at the RPC layer (not in the wallet actor) so the dry_run
+	// path can echo the planned outpoint set without reserving
+	// anything, and so the wallet does not need its own live-set
+	// listing seam. The enumeration drops coins already committed to
+	// a round; see sweepAllTargets for why.
 	var sweepOutpoints []wire.OutPoint
 	if sweepAll {
-		if r.server.vtxoStore == nil {
-			return nil, status.Errorf(codes.Internal, "vtxo "+
-				"store not initialized")
-		}
-
-		liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(ctx)
+		sweepOutpoints, err = r.sweepAllTargets(ctx)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "list live "+
-				"VTXOs: %v", err)
-		}
-		if len(liveVTXOs) == 0 {
-			return nil, status.Errorf(codes.FailedPrecondition,
-				"no live VTXOs to sweep")
-		}
-
-		for _, v := range liveVTXOs {
-			sweepOutpoints = append(sweepOutpoints, v.Outpoint)
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Fixes #1270.

In this PR, we close a gap left open by the #577 fix. `LeaveVTXOs` with `selection=all` learned to drop coins already committed to a round before handing the set to the wallet, but `SendOnChain` with `sweep_all=true` kept enumerating the raw `ListLiveVTXOs` result. That query returns every non-terminal VTXO, `PendingForfeit` and `Forfeiting` included, and the wallet reserves the sweep set strictly, so one coin sitting in an unconfirmed round fails the entire sweep with the VTXO manager's raw reservation error.

This is what a signet user hit: an automatic refresh committed one of their two coins to a round, and 56 seconds later their "exit my whole balance" request was refused outright while the commitment transaction waited on a slow signet block. Full log trace in #1270.

## Change

The sweep-all enumeration moves into `sweepAllTargets`, which runs the same `admitLeaveTargets` filter in non-strict mode:

- coins committed to a round are dropped, and the skipped count is logged;
- when nothing admissible remains, the RPC answers `FailedPrecondition` naming the committed count, so an all-committed wallet is distinguishable from an empty one and the caller knows to retry once the round confirms.

The `dry_run` preview goes through the same path, so it echoes the set the real dispatch will actually reserve.

## Tests

Three new tests in `rpc_leave_admission_test.go` drive `sweepAllTargets` against the SQL VTXO store: a mixed Live/Forfeiting/PendingForfeit wallet yields only the Live coin, an all-committed wallet answers `FailedPrecondition` with the retry hint, and an empty wallet keeps its pre-existing "no live VTXOs to sweep" answer.
