### PR TITLE
serverconn: Validate returned mailbox cursors

### DIFF
--- a/docs/RPC_MAILBOX_CONTRACT.md
+++ b/docs/RPC_MAILBOX_CONTRACT.md
@@ -100,6 +100,11 @@ Ordering constraints apply only within the scope of a single mailbox stream:
 - The RPC layer MUST NOT require strict ordering between requests and responses
   beyond correlation.
 
+Within one `Pull` response, envelopes are strictly increasing in `event_seq`.
+The pre-existing [`PullResponse.next_cursor` wire definition](../mailbox/pb/mailbox.proto)
+is the highest returned sequence plus one. This does not imply causal ordering
+between different producers or contiguous sequence allocation.
+
 ## Ack watermark
 
 Acking is described as advancing a watermark rather than deleting individual
@@ -164,3 +169,28 @@ The mailbox transport and RPC overlay MUST be designed for evolution:
 Generated RPC-over-mailbox stubs should be treated as a convenience layer; they
 MUST NOT prevent using the underlying transport for experimental or
 operator-specific payloads.
+
+## Client cursor validation and omission limits
+
+Before dispatching any part of a pull response, `serverconn` validates the
+whole response. Each returned sequence must be nonzero, at least the requested
+cursor, and strictly greater than the preceding returned sequence. For a
+nonempty response, `next_cursor` must equal the final sequence plus one without
+overflow. An invalid response is retried without dispatch or cursor advancement.
+An empty response may return zero (legacy behavior) or echo the requested
+cursor; it never advances local state.
+
+Sequence numbers need not be contiguous or begin exactly at the requested
+cursor. A mailbox store may allocate them globally across recipients, and a
+rolled-back insert may consume a sequence. For example, a client requesting
+cursor 10 may legitimately receive sequences 13, 18, and 21 with next cursor 22.
+Requiring 10, 11, and 12 would reject such a healthy server.
+
+This validates the returned rows, not the completeness of the server's history.
+A server can omit an envelope between two returned rows or consistently relabel
+sequences. The current protocol supplies no independently verifiable evidence
+that distinguishes omission from legitimate gaps. Detecting that requires a
+separate authenticated history protocol. Cursor validation does prevent a
+server from returning sequences 13 and 18 while asking the client to acknowledge
+through cursor 1000. Durable dispatch and the validated cursor still commit in
+one transaction; rollback preserves the old cursor for redelivery.

--- a/serverconn/ingress.go
+++ b/serverconn/ingress.go
@@ -525,6 +525,9 @@ func (a *ServerConnectionActor) pullBatch(ctx context.Context, cursor uint64) (
 	if sErr := edgeResponseError("Pull", resp, err); sErr != nil {
 		return nil, 0, sErr
 	}
+	if err := validatePullCursor(cursor, resp); err != nil {
+		return nil, 0, err
+	}
 
 	return resp.Envelopes, resp.NextCursor, nil
 }

--- a/serverconn/ingress_cursor.go
+++ b/serverconn/ingress_cursor.go
@@ -1,0 +1,43 @@
+package serverconn
+
+import (
+	"fmt"
+	"math"
+
+	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
+)
+
+// validatePullCursor checks the entire response before any dispatch can cause
+// an irreversible side effect. Sequences may have gaps: allocation need not be
+// recipient-local or rollback-free. The wire contract only proves ordering and
+// the successor of the returned rows, not that the server omitted no rows.
+func validatePullCursor(cursor uint64, resp *mailboxpb.PullResponse) error {
+	if len(resp.Envelopes) == 0 {
+		// Older edges return zero on an empty long-poll. Neither zero
+		// nor an echoed cursor advances the client's persisted state.
+		if resp.NextCursor != 0 && resp.NextCursor != cursor {
+			return fmt.Errorf("empty pull changed cursor from "+
+				"%d to %d", cursor, resp.NextCursor)
+		}
+
+		return nil
+	}
+
+	var previous uint64
+	for _, env := range resp.Envelopes {
+		if env == nil || env.EventSeq == 0 || env.EventSeq < cursor ||
+			env.EventSeq <= previous {
+			return fmt.Errorf("invalid pull sequence %d after %d "+
+				"at cursor %d", env.GetEventSeq(), previous,
+				cursor)
+		}
+
+		previous = env.EventSeq
+	}
+	if previous == math.MaxUint64 || resp.NextCursor != previous+1 {
+		return fmt.Errorf("invalid next cursor %d after sequence %d",
+			resp.NextCursor, previous)
+	}
+
+	return nil
+}

--- a/serverconn/ingress_cursor_test.go
+++ b/serverconn/ingress_cursor_test.go
@@ -1,0 +1,173 @@
+package serverconn
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// TestPullBatchCursorContract exercises the untrusted pull response boundary.
+// Gaps are legal; regressions, overlapping rows and invented successors are
+// not.
+func TestPullBatchCursorContract(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		cursor  uint64
+		seqs    []uint64
+		next    uint64
+		invalid bool
+	}{
+		{
+			name: "initial global gap",
+			seqs: []uint64{
+				4,
+				9,
+			},
+			next: 10,
+		},
+		{
+			name:   "interleaved recipients and rollback gaps",
+			cursor: 10,
+			seqs: []uint64{
+				13,
+				18,
+				21,
+			},
+			next: 22,
+		},
+		{
+			name:   "inclusive start",
+			cursor: 10,
+			seqs: []uint64{
+				10,
+				11,
+			},
+			next: 12,
+		},
+		{
+			name:   "overlapping pull",
+			cursor: 10,
+			seqs: []uint64{
+				9,
+				10,
+			},
+			next:    11,
+			invalid: true,
+		},
+		{
+			name:   "duplicate sequence",
+			cursor: 10,
+			seqs: []uint64{
+				10,
+				10,
+			},
+			next:    11,
+			invalid: true,
+		},
+		{
+			name:   "unordered rows",
+			cursor: 10,
+			seqs: []uint64{
+				12,
+				11,
+			},
+			next:    13,
+			invalid: true,
+		},
+		{
+			name:   "inflated cursor",
+			cursor: 10,
+			seqs: []uint64{
+				10,
+				11,
+			},
+			next:    1000,
+			invalid: true,
+		},
+		{
+			name:   "regressed cursor",
+			cursor: 10,
+			seqs: []uint64{
+				10,
+				11,
+			},
+			next:    10,
+			invalid: true,
+		},
+		{
+			name: "zero sequence",
+			seqs: []uint64{
+				0,
+			},
+			next:    1,
+			invalid: true,
+		},
+		{
+			name: "overflow",
+			seqs: []uint64{
+				math.MaxUint64,
+			},
+			next:    0,
+			invalid: true,
+		},
+		{
+			name:   "legacy empty zero",
+			cursor: 10,
+		},
+		{
+			name:   "empty unchanged",
+			cursor: 10,
+			next:   10,
+		},
+		{
+			name:    "empty inflation",
+			cursor:  10,
+			next:    1000,
+			invalid: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			envelopes := make([]*mailboxpb.Envelope, len(tc.seqs))
+			for i, seq := range tc.seqs {
+				envelopes[i] = &mailboxpb.Envelope{
+					EventSeq: seq,
+				}
+			}
+			edge := &mailboxClientStub{pullFn: func(
+				_ context.Context, req *mailboxpb.PullRequest,
+				_ ...grpc.CallOption) (*mailboxpb.PullResponse,
+				error) {
+
+				require.Equal(t, tc.cursor, req.Cursor)
+
+				return &mailboxpb.PullResponse{
+					Status: &mailboxpb.Status{
+						Ok: true,
+					},
+					Envelopes:  envelopes,
+					NextCursor: tc.next,
+				}, nil
+			}}
+			conn := newErrorPathActor(edge, newMemCheckpointStore())
+			got, next, err := conn.pullBatch(
+				context.Background(), tc.cursor,
+			)
+			if tc.invalid {
+				require.Error(t, err)
+				require.Empty(t, got)
+				require.Zero(t, next)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, envelopes, got)
+			require.Equal(t, tc.next, next)
+		})
+	}
+}

--- a/serverconn/ingress_durable_test.go
+++ b/serverconn/ingress_durable_test.go
@@ -1,0 +1,291 @@
+package serverconn_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/db/actordelivery"
+	"github.com/lightninglabs/wavelength/db/sqlc"
+	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
+	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
+	"github.com/lightninglabs/wavelength/serverconn"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	_ "modernc.org/sqlite"
+)
+
+// openIngressStore opens real delivery persistence. A supplied PostgreSQL DSN
+// must name an isolated test database; otherwise a file-backed SQLite store is
+// used. Reopening the same DSN models process loss, including lost Go state.
+func openIngressStore(t *testing.T,
+	dsn string) (*sql.DB, actor.TxAwareDeliveryStore) {
+
+	t.Helper()
+	driver := "sqlite"
+	backend := sqlc.BackendTypeSqlite
+	if os.Getenv("WAVELENGTH_INGRESS_POSTGRES_DSN") != "" {
+		driver = "pgx"
+		backend = sqlc.BackendTypePostgres
+	}
+	raw, err := sql.Open(driver, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	require.NoError(t, actordelivery.RunMigrations(raw, backend))
+	store, err := actordelivery.NewTxAwareDeliveryStoreFromDB(
+		raw, backend, nil, nil,
+	)
+	require.NoError(t, err)
+
+	return raw, store
+}
+
+// ingressTestDSN gives each SQLite test a persistent file. PostgreSQL test runs
+// use a dedicated database and unique mailbox names instead.
+func ingressTestDSN(t *testing.T) string {
+	t.Helper()
+	if dsn := os.Getenv("WAVELENGTH_INGRESS_POSTGRES_DSN"); dsn != "" {
+		return dsn
+	}
+
+	return filepath.Join(t.TempDir(), "ingress.db") +
+		"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(30000)" +
+		"&_txlock=immediate"
+}
+
+// rollbackIngressStore simulates process loss after all folded writes execute
+// but before their transaction commits. It uses the real store's rollback.
+type rollbackIngressStore struct{ actor.TxAwareDeliveryStore }
+
+// ExecTx aborts the fold after enqueues and checkpoint writes have succeeded.
+func (s rollbackIngressStore) ExecTx(ctx context.Context, readOnly bool,
+	fn actor.TxFunc) error {
+
+	return s.TxAwareDeliveryStore.ExecTx(
+		ctx, readOnly,
+		func(txCtx context.Context, store actor.DeliveryStore) error {
+			if err := fn(txCtx, store); err != nil {
+				return err
+			}
+
+			return errors.New("injected crash before ingress " +
+				"commit")
+		},
+	)
+}
+
+// TestIngressCursorDurableRestart drives the production ingress loop across an
+// inflated response, a rolled-back fold and a fresh process opening the same
+// DB. Only the final run may ACK, after inbox rows and cursor are both durable.
+func TestIngressCursorDurableRestart(t *testing.T) {
+	ctx := context.Background()
+	dsn := ingressTestDSN(t)
+	raw, store := openIngressStore(t, dsn)
+	lane := t.Name() + "/" + uuid.NewString()
+	envs := []*mailboxpb.Envelope{}
+	for _, seq := range []uint64{4, 9} {
+		envs = append(
+			envs, &mailboxpb.Envelope{
+				ProtocolVersion:    1,
+				ArkProtocolVersion: 1,
+				EventSeq:           seq,
+				Rpc: &mailboxpb.RpcMeta{
+					Kind:    mailboxpb.RpcMeta_KIND_EVENT,
+					Service: "test",
+					Method:  "event",
+				},
+			},
+		)
+	}
+	cfg := serverconn.DefaultConnectorConfig()
+	cfg.LocalMailboxID = lane
+	cfg.RemoteMailboxID = "server"
+	cfg.ArkProtocolVersion = 1
+	cfg.Store = store
+	cfg.RetryBaseDelay = time.Millisecond
+	cfg.RetryMaxDelay = time.Millisecond
+	dispatches := 0
+	cfg.Dispatchers = serverconn.DispatcherMap{mailboxrpc.ServiceMethod{
+		Service: "test",
+		Method:  "event",
+	}: func(ctx context.Context, env *mailboxpb.Envelope) error {
+		dispatches++
+		id := fmt.Sprintf("%s/%d", lane, env.EventSeq)
+
+		return store.EnqueueMessage(
+			ctx, actor.EnqueueParams{
+				ID:          id,
+				MailboxID:   lane,
+				MessageType: "test",
+				Payload:     []byte{byte(env.EventSeq)},
+				AvailableAt: time.Now(),
+				MaxAttempts: 5,
+			},
+		)
+	}}
+	next := uint64(1000)
+	pulls := 0
+	done := make(chan struct{})
+	acked := uint64(0)
+	edge := &durableIngressEdge{}
+	edge.pull = func(ctx context.Context, req *mailboxpb.PullRequest) (
+		*mailboxpb.PullResponse, error) {
+
+		pulls++
+		if pulls == 2 {
+			close(done)
+			<-ctx.Done()
+
+			return nil, ctx.Err()
+		}
+
+		return &mailboxpb.PullResponse{
+			Status: &mailboxpb.Status{
+				Ok: true,
+			},
+			Envelopes:  envs,
+			NextCursor: next,
+		}, nil
+	}
+	edge.ack = func(_ context.Context, req *mailboxpb.AckUpToRequest) (
+		*mailboxpb.AckUpToResponse, error) {
+
+		acked = req.Cursor
+
+		return &mailboxpb.AckUpToResponse{
+			Status: &mailboxpb.Status{
+				Ok: true,
+			},
+		}, nil
+	}
+	cfg.Edge = edge
+	runDurableIngress(t, cfg, done)
+	require.Zero(t, dispatches)
+	require.Zero(t, acked)
+	checkpoint, err := store.LoadCheckpoint(
+		ctx, serverconn.DurableActorID(lane),
+	)
+	require.NoError(t, err)
+	require.Nil(t, checkpoint)
+
+	next = 10
+	pulls = 0
+	done = make(chan struct{})
+	cfg.Store = rollbackIngressStore{TxAwareDeliveryStore: store}
+	runDurableIngress(t, cfg, done)
+	require.Equal(t, 2, dispatches)
+	require.Zero(t, acked)
+	require.NoError(t, raw.Close())
+
+	_, store = openIngressStore(t, dsn)
+	cfg.Store = store
+	checkpoint, err = store.LoadCheckpoint(
+		ctx, serverconn.DurableActorID(lane),
+	)
+	require.NoError(t, err)
+	require.Nil(t, checkpoint)
+	row, err := store.PeekNextMessage(ctx, lane)
+	require.NoError(t, err)
+	require.Nil(t, row)
+	pulls = 0
+	done = make(chan struct{})
+	edge.ack = func(_ context.Context, req *mailboxpb.AckUpToRequest) (
+		*mailboxpb.AckUpToResponse, error) {
+
+		acked = req.Cursor
+		close(done)
+
+		return &mailboxpb.AckUpToResponse{
+			Status: &mailboxpb.Status{
+				Ok: true,
+			},
+		}, nil
+	}
+	// After ACK, block the next long-poll until StopIngress cancels it.
+	edge.pull = func(ctx context.Context, req *mailboxpb.PullRequest) (
+		*mailboxpb.PullResponse, error) {
+
+		pulls++
+		if pulls > 1 {
+			<-ctx.Done()
+
+			return nil, ctx.Err()
+		}
+
+		return &mailboxpb.PullResponse{
+			Status: &mailboxpb.Status{
+				Ok: true,
+			},
+			Envelopes:  envs,
+			NextCursor: next,
+		}, nil
+	}
+	runDurableIngress(t, cfg, done)
+	require.Equal(t, uint64(10), acked)
+	checkpoint, err = store.LoadCheckpoint(
+		ctx, serverconn.DurableActorID(lane),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, checkpoint)
+	var state serverconn.AckState
+	require.NoError(t, state.Decode(bytes.NewReader(checkpoint.StateData)))
+	require.Equal(t, uint64(10), state.PullCursor)
+	for _, seq := range []uint64{4, 9} {
+		row, err := store.PeekNextMessage(ctx, lane)
+		require.NoError(t, err)
+		require.NotNil(t, row)
+		require.Equal(t, []byte{byte(seq)}, row.Payload)
+		_, err = store.AckMessageByID(ctx, row.ID)
+		require.NoError(t, err)
+	}
+}
+
+// durableIngressEdge is a programmable network boundary around the real loop.
+type durableIngressEdge struct {
+	mailboxpb.MailboxServiceClient
+	pull func(context.Context, *mailboxpb.PullRequest) (
+		*mailboxpb.PullResponse, error)
+	ack func(context.Context, *mailboxpb.AckUpToRequest) (
+		*mailboxpb.AckUpToResponse, error)
+}
+
+// Pull returns the next scripted batch or blocks as a real long-poll would.
+func (e *durableIngressEdge) Pull(ctx context.Context,
+	req *mailboxpb.PullRequest, _ ...grpc.CallOption) (
+	*mailboxpb.PullResponse, error) {
+
+	return e.pull(ctx, req)
+}
+
+// AckUpTo records the remote deletion watermark chosen by production ingress.
+func (e *durableIngressEdge) AckUpTo(ctx context.Context,
+	req *mailboxpb.AckUpToRequest, _ ...grpc.CallOption) (
+	*mailboxpb.AckUpToResponse, error) {
+
+	return e.ack(ctx, req)
+}
+
+// runDurableIngress waits for an observed boundary before stopping both the
+// ingress loop and heartbeat; test assertions then read quiescent durable
+// state.
+func runDurableIngress(t *testing.T, cfg serverconn.ConnectorConfig,
+	done <-chan struct{}) {
+
+	t.Helper()
+	conn := serverconn.NewServerConnectionActor(cfg)
+	require.NoError(t, conn.StartIngress(context.Background()))
+	defer conn.StopIngress()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ingress did not reach expected boundary")
+	}
+}


### PR DESCRIPTION
## The problem

After receiving mailbox events, the client commits their local delivery and acknowledges a cursor so the server can delete the delivered envelopes. Today it accepts the server's returned cursor without checking that it matches the returned events. A response containing sequences 13 and 18 with `next_cursor=1000` therefore makes the client acknowledge through 999.

## The fix

Validate the entire pull response before dispatching events, waking response waiters, or serving inbound requests. Returned sequences must be nonzero, strictly increasing, and at least the requested cursor. The next cursor must be exactly one past the final returned sequence, without overflow. Invalid responses follow the existing pull retry path and do not advance the checkpoint.

## Safety rule

A successful nonempty pull can advance only to the successor of its final returned sequence. Durable inbox writes and that cursor still commit together; a rollback allows the same events to be delivered after restart.

## Compatibility and limits

Sequences may have gaps. Global allocation across recipients and rolled-back inserts can consume sequence numbers that do not appear in a client's mailbox. A request at cursor 10 may legitimately return 13, 18, and 21 with next cursor 22. This PR accepts that response and does not require a server upgrade or database migration. Empty responses may echo the cursor or use the legacy zero value; neither advances local state.

The existing protocol cannot prove that the server omitted no envelopes or relabeled no sequences. Authenticated completeness needs a separate protocol design. This PR validates response consistency and rejects cursor inflation beyond the returned rows. It does not add semantic replay retention or poison-event recovery.

## Tests

- Legal initial gaps, recipient interleaving, rollback gaps, and inclusive pull starts.
- Regressed, overlapping, duplicate, unordered, zero and overflowing sequences; inflated or regressed next cursors; empty-response compatibility.
- Production ingress loop with real SQLite and PostgreSQL delivery stores: invalid cursor causes no dispatch or ACK; failure after inbox/checkpoint writes rolls back both; reopening the store permits redelivery and commits both inbox rows before ACK.
- `go test ./serverconn -count=1`
- `go test -race ./serverconn ./db/actordelivery -count=1`
- `WAVELENGTH_INGRESS_POSTGRES_DSN=... go test ./serverconn -run TestIngressCursorDurableRestart -count=1` against an isolated PostgreSQL 16 database.

The cursor-contract negative tests fail on the base revision and pass with this change. Formatting, changed-code lint, and Go declaration documentation were also checked.
