### PR TITLE
db: stamp observation time on stale activity transitions

### DIFF
--- a/swapwallet/projector.go
+++ b/swapwallet/projector.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/db/sqlc"
@@ -60,6 +61,9 @@ func (r *Runtime) project(ctx context.Context,
 		effectiveEntry = mergeActivityContext(
 			existingEntry, effectiveEntry,
 		)
+		stampLateTransition(
+			effectiveEntry, existingRow.UpdatedAtUnix, time.Now(),
+		)
 
 	case errors.Is(err, sql.ErrNoRows):
 	default:
@@ -84,6 +88,25 @@ func (r *Runtime) project(ctx context.Context,
 	}
 
 	return seq, effectiveEntry, nil
+}
+
+// stampLateTransition advances a projection's update time past the stored
+// row's when the derived value does not: ledger-derived transitions carry
+// their source row's creation time, which would otherwise hide the change
+// from recency ordering, pollers, and subscriber payloads. The stamp never
+// regresses a stored value under a stepped-back clock.
+func stampLateTransition(entry *wavewalletrpc.WalletEntry,
+	storedUpdatedAt int64, now time.Time) {
+
+	if entry.GetUpdatedAtUnix() > storedUpdatedAt {
+		return
+	}
+
+	ts := now.Unix()
+	if ts < storedUpdatedAt {
+		ts = storedUpdatedAt
+	}
+	entry.UpdatedAtUnix = ts
 }
 
 // mergeActivityContext carries immutable request and correlation context from

--- a/swapwallet/projector_test.go
+++ b/swapwallet/projector_test.go
@@ -162,6 +162,103 @@ func sampleWalletEntry() *wavewalletrpc.WalletEntry {
 	}
 }
 
+// TestStampLateTransition verifies the update-time stamping rules: a newer
+// derived time is kept, a stale one is stamped with the observation time, a
+// same-second transition shares its second, and a stepped-back clock never
+// regresses the stored value.
+func TestStampLateTransition(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		derived int64
+		stored  int64
+		now     int64
+		want    int64
+	}{
+		{
+			name:    "newer derived time kept",
+			derived: 200,
+			stored:  100,
+			now:     5000,
+			want:    200,
+		},
+		{
+			name:    "stale derived time stamped",
+			derived: 100,
+			stored:  100,
+			now:     5000,
+			want:    5000,
+		},
+		{
+			name:    "same-second transition shares the second",
+			derived: 100,
+			stored:  5000,
+			now:     5000,
+			want:    5000,
+		},
+		{
+			name:    "regressed clock never rolls back",
+			derived: 100,
+			stored:  5000,
+			now:     4000,
+			want:    5000,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			entry := &wavewalletrpc.WalletEntry{
+				UpdatedAtUnix: tc.derived,
+			}
+			stampLateTransition(
+				entry, tc.stored, time.Unix(tc.now, 0),
+			)
+			require.Equal(t, tc.want, entry.GetUpdatedAtUnix())
+		})
+	}
+}
+
+// TestProjectStampsLateTransition verifies that a material transition carrying
+// a stale derived update time lands with an advanced updated_at everywhere a
+// consumer reads it: the current-state row and the replayable event payload.
+func TestProjectStampsLateTransition(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtime, _, _, store := newDualWriteFixture(t)
+
+	pending := sampleWalletEntry()
+	runtime.projectAndEmit(ctx, pending)
+
+	// Complete the entry while carrying the pending row's timestamp, the
+	// shape a ledger-derived reconcile pass produces.
+	before := time.Now().Unix()
+	complete := sampleWalletEntry()
+	complete.Status = wavewalletrpc.EntryStatus_ENTRY_STATUS_COMPLETE
+	runtime.projectAndEmit(ctx, complete)
+
+	row, err := store.GetEntry(ctx, pending.GetId())
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, row.UpdatedAtUnix, before)
+	require.Equal(
+		t, int64(100), row.CreatedAtUnix, "created_at preserved",
+	)
+
+	events, err := store.PullEvents(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+
+	replayed, err := walletEntryFromEventJSON(events[1].EntryJson)
+	require.NoError(t, err)
+	require.Equal(
+		t, row.UpdatedAtUnix, replayed.GetUpdatedAtUnix(),
+		"replay payload carries the stamped time",
+	)
+}
+
 // TestEntryToProjection verifies the WalletEntry → projection mapping: enum
 // integers, signed amount, hex-decoded handles, the confirmation-height
 // pointer, and a lossless entry_json round-trip.


### PR DESCRIPTION
Fixes #1211.

A derive-on-read projection carries its source row's creation time, so a terminal transition observed later kept a stale `updated_at`. Observed live on mainnet: a boarded deposit flipped PENDING to COMPLETE roughly 14 minutes after creation with `LAST UPDATE` frozen at the boarding time, and a completed cooperative-leave EXIT row showed the same. Since `deriveActivity` sorts by `updated_at` and pollers watch it for changes, the transition is invisible to both.

`ProjectEntry` now stamps the store clock's observation time when a material change arrives whose derived update time does not advance the stored row's. A projection carrying a genuinely newer time keeps it, inserts keep their derived timestamps (startup backfill of history preserves ordering), and change-suppressed re-projections are untouched, so idempotent reconcile passes still never churn timestamps. The appended `activity_events` row is stamped with the same time, so subscriber replay sees the transition when it was observed.