### PR TITLE
docs: nightly doc-gardening sweep 2026-09-05

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,6 +26,7 @@ package may import from a higher layer.
 | [`lib/tx/oor`](lib/tx/oor/) | OOR submit/finalize package builders and validators |
 | [`lib/tx/psbtutil`](lib/tx/psbtutil/) | PSBT encoding, decoding, and signature attachment helpers |
 | [`lib/recovery`](lib/recovery/) | Immutable recovery proof graph, session state machine, TLV codec for unilateral exit |
+| [`tapassets`](tapassets/) | Adapts tap-sdk custom-anchor transitions to Ark trees: caller-funded asset batch outputs and journaled per-node asset tree materialization. Not yet wired into the daemon |
 | [`unrollplan`](unrollplan/) | Pure dependency-resolution planner driving unilateral-exit broadcast/sweep ordering |
 | [`vhtlcrecovery`](vhtlcrecovery/) | Durable control-plane types for vHTLC on-chain recovery jobs (action, state, script parameters, swap linkage) |
 | [`credit`](credit/) | Client-side credit subsystem: supervisor/per-operation-actor pair driving fault-tolerant sub-floor pay, credit-receive, and redeem flows against the authoritative server ledger |

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -12,6 +12,8 @@ message interfaces, and core Ark types.
 - `Tree` — Root node plus batch outpoint/output (encapsulates VTXO Merkle tree).
 - `Node` — Individual tree node with children and outputs.
 - `LeafDescriptor` — VTXO or connector output to include in tree construction.
+- `BatchOutputSpec` — Batch output plus its taproot material (internal key, sweep leaf, tap tree bytes).
+- `AssetTreeContext` — Optional Taproot Assets side-table for a tree (nil for Bitcoin-only trees); consumed by `tapassets`.
 
 ### lib/arkscript
 - `Node` — Sealed AST interface for tapscript spending conditions (Multisig, CSV, Condition, etc.).

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -12,6 +12,8 @@ message interfaces, and core Ark types.
 - `Tree` — Root node plus batch outpoint/output (encapsulates VTXO Merkle tree).
 - `Node` — Individual tree node with children and outputs.
 - `LeafDescriptor` — VTXO or connector output to include in tree construction.
+- `BatchOutputSpec` — Batch output plus its taproot material (internal key, sweep leaf, tap tree bytes).
+- `AssetTreeContext` — Optional Taproot Assets side-table for a tree (nil for Bitcoin-only trees); consumed by `tapassets`.
 
 ### lib/arkscript
 - `Node` — Sealed AST interface for tapscript spending conditions (Multisig, CSV, Condition, etc.).

--- a/lib/actormsg/AGENTS.md
+++ b/lib/actormsg/AGENTS.md
@@ -15,7 +15,7 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - `SelectAndReserveSpendRequest` / `SelectAndReserveSpendResponse` — Ask-message to select and lock VTXOs for OOR spend.
 - `SelectAndReserveForfeitRequest` / `SelectAndReserveForfeitResponse` — Ask-message to atomically select and reserve VTXOs for cooperative forfeit (directed sends). Combines coin selection and PendingForfeit reservation in one step to close a race window.
 - `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
-- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
+- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages. `ReleaseSpendRequest.ReserveEpochs` optionally names, per outpoint, the reservation epoch the releasing owner held, so the manager can refuse a release whose reservation was superseded.
 - `ForceUnrollRequest` / `ForceUnrollResponse` — Ask-message that routes an operator or chain-resolver unroll trigger through the VTXO manager into the per-VTXO FSM. `ForceUnrollRequest.Trigger` (a `UnrollTrigger`) names *why* the coin is exiting, and `ForceUnrollRequest.ExitPolicy` (an `fn.Option[ExitPolicy]`) names *which* exit-spend policy the target unrolls under, so a single admission path carries manual, critical-expiry, fraud, and vHTLC-recovery intent through to the unroll registry. `ForceUnrollResponse.Accepted` is true when the request caused a state transition; when false, `Reason` distinguishes `"no such vtxo"` from `"already terminal"` so callers don't misread a silent self-loop as success.
 - `UnrollTrigger` — String-typed enum naming why a unilateral exit was started (`UnrollTriggerCriticalExpiry` is the empty-string zero value and preserves the historical critical-expiry admission, `UnrollTriggerManual`, `UnrollTriggerFraudSpend`). It mirrors the unroll package's `StartTrigger` so `vtxo` and `actormsg` can thread the trigger through `ForceUnroll` without importing `unroll` (which would form a cycle); the waved chain resolver bridge converts it back at the seam.
 - `ExitPolicyKind` / `ExitPolicyRef` / `ExitPolicy` — Durable exit-spend policy identity for a forced exit. `ExitPolicyKind` is a string-typed enum of the non-standard policies that ride `ForceUnroll` (`ExitPolicyVHTLCClaim`, `ExitPolicyVHTLCRefundWithoutReceiver`), with `Valid()` true only for those two vHTLC kinds; `ExitPolicyRef` is the policy-specific durable reference (e.g. a vHTLC recovery job id), kept a distinct type so `Kind` and `Ref` can't be transposed; `ExitPolicy` bundles the pair as one identity validated at the registry admission boundary. A `None` `ExitPolicy` selects the standard VTXO timeout policy.
@@ -25,7 +25,7 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
   (`true` for directed sends) or parks in `PendingRoundAssembly` for
   batching (`false` for refresh/leave flows).
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
-- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
+- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript, `ReserveEpoch`).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.
 
 ## Relationships
@@ -38,6 +38,15 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - All cross-boundary actor messages must implement the appropriate marker interface (`RoundReceivable`, `VTXOManagerMsg`, etc.) for type-safe actor routing.
 - Service key names are constants (`RoundActorServiceKeyName`, `VTXOManagerServiceKeyName`) shared across the codebase for consistent actor discovery.
 - `SelectedVTXO` intentionally duplicates minimal VTXO info to avoid `wallet` importing `vtxo.Descriptor`.
+- The reservation epoch is a **monotonic in-process counter**, not a durable
+  identity: it is stamped by the manager on reserve, echoed through
+  `SelectedVTXO.ReserveEpoch`, carried into the owner's durable state, and
+  presented back on `ReleaseSpendRequest.ReserveEpochs`. Zero means "no epoch
+  known" and always releases unconditionally, which is what keeps pre-epoch
+  snapshots and manual unlocks working. Because the counter restarts at 0 on
+  boot, an epoch may only ever be compared against a live in-memory
+  reservation from the same process — never persisted and compared across
+  restarts.
 
 ## Deep Docs
 

--- a/lib/actormsg/CLAUDE.md
+++ b/lib/actormsg/CLAUDE.md
@@ -15,7 +15,7 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - `SelectAndReserveSpendRequest` / `SelectAndReserveSpendResponse` — Ask-message to select and lock VTXOs for OOR spend.
 - `SelectAndReserveForfeitRequest` / `SelectAndReserveForfeitResponse` — Ask-message to atomically select and reserve VTXOs for cooperative forfeit (directed sends). Combines coin selection and PendingForfeit reservation in one step to close a race window.
 - `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
-- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
+- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages. `ReleaseSpendRequest.ReserveEpochs` optionally names, per outpoint, the reservation epoch the releasing owner held, so the manager can refuse a release whose reservation was superseded.
 - `ForceUnrollRequest` / `ForceUnrollResponse` — Ask-message that routes an operator or chain-resolver unroll trigger through the VTXO manager into the per-VTXO FSM. `ForceUnrollRequest.Trigger` (a `UnrollTrigger`) names *why* the coin is exiting, and `ForceUnrollRequest.ExitPolicy` (an `fn.Option[ExitPolicy]`) names *which* exit-spend policy the target unrolls under, so a single admission path carries manual, critical-expiry, fraud, and vHTLC-recovery intent through to the unroll registry. `ForceUnrollResponse.Accepted` is true when the request caused a state transition; when false, `Reason` distinguishes `"no such vtxo"` from `"already terminal"` so callers don't misread a silent self-loop as success.
 - `UnrollTrigger` — String-typed enum naming why a unilateral exit was started (`UnrollTriggerCriticalExpiry` is the empty-string zero value and preserves the historical critical-expiry admission, `UnrollTriggerManual`, `UnrollTriggerFraudSpend`). It mirrors the unroll package's `StartTrigger` so `vtxo` and `actormsg` can thread the trigger through `ForceUnroll` without importing `unroll` (which would form a cycle); the waved chain resolver bridge converts it back at the seam.
 - `ExitPolicyKind` / `ExitPolicyRef` / `ExitPolicy` — Durable exit-spend policy identity for a forced exit. `ExitPolicyKind` is a string-typed enum of the non-standard policies that ride `ForceUnroll` (`ExitPolicyVHTLCClaim`, `ExitPolicyVHTLCRefundWithoutReceiver`), with `Valid()` true only for those two vHTLC kinds; `ExitPolicyRef` is the policy-specific durable reference (e.g. a vHTLC recovery job id), kept a distinct type so `Kind` and `Ref` can't be transposed; `ExitPolicy` bundles the pair as one identity validated at the registry admission boundary. A `None` `ExitPolicy` selects the standard VTXO timeout policy.
@@ -25,7 +25,7 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
   (`true` for directed sends) or parks in `PendingRoundAssembly` for
   batching (`false` for refresh/leave flows).
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
-- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
+- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript, `ReserveEpoch`).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.
 
 ## Relationships
@@ -38,6 +38,15 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - All cross-boundary actor messages must implement the appropriate marker interface (`RoundReceivable`, `VTXOManagerMsg`, etc.) for type-safe actor routing.
 - Service key names are constants (`RoundActorServiceKeyName`, `VTXOManagerServiceKeyName`) shared across the codebase for consistent actor discovery.
 - `SelectedVTXO` intentionally duplicates minimal VTXO info to avoid `wallet` importing `vtxo.Descriptor`.
+- The reservation epoch is a **monotonic in-process counter**, not a durable
+  identity: it is stamped by the manager on reserve, echoed through
+  `SelectedVTXO.ReserveEpoch`, carried into the owner's durable state, and
+  presented back on `ReleaseSpendRequest.ReserveEpochs`. Zero means "no epoch
+  known" and always releases unconditionally, which is what keeps pre-epoch
+  snapshots and manual unlocks working. Because the counter restarts at 0 on
+  boot, an epoch may only ever be compared against a live in-memory
+  reservation from the same process — never persisted and compared across
+  restarts.
 
 ## Deep Docs
 

--- a/lib/tree/AGENTS.md
+++ b/lib/tree/AGENTS.md
@@ -19,11 +19,22 @@ descriptors through branch nodes to the batch output.
 - `Materializer` / `BTCMaterializer` — Interface and implementation for materializing tree nodes into actual Bitcoin transactions.
 - `TreeAssembler` — Two-pass builder (`BuildStructure` then `Materialize`) driven by `TreeConfig`.
 - `Queue[T]` — Generic queue used internally for BFS tree traversal.
+- `BatchOutputSpec` — A batch output plus the taproot material behind it
+  (`Output`, untweaked MuSig2 `InternalKey`, operator `SweepLeaf`, and
+  `TapTreeBytes`). Built by `BuildBatchOutputSpec`; `BuildBatchOutput` remains
+  the narrower helper returning only the `*wire.TxOut`. Callers that must
+  re-derive or tweak the batch output — notably asset anchoring — need the
+  spec, not just the output.
+- `AssetTreeContext` — Side-table of Taproot Assets material for a tree,
+  populated by the builder before the tree is shared: per-node subtree asset
+  amount, per-input signing tweak and sealed transfer package, per-leaf asset
+  commitment root, and the tree's asset reference. `IsEmpty` reports a tree
+  with no asset data, which is the ordinary Bitcoin-only case.
 
 ## Relationships
 
 - **Depends on**: `lib/arkscript` (taproot script construction, policy templates, `SpendInfo`).
-- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization).
+- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization), `tapassets` (asset materialization onto `Tree`/`Node`, via `AssetTreeContext` and `BatchOutputSpec`).
 
 ## Invariants
 
@@ -42,6 +53,17 @@ descriptors through branch nodes to the batch output.
   all outputs and recurses only into retained children. The traversal rejects
   cycles and nodes shared by multiple parents. `Node.Verify` checks only
   parent-child outpoint topology and is not a trust-boundary validator.
+- `Tree.AssetContext` is **nil for an ordinary Bitcoin-only tree**; every
+  accessor (`AssetTreeContext` methods, `Tree.LeafAssetRoot`) is nil-receiver
+  safe and returns the zero value, so a Bitcoin-only caller never needs to
+  branch on it. Getters returning byte slices copy, so a caller cannot mutate
+  the context's stored roots or tweaks through the returned slice. When the
+  context is populated it drives the per-node signing tweak lookup used by tree
+  signing, so it must be complete before the tree is shared — it is subject to
+  the same cache-aliasing rule as the tree itself. `Tree` shallow-copy paths
+  carry the same `*AssetTreeContext` pointer, they do not clone it.
+- Subtree asset amounts aggregate bottom-up with an explicit overflow check;
+  a subtree total that would exceed `math.MaxUint64` is an error, never a wrap.
 - **Cache-aliasing invariant**: a `*Tree` is effectively immutable once published from
   a builder or resolver. Multiple downstream consumers may share the same `*Tree`
   pointer through caches and ancestry-fragment slices. Silently mutating a shared

--- a/lib/tree/CLAUDE.md
+++ b/lib/tree/CLAUDE.md
@@ -19,11 +19,22 @@ descriptors through branch nodes to the batch output.
 - `Materializer` / `BTCMaterializer` — Interface and implementation for materializing tree nodes into actual Bitcoin transactions.
 - `TreeAssembler` — Two-pass builder (`BuildStructure` then `Materialize`) driven by `TreeConfig`.
 - `Queue[T]` — Generic queue used internally for BFS tree traversal.
+- `BatchOutputSpec` — A batch output plus the taproot material behind it
+  (`Output`, untweaked MuSig2 `InternalKey`, operator `SweepLeaf`, and
+  `TapTreeBytes`). Built by `BuildBatchOutputSpec`; `BuildBatchOutput` remains
+  the narrower helper returning only the `*wire.TxOut`. Callers that must
+  re-derive or tweak the batch output — notably asset anchoring — need the
+  spec, not just the output.
+- `AssetTreeContext` — Side-table of Taproot Assets material for a tree,
+  populated by the builder before the tree is shared: per-node subtree asset
+  amount, per-input signing tweak and sealed transfer package, per-leaf asset
+  commitment root, and the tree's asset reference. `IsEmpty` reports a tree
+  with no asset data, which is the ordinary Bitcoin-only case.
 
 ## Relationships
 
 - **Depends on**: `lib/arkscript` (taproot script construction, policy templates, `SpendInfo`).
-- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization).
+- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization), `tapassets` (asset materialization onto `Tree`/`Node`, via `AssetTreeContext` and `BatchOutputSpec`).
 
 ## Invariants
 
@@ -42,6 +53,17 @@ descriptors through branch nodes to the batch output.
   all outputs and recurses only into retained children. The traversal rejects
   cycles and nodes shared by multiple parents. `Node.Verify` checks only
   parent-child outpoint topology and is not a trust-boundary validator.
+- `Tree.AssetContext` is **nil for an ordinary Bitcoin-only tree**; every
+  accessor (`AssetTreeContext` methods, `Tree.LeafAssetRoot`) is nil-receiver
+  safe and returns the zero value, so a Bitcoin-only caller never needs to
+  branch on it. Getters returning byte slices copy, so a caller cannot mutate
+  the context's stored roots or tweaks through the returned slice. When the
+  context is populated it drives the per-node signing tweak lookup used by tree
+  signing, so it must be complete before the tree is shared — it is subject to
+  the same cache-aliasing rule as the tree itself. `Tree` shallow-copy paths
+  carry the same `*AssetTreeContext` pointer, they do not clone it.
+- Subtree asset amounts aggregate bottom-up with an explicit overflow check;
+  a subtree total that would exceed `math.MaxUint64` is an error, never a wrap.
 - **Cache-aliasing invariant**: a `*Tree` is effectively immutable once published from
   a builder or resolver. Multiple downstream consumers may share the same `*Tree`
   pointer through caches and ancestry-fragment slices. Silently mutating a shared

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -148,6 +148,15 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
 - Witness/script decode bounds mirror consensus limits:
   `maxConditionWitnessItems = 64` items of at most 520 bytes each (Bitcoin's
   `MAX_SCRIPT_ELEMENT_SIZE`), enforced on both encode and decode.
+- `TransferInput.ReserveEpoch` carries the VTXO manager's reservation epoch for
+  each spend input, persisted in `TransferInputSnapshot` (TLV record type 18,
+  appended last so the stream stays canonical; a pre-upgrade snapshot decodes
+  it to 0). `ReleaseInputsRequest.ReserveEpochs` is rebuilt from those durable
+  inputs every time the FSM re-enters the failure transition, so a release
+  replayed after a rolled-back commit still names the reservation it held and
+  the manager refuses it if a newer session has since re-reserved the coin.
+  `ReserveEpochs` is an in-memory side channel only — `ToProto` does not
+  serialize it, because the request is never a persisted transport message.
 - Terminal rows (completed and failed) are retained in
   `oor_session_registry` for status/diagnostics; reaping only removes the
   in-memory child, never the row.

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -148,6 +148,15 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
 - Witness/script decode bounds mirror consensus limits:
   `maxConditionWitnessItems = 64` items of at most 520 bytes each (Bitcoin's
   `MAX_SCRIPT_ELEMENT_SIZE`), enforced on both encode and decode.
+- `TransferInput.ReserveEpoch` carries the VTXO manager's reservation epoch for
+  each spend input, persisted in `TransferInputSnapshot` (TLV record type 18,
+  appended last so the stream stays canonical; a pre-upgrade snapshot decodes
+  it to 0). `ReleaseInputsRequest.ReserveEpochs` is rebuilt from those durable
+  inputs every time the FSM re-enters the failure transition, so a release
+  replayed after a rolled-back commit still names the reservation it held and
+  the manager refuses it if a newer session has since re-reserved the coin.
+  `ReserveEpochs` is an in-memory side channel only — `ToProto` does not
+  serialize it, because the request is never a persisted transport message.
 - Terminal rows (completed and failed) are retained in
   `oor_session_registry` for status/diagnostics; reaping only removes the
   in-memory child, never the row.

--- a/tapassets/AGENTS.md
+++ b/tapassets/AGENTS.md
@@ -1,0 +1,93 @@
+# tapassets
+
+## Purpose
+
+Adapts tap-sdk custom-anchor transitions to Ark trees, so a VTXO tree can carry
+Taproot Assets alongside its Bitcoin value. Two entry points: a *batch anchor*
+that moves confirmed assets into one caller-funded batch output, and a *tree
+materializer* that walks that batch output down through branch nodes into asset
+leaves, committing one tap-sdk transition per node transaction.
+
+## Key Types
+
+For field-level detail, use
+`go doc github.com/lightninglabs/wavelength/tapassets.<Symbol>`.
+
+- `BatchAnchorCommitter` — Creates caller-funded asset batch outputs. Three
+  ordered steps: `DeriveScript` (compute the batch output script before
+  Bitcoin funding), `Commit` (seal and validate the transition against the
+  funded anchor PSBT), `Publish` (verify a finalized anchor PSBT and record it
+  in tapd).
+- `BatchAnchorRequest` / `BatchAnchorScript` / `BatchAnchorCommit` — Request,
+  derived script material (`PkScript`, `InternalKey`, `SigningTweak`,
+  `AssetRoot`), and sealed result (`PackageBytes`, `AnchorPSBT`, `RootSource`)
+  for one batch anchor.
+- `BatchAnchorSource` / `BatchAnchorChange` — One confirmed asset input, and
+  the optional surplus output returned to the operator's tapd wallet
+  (`DeriveBatchAnchorChange` derives its wallet keys).
+- `BuildAssetTree` / `AssetTreeRequest` / `TreeMaterializerConfig` — Builds an
+  asset VTXO tree below a batch output, committing each node's asset transition
+  as it descends.
+- `TreeRootAssetSource` / `TreeRootAssetInput` — The asset states the root node
+  spends, plus the batch output's taproot tweak and P2TR script.
+- `TreeLeafAnchor` / `StandardVTXOLeafAnchor` — Taproot data (uncomposed
+  pkScript, internal key, canonical tap leaves) for a leaf VTXO output, before
+  the asset root is folded in.
+- `Store` — `Load`/`Store` key-value interface persisting sealed transition
+  packages. Implementations must replace each value atomically.
+- `ErrReconciliationRequired` — Publication may have succeeded; the caller must
+  check its outcome before retrying.
+- `ErrStoreNotFound` — A journal key has no durable value.
+
+## Relationships
+
+- **Depends on**: `lib/tree` (`Tree`, `Node`, `LeafDescriptor` — the tree the
+  assets are materialized onto), `lib/arkscript` (leaf policy compilation and
+  taproot spend info), `lib/tx/psbtutil` (PSBT encoding and signature
+  attachment), `tap-sdk` (`Wallet`, `CustomAnchorTxBuilder`,
+  `CustomAnchorTransferPackage` — the external Taproot Assets driver).
+- **Depended on by**: nothing yet. The package is foundational: it is built and
+  tested standalone ahead of the operator-side wiring that will call it.
+- **Sends / Receives**: no actor messages. `tapassets` is a synchronous library
+  called on the caller's goroutine, not an actor.
+
+## Invariants
+
+- Node transactions are **zero fee**. `AssetTreeRequest.BatchOutput.Value` must
+  equal the sum of the leaf amounts exactly, and `AssetAmount` must equal the
+  sum of the leaf asset amounts exactly. Every leaf must carry a non-zero asset
+  amount.
+- Every commit is **journaled before it is observable**. `commitDurably` keys a
+  `customAnchorCommitState` by `asset-tree/<digest>/<outpoint>`, replays a
+  previously sealed package on restart instead of re-committing, and refuses a
+  key reused with a different request digest (the digest is a SHA-256 over the
+  domain string plus the encoded request). The journal write runs under
+  `context.WithoutCancel` with a 5s timeout, so a cancelled caller cannot lose
+  a package tapd has already sealed.
+- Commit state is versioned (`customAnchorCommitStateVersion = 0`) and bounded
+  (`maxCustomAnchorCommitStateSize = 128 MiB`); an unsupported version or an
+  out-of-range size is an error, never a silent reset.
+- The driver commits with `SkipAnchorTxBroadcast` and `ExternalBroadcast` set:
+  tapd seals and records the transition but **never broadcasts**. Broadcast is
+  the caller's responsibility, via `Publish` after the anchor PSBT is finalized.
+- A failure *after* tapd returned a committed response is distinct from a
+  failure to commit: `commitResponseError` wraps the local conversion error, and
+  `ErrReconciliationRequired` marks the publish path where the transaction may
+  already be live. Neither may be treated as a clean retry.
+- Batch output indexes must be final before deriving a request that carries
+  change — `BatchAnchorRequest.OutputIndex` and `BatchAnchorChange.OutputIndex`
+  are committed to by the derived script.
+- The batch output's internal key is the untweaked cosigner aggregate; the
+  `SigningTweak` commits to both the operator sweep leaf and the asset root, so
+  the node keys are re-checked against the output being spent (`boundFinalKey`)
+  before a MuSig2 signing plan is produced.
+- Every tap-sdk output must carry a matching proof update; a missing proof blob
+  fails the conversion rather than producing a tree node with no proof.
+
+## Deep Docs
+
+- [lib/tree/CLAUDE.md](../lib/tree/CLAUDE.md) — Tree construction this package
+  materializes assets onto.
+- [lib/arkscript/CLAUDE.md](../lib/arkscript/CLAUDE.md) — Policy compilation
+  used for leaf anchors.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/tapassets/CLAUDE.md
+++ b/tapassets/CLAUDE.md
@@ -1,0 +1,93 @@
+# tapassets
+
+## Purpose
+
+Adapts tap-sdk custom-anchor transitions to Ark trees, so a VTXO tree can carry
+Taproot Assets alongside its Bitcoin value. Two entry points: a *batch anchor*
+that moves confirmed assets into one caller-funded batch output, and a *tree
+materializer* that walks that batch output down through branch nodes into asset
+leaves, committing one tap-sdk transition per node transaction.
+
+## Key Types
+
+For field-level detail, use
+`go doc github.com/lightninglabs/wavelength/tapassets.<Symbol>`.
+
+- `BatchAnchorCommitter` — Creates caller-funded asset batch outputs. Three
+  ordered steps: `DeriveScript` (compute the batch output script before
+  Bitcoin funding), `Commit` (seal and validate the transition against the
+  funded anchor PSBT), `Publish` (verify a finalized anchor PSBT and record it
+  in tapd).
+- `BatchAnchorRequest` / `BatchAnchorScript` / `BatchAnchorCommit` — Request,
+  derived script material (`PkScript`, `InternalKey`, `SigningTweak`,
+  `AssetRoot`), and sealed result (`PackageBytes`, `AnchorPSBT`, `RootSource`)
+  for one batch anchor.
+- `BatchAnchorSource` / `BatchAnchorChange` — One confirmed asset input, and
+  the optional surplus output returned to the operator's tapd wallet
+  (`DeriveBatchAnchorChange` derives its wallet keys).
+- `BuildAssetTree` / `AssetTreeRequest` / `TreeMaterializerConfig` — Builds an
+  asset VTXO tree below a batch output, committing each node's asset transition
+  as it descends.
+- `TreeRootAssetSource` / `TreeRootAssetInput` — The asset states the root node
+  spends, plus the batch output's taproot tweak and P2TR script.
+- `TreeLeafAnchor` / `StandardVTXOLeafAnchor` — Taproot data (uncomposed
+  pkScript, internal key, canonical tap leaves) for a leaf VTXO output, before
+  the asset root is folded in.
+- `Store` — `Load`/`Store` key-value interface persisting sealed transition
+  packages. Implementations must replace each value atomically.
+- `ErrReconciliationRequired` — Publication may have succeeded; the caller must
+  check its outcome before retrying.
+- `ErrStoreNotFound` — A journal key has no durable value.
+
+## Relationships
+
+- **Depends on**: `lib/tree` (`Tree`, `Node`, `LeafDescriptor` — the tree the
+  assets are materialized onto), `lib/arkscript` (leaf policy compilation and
+  taproot spend info), `lib/tx/psbtutil` (PSBT encoding and signature
+  attachment), `tap-sdk` (`Wallet`, `CustomAnchorTxBuilder`,
+  `CustomAnchorTransferPackage` — the external Taproot Assets driver).
+- **Depended on by**: nothing yet. The package is foundational: it is built and
+  tested standalone ahead of the operator-side wiring that will call it.
+- **Sends / Receives**: no actor messages. `tapassets` is a synchronous library
+  called on the caller's goroutine, not an actor.
+
+## Invariants
+
+- Node transactions are **zero fee**. `AssetTreeRequest.BatchOutput.Value` must
+  equal the sum of the leaf amounts exactly, and `AssetAmount` must equal the
+  sum of the leaf asset amounts exactly. Every leaf must carry a non-zero asset
+  amount.
+- Every commit is **journaled before it is observable**. `commitDurably` keys a
+  `customAnchorCommitState` by `asset-tree/<digest>/<outpoint>`, replays a
+  previously sealed package on restart instead of re-committing, and refuses a
+  key reused with a different request digest (the digest is a SHA-256 over the
+  domain string plus the encoded request). The journal write runs under
+  `context.WithoutCancel` with a 5s timeout, so a cancelled caller cannot lose
+  a package tapd has already sealed.
+- Commit state is versioned (`customAnchorCommitStateVersion = 0`) and bounded
+  (`maxCustomAnchorCommitStateSize = 128 MiB`); an unsupported version or an
+  out-of-range size is an error, never a silent reset.
+- The driver commits with `SkipAnchorTxBroadcast` and `ExternalBroadcast` set:
+  tapd seals and records the transition but **never broadcasts**. Broadcast is
+  the caller's responsibility, via `Publish` after the anchor PSBT is finalized.
+- A failure *after* tapd returned a committed response is distinct from a
+  failure to commit: `commitResponseError` wraps the local conversion error, and
+  `ErrReconciliationRequired` marks the publish path where the transaction may
+  already be live. Neither may be treated as a clean retry.
+- Batch output indexes must be final before deriving a request that carries
+  change — `BatchAnchorRequest.OutputIndex` and `BatchAnchorChange.OutputIndex`
+  are committed to by the derived script.
+- The batch output's internal key is the untweaked cosigner aggregate; the
+  `SigningTweak` commits to both the operator sweep leaf and the asset root, so
+  the node keys are re-checked against the output being spent (`boundFinalKey`)
+  before a MuSig2 signing plan is produced.
+- Every tap-sdk output must carry a matching proof update; a missing proof blob
+  fails the conversion rather than producing a tree node with no proof.
+
+## Deep Docs
+
+- [lib/tree/CLAUDE.md](../lib/tree/CLAUDE.md) — Tree construction this package
+  materializes assets onto.
+- [lib/arkscript/CLAUDE.md](../lib/arkscript/CLAUDE.md) — Policy compilation
+  used for leaf anchors.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -164,6 +164,23 @@ when the local wallet owns the receive script.
   actors from. Coin selection is already `VTXOStatusLive`-scoped via
   `ListSelectionCandidatesByStatus`, so it excludes them by construction.
 - VTXO actor state is the single source of truth for availability.
+- **A spend release is scoped to the reservation it names.** `markReserved`
+  stamps a monotonic `reserveEpoch` per outpoint, echoed back through
+  `SelectedVTXO.ReserveEpoch` so the spend that owns the coin can present it on
+  `ReleaseSpendRequest.ReserveEpochs`. `handleReleaseSpend` refuses a release
+  only when a *live* in-memory reservation names a *different* non-zero epoch:
+  that reservation was superseded (released and re-reserved by a newer owner in
+  the same process), so honouring the stale release would return to the live
+  set a coin the newer owner is spending. Everything else releases — a zero
+  epoch is "unknown" (pre-upgrade snapshot, or a manual unlock) and releases
+  unconditionally, and a missing live reservation means the manager restarted
+  without repopulating the map, where refusing would strand the coin in
+  `Spending` forever.
+- The startup orphan sweep re-marks with `markReservedUnknown` (epoch 0), not a
+  fresh epoch. The epoch counter restarts at 0 on boot, so a fresh mark would
+  not match the epoch a resumed session persisted and its later release would
+  be wrongly refused. Admission only tests presence (`isReserved`), so nothing
+  on that path needs the real epoch.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
 - `ExpiryConfig.MaxPaymentCLTV` reserves a total Lightning CLTV window above

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -164,6 +164,23 @@ when the local wallet owns the receive script.
   actors from. Coin selection is already `VTXOStatusLive`-scoped via
   `ListSelectionCandidatesByStatus`, so it excludes them by construction.
 - VTXO actor state is the single source of truth for availability.
+- **A spend release is scoped to the reservation it names.** `markReserved`
+  stamps a monotonic `reserveEpoch` per outpoint, echoed back through
+  `SelectedVTXO.ReserveEpoch` so the spend that owns the coin can present it on
+  `ReleaseSpendRequest.ReserveEpochs`. `handleReleaseSpend` refuses a release
+  only when a *live* in-memory reservation names a *different* non-zero epoch:
+  that reservation was superseded (released and re-reserved by a newer owner in
+  the same process), so honouring the stale release would return to the live
+  set a coin the newer owner is spending. Everything else releases — a zero
+  epoch is "unknown" (pre-upgrade snapshot, or a manual unlock) and releases
+  unconditionally, and a missing live reservation means the manager restarted
+  without repopulating the map, where refusing would strand the coin in
+  `Spending` forever.
+- The startup orphan sweep re-marks with `markReservedUnknown` (epoch 0), not a
+  fresh epoch. The epoch counter restarts at 0 on boot, so a fresh mark would
+  not match the epoch a resumed session persisted and its later release would
+  be wrongly refused. Admission only tests presence (`isReserved`), so nothing
+  on that path needs the real epoch.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
 - `ExpiryConfig.MaxPaymentCLTV` reserves a total Lightning CLTV window above

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -20,7 +20,7 @@ refresh, leave, OOR spend, and directed send flows.
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
-- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
+- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript, `ReserveEpoch`). Breaks the vtxo → round → wallet import cycle. `ReserveEpoch` is the manager reservation epoch, carried so the OOR transfer that spends the input can name that reservation on release.
 - `CreateBoardingAddressRequest` / `CreateBoardingAddressResponse` — Ask-request for deriving new address.
 - `BlockEpochNotification` — Tell-message from chain source triggering UTXO polling.
 - `BoardingUtxoConfirmedEvent` — Tell-message sent when a VTXO confirms.

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -20,7 +20,7 @@ refresh, leave, OOR spend, and directed send flows.
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
-- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
+- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript, `ReserveEpoch`). Breaks the vtxo → round → wallet import cycle. `ReserveEpoch` is the manager reservation epoch, carried so the OOR transfer that spends the input can name that reservation on release.
 - `CreateBoardingAddressRequest` / `CreateBoardingAddressResponse` — Ask-request for deriving new address.
 - `BlockEpochNotification` — Tell-message from chain source triggering UTXO polling.
 - `BoardingUtxoConfirmedEvent` — Tell-message sent when a VTXO confirms.


### PR DESCRIPTION
Automated nightly doc-gardening sweep: documents the new `tapassets` package and the cross-package VTXO reservation-epoch release guard.

Workflow run: https://github.com/lightninglabs/wavelength/actions/workflows/doc-gardening-nightly.yml

Baseline for this sweep was the last merged nightly (`9e03582`, 2026-09-02), covering 34 commits.

**What changed**

- **`tapassets/`** — new package, new `CLAUDE.md`/`AGENTS.md`. Covers the batch-anchor committer (`DeriveScript` → `Commit` → `Publish`), asset tree materialization, the commit journal, and the zero-fee / journal-before-observable / no-broadcast-from-tapd invariants.
- **`vtxo`, `oor`, `wallet`, `lib/actormsg`** — the reservation-epoch release guard added since the last sweep was undocumented in all four. Now records why a stale release is refused, why epoch 0 always releases, and why the startup orphan sweep re-marks with an unknown epoch.
- **`lib/tree`, `lib`** — adds the new exported `AssetTreeContext` and `BatchOutputSpec` types plus their nil-receiver and overflow invariants.
- **`ARCHITECTURE.md`** — adds `tapassets` to the Layer 1 table.

Packages whose docs were already updated in-range (`db`, `round`, `serverconn`, `unroll`, `waved`, `cmd/waved`, `sdk/wavewalletdk`) were verified as current and left alone.

Please review the updated CLAUDE.md/AGENTS.md and ARCHITECTURE.md diffs. `make doc-check` passes.
