### PR TITLE
unroll: Resume staged work after re-admission

### DIFF
--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -36,7 +36,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   retries and replays converge on a single sweep txid / pkScript under
   `txconfirm`'s txid-keyed dedup. The `dispatch` method runs the full
   FSM pipeline including Stage writes; `Receive` owns the single
-  lease-fenced Commit.
+  lease-fenced Commit. It also tracks whether a restored checkpoint still
+  needs its first reissue after re-admission.
 - `Msg` / `Resp` / `Event` / `OutboxEvent` — sealed durable-mailbox,
   response, FSM event, and FSM outbox interfaces.
 - Mailbox messages: `StartUnrollRequest`, `ResumeUnrollRequest`,
@@ -274,6 +275,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   outbox branches return errors on a missing proof node or nil
   `sweepTx`. A silent `continue` would strand the FSM with no
   pending `txconfirm` subscription.
+- **Re-admission resumes restored work.** `restoreCheckpoint` arms an
+  actor-lifetime marker when the checkpoint is started. The first admission
+  `Start` then uses `Resume` semantics to reissue staged work. The marker
+  survives unrelated queued messages and clears only after a successful
+  admission commit or an existing live-route retry performs the reissue.
+  Later duplicate `Start` messages remain idempotent.
 - **Registry dedup covers the whole trail.** `handleEnsure` checks
   `r.active`, `r.pending`, AND `Store.GetRecord` before spawning so
   a repeat for an already-terminal outpoint returns the historical

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -36,7 +36,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   retries and replays converge on a single sweep txid / pkScript under
   `txconfirm`'s txid-keyed dedup. The `dispatch` method runs the full
   FSM pipeline including Stage writes; `Receive` owns the single
-  lease-fenced Commit.
+  lease-fenced Commit. It also tracks whether a restored checkpoint still
+  needs its first reissue after re-admission.
 - `Msg` / `Resp` / `Event` / `OutboxEvent` — sealed durable-mailbox,
   response, FSM event, and FSM outbox interfaces.
 - Mailbox messages: `StartUnrollRequest`, `ResumeUnrollRequest`,
@@ -274,6 +275,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   outbox branches return errors on a missing proof node or nil
   `sweepTx`. A silent `continue` would strand the FSM with no
   pending `txconfirm` subscription.
+- **Re-admission resumes restored work.** `restoreCheckpoint` arms an
+  actor-lifetime marker when the checkpoint is started. The first admission
+  `Start` then uses `Resume` semantics to reissue staged work. The marker
+  survives unrelated queued messages and clears only after a successful
+  admission commit or an existing live-route retry performs the reissue.
+  Later duplicate `Start` messages remain idempotent.
 - **Registry dedup covers the whole trail.** `handleEnsure` checks
   `r.active`, `r.pending`, AND `Store.GetRecord` before spawning so
   a repeat for an already-terminal outpoint returns the historical

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -168,7 +168,13 @@ type behavior struct {
 	session *Session
 	pending *actorCheckpoint
 
-	sweepTx                    *wire.MsgTx
+	sweepTx *wire.MsgTx
+
+	// restoredCheckpointPending keeps the first admission message on a
+	// newly constructed actor responsible for reissuing restored work, even
+	// if an older durable notification reaches the actor first.
+	restoredCheckpointPending bool
+
 	blockSubActive             bool
 	spendWatchActive           bool
 	proofSpendWatches          map[wire.OutPoint]struct{}
@@ -276,6 +282,11 @@ func (b *behavior) Receive(ctx context.Context, msg Msg,
 		if err := b.reissueStagedRoute(ctx, ax); err != nil {
 			return fn.Err[Resp](err)
 		}
+
+		// The retry just reissued every effect from the restored
+		// checkpoint. Do not translate a following Start into a second
+		// Resume during the same turn.
+		b.restoredCheckpointPending = false
 	}
 
 	res := b.dispatch(ctx, ax, msg)
@@ -297,6 +308,10 @@ func (b *behavior) Receive(ctx context.Context, msg Msg,
 		return fn.Err[Resp](err)
 	}
 	b.routeRetryPending = false
+	switch msg.(type) {
+	case *StartUnrollRequest, *ResumeUnrollRequest:
+		b.restoredCheckpointPending = false
+	}
 
 	return res
 }
@@ -329,6 +344,17 @@ func (b *behavior) dispatch(ctx context.Context, ax actor.Exec[unrollTx],
 
 	switch m := msg.(type) {
 	case *StartUnrollRequest:
+		// A new actor can receive Start with an existing checkpoint
+		// when the registry re-admits a job after an initial route
+		// error stopped its prior child. Resume that staged work before
+		// treating any later Start as the normal idempotent live-actor
+		// duplicate.
+		if b.restoredCheckpointPending {
+			return b.handleEvent(ctx, ax, &ResumeEvent{
+				Height: m.Height,
+			})
+		}
+
 		return b.handleEvent(ctx, ax, &StartEvent{
 			Height:         m.Height,
 			Trigger:        m.Trigger,
@@ -1465,6 +1491,7 @@ func (b *behavior) restoreCheckpoint(ctx context.Context) error {
 
 	b.pending = decoded
 	b.sweepTx = copyTx(decoded.SweepTx)
+	b.restoredCheckpointPending = decoded.Started
 
 	return nil
 }

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -3137,6 +3137,88 @@ func TestResumeReissuesInflightWork(t *testing.T) {
 	)
 }
 
+// TestRestoredStartReissuesAfterPriorMessage verifies that a message queued
+// ahead of registry re-admission cannot hide the restored checkpoint from the
+// later Start request. The first successful admission request must still use
+// Resume semantics and restore the staged txconfirm subscription.
+func TestRestoredStartReissuesAfterPriorMessage(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	txconfirmRef := &fakeTxConfirmRef{}
+	store := newMemCheckpointStore()
+	rootTxid := proof.RootTxids()[0]
+
+	raw, err := encodeCheckpoint(&actorCheckpoint{
+		Version: checkpointVersion,
+		Height:  110,
+		Started: true,
+		Trigger: TriggerManual,
+		State: unrollplan.State{
+			InFlightTxids: []chainhash.Hash{rootTxid},
+		},
+	})
+	require.NoError(t, err)
+
+	const actorID = "restored-start-after-message"
+	err = store.SaveCheckpoint(t.Context(), actor.CheckpointParams{
+		ActorID:   actorID,
+		StateType: checkpointStateType,
+		StateData: raw,
+		Version:   checkpointVersion,
+	})
+	require.NoError(t, err)
+
+	behavior := &behavior{
+		cfg: Config{
+			TargetOutpoint: proof.TargetOutpoint(),
+			ActorID:        actorID,
+			DeliveryStore:  store,
+			ProofAssembler: &mockProofAssembler{
+				proof: proof,
+			},
+			VTXOStore: &mockVTXOStore{
+				desc: desc,
+			},
+			TxConfirmRef: txconfirmRef,
+			ChainSource:  &fakeChainSourceRef{},
+			Wallet:       &fakeSweepWallet{},
+		},
+		log: btclog.Disabled,
+	}
+	require.NoError(t, behavior.restoreCheckpoint(t.Context()))
+
+	actorInstance := actor.NewActor(actor.ActorConfig[Msg, Resp]{
+		ID:          actorID,
+		Behavior:    adaptTx(behavior),
+		MailboxSize: 64,
+	})
+	behavior.selfRef = actorInstance.TellRef()
+	actorInstance.Start()
+	t.Cleanup(actorInstance.Stop)
+
+	// A queued height update loads and advances the restored FSM, but it
+	// cannot reissue the already in-flight root by itself.
+	mustAsk(t, actorInstance.Ref(), &HeightObservedMsg{Height: 111})
+	require.Equal(t, 0, txconfirmRef.requestCount())
+
+	// The later Start is the registry's re-admission message. It must
+	// retain Resume semantics even though the prior height update loaded
+	// the FSM.
+	mustAsk(t, actorInstance.Ref(), &StartUnrollRequest{
+		Height:  112,
+		Trigger: TriggerManual,
+	})
+	require.Equal(t, 1, txconfirmRef.requestCountForTxid(rootTxid))
+
+	// Once admission commits, a live duplicate Start remains idempotent and
+	// does not reissue the root again.
+	mustAsk(t, actorInstance.Ref(), &StartUnrollRequest{
+		Height:  113,
+		Trigger: TriggerManual,
+	})
+	require.Equal(t, 1, txconfirmRef.requestCountForTxid(rootTxid))
+}
+
 // TestStartUnrollMultiParentSubmitsAllRoots verifies that the initial planner
 // frontier contains every independent root transaction.
 func TestStartUnrollMultiParentSubmitsAllRoots(t *testing.T) {

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -3201,14 +3201,25 @@ func TestRestoredStartReissuesAfterPriorMessage(t *testing.T) {
 	mustAsk(t, actorInstance.Ref(), &HeightObservedMsg{Height: 111})
 	require.Equal(t, 0, txconfirmRef.requestCount())
 
-	// The later Start is the registry's re-admission message. It must
-	// retain Resume semantics even though the prior height update loaded
-	// the FSM.
+	// The later Start is the registry's re-admission message. Its first
+	// route attempt fails after arming the actor's normal live-route retry.
+	// The next Start must let that retry perform the restored reissue once,
+	// rather than translating the same message into a second Resume.
+	txconfirmRef.failNextAsks(rootTxid, 1)
+	_, err = actorInstance.Ref().Ask(
+		t.Context(), &StartUnrollRequest{
+			Height:  112,
+			Trigger: TriggerManual,
+		},
+	).Await(t.Context()).Unpack()
+	require.ErrorContains(t, err, "injected txconfirm ask failure")
+	require.Equal(t, 1, txconfirmRef.requestCountForTxid(rootTxid))
+
 	mustAsk(t, actorInstance.Ref(), &StartUnrollRequest{
 		Height:  112,
 		Trigger: TriggerManual,
 	})
-	require.Equal(t, 1, txconfirmRef.requestCountForTxid(rootTxid))
+	require.Equal(t, 2, txconfirmRef.requestCountForTxid(rootTxid))
 
 	// Once admission commits, a live duplicate Start remains idempotent and
 	// does not reissue the root again.
@@ -3216,7 +3227,7 @@ func TestRestoredStartReissuesAfterPriorMessage(t *testing.T) {
 		Height:  113,
 		Trigger: TriggerManual,
 	})
-	require.Equal(t, 1, txconfirmRef.requestCountForTxid(rootTxid))
+	require.Equal(t, 2, txconfirmRef.requestCountForTxid(rootTxid))
 }
 
 // TestStartUnrollMultiParentSubmitsAllRoots verifies that the initial planner

--- a/unroll/registry_exit_test.go
+++ b/unroll/registry_exit_test.go
@@ -2,6 +2,7 @@ package unroll
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sync"
@@ -10,9 +11,13 @@ import (
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/db/actordelivery"
 	"github.com/lightninglabs/wavelength/lib/actormsg"
 	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -553,4 +558,137 @@ func TestRegistryReadmitsTargetAfterRecoverableFailureAcrossRestart(
 		t, post.RecoverableFailure,
 		"re-admission must overwrite the stale recoverable record",
 	)
+}
+
+// TestRegistryReadmissionReissuesStagedRoot verifies that a failed initial
+// root submission does not strand the restored checkpoint when the recovered
+// VTXO is admitted again. The test uses the real registry, durable child, and
+// SQLite delivery store so the checkpoint survives each stopped child.
+func TestRegistryReadmissionReissuesStagedRoot(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	target := proof.TargetOutpoint()
+	rootTxid := proof.RootTxids()[0]
+
+	sqlDB := db.NewTestDB(t)
+	deliveryStore, err := actordelivery.NewTxAwareDeliveryStoreFromDB(
+		sqlDB.DB, sqlDB.Backend(), clock.NewDefaultClock(),
+		btclog.Disabled,
+	)
+	require.NoError(t, err)
+
+	exitDB := db.NewTransactionExecutor(
+		sqlDB.BaseDB,
+		func(tx *sql.Tx) db.UnilateralExitStore {
+			return sqlDB.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	registryStore := &DBRegistryStore{
+		UEStore: db.NewUnilateralExitPersistenceStore(
+			exitDB, clock.NewDefaultClock(),
+		),
+	}
+	txconfirmRef := &fakeTxConfirmRef{}
+	txconfirmRef.failNextAsks(rootTxid, 2)
+
+	cfg := RegistryConfig{
+		Store:         registryStore,
+		DeliveryStore: deliveryStore,
+		ProofAssembler: &mockProofAssembler{
+			proof: proof,
+		},
+		VTXOStore: &mockVTXOStore{
+			desc: desc,
+		},
+		TxConfirmRef: txconfirmRef,
+		ChainSource: &fakeRegistryChainSourceRef{
+			height: 200,
+		},
+		Wallet: &fakeSweepWallet{},
+		Log:    fn.Some(btclog.Disabled),
+	}
+
+	registry := NewUnrollRegistryActor(cfg)
+	t.Cleanup(registry.Stop)
+
+	ensure := func() (*EnsureUnrollResp, error) {
+		t.Helper()
+
+		resp, err := registry.Ref().Ask(
+			t.Context(), &EnsureUnrollRequest{
+				Outpoint: target,
+				Trigger:  TriggerManual,
+			},
+		).Await(t.Context()).Unpack()
+		if err != nil {
+			return nil, err
+		}
+
+		ensureResp, ok := resp.(*EnsureUnrollResp)
+		require.True(t, ok)
+
+		return ensureResp, nil
+	}
+
+	// The first submission is staged before txconfirm returns the injected
+	// error. The registry stops the child and records a recoverable
+	// failure, but the child checkpoint must retain the exact root
+	// transaction.
+	_, err = ensure()
+	require.ErrorContains(t, err, "injected txconfirm ask failure")
+	require.Equal(t, 1, txconfirmRef.requestCountForTxid(rootTxid))
+
+	actorID := actorIDForTarget(target)
+	checkpoint, err := deliveryStore.LoadCheckpoint(t.Context(), actorID)
+	require.NoError(t, err)
+	require.NotNil(t, checkpoint)
+
+	decoded, err := decodeCheckpoint(checkpoint.StateData)
+	require.NoError(t, err)
+	require.True(t, decoded.Started)
+	require.Equal(
+		t, []chainhash.Hash{rootTxid}, decoded.State.InFlightTxids,
+	)
+
+	failed, err := registryStore.GetRecord(t.Context(), target)
+	require.NoError(t, err)
+	require.NotNil(t, failed)
+	require.Equal(t, PhaseFailed, failed.Phase)
+	require.True(t, failed.RecoverableFailure)
+
+	// Re-admission restores the staged checkpoint. A second injected error
+	// proves it reissues the root instead of silently accepting a non-idle
+	// Start, and that another recovery attempt remains possible.
+	_, err = ensure()
+	require.ErrorContains(t, err, "injected txconfirm ask failure")
+	require.Equal(t, 2, txconfirmRef.requestCountForTxid(rootTxid))
+
+	// The third admission succeeds with the same actor and transaction
+	// identity. A normal duplicate Ensure while it is active must not
+	// submit a second exit.
+	admitted, err := ensure()
+	require.NoError(t, err)
+	require.True(t, admitted.Created)
+	require.Equal(t, actorID, admitted.ActorID)
+	require.Equal(t, 3, txconfirmRef.requestCountForTxid(rootTxid))
+	require.Equal(t, 3, txconfirmRef.requestCount())
+
+	duplicate, err := ensure()
+	require.NoError(t, err)
+	require.False(t, duplicate.Created)
+	require.Equal(t, actorID, duplicate.ActorID)
+	require.Equal(t, 3, txconfirmRef.requestCount())
+
+	// Restart recovery uses Resume and reissues the same staged root once.
+	registry.Stop()
+	restarted := NewUnrollRegistryActor(cfg)
+	t.Cleanup(restarted.Stop)
+	require.NoError(t, restarted.RestoreNonTerminal(t.Context()))
+
+	require.Equal(t, 4, txconfirmRef.requestCountForTxid(rootTxid))
+	require.Equal(t, 4, txconfirmRef.requestCount())
+	for _, txid := range txconfirmRef.requestedTxids() {
+		require.Equal(t, rootTxid, txid)
+	}
 }


### PR DESCRIPTION
## The problem

A unilateral exit normally checkpoints each proof transaction before asking `txconfirm` to submit and monitor it. If the first root request fails, the registry stops the child and records a recoverable failure. The checkpoint still says that the root is in flight.

When the VTXO is admitted again, the replacement child restores that checkpoint. The registry sends `StartUnrollRequest`, but a live `Start` deliberately does not resubmit in-flight work. The second admission can therefore return success without restoring the root subscription. Progress resumes only after a daemon restart sends `ResumeUnrollRequest`.

Before this change:

1. Root `A` is staged and its `txconfirm` request fails.
2. Re-admission restores root `A` as in flight.
3. `Start` submits nothing and the exit remains in materialization.

After this change, step 3 uses the existing Resume path and reissues the same root `A`.

```mermaid
sequenceDiagram
    participant R as Registry
    participant C as Unroll child
    participant D as Durable checkpoint
    participant T as txconfirm
    R->>C: Start
    C->>D: Stage root A as in flight
    C->>T: Ensure root A
    T-->>C: Error
    R->>C: Stop child
    R->>C: Re-admit replacement with checkpoint
    C->>T: Resume and ensure the same root A
```

## The fix

A newly constructed child now remembers when it loaded a started checkpoint. Its first successful `Start` or `Resume` admission consumes that marker. While the marker is set, `Start` is translated to `Resume`, which reissues the checkpoint's in-flight transactions.

The marker survives an older durable notification arriving before re-admission. It is actor-lifetime state only. It adds no database field or mailbox message.

## Safety rule

Re-admission resumes the existing checkpoint. It does not build a new proof transaction, choose a new destination, or create another exit. `txconfirm` receives the same transaction ID and applies its existing deduplication.

## What does not change

- A fresh `Start` from `Idle` keeps the normal admission path.
- A duplicate `Start` on a live actor remains idempotent and does not reissue work.
- Explicit restart recovery still uses `ResumeUnrollRequest`.
- Checkpoint, mailbox, database, RPC, and wire formats do not change.

## Tests

- Reproduced the failure before the fix with the real registry, durable child actor, SQLite delivery store, and SQL registry store.
- Injected two consecutive root-request errors and verified that each re-admission retries the same root.
- Verified that the successful third admission keeps the same actor ID and transaction ID.
- Verified that a duplicate active-job admission creates no extra request.
- Restarted the registry and verified that normal restart recovery reissues the same staged root once.
- Queued a height update before `Start` and verified that the later re-admission still resumes the checkpoint.
- Kept the existing live duplicate-`Start` idempotency regression green.

Local verification:

```text
go test ./unroll -run '<focused admission and resume tests>' -count=10
go test -race ./unroll -run '<focused admission and resume tests>' -count=3
go test ./unroll -count=3 -timeout=10m
go test -race ./unroll -count=1 -timeout=15m
make fmt-changed-check
make tidy-module-check
make lint-changed-local
make commitmsg-lint range='origin/main..HEAD'
```

All passed. The changed-code linter reported zero issues.

## Compatibility and rollout

No migration, protocol change, dependency update, or coordinated rollout is required. This is delayed-recovery repair; the reproduction does not demonstrate fund loss.

Fixes #1275.
