### PR TITLE
swapwallet: Quote onchain fees for every selected VTXO

### DIFF
--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -105,6 +105,8 @@ type fakeRPCServer struct {
 	estimateFeeErr     error
 	estimateFeeCalls   int
 	estimateFeeLastReq *waverpc.EstimateFeeRequest
+	estimateFeeFn      func(*waverpc.EstimateFeeRequest) (
+		*waverpc.EstimateFeeResponse, error)
 }
 
 func (f *fakeRPCServer) LeaveVTXOs(_ context.Context,
@@ -170,6 +172,9 @@ func (f *fakeRPCServer) EstimateFee(_ context.Context,
 
 	f.estimateFeeCalls++
 	f.estimateFeeLastReq = req
+	if f.estimateFeeFn != nil {
+		return f.estimateFeeFn(req)
+	}
 
 	return f.estimateFeeResp, f.estimateFeeErr
 }

--- a/swapwallet/onchain_fee.go
+++ b/swapwallet/onchain_fee.go
@@ -44,20 +44,18 @@ type onchainFeeQuote struct {
 	warning     string
 }
 
-// onchainTerms holds the operator-policy values the preview needs from a
-// single GetInfo call: the target feerate plus the minimum-operator-fee
-// and dust-limit headroom the daemon selects against. All zero when GetInfo
-// or its ServerInfo is unavailable, which degrades the preview to a
-// zero-headroom, zero-floor estimate rather than failing outright.
+// onchainTerms holds the chain height and operator policy from one GetInfo
+// call. Missing operator terms leave selection headroom and the local floor
+// at zero; missing height prevents a complete lifetime-aware operator quote.
 type onchainTerms struct {
+	blockHeight    uint32
 	feeRate        btcutil.Amount
 	minOperatorFee btcutil.Amount
 	dustLimit      btcutil.Amount
 }
 
-// fetchOnchainTerms reads the daemon's cached operator terms once so the
-// caller can size both the coin-selection headroom and the local fee floor
-// from a single lookup. A failed lookup (or a nil response/ServerInfo)
+// fetchOnchainTerms reads the chain height and cached operator terms once
+// for coin selection and fee estimation. A failed lookup or nil response
 // yields a zero-valued struct so the preview still renders.
 func (r *router) fetchOnchainTerms(ctx context.Context) onchainTerms {
 	info, err := r.deps.RPCServer.GetInfo(
@@ -68,11 +66,9 @@ func (r *router) fetchOnchainTerms(ctx context.Context) onchainTerms {
 	}
 
 	server := info.GetServerInfo()
-	if server == nil {
-		return onchainTerms{}
-	}
 
 	return onchainTerms{
+		blockHeight:    info.GetBlockHeight(),
 		feeRate:        btcutil.Amount(server.GetFeeRate()),
 		minOperatorFee: btcutil.Amount(server.GetMinOperatorFee()),
 		dustLimit:      btcutil.Amount(server.GetDustLimit()),
@@ -84,28 +80,16 @@ func (r *router) fetchOnchainTerms(ctx context.Context) onchainTerms {
 // (which folds in the on-chain share, liquidity, and margin the server
 // charges at seal time) and falls back to a purely local batch-size-1
 // floor when the operator is unreachable, so a preview is still produced
-// offline. amountSat is the leave amount; numInputs and sweepAll size the
-// local fallback's on-chain footprint; terms supplies the floor's feerate
-// and minimum-fee inputs.
-func (r *router) estimateOnchainFee(ctx context.Context, amountSat int64,
-	numInputs int, sweepAll bool, terms onchainTerms) onchainFeeQuote {
+// offline. inputs contains the selected VTXOs, whose values and remaining
+// lifetimes determine the operator's per-forfeit charges. sweepAll sizes
+// the local fallback's outputs; terms supplies the chain height and policy.
+func (r *router) estimateOnchainFee(ctx context.Context, inputs []*waverpc.VTXO,
+	sweepAll bool, terms onchainTerms) onchainFeeQuote {
 
-	// Prefer the operator's dynamic quote. RemainingBlocks is zero: a
-	// leave exits the funds now, so there is no residual lock time to
-	// price the time-value component against. A successful quote backs
-	// every fee field, so the preview is COMPLETE. The feeResp nil guard
-	// is belt-and-suspenders: the generated getter is nil-safe, but the
-	// explicit check keeps the intent obvious at the call site.
-	feeResp, err := r.deps.RPCServer.EstimateFee(
-		ctx, &waverpc.EstimateFeeRequest{
-			AmountSat:       amountSat,
-			IsBoarding:      false,
-			RemainingBlocks: 0,
-		},
-	)
-	if err == nil && feeResp != nil && feeResp.GetTotalFeeSat() > 0 {
+	fee, ok := r.quoteOnchainInputs(ctx, inputs, terms.blockHeight)
+	if ok {
 		return onchainFeeQuote{
-			feeSat:   feeResp.GetTotalFeeSat(),
+			feeSat:   fee,
 			feeKnown: true,
 			quoteStatus: wavewalletrpc.
 				SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE,
@@ -117,7 +101,7 @@ func (r *router) estimateOnchainFee(ctx context.Context, amountSat int64,
 	// at batch size 1 plus the operator's minimum fee, but cannot see
 	// the operator's liquidity/congestion components, so it is a lower
 	// bound the caller must treat as LOCAL_ONLY.
-	floor := localOnchainFeeFloor(numInputs, sweepAll, terms)
+	floor := localOnchainFeeFloor(len(inputs), sweepAll, terms)
 
 	return onchainFeeQuote{
 		feeSat:   floor,
@@ -125,9 +109,70 @@ func (r *router) estimateOnchainFee(ctx context.Context, amountSat int64,
 		quoteStatus: wavewalletrpc.
 			SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
 		warning: "fee is a local estimate assuming a batch size of " +
-			"one; the operator quote was unavailable and the " +
-			"binding fee is set when the round seals",
+			"one; a complete per-input operator quote was " +
+			"unavailable; the binding fee is set when the round " +
+			"seals",
 	}
+}
+
+// onchainQuoteKey identifies VTXOs that can reuse the same operator quote.
+type onchainQuoteKey struct {
+	amountSat       int64
+	remainingBlocks uint32
+}
+
+// quoteOnchainInputs sums the operator's per-forfeit fees for a leave.
+// Each input pays its own fixed components, even when all inputs belong to
+// one wallet. Quoting the destination amount once misses those charges and
+// also prices the wrong principal when a bounded send returns change.
+// Quotes assume batch size one; the binding fee uses actual round occupancy.
+// Any missing timing context or invalid quote discards the entire remote
+// estimate, so a partial sum can never masquerade as a complete quote.
+func (r *router) quoteOnchainInputs(ctx context.Context, inputs []*waverpc.VTXO,
+	height uint32) (int64, bool) {
+
+	if height == 0 || len(inputs) == 0 {
+		return 0, false
+	}
+
+	quotes := make(map[onchainQuoteKey]int64)
+	var total int64
+	for _, input := range inputs {
+		if input.GetBatchExpiry() <= 0 || input.GetAmountSat() <= 0 {
+			return 0, false
+		}
+
+		// Zero means "use the full default lifetime" to the operator.
+		// Clamp expiring inputs to one block, as in refresh previews.
+		remaining := max(int64(input.GetBatchExpiry())-int64(height), 1)
+		key := onchainQuoteKey{
+			amountSat:       input.GetAmountSat(),
+			remainingBlocks: uint32(remaining),
+		}
+		fee, ok := quotes[key]
+		if !ok {
+			resp, err := r.deps.RPCServer.EstimateFee(
+				ctx, &waverpc.EstimateFeeRequest{
+					AmountSat:       key.amountSat,
+					RemainingBlocks: key.remainingBlocks,
+				},
+			)
+			if err != nil || resp == nil {
+				return 0, false
+			}
+
+			fee = resp.GetTotalFeeSat()
+			quotes[key] = fee
+		}
+
+		// Bound the addition before accumulating untrusted totals.
+		if fee < 0 || fee > int64(btcutil.MaxSatoshi)-total {
+			return 0, false
+		}
+		total += fee
+	}
+
+	return total, true
 }
 
 // localOnchainFeeFloor computes a batch-size-1 fee lower bound from the

--- a/swapwallet/onchain_fee.go
+++ b/swapwallet/onchain_fee.go
@@ -8,6 +8,8 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
 	"github.com/lightninglabs/wavelength/waverpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Local cooperative-leave fee-floor sizing. These virtual sizes drive the
@@ -84,16 +86,19 @@ func (r *router) fetchOnchainTerms(ctx context.Context) onchainTerms {
 // lifetimes determine the operator's per-forfeit charges. sweepAll sizes
 // the local fallback's outputs; terms supplies the chain height and policy.
 func (r *router) estimateOnchainFee(ctx context.Context, inputs []*waverpc.VTXO,
-	sweepAll bool, terms onchainTerms) onchainFeeQuote {
+	sweepAll bool, terms onchainTerms) (onchainFeeQuote, error) {
 
-	fee, ok := r.quoteOnchainInputs(ctx, inputs, terms.blockHeight)
+	fee, ok, err := r.quoteOnchainInputs(ctx, inputs, terms.blockHeight)
+	if err != nil {
+		return onchainFeeQuote{}, err
+	}
 	if ok {
 		return onchainFeeQuote{
 			feeSat:   fee,
 			feeKnown: true,
 			quoteStatus: wavewalletrpc.
 				SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE,
-		}
+		}, nil
 	}
 
 	// Operator quote unavailable: fall back to a local floor derived
@@ -112,7 +117,7 @@ func (r *router) estimateOnchainFee(ctx context.Context, inputs []*waverpc.VTXO,
 			"one; a complete per-input operator quote was " +
 			"unavailable; the binding fee is set when the round " +
 			"seals",
-	}
+	}, nil
 }
 
 // onchainQuoteKey identifies VTXOs that can reuse the same operator quote.
@@ -128,18 +133,20 @@ type onchainQuoteKey struct {
 // Quotes assume batch size one; the binding fee uses actual round occupancy.
 // Any missing timing context or invalid quote discards the entire remote
 // estimate, so a partial sum can never masquerade as a complete quote.
+// An explicit economic warning instead rejects the preview: substituting a
+// local floor would hide an operator quote that is already known to be costly.
 func (r *router) quoteOnchainInputs(ctx context.Context, inputs []*waverpc.VTXO,
-	height uint32) (int64, bool) {
+	height uint32) (int64, bool, error) {
 
 	if height == 0 || len(inputs) == 0 {
-		return 0, false
+		return 0, false, nil
 	}
 
 	quotes := make(map[onchainQuoteKey]int64)
 	var total int64
 	for _, input := range inputs {
 		if input.GetBatchExpiry() <= 0 || input.GetAmountSat() <= 0 {
-			return 0, false
+			return 0, false, nil
 		}
 
 		// Zero means "use the full default lifetime" to the operator.
@@ -158,7 +165,19 @@ func (r *router) quoteOnchainInputs(ctx context.Context, inputs []*waverpc.VTXO,
 				},
 			)
 			if err != nil || resp == nil {
-				return 0, false
+
+				//nolint:nilerr // Use the local floor.
+				return 0, false, nil
+			}
+			if resp.GetBelowDustWarning() {
+				const reason = "uneconomic input %s: " +
+					"amount=%d sat, fee=%d sat"
+
+				return 0, false, status.Errorf(
+					codes.FailedPrecondition, reason,
+					input.GetOutpoint(),
+					input.GetAmountSat(),
+					resp.GetTotalFeeSat())
 			}
 
 			fee = resp.GetTotalFeeSat()
@@ -167,12 +186,12 @@ func (r *router) quoteOnchainInputs(ctx context.Context, inputs []*waverpc.VTXO,
 
 		// Bound the addition before accumulating untrusted totals.
 		if fee < 0 || fee > int64(btcutil.MaxSatoshi)-total {
-			return 0, false
+			return 0, false, nil
 		}
 		total += fee
 	}
 
-	return total, true
+	return total, true, nil
 }
 
 // localOnchainFeeFloor computes a batch-size-1 fee lower bound from the

--- a/swapwallet/onchain_fee_test.go
+++ b/swapwallet/onchain_fee_test.go
@@ -1,0 +1,336 @@
+//go:build wavewalletrpc && swapruntime
+
+package swapwallet
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouterOnchainSweepQuotesEveryInput prevents a multi-input sweep from
+// presenting a single-input fee as the cost of the entire leave.
+func TestRouterOnchainSweepQuotesEveryInput(t *testing.T) {
+	t.Parallel()
+
+	r, _, rpc := newRouterFixture(t)
+	rpc.getInfoResp = &waverpc.GetInfoResponse{BlockHeight: 1000}
+	rpc.listVTXOsResp = &waverpc.ListVTXOsResponse{}
+	for i := range 6 {
+		rpc.listVTXOsResp.Vtxos = append(
+			rpc.listVTXOsResp.Vtxos, &waverpc.VTXO{
+				Outpoint:    fmt.Sprintf("tx%d:0", i),
+				AmountSat:   46000,
+				BatchExpiry: 1200,
+			},
+		)
+	}
+	rpc.listVTXOsResp.Vtxos[0].AmountSat = 49681
+	rpc.listVTXOsResp.Vtxos[0].BatchExpiry = 1300
+	rpc.estimateFeeFn = func(req *waverpc.EstimateFeeRequest) (
+		*waverpc.EstimateFeeResponse, error) {
+
+		require.False(t, req.GetIsBoarding())
+		if req.GetAmountSat() == 49681 {
+			require.Equal(t, uint32(300), req.GetRemainingBlocks())
+
+			return &waverpc.EstimateFeeResponse{
+				TotalFeeSat: 382,
+			}, nil
+		}
+
+		require.Equal(t, int64(46000), req.GetAmountSat())
+		require.Equal(t, uint32(200), req.GetRemainingBlocks())
+
+		return &waverpc.EstimateFeeResponse{TotalFeeSat: 300}, nil
+	}
+
+	resp, err := r.PrepareSend(
+		t.Context(), &wavewalletrpc.PrepareSendRequest{
+			Destination: &wavewalletrpc.
+				PrepareSendRequest_OnchainAddress{
+				OnchainAddress: "bcrt1qaddr",
+			},
+			SweepAll: true,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, resp.GetSelectedOutpoints(), 6)
+	require.Equal(t, int64(279681), resp.GetExpectedTotalOutflowSat())
+	require.Equal(t, int64(1882), resp.GetExpectedFeeSat())
+	require.True(t, resp.GetFeeKnown())
+	require.Equal(
+		t, wavewalletrpc.SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE,
+		resp.GetQuoteStatus(),
+	)
+	require.Empty(t, resp.GetWarning())
+
+	// Identical inputs reuse a request, but each contributes its fee.
+	require.Equal(t, 2, rpc.estimateFeeCalls)
+}
+
+// TestRouterOnchainRejectsUnfundedInputFees ensures a bounded preview checks
+// affordability against all input fees before creating a send intent.
+func TestRouterOnchainRejectsUnfundedInputFees(t *testing.T) {
+	t.Parallel()
+
+	r, _, rpc := newRouterFixture(t)
+	rpc.getInfoResp = &waverpc.GetInfoResponse{BlockHeight: 1000}
+	rpc.listVTXOsResp = &waverpc.ListVTXOsResponse{
+		Vtxos: []*waverpc.VTXO{
+			{
+				Outpoint:    "tx1:0",
+				AmountSat:   6000,
+				BatchExpiry: 1200,
+			},
+			{
+				Outpoint:    "tx2:0",
+				AmountSat:   5000,
+				BatchExpiry: 1200,
+			},
+		},
+	}
+	rpc.estimateFeeResp = &waverpc.EstimateFeeResponse{TotalFeeSat: 600}
+
+	resp, err := r.PrepareSend(
+		t.Context(), &wavewalletrpc.PrepareSendRequest{
+			Destination: &wavewalletrpc.
+				PrepareSendRequest_OnchainAddress{
+				OnchainAddress: "bcrt1qaddr",
+			},
+			AmtSat: 10000,
+		},
+	)
+	require.ErrorIs(t, err, ErrAmountRequired)
+	require.Nil(t, resp)
+	require.Equal(t, 2, rpc.estimateFeeCalls)
+}
+
+// TestOnchainFeeQuoteCompleteness checks lifetime-sensitive quote reuse,
+// zero-fee schedules, and all-or-nothing fallback for incomplete estimates.
+func TestOnchainFeeQuoteCompleteness(t *testing.T) {
+	t.Parallel()
+	complete := wavewalletrpc.SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE
+
+	tests := []struct {
+		name          string
+		height        uint32
+		expiries      []int32
+		fees          []int64
+		nilReply      bool
+		failLast      bool
+		wantCalls     int
+		wantRemaining []uint32
+		wantFee       int64
+		wantKnown     bool
+	}{
+		{
+			name:   "different lifetimes are quoted separately",
+			height: 1000,
+			expiries: []int32{
+				1200,
+				1300,
+			},
+			fees: []int64{
+				200,
+				300,
+			},
+			wantCalls: 2,
+			wantRemaining: []uint32{
+				200,
+				300,
+			},
+			wantFee:   500,
+			wantKnown: true,
+		},
+		{
+			name:   "expired inputs never request default lifetime",
+			height: 1000,
+			expiries: []int32{
+				999,
+				1000,
+				1001,
+			},
+			fees: []int64{
+				200,
+			},
+			wantCalls: 1,
+			wantRemaining: []uint32{
+				1,
+			},
+			wantFee:   600,
+			wantKnown: true,
+		},
+		{
+			name:   "zero fee is a valid quote",
+			height: 1000,
+			expiries: []int32{
+				1200,
+			},
+			fees: []int64{
+				0,
+			},
+			wantCalls: 1,
+			wantKnown: true,
+		},
+		{
+			name: "missing height cannot produce complete quote",
+			expiries: []int32{
+				1200,
+			},
+			wantFee: 161,
+		},
+		{
+			name:   "missing expiry cannot produce complete quote",
+			height: 1000,
+			expiries: []int32{
+				0,
+			},
+			wantFee: 161,
+		},
+		{
+			name:   "missing later expiry discards partial sum",
+			height: 1000,
+			expiries: []int32{
+				1200,
+				0,
+			},
+			fees: []int64{
+				500,
+			},
+			wantCalls: 1,
+			wantFee:   219,
+		},
+		{
+			name:   "operator failure discards partial sum",
+			height: 1000,
+			expiries: []int32{
+				1200,
+				1300,
+			},
+			fees: []int64{
+				500,
+				500,
+			},
+			failLast:  true,
+			wantCalls: 2,
+			wantFee:   219,
+		},
+		{
+			name:   "nil response falls back",
+			height: 1000,
+			expiries: []int32{
+				1200,
+			},
+			nilReply:  true,
+			wantCalls: 1,
+			wantFee:   161,
+		},
+		{
+			name:   "negative fee falls back",
+			height: 1000,
+			expiries: []int32{
+				1200,
+			},
+			fees: []int64{
+				-1,
+			},
+			wantCalls: 1,
+			wantFee:   161,
+		},
+		{
+			name:   "excessive fee falls back",
+			height: 1000,
+			expiries: []int32{
+				1200,
+			},
+			fees: []int64{
+				btcutil.MaxSatoshi + 1,
+			},
+			wantCalls: 1,
+			wantFee:   161,
+		},
+		{
+			name:   "excessive sum with reused quote",
+			height: 1000,
+			expiries: []int32{
+				1200,
+				1200,
+			},
+			fees: []int64{
+				btcutil.MaxSatoshi,
+			},
+			wantCalls: 1,
+			wantFee:   219,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, _, rpc := newRouterFixture(t)
+			var inputs []*waverpc.VTXO
+			for _, expiry := range tt.expiries {
+				inputs = append(inputs, &waverpc.VTXO{
+					AmountSat:   10000,
+					BatchExpiry: expiry,
+				})
+			}
+			var remaining []uint32
+			rpc.estimateFeeFn = func(
+				req *waverpc.EstimateFeeRequest) (
+				*waverpc.EstimateFeeResponse, error) {
+
+				remaining = append(
+					remaining, req.GetRemainingBlocks(),
+				)
+				if tt.nilReply {
+					return nil, nil
+				}
+				if tt.failLast &&
+					len(remaining) == tt.wantCalls {
+					return nil, errors.New("operator " +
+						"unavailable")
+				}
+
+				return &waverpc.EstimateFeeResponse{
+					TotalFeeSat: tt.fees[len(remaining)-1],
+				}, nil
+			}
+
+			quote := r.estimateOnchainFee(
+				t.Context(), inputs, true, onchainTerms{
+					blockHeight: tt.height,
+					feeRate:     1,
+				},
+			)
+			require.Equal(t, tt.wantFee, quote.feeSat)
+			require.Equal(t, tt.wantKnown, quote.feeKnown)
+			require.Equal(t, tt.wantCalls, rpc.estimateFeeCalls)
+			if tt.wantRemaining != nil {
+				require.Equal(t, tt.wantRemaining, remaining)
+			}
+			wantStatus := wavewalletrpc.
+				SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY
+			if tt.wantKnown {
+				wantStatus = complete
+			}
+			require.Equal(t, wantStatus, quote.quoteStatus)
+			if tt.wantKnown {
+				require.Empty(t, quote.warning)
+
+				return
+			}
+
+			require.Contains(
+				t, quote.warning, "per-input operator quote",
+			)
+		})
+	}
+}

--- a/swapwallet/onchain_fee_test.go
+++ b/swapwallet/onchain_fee_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestRouterOnchainSweepQuotesEveryInput prevents a multi-input sweep from
@@ -304,12 +306,13 @@ func TestOnchainFeeQuoteCompleteness(t *testing.T) {
 				}, nil
 			}
 
-			quote := r.estimateOnchainFee(
+			quote, err := r.estimateOnchainFee(
 				t.Context(), inputs, true, onchainTerms{
 					blockHeight: tt.height,
 					feeRate:     1,
 				},
 			)
+			require.NoError(t, err)
 			require.Equal(t, tt.wantFee, quote.feeSat)
 			require.Equal(t, tt.wantKnown, quote.feeKnown)
 			require.Equal(t, tt.wantCalls, rpc.estimateFeeCalls)
@@ -331,6 +334,211 @@ func TestOnchainFeeQuoteCompleteness(t *testing.T) {
 			require.Contains(
 				t, quote.warning, "per-input operator quote",
 			)
+		})
+	}
+}
+
+// TestRouterOnchainRejectsUneconomicInput prevents an explicit operator
+// warning from being replaced by the cheaper local fallback estimate.
+func TestRouterOnchainRejectsUneconomicInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		sweepAll bool
+		fee      int64
+	}{
+		{
+			sweepAll: false,
+			fee:      600,
+		},
+		{
+			sweepAll: false,
+			fee:      1200,
+		},
+		{
+			sweepAll: true,
+			fee:      600,
+		},
+		{
+			sweepAll: true,
+			fee:      1200,
+		},
+	}
+	for _, tt := range tests {
+		name := fmt.Sprintf("sweep=%t/fee=%d", tt.sweepAll, tt.fee)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			r, _, rpc := newRouterFixture(t)
+			rpc.getInfoResp = &waverpc.GetInfoResponse{
+				BlockHeight: 1000,
+				ServerInfo: &waverpc.ServerInfo{
+					FeeRate: 1,
+				},
+			}
+			rpc.listVTXOsResp = &waverpc.ListVTXOsResponse{
+				Vtxos: []*waverpc.VTXO{
+					{
+						Outpoint:    "large:0",
+						AmountSat:   10000,
+						BatchExpiry: 1200,
+					},
+					{
+						Outpoint:    "small:0",
+						AmountSat:   1000,
+						BatchExpiry: 1200,
+					},
+				},
+			}
+			rpc.estimateFeeFn = func(
+				req *waverpc.EstimateFeeRequest) (
+				*waverpc.EstimateFeeResponse, error) {
+
+				if req.GetAmountSat() == 10000 {
+					return &waverpc.EstimateFeeResponse{
+						TotalFeeSat: 100,
+					}, nil
+				}
+
+				return &waverpc.EstimateFeeResponse{
+					TotalFeeSat:      tt.fee,
+					BelowDustWarning: true,
+				}, nil
+			}
+			req := &wavewalletrpc.PrepareSendRequest{
+				Destination: &wavewalletrpc.
+					PrepareSendRequest_OnchainAddress{
+					OnchainAddress: "bcrt1qaddr",
+				},
+				SweepAll: tt.sweepAll,
+			}
+			if !tt.sweepAll {
+				req.AmtSat = 10001
+			}
+
+			resp, err := r.PrepareSend(t.Context(), req)
+			require.Equal(
+				t, codes.FailedPrecondition, status.Code(err),
+			)
+			require.ErrorContains(t, err, "small:0")
+			require.ErrorContains(t, err, "uneconomic")
+			require.Nil(t, resp)
+			require.Empty(t, r.intents.intents)
+			require.Equal(t, 2, rpc.estimateFeeCalls)
+		})
+	}
+}
+
+// TestRouterOnchainSweepOutputFloor checks the destination amount after all
+// fees, even when the operator does not flag individual inputs as uneconomic.
+func TestRouterOnchainSweepOutputFloor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		amount     int64
+		fee        int64
+		dust       uint64
+		local      bool
+		wantReject bool
+	}{
+		{
+			name:       "fee exceeds balance",
+			amount:     1000,
+			fee:        1200,
+			wantReject: true,
+		},
+		{
+			name:       "fee consumes balance",
+			amount:     1000,
+			fee:        1000,
+			wantReject: true,
+		},
+		{
+			name:       "below advertised floor",
+			amount:     1000,
+			fee:        671,
+			dust:       330,
+			wantReject: true,
+		},
+		{
+			name:   "at advertised floor",
+			amount: 1000,
+			fee:    670,
+			dust:   330,
+		},
+		{
+			name:   "zero fee",
+			amount: 330,
+			dust:   330,
+		},
+		{
+			name:       "local below floor",
+			amount:     490,
+			dust:       330,
+			local:      true,
+			wantReject: true,
+		},
+		{
+			name:   "local at floor",
+			amount: 491,
+			dust:   330,
+			local:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, _, rpc := newRouterFixture(t)
+			rpc.getInfoResp = &waverpc.GetInfoResponse{
+				BlockHeight: 1000,
+				ServerInfo: &waverpc.ServerInfo{
+					FeeRate:   1,
+					DustLimit: tt.dust,
+				},
+			}
+			rpc.listVTXOsResp = &waverpc.ListVTXOsResponse{
+				Vtxos: []*waverpc.VTXO{
+					{
+						Outpoint:    "tx1:0",
+						AmountSat:   tt.amount,
+						BatchExpiry: 1200,
+					},
+				},
+			}
+			rpc.estimateFeeResp = &waverpc.EstimateFeeResponse{
+				TotalFeeSat: tt.fee,
+			}
+			if tt.local {
+				rpc.estimateFeeErr = errors.New("operator " +
+					"unavailable")
+			}
+
+			dst := &wavewalletrpc.PrepareSendRequest_OnchainAddress{
+				OnchainAddress: "bcrt1qaddr",
+			}
+			resp, err := r.PrepareSend(
+				t.Context(), &wavewalletrpc.PrepareSendRequest{
+					Destination: dst,
+					SweepAll:    true,
+				},
+			)
+			if tt.wantReject {
+				require.Equal(
+					t, codes.FailedPrecondition,
+					status.Code(err),
+				)
+				require.ErrorContains(t, err, "after fees")
+				require.Nil(t, resp)
+				require.Empty(t, r.intents.intents)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotEmpty(t, resp.GetSendIntentId())
+			require.Equal(t, !tt.local, resp.GetFeeKnown())
 		})
 	}
 }

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -500,7 +500,7 @@ func (r *router) prepareOnchain(ctx context.Context, addr string,
 	}
 
 	feeQuote := r.estimateOnchainFee(
-		ctx, previewAmount, len(res.Selected), sweepAll, terms,
+		ctx, res.Selected, sweepAll, terms,
 	)
 
 	// Guard the preview's coherence: a bounded send must not report an

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -499,22 +499,35 @@ func (r *router) prepareOnchain(ctx context.Context, addr string,
 		previewAmount = selectedTotal
 	}
 
-	feeQuote := r.estimateOnchainFee(
+	feeQuote, err := r.estimateOnchainFee(
 		ctx, res.Selected, sweepAll, terms,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Guard the preview's coherence: a bounded send must not report an
 	// outflow its own selected funds cannot cover. The daemon re-selects
 	// for the real send, but the preview should reject an unaffordable
 	// amount + fee here rather than confirm a stale, unfundable quote
-	// that the SendOnChain path will later fail. A sweep moves the whole
-	// balance, so it is affordable by construction.
+	// that the SendOnChain path will later fail. A sweep absorbs the fee
+	// into its leave output, which must remain positive and meet the
+	// operator's advertised output floor.
 	if !sweepAll {
 		needed := int64(amtSat) + feeQuote.feeSat
 		if selectedTotal < needed {
 			return nil, fmt.Errorf("%w: live VTXOs cover %d sat, "+
 				"need %d sat (amount plus fee)",
 				ErrAmountRequired, selectedTotal, needed)
+		}
+	} else {
+		remaining := selectedTotal - feeQuote.feeSat
+		minOutput := max(int64(terms.dustLimit), 1)
+		if remaining < minOutput {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"sweep leaves %d sat after fees, below the "+
+					"minimum output of %d sat", remaining,
+				minOutput)
 		}
 	}
 

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -569,11 +569,14 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 		Status: "submitted",
 	}
 
-	// The operator returns a dynamic fee quote, so the preview is a
-	// COMPLETE quote: net outflow is the amount delivered plus the fee,
-	// not the gross VTXO bundle selected to cover it.
+	// Both selected inputs have timing context and a 250 sat operator
+	// quote, so the complete preview includes their combined 500 sat fee.
+	for _, input := range rpc.listVTXOsResp.Vtxos {
+		input.BatchExpiry = 1200
+	}
+	rpc.getInfoResp = &waverpc.GetInfoResponse{BlockHeight: 1000}
 	rpc.estimateFeeResp = &waverpc.EstimateFeeResponse{
-		TotalFeeSat: 500,
+		TotalFeeSat: 250,
 	}
 
 	prepareResp, err := r.PrepareSend(
@@ -597,6 +600,11 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 	require.True(t, prepareResp.GetFeeKnown())
 	require.Equal(
 		t, int64(500), prepareResp.GetExpectedFeeSat(),
+	)
+	require.Equal(t, 2, rpc.estimateFeeCalls)
+	require.Equal(t, int64(5000), rpc.estimateFeeLastReq.GetAmountSat())
+	require.Equal(
+		t, uint32(200), rpc.estimateFeeLastReq.GetRemainingBlocks(),
 	)
 
 	// Net outflow is amount + fee (10000 + 500); the ~2000 sat residual
@@ -686,8 +694,9 @@ func TestRouterSendOnchainFeeFallsBackToLocalFloor(t *testing.T) {
 	rpc.listVTXOsResp = &waverpc.ListVTXOsResponse{
 		Vtxos: []*waverpc.VTXO{
 			{
-				Outpoint:  "tx1:0",
-				AmountSat: 10000,
+				Outpoint:    "tx1:0",
+				AmountSat:   10000,
+				BatchExpiry: 1200,
 			},
 		},
 	}
@@ -701,6 +710,7 @@ func TestRouterSendOnchainFeeFallsBackToLocalFloor(t *testing.T) {
 	// exceeds the 300 sat minimum operator fee.
 	rpc.getInfoResp = &waverpc.GetInfoResponse{
 		WalletState: waverpc.WalletState_WALLET_STATE_READY,
+		BlockHeight: 1000,
 		ServerInfo: &waverpc.ServerInfo{
 			FeeRate:        10,
 			MinOperatorFee: 300,
@@ -727,6 +737,7 @@ func TestRouterSendOnchainFeeFallsBackToLocalFloor(t *testing.T) {
 		t, int64(7040), prepareResp.GetExpectedTotalOutflowSat(),
 	)
 	require.NotEmpty(t, prepareResp.GetWarning())
+	require.Equal(t, 1, rpc.estimateFeeCalls)
 }
 
 // TestRouterSendOnchainRejectsWhenFundsCannotCoverFee verifies that a


### PR DESCRIPTION
Onchain send previews priced the destination amount as a single forfeit, underestimating fees when the leave consumed multiple VTXOs. Quote each selected VTXO using its full value and remaining lifetime, then sum the fees. Reuse quotes for identical inputs while counting each input's fee, and check bounded-send affordability against the combined total.

Missing timing information, failed requests, or invalid fee totals discard the partial operator estimate and produce a local estimate for the entire selection with `LOCAL_ONLY`, `fee_known: false`, and a warning. Zero-fee operator quotes are accepted.

An operator quote with `below_dust_warning` rejects the preview with `FailedPrecondition` rather than falling back to a cheaper local estimate. Sweep previews also reject fees that leave a zero or negative destination amount, or an amount below the advertised output floor. These checks run before a send intent is created.

Fixes #1278.
