### PR TITLE
vtxo: persist and recover asset rounds with spend guards

### DIFF
--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -112,7 +112,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   safety bounds enforced during `DeserializeTree`.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
-- `LatestMigrationVersion = 18` — current schema version.
+- `LatestMigrationVersion = 20` — current schema version.
 - `PendingIntentPersistenceStore` — implements `wallet.PendingIntentStore`,
   the persistence half of the generic restart-safe intent outbox (header
   `pending_intents` + per-kind detail tables + `pending_intent_anchors`).
@@ -167,6 +167,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   interfaces), `waved` (wires DB backends).
 
 ## Invariants
+
+- Asset VTXO rows persist the commitment root, opaque asset reference,
+  uint64 units, and optional sealed leaf package. These fields are one
+  identity: writes and reads reject incomplete state or a composed-script
+  mismatch. Minimal replays preserve the identity; conflicting replays fail.
+  Bitcoin selection omits asset rows. Asset descriptors do not expose a
+  plain standard-policy `TapScript`.
 
 - **Never write raw SQL in Go** — add queries to `db/queries/`,
   regenerate with `make sqlc`.

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -112,7 +112,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   safety bounds enforced during `DeserializeTree`.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
-- `LatestMigrationVersion = 18` — current schema version.
+- `LatestMigrationVersion = 20` — current schema version.
 - `PendingIntentPersistenceStore` — implements `wallet.PendingIntentStore`,
   the persistence half of the generic restart-safe intent outbox (header
   `pending_intents` + per-kind detail tables + `pending_intent_anchors`).
@@ -167,6 +167,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   interfaces), `waved` (wires DB backends).
 
 ## Invariants
+
+- Asset VTXO rows persist the commitment root, opaque asset reference,
+  uint64 units, and optional sealed leaf package. These fields are one
+  identity: writes and reads reject incomplete state or a composed-script
+  mismatch. Minimal replays preserve the identity; conflicting replays fail.
+  Bitcoin selection omits asset rows. Asset descriptors do not expose a
+  plain standard-policy `TapScript`.
 
 - **Never write raw SQL in Go** — add queries to `db/queries/`,
   regenerate with `make sqlc`.

--- a/db/boarding_wallet.go
+++ b/db/boarding_wallet.go
@@ -14,7 +14,6 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
-	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/wavelength/build"
 	"github.com/lightninglabs/wavelength/db/sqlc"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
@@ -755,7 +754,7 @@ func (b *BoardingWalletStore) dbIntentToDomainIntent(ctx context.Context,
 	// This intentionally diverges from db/round_store.go which fails
 	// hard on the same decoder: round-state load has no rebuild
 	// fallback, so the strict policy is appropriate there.
-	txProofOpt := fn.None[proof.TxProof]()
+	txProofOpt := fn.None[types.TxProof]()
 	if len(dbIntent.TxProof) > 0 {
 		decoded, err := types.DeserializeTxProof(dbIntent.TxProof)
 		switch {
@@ -824,7 +823,7 @@ func domainIntentToInsertParams(intent wallet.BoardingIntent,
 		txProofBytes  []byte
 		txProofSerErr error
 	)
-	intent.ChainInfo.TxProof.WhenSome(func(p proof.TxProof) {
+	intent.ChainInfo.TxProof.WhenSome(func(p types.TxProof) {
 		data, err := types.SerializeTxProof(&p)
 		if err != nil {
 			txProofSerErr = err

--- a/db/boarding_wallet_test.go
+++ b/db/boarding_wallet_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
-	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/wavelength/db/sqlc"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/types"
 	"github.com/lightninglabs/wavelength/wallet"
 	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -1320,13 +1320,13 @@ func TestIntentTxProofRoundTrip(t *testing.T) {
 		Value:    100000,
 		PkScript: []byte{0x51, 0x20, 0x03, 0x04},
 	})
-	merkleProof, err := proof.NewTxMerkleProof(
+	merkleProof, err := types.NewTxMerkleProof(
 		[]*wire.MsgTx{confTx}, 0,
 	)
 	require.NoError(t, err)
 
 	outpoint := wire.OutPoint{Hash: confTx.TxHash(), Index: 0}
-	originalProof := proof.TxProof{
+	originalProof := types.TxProof{
 		MsgTx: *confTx,
 		BlockHeader: wire.BlockHeader{
 			Version: 4,
@@ -1482,7 +1482,7 @@ func TestIntentTxProofCorruptDecodesAsNone(t *testing.T) {
 
 	// Inject a malformed TLV blob directly into the tx_proof column.
 	// `0xde 0xad 0xbe 0xef` is not a valid TLV record stream for
-	// proof.TxProof, so DeserializeTxProof must error. Switch
+	// types.TxProof, so DeserializeTxProof must error. Switch
 	// placeholder style on the backend dialect: SQLite uses `?` while
 	// Postgres requires `$N`.
 	garbage := []byte{0xde, 0xad, 0xbe, 0xef}

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 19
+	LatestMigrationVersion uint = 20
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/round_asset_state_test.go
+++ b/db/round_asset_state_test.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/wavelength/round"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRoundAssetVTXOState persists the asset marker in the round transaction,
+// before any manager notification, and preserves it through both read APIs.
+func TestRoundAssetVTXOState(t *testing.T) {
+	t.Parallel()
+	vtxoStore, roundStore, _ := newVTXOStoreForTest(t)
+	ctx := t.Context()
+	roundID := round.RoundID{1}
+	require.NoError(
+		t,
+		roundStore.CommitState(
+			ctx, createTestRound(t, roundID),
+			&round.InputSigSentState{
+				RoundID: roundID,
+			},
+		),
+	)
+	desc := testAssetDescriptor(t, 1)
+	cv := &round.ClientVTXO{
+		Outpoint:                  desc.Outpoint,
+		Amount:                    desc.Amount,
+		PolicyTemplate:            desc.PolicyTemplate,
+		PkScript:                  desc.PkScript,
+		OwnerKey:                  desc.ClientKey,
+		OperatorKey:               desc.OperatorKey,
+		Expiry:                    desc.RelativeExpiry,
+		RoundID:                   fn.Some(roundID),
+		TaprootAssetRoot:          desc.TaprootAssetRoot,
+		TaprootAssetRef:           desc.TaprootAssetRef,
+		TaprootAssetAmount:        desc.TaprootAssetAmount,
+		TaprootAssetSealedPackage: desc.TaprootAssetSealedPackage,
+	}
+	require.NoError(t, roundStore.SaveVTXOs(ctx, []*round.ClientVTXO{cv}))
+	got, err := vtxoStore.GetVTXO(ctx, desc.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, desc.TaprootAssetAmount, got.TaprootAssetAmount)
+	require.Equal(
+		t, desc.TaprootAssetSealedPackage,
+		got.TaprootAssetSealedPackage,
+	)
+	require.Nil(t, got.TapScript)
+	fromRound, err := roundStore.GetVTXO(ctx, desc.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, cv.TaprootAssetRoot, fromRound.TaprootAssetRoot)
+	require.Equal(t, cv.TaprootAssetRef, fromRound.TaprootAssetRef)
+	require.Equal(t, cv.TaprootAssetAmount, fromRound.TaprootAssetAmount)
+	require.Equal(
+		t, cv.TaprootAssetSealedPackage,
+		fromRound.TaprootAssetSealedPackage,
+	)
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, desc))
+	cv.TaprootAssetAmount--
+	require.Error(t, roundStore.SaveVTXOs(ctx, []*round.ClientVTXO{cv}))
+}

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -14,7 +14,6 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/wire/v2"
-	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/db/sqlc"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
@@ -1264,7 +1263,7 @@ func (s *RoundPersistenceStore) dbRoundIntentToDomainIntent(ctx context.Context,
 	}
 
 	// Deserialize TxProof if present.
-	var txProofOpt fn.Option[proof.TxProof]
+	var txProofOpt fn.Option[types.TxProof]
 	if len(dbRoundIntent.TxProof) > 0 {
 		txProof, err := types.DeserializeTxProof(dbRoundIntent.TxProof)
 		if err != nil {

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lightninglabs/wavelength/lib/types"
 	"github.com/lightninglabs/wavelength/round"
 	"github.com/lightninglabs/wavelength/rpc/roundpb"
+	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -1719,16 +1720,16 @@ func dbVtxoRequestRowToVTXORequest(ctx context.Context, q RoundStore,
 // upsertRoundClientVTXOAncestry alongside InsertVTXO inside the same
 // transaction.
 func (s *RoundPersistenceStore) domainVTXOToInsertParams(ctx context.Context,
-	q RoundStore, vtxo *round.ClientVTXO) (InsertVTXOParams, error) {
+	q RoundStore, cv *round.ClientVTXO) (InsertVTXOParams, error) {
 
 	roundIDStr := ""
-	vtxo.RoundID.WhenSome(func(rid round.RoundID) {
+	cv.RoundID.WhenSome(func(rid round.RoundID) {
 		roundIDStr = rid.String()
 	})
 
 	var operatorPubkey []byte
-	if vtxo.OperatorKey != nil {
-		operatorPubkey = vtxo.OperatorKey.SerializeCompressed()
+	if cv.OperatorKey != nil {
+		operatorPubkey = cv.OperatorKey.SerializeCompressed()
 	}
 
 	nowUnix := s.clock.Now().Unix()
@@ -1738,8 +1739,8 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(ctx context.Context,
 	// owner pubkey yet; in that case the FK stays NULL until the VTXO
 	// manager heals the row with the full descriptor.
 	var clientKeyID sql.NullInt64
-	if vtxo.OwnerKey.PubKey != nil {
-		id, err := RegisterInternalKeyTx(ctx, q, nowUnix, vtxo.OwnerKey)
+	if cv.OwnerKey.PubKey != nil {
+		id, err := RegisterInternalKeyTx(ctx, q, nowUnix, cv.OwnerKey)
 		if err != nil {
 			return InsertVTXOParams{}, fmt.Errorf("register "+
 				"owner key: %w", err)
@@ -1748,12 +1749,12 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(ctx context.Context,
 		clientKeyID = sql.NullInt64{Int64: id, Valid: true}
 	}
 
-	policyTemplate := bytes.Clone(vtxo.PolicyTemplate)
-	if len(policyTemplate) == 0 && vtxo.OwnerKey.PubKey != nil &&
-		vtxo.OperatorKey != nil && vtxo.Expiry != 0 {
+	policyTemplate := bytes.Clone(cv.PolicyTemplate)
+	if len(policyTemplate) == 0 && cv.OwnerKey.PubKey != nil &&
+		cv.OperatorKey != nil && cv.Expiry != 0 {
 
 		encodedPolicy, err := arkscript.EncodeStandardVTXOTemplate(
-			vtxo.OwnerKey.PubKey, vtxo.OperatorKey, vtxo.Expiry,
+			cv.OwnerKey.PubKey, cv.OperatorKey, cv.Expiry,
 		)
 		if err != nil {
 			return InsertVTXOParams{}, fmt.Errorf("encode client "+
@@ -1763,20 +1764,41 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(ctx context.Context,
 		policyTemplate = encodedPolicy
 	}
 
+	assetDesc := &vtxo.Descriptor{
+		Outpoint:                  cv.Outpoint,
+		PolicyTemplate:            policyTemplate,
+		PkScript:                  cv.PkScript,
+		TaprootAssetRoot:          cv.TaprootAssetRoot,
+		TaprootAssetRef:           cv.TaprootAssetRef,
+		TaprootAssetAmount:        cv.TaprootAssetAmount,
+		TaprootAssetSealedPackage: cv.TaprootAssetSealedPackage,
+	}
+	assetRef, assetAmount, err := encodeTaprootAssetMetadata(assetDesc)
+	if err != nil {
+		return InsertVTXOParams{}, err
+	}
+	if err := validateAssetVTXOReplay(ctx, q, assetDesc); err != nil {
+		return InsertVTXOParams{}, err
+	}
+	var assetRoot []byte
+	if cv.TaprootAssetRoot != nil {
+		assetRoot = cv.TaprootAssetRoot.CloneBytes()
+	}
+
 	return InsertVTXOParams{
-		OutpointHash:   vtxo.Outpoint.Hash[:],
-		OutpointIndex:  int32(vtxo.Outpoint.Index),
+		OutpointHash:   cv.Outpoint.Hash[:],
+		OutpointIndex:  int32(cv.Outpoint.Index),
 		RoundID:        roundIDStr,
-		Amount:         int64(vtxo.Amount),
-		PkScript:       vtxo.PkScript,
-		Expiry:         int32(vtxo.Expiry),
+		Amount:         int64(cv.Amount),
+		PkScript:       cv.PkScript,
+		Expiry:         int32(cv.Expiry),
 		PolicyTemplate: policyTemplate,
 		ClientKeyID:    clientKeyID,
 		OperatorPubkey: operatorPubkey,
-		BatchExpiry:    vtxo.BatchExpiry,
+		BatchExpiry:    cv.BatchExpiry,
 		ChainDepth:     0,
-		CreatedHeight:  vtxo.CreatedHeight,
-		CommitmentTxid: vtxo.CommitmentTxID[:],
+		CreatedHeight:  cv.CreatedHeight,
+		CommitmentTxid: cv.CommitmentTxID[:],
 		Spent:          false,
 		CreationTime:   nowUnix,
 		LastUpdateTime: nowUnix,
@@ -1787,6 +1809,12 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(ctx context.Context,
 		// descriptor-heal path so the write-once construction_version
 		// is set deliberately at creation rather than defaulted.
 		ConstructionVersion: int32(arkrpc.ConstructionVersionV1),
+		TaprootAssetRoot:    assetRoot,
+		TaprootAssetRef:     assetRef,
+		TaprootAssetAmount:  assetAmount,
+		TaprootAssetSealedPackage: bytes.Clone(
+			cv.TaprootAssetSealedPackage,
+		),
 	}, nil
 }
 
@@ -1931,19 +1959,28 @@ func (s *RoundPersistenceStore) dbVTXOToDomainVTXO(ctx context.Context,
 		copy(commitmentTxID[:], dbVTXO.CommitmentTxid)
 	}
 
+	assetDesc, assetErr := decodeAssetVTXOState(dbVTXO)
+	if assetErr != nil {
+		return nil, assetErr
+	}
+
 	return &round.ClientVTXO{
-		Outpoint:       outpoint,
-		Amount:         btcutil.Amount(dbVTXO.Amount),
-		PolicyTemplate: policyTemplate,
-		PkScript:       dbVTXO.PkScript,
-		Expiry:         expiry,
-		OwnerKey:       ownerKey,
-		OperatorKey:    operatorPubkey,
-		Ancestry:       ancestry,
-		RoundID:        roundIDOpt,
-		CommitmentTxID: commitmentTxID,
-		BatchExpiry:    dbVTXO.BatchExpiry,
-		CreatedHeight:  dbVTXO.CreatedHeight,
+		Outpoint:                  outpoint,
+		Amount:                    btcutil.Amount(dbVTXO.Amount),
+		PolicyTemplate:            policyTemplate,
+		PkScript:                  dbVTXO.PkScript,
+		TaprootAssetRoot:          assetDesc.TaprootAssetRoot,
+		TaprootAssetRef:           assetDesc.TaprootAssetRef,
+		TaprootAssetAmount:        assetDesc.TaprootAssetAmount,
+		TaprootAssetSealedPackage: assetDesc.TaprootAssetSealedPackage,
+		Expiry:                    expiry,
+		OwnerKey:                  ownerKey,
+		OperatorKey:               operatorPubkey,
+		Ancestry:                  ancestry,
+		RoundID:                   roundIDOpt,
+		CommitmentTxID:            commitmentTxID,
+		BatchExpiry:               dbVTXO.BatchExpiry,
+		CreatedHeight:             dbVTXO.CreatedHeight,
 	}, nil
 }
 

--- a/db/sqlc/migrations/000020_taproot_asset_vtxo_state.down.sql
+++ b/db/sqlc/migrations/000020_taproot_asset_vtxo_state.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE vtxos DROP COLUMN taproot_asset_sealed_package;
+ALTER TABLE vtxos DROP COLUMN taproot_asset_amount;
+ALTER TABLE vtxos DROP COLUMN taproot_asset_ref;
+ALTER TABLE vtxos DROP COLUMN taproot_asset_root;

--- a/db/sqlc/migrations/000020_taproot_asset_vtxo_state.up.sql
+++ b/db/sqlc/migrations/000020_taproot_asset_vtxo_state.up.sql
@@ -1,0 +1,17 @@
+-- Keep asset units separate from the Bitcoin carrier. An eight-byte BLOB
+-- preserves the complete uint64 amount range on SQLite and PostgreSQL.
+ALTER TABLE vtxos ADD COLUMN taproot_asset_root BLOB
+    CHECK (taproot_asset_root IS NULL OR length(taproot_asset_root) = 32);
+ALTER TABLE vtxos ADD COLUMN taproot_asset_ref TEXT
+    CHECK (taproot_asset_ref IS NULL OR length(taproot_asset_ref) BETWEEN 1 AND 512);
+ALTER TABLE vtxos ADD COLUMN taproot_asset_amount BLOB
+    CHECK (taproot_asset_amount IS NULL OR length(taproot_asset_amount) = 8);
+ALTER TABLE vtxos ADD COLUMN taproot_asset_sealed_package BLOB
+    CHECK (
+        (taproot_asset_root IS NULL AND taproot_asset_ref IS NULL
+         AND taproot_asset_amount IS NULL
+         AND taproot_asset_sealed_package IS NULL)
+        OR
+        (taproot_asset_root IS NOT NULL AND taproot_asset_ref IS NOT NULL
+         AND taproot_asset_amount IS NOT NULL)
+    );

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -437,29 +437,33 @@ type VhtlcRecoveryJob struct {
 }
 
 type Vtxo struct {
-	OutpointHash        []byte
-	OutpointIndex       int32
-	RoundID             string
-	Amount              int64
-	PkScript            []byte
-	Expiry              int32
-	PolicyTemplate      []byte
-	ClientKeyID         sql.NullInt64
-	OperatorPubkey      []byte
-	BatchExpiry         int32
-	CreatedHeight       int32
-	CommitmentTxid      []byte
-	Spent               bool
-	Status              int32
-	ForfeitRoundID      sql.NullString
-	ForfeitTx           []byte
-	ForfeitTxid         []byte
-	ReplacedByHash      []byte
-	ReplacedByIndex     sql.NullInt32
-	CreationTime        int64
-	LastUpdateTime      int64
-	ChainDepth          int32
-	ConstructionVersion int32
+	OutpointHash              []byte
+	OutpointIndex             int32
+	RoundID                   string
+	Amount                    int64
+	PkScript                  []byte
+	Expiry                    int32
+	PolicyTemplate            []byte
+	ClientKeyID               sql.NullInt64
+	OperatorPubkey            []byte
+	BatchExpiry               int32
+	CreatedHeight             int32
+	CommitmentTxid            []byte
+	Spent                     bool
+	Status                    int32
+	ForfeitRoundID            sql.NullString
+	ForfeitTx                 []byte
+	ForfeitTxid               []byte
+	ReplacedByHash            []byte
+	ReplacedByIndex           sql.NullInt32
+	CreationTime              int64
+	LastUpdateTime            int64
+	ChainDepth                int32
+	ConstructionVersion       int32
+	TaprootAssetRoot          []byte
+	TaprootAssetRef           sql.NullString
+	TaprootAssetAmount        []byte
+	TaprootAssetSealedPackage []byte
 }
 
 type VtxoAncestryPath struct {

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -333,6 +333,7 @@ type Querier interface {
 	// every payment and only needs these three fields, so this avoids decoding
 	// full descriptors (pubkey parsing, taproot script reconstruction, policy
 	// template decode) and the batched ancestry-path query on the hot path.
+	// Asset carriers cannot fund Bitcoin payments and are excluded here.
 	ListVTXOSelectionCandidatesByStatus(ctx context.Context, status int32) ([]ListVTXOSelectionCandidatesByStatusRow, error)
 	ListVTXOsByRound(ctx context.Context, roundID string) ([]Vtxo, error)
 	// VTXO status and lifecycle queries.

--- a/db/sqlc/queries/round.sql
+++ b/db/sqlc/queries/round.sql
@@ -176,10 +176,11 @@ INSERT INTO vtxos (
     policy_template, client_key_id,
     operator_pubkey, batch_expiry, chain_depth,
     created_height, commitment_txid, spent, creation_time, last_update_time,
-    construction_version
+    construction_version, taproot_asset_root, taproot_asset_ref,
+    taproot_asset_amount, taproot_asset_sealed_package
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-    $17
+    $17, $18, $19, $20, $21
 )
 ON CONFLICT (outpoint_hash, outpoint_index) DO UPDATE SET
     pk_script = CASE WHEN excluded.pk_script IS NOT NULL AND length(excluded.pk_script) > 0 THEN excluded.pk_script ELSE vtxos.pk_script END,
@@ -191,6 +192,10 @@ ON CONFLICT (outpoint_hash, outpoint_index) DO UPDATE SET
     chain_depth = CASE WHEN excluded.chain_depth != 0 THEN excluded.chain_depth ELSE vtxos.chain_depth END,
     created_height = CASE WHEN excluded.created_height != 0 THEN excluded.created_height ELSE vtxos.created_height END,
     commitment_txid = CASE WHEN excluded.commitment_txid IS NOT NULL AND length(excluded.commitment_txid) > 0 THEN excluded.commitment_txid ELSE vtxos.commitment_txid END,
+    taproot_asset_root = COALESCE(vtxos.taproot_asset_root, excluded.taproot_asset_root),
+    taproot_asset_ref = COALESCE(vtxos.taproot_asset_ref, excluded.taproot_asset_ref),
+    taproot_asset_amount = COALESCE(vtxos.taproot_asset_amount, excluded.taproot_asset_amount),
+    taproot_asset_sealed_package = COALESCE(vtxos.taproot_asset_sealed_package, excluded.taproot_asset_sealed_package),
     last_update_time = excluded.last_update_time;
 
 -- name: InsertVTXOAncestryPath :exec

--- a/db/sqlc/queries/vtxo.sql
+++ b/db/sqlc/queries/vtxo.sql
@@ -43,9 +43,10 @@ ORDER BY vtxos.creation_time DESC;
 -- every payment and only needs these three fields, so this avoids decoding
 -- full descriptors (pubkey parsing, taproot script reconstruction, policy
 -- template decode) and the batched ancestry-path query on the hot path.
+-- Asset carriers cannot fund Bitcoin payments and are excluded here.
 SELECT outpoint_hash, outpoint_index, amount, pk_script
 FROM vtxos
-WHERE status = $1
+WHERE status = $1 AND taproot_asset_root IS NULL
 ORDER BY creation_time DESC;
 
 -- name: ListLiveVTXOs :many

--- a/db/sqlc/round.sql.go
+++ b/db/sqlc/round.sql.go
@@ -354,7 +354,7 @@ func (q *Queries) GetRoundVtxoRequests(ctx context.Context, roundID string) ([]R
 }
 
 const GetVTXO = `-- name: GetVTXO :one
-SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version FROM vtxos
+SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version, taproot_asset_root, taproot_asset_ref, taproot_asset_amount, taproot_asset_sealed_package FROM vtxos
 WHERE outpoint_hash = $1 AND outpoint_index = $2
 `
 
@@ -390,6 +390,10 @@ func (q *Queries) GetVTXO(ctx context.Context, arg GetVTXOParams) (Vtxo, error) 
 		&i.LastUpdateTime,
 		&i.ChainDepth,
 		&i.ConstructionVersion,
+		&i.TaprootAssetRoot,
+		&i.TaprootAssetRef,
+		&i.TaprootAssetAmount,
+		&i.TaprootAssetSealedPackage,
 	)
 	return i, err
 }
@@ -586,10 +590,11 @@ INSERT INTO vtxos (
     policy_template, client_key_id,
     operator_pubkey, batch_expiry, chain_depth,
     created_height, commitment_txid, spent, creation_time, last_update_time,
-    construction_version
+    construction_version, taproot_asset_root, taproot_asset_ref,
+    taproot_asset_amount, taproot_asset_sealed_package
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-    $17
+    $17, $18, $19, $20, $21
 )
 ON CONFLICT (outpoint_hash, outpoint_index) DO UPDATE SET
     pk_script = CASE WHEN excluded.pk_script IS NOT NULL AND length(excluded.pk_script) > 0 THEN excluded.pk_script ELSE vtxos.pk_script END,
@@ -601,27 +606,35 @@ ON CONFLICT (outpoint_hash, outpoint_index) DO UPDATE SET
     chain_depth = CASE WHEN excluded.chain_depth != 0 THEN excluded.chain_depth ELSE vtxos.chain_depth END,
     created_height = CASE WHEN excluded.created_height != 0 THEN excluded.created_height ELSE vtxos.created_height END,
     commitment_txid = CASE WHEN excluded.commitment_txid IS NOT NULL AND length(excluded.commitment_txid) > 0 THEN excluded.commitment_txid ELSE vtxos.commitment_txid END,
+    taproot_asset_root = COALESCE(vtxos.taproot_asset_root, excluded.taproot_asset_root),
+    taproot_asset_ref = COALESCE(vtxos.taproot_asset_ref, excluded.taproot_asset_ref),
+    taproot_asset_amount = COALESCE(vtxos.taproot_asset_amount, excluded.taproot_asset_amount),
+    taproot_asset_sealed_package = COALESCE(vtxos.taproot_asset_sealed_package, excluded.taproot_asset_sealed_package),
     last_update_time = excluded.last_update_time
 `
 
 type InsertVTXOParams struct {
-	OutpointHash        []byte
-	OutpointIndex       int32
-	RoundID             string
-	Amount              int64
-	PkScript            []byte
-	Expiry              int32
-	PolicyTemplate      []byte
-	ClientKeyID         sql.NullInt64
-	OperatorPubkey      []byte
-	BatchExpiry         int32
-	ChainDepth          int32
-	CreatedHeight       int32
-	CommitmentTxid      []byte
-	Spent               bool
-	CreationTime        int64
-	LastUpdateTime      int64
-	ConstructionVersion int32
+	OutpointHash              []byte
+	OutpointIndex             int32
+	RoundID                   string
+	Amount                    int64
+	PkScript                  []byte
+	Expiry                    int32
+	PolicyTemplate            []byte
+	ClientKeyID               sql.NullInt64
+	OperatorPubkey            []byte
+	BatchExpiry               int32
+	ChainDepth                int32
+	CreatedHeight             int32
+	CommitmentTxid            []byte
+	Spent                     bool
+	CreationTime              int64
+	LastUpdateTime            int64
+	ConstructionVersion       int32
+	TaprootAssetRoot          []byte
+	TaprootAssetRef           sql.NullString
+	TaprootAssetAmount        []byte
+	TaprootAssetSealedPackage []byte
 }
 
 // VTXO queries.
@@ -648,6 +661,10 @@ func (q *Queries) InsertVTXO(ctx context.Context, arg InsertVTXOParams) error {
 		arg.CreationTime,
 		arg.LastUpdateTime,
 		arg.ConstructionVersion,
+		arg.TaprootAssetRoot,
+		arg.TaprootAssetRef,
+		arg.TaprootAssetAmount,
+		arg.TaprootAssetSealedPackage,
 	)
 	return err
 }
@@ -731,7 +748,7 @@ func (q *Queries) ListActiveRounds(ctx context.Context) ([]Round, error) {
 }
 
 const ListAllVTXOs = `-- name: ListAllVTXOs :many
-SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version FROM vtxos ORDER BY creation_time DESC
+SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version, taproot_asset_root, taproot_asset_ref, taproot_asset_amount, taproot_asset_sealed_package FROM vtxos ORDER BY creation_time DESC
 `
 
 func (q *Queries) ListAllVTXOs(ctx context.Context) ([]Vtxo, error) {
@@ -767,6 +784,10 @@ func (q *Queries) ListAllVTXOs(ctx context.Context) ([]Vtxo, error) {
 			&i.LastUpdateTime,
 			&i.ChainDepth,
 			&i.ConstructionVersion,
+			&i.TaprootAssetRoot,
+			&i.TaprootAssetRef,
+			&i.TaprootAssetAmount,
+			&i.TaprootAssetSealedPackage,
 		); err != nil {
 			return nil, err
 		}
@@ -977,7 +998,7 @@ func (q *Queries) ListUnspentVTXOAncestryPaths(ctx context.Context) ([]VtxoAnces
 }
 
 const ListUnspentVTXOs = `-- name: ListUnspentVTXOs :many
-SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version FROM vtxos
+SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version, taproot_asset_root, taproot_asset_ref, taproot_asset_amount, taproot_asset_sealed_package FROM vtxos
 WHERE spent = FALSE
     AND status != 4
 ORDER BY creation_time DESC
@@ -1017,6 +1038,10 @@ func (q *Queries) ListUnspentVTXOs(ctx context.Context) ([]Vtxo, error) {
 			&i.LastUpdateTime,
 			&i.ChainDepth,
 			&i.ConstructionVersion,
+			&i.TaprootAssetRoot,
+			&i.TaprootAssetRef,
+			&i.TaprootAssetAmount,
+			&i.TaprootAssetSealedPackage,
 		); err != nil {
 			return nil, err
 		}
@@ -1123,7 +1148,7 @@ func (q *Queries) ListVTXOAncestryPathsByStatus(ctx context.Context, status int3
 }
 
 const ListVTXOsByRound = `-- name: ListVTXOsByRound :many
-SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version FROM vtxos WHERE round_id = $1 ORDER BY creation_time DESC
+SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version, taproot_asset_root, taproot_asset_ref, taproot_asset_amount, taproot_asset_sealed_package FROM vtxos WHERE round_id = $1 ORDER BY creation_time DESC
 `
 
 func (q *Queries) ListVTXOsByRound(ctx context.Context, roundID string) ([]Vtxo, error) {
@@ -1159,6 +1184,10 @@ func (q *Queries) ListVTXOsByRound(ctx context.Context, roundID string) ([]Vtxo,
 			&i.LastUpdateTime,
 			&i.ChainDepth,
 			&i.ConstructionVersion,
+			&i.TaprootAssetRoot,
+			&i.TaprootAssetRef,
+			&i.TaprootAssetAmount,
+			&i.TaprootAssetSealedPackage,
 		); err != nil {
 			return nil, err
 		}

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -1733,7 +1733,18 @@ CREATE TABLE vtxos (
     -- zero-indexed, so the only understood value today is 0 (V1); a future,
     -- genuinely different construction is added additively (V2 == 1, and so
     -- on). NOT NULL DEFAULT 0 keeps every row a valid V1 object.
-    construction_version INTEGER NOT NULL DEFAULT 0,
+    construction_version INTEGER NOT NULL DEFAULT 0, taproot_asset_root BLOB
+    CHECK (taproot_asset_root IS NULL OR length(taproot_asset_root) = 32), taproot_asset_ref TEXT
+    CHECK (taproot_asset_ref IS NULL OR length(taproot_asset_ref) BETWEEN 1 AND 512), taproot_asset_amount BLOB
+    CHECK (taproot_asset_amount IS NULL OR length(taproot_asset_amount) = 8), taproot_asset_sealed_package BLOB
+    CHECK (
+        (taproot_asset_root IS NULL AND taproot_asset_ref IS NULL
+         AND taproot_asset_amount IS NULL
+         AND taproot_asset_sealed_package IS NULL)
+        OR
+        (taproot_asset_root IS NOT NULL AND taproot_asset_ref IS NOT NULL
+         AND taproot_asset_amount IS NOT NULL)
+    ),
 
     PRIMARY KEY (outpoint_hash, outpoint_index),
     FOREIGN KEY (round_id) REFERENCES rounds(round_id)

--- a/db/sqlc/vtxo.sql.go
+++ b/db/sqlc/vtxo.sql.go
@@ -129,7 +129,7 @@ func (q *Queries) ListForfeitingVTXOsByRound(ctx context.Context, forfeitRoundID
 }
 
 const ListLiveVTXOs = `-- name: ListLiveVTXOs :many
-SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version FROM vtxos
+SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version, taproot_asset_root, taproot_asset_ref, taproot_asset_amount, taproot_asset_sealed_package FROM vtxos
 WHERE (status < 3 OR status = 7) AND spent = FALSE
 ORDER BY creation_time DESC
 `
@@ -175,6 +175,10 @@ func (q *Queries) ListLiveVTXOs(ctx context.Context) ([]Vtxo, error) {
 			&i.LastUpdateTime,
 			&i.ChainDepth,
 			&i.ConstructionVersion,
+			&i.TaprootAssetRoot,
+			&i.TaprootAssetRef,
+			&i.TaprootAssetAmount,
+			&i.TaprootAssetSealedPackage,
 		); err != nil {
 			return nil, err
 		}
@@ -190,7 +194,7 @@ func (q *Queries) ListLiveVTXOs(ctx context.Context) ([]Vtxo, error) {
 }
 
 const ListRecoverableVTXOs = `-- name: ListRecoverableVTXOs :many
-SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version FROM vtxos
+SELECT outpoint_hash, outpoint_index, round_id, amount, pk_script, expiry, policy_template, client_key_id, operator_pubkey, batch_expiry, created_height, commitment_txid, spent, status, forfeit_round_id, forfeit_tx, forfeit_txid, replaced_by_hash, replaced_by_index, creation_time, last_update_time, chain_depth, construction_version, taproot_asset_root, taproot_asset_ref, taproot_asset_amount, taproot_asset_sealed_package FROM vtxos
 WHERE (status < 3 OR status = 7 OR status = 8) AND spent = FALSE
 ORDER BY creation_time DESC
 `
@@ -236,6 +240,10 @@ func (q *Queries) ListRecoverableVTXOs(ctx context.Context) ([]Vtxo, error) {
 			&i.LastUpdateTime,
 			&i.ChainDepth,
 			&i.ConstructionVersion,
+			&i.TaprootAssetRoot,
+			&i.TaprootAssetRef,
+			&i.TaprootAssetAmount,
+			&i.TaprootAssetSealedPackage,
 		); err != nil {
 			return nil, err
 		}
@@ -253,7 +261,7 @@ func (q *Queries) ListRecoverableVTXOs(ctx context.Context) ([]Vtxo, error) {
 const ListVTXOSelectionCandidatesByStatus = `-- name: ListVTXOSelectionCandidatesByStatus :many
 SELECT outpoint_hash, outpoint_index, amount, pk_script
 FROM vtxos
-WHERE status = $1
+WHERE status = $1 AND taproot_asset_root IS NULL
 ORDER BY creation_time DESC
 `
 
@@ -269,6 +277,7 @@ type ListVTXOSelectionCandidatesByStatusRow struct {
 // every payment and only needs these three fields, so this avoids decoding
 // full descriptors (pubkey parsing, taproot script reconstruction, policy
 // template decode) and the batched ancestry-path query on the hot path.
+// Asset carriers cannot fund Bitcoin payments and are excluded here.
 func (q *Queries) ListVTXOSelectionCandidatesByStatus(ctx context.Context, status int32) ([]ListVTXOSelectionCandidatesByStatusRow, error) {
 	rows, err := q.db.QueryContext(ctx, ListVTXOSelectionCandidatesByStatus, status)
 	if err != nil {
@@ -299,7 +308,7 @@ func (q *Queries) ListVTXOSelectionCandidatesByStatus(ctx context.Context, statu
 
 const ListVTXOsByStatus = `-- name: ListVTXOsByStatus :many
 
-SELECT vtxos.outpoint_hash, vtxos.outpoint_index, vtxos.round_id, vtxos.amount, vtxos.pk_script, vtxos.expiry, vtxos.policy_template, vtxos.client_key_id, vtxos.operator_pubkey, vtxos.batch_expiry, vtxos.created_height, vtxos.commitment_txid, vtxos.spent, vtxos.status, vtxos.forfeit_round_id, vtxos.forfeit_tx, vtxos.forfeit_txid, vtxos.replaced_by_hash, vtxos.replaced_by_index, vtxos.creation_time, vtxos.last_update_time, vtxos.chain_depth, vtxos.construction_version,
+SELECT vtxos.outpoint_hash, vtxos.outpoint_index, vtxos.round_id, vtxos.amount, vtxos.pk_script, vtxos.expiry, vtxos.policy_template, vtxos.client_key_id, vtxos.operator_pubkey, vtxos.batch_expiry, vtxos.created_height, vtxos.commitment_txid, vtxos.spent, vtxos.status, vtxos.forfeit_round_id, vtxos.forfeit_tx, vtxos.forfeit_txid, vtxos.replaced_by_hash, vtxos.replaced_by_index, vtxos.creation_time, vtxos.last_update_time, vtxos.chain_depth, vtxos.construction_version, vtxos.taproot_asset_root, vtxos.taproot_asset_ref, vtxos.taproot_asset_amount, vtxos.taproot_asset_sealed_package,
     rounds.commitment_txid AS settlement_txid,
     rounds.confirmation_height AS settlement_height,
     CAST(COALESCE((
@@ -377,6 +386,10 @@ func (q *Queries) ListVTXOsByStatus(ctx context.Context, status int32) ([]ListVT
 			&i.Vtxo.LastUpdateTime,
 			&i.Vtxo.ChainDepth,
 			&i.Vtxo.ConstructionVersion,
+			&i.Vtxo.TaprootAssetRoot,
+			&i.Vtxo.TaprootAssetRef,
+			&i.Vtxo.TaprootAssetAmount,
+			&i.Vtxo.TaprootAssetSealedPackage,
 			&i.SettlementTxid,
 			&i.SettlementHeight,
 			&i.SettlementFeeSat,

--- a/db/vtxo_asset_state.go
+++ b/db/vtxo_asset_state.go
@@ -1,0 +1,148 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/db/sqlc"
+	"github.com/lightninglabs/wavelength/vtxo"
+)
+
+// encodeTaprootAssetMetadata rejects partial identities and binds asset state
+// to the composed output before it enters the durable wallet inventory.
+func encodeTaprootAssetMetadata(desc *vtxo.Descriptor) (sql.NullString, []byte,
+	error) {
+
+	if desc == nil {
+		return sql.NullString{}, nil, fmt.Errorf("descriptor must be " +
+			"provided")
+	}
+	if desc.TaprootAssetRoot == nil {
+		if desc.TaprootAssetRef != "" || desc.TaprootAssetAmount != 0 ||
+			len(desc.TaprootAssetSealedPackage) != 0 {
+			return sql.NullString{}, nil, fmt.Errorf("Taproot " +
+				"Asset metadata requires a commitment root")
+		}
+
+		return sql.NullString{}, nil, nil
+	}
+	if desc.TaprootAssetRef == "" || desc.TaprootAssetAmount == 0 {
+		return sql.NullString{}, nil, fmt.Errorf("Taproot Asset ref " +
+			"and positive amount must both be provided")
+	}
+	if len(desc.TaprootAssetRef) > vtxo.MaxTaprootAssetRefBytes {
+		return sql.NullString{}, nil, fmt.Errorf("Taproot Asset ref "+
+			"exceeds %d bytes", vtxo.MaxTaprootAssetRefBytes)
+	}
+	script, err := desc.EffectivePkScript()
+	if err != nil {
+		return sql.NullString{}, nil, err
+	}
+	if !bytes.Equal(script, desc.PkScript) {
+		return sql.NullString{}, nil, fmt.Errorf("Taproot Asset " +
+			"composed output script mismatch")
+	}
+	amount := make([]byte, 8)
+	binary.BigEndian.PutUint64(amount, desc.TaprootAssetAmount)
+
+	return sql.NullString{
+		String: desc.TaprootAssetRef,
+		Valid:  true,
+	}, amount, nil
+}
+
+// decodeAssetVTXOState validates persisted asset state on every load, including
+// cache hits, so malformed state can never become an ordinary Bitcoin VTXO.
+func decodeAssetVTXOState(row VTXORow) (*vtxo.Descriptor, error) {
+	desc := &vtxo.Descriptor{
+		PolicyTemplate:  row.PolicyTemplate,
+		PkScript:        row.PkScript,
+		TaprootAssetRef: row.TaprootAssetRef.String,
+		TaprootAssetSealedPackage: bytes.Clone(
+			row.TaprootAssetSealedPackage,
+		),
+	}
+	if row.TaprootAssetRoot != nil {
+		if len(row.TaprootAssetRoot) != chainhash.HashSize {
+			return nil, fmt.Errorf("invalid Taproot Asset root "+
+				"length: %d", len(row.TaprootAssetRoot))
+		}
+		root := chainhash.Hash{}
+		copy(root[:], row.TaprootAssetRoot)
+		desc.TaprootAssetRoot = &root
+	}
+	if row.TaprootAssetAmount != nil {
+		if len(row.TaprootAssetAmount) != 8 {
+			return nil, fmt.Errorf("invalid Taproot Asset amount "+
+				"length: %d", len(row.TaprootAssetAmount))
+		}
+		desc.TaprootAssetAmount = binary.BigEndian.Uint64(
+			row.TaprootAssetAmount,
+		)
+	}
+	hasAsset := desc.TaprootAssetRoot != nil
+	if row.TaprootAssetRef.Valid != hasAsset ||
+		(row.TaprootAssetAmount != nil) != hasAsset {
+		return nil, fmt.Errorf("incomplete Taproot Asset metadata")
+	}
+	if _, _, err := encodeTaprootAssetMetadata(desc); err != nil {
+		return nil, err
+	}
+
+	return desc, nil
+}
+
+// validateAssetVTXOReplay keeps an outpoint's asset identity immutable while
+// allowing a minimal round row to be enriched with its verified leaf state.
+func validateAssetVTXOReplay(ctx context.Context, q RoundStore,
+	desc *vtxo.Descriptor) error {
+
+	row, err := q.GetVTXO(ctx, sqlc.GetVTXOParams{
+		OutpointHash:  desc.Outpoint.Hash[:],
+		OutpointIndex: int32(desc.Outpoint.Index),
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if row.TaprootAssetRoot == nil && desc.TaprootAssetRoot == nil {
+		return nil
+	}
+	old, err := decodeAssetVTXOState(row)
+	if err != nil {
+		return err
+	}
+	if len(desc.PkScript) != 0 &&
+		!bytes.Equal(desc.PkScript, row.PkScript) {
+		return fmt.Errorf("asset VTXO replay changes output script")
+	}
+	if len(desc.PolicyTemplate) != 0 &&
+		!bytes.Equal(desc.PolicyTemplate, row.PolicyTemplate) {
+		return fmt.Errorf("asset VTXO replay changes policy template")
+	}
+	if old.TaprootAssetRoot == nil || desc.TaprootAssetRoot == nil {
+		return nil
+	}
+	if *old.TaprootAssetRoot != *desc.TaprootAssetRoot ||
+		old.TaprootAssetRef != desc.TaprootAssetRef ||
+		old.TaprootAssetAmount != desc.TaprootAssetAmount {
+		return fmt.Errorf("asset VTXO replay changes asset identity")
+	}
+	if len(old.TaprootAssetSealedPackage) != 0 &&
+		len(desc.TaprootAssetSealedPackage) != 0 &&
+		!bytes.Equal(
+			old.TaprootAssetSealedPackage,
+			desc.TaprootAssetSealedPackage,
+		) {
+		return fmt.Errorf("asset VTXO replay changes sealed package")
+	}
+
+	return nil
+}

--- a/db/vtxo_asset_state_test.go
+++ b/db/vtxo_asset_state_test.go
@@ -1,0 +1,235 @@
+package db
+
+import (
+	"bytes"
+	"database/sql"
+	"math"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/round"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// testAssetDescriptor creates a composed leaf with independently sized asset
+// units and carrier satoshis.
+func testAssetDescriptor(t *testing.T, idx int) *vtxo.Descriptor {
+	t.Helper()
+	desc := createTestVTXODescriptor(t, round.RoundID{1}, idx)
+	root := chainhash.Hash{3}
+	desc.TaprootAssetRoot = &root
+	desc.TaprootAssetRef = "group:asset-test"
+	desc.TaprootAssetAmount = math.MaxUint64
+	desc.TaprootAssetSealedPackage = []byte{1, 2, 3}
+	var err error
+	desc.PkScript, err = desc.EffectivePkScript()
+	require.NoError(t, err)
+
+	return desc
+}
+
+// TestAssetVTXOStateRestart preserves the complete unsigned asset amount,
+// package, and composed script through every inventory read path.
+func TestAssetVTXOStateRestart(t *testing.T) {
+	t.Parallel()
+	store, _, _ := newVTXOStoreForTest(t)
+	ctx := t.Context()
+	asset := testAssetDescriptor(t, 1)
+	require.NoError(t, store.SaveVTXO(ctx, asset))
+	bitcoin := createTestVTXODescriptor(t, round.RoundID{1}, 2)
+	require.NoError(t, store.SaveVTXO(ctx, bitcoin))
+
+	// Reconstruct the store to discard both process-local caches.
+	store = NewVTXOPersistenceStore(store.db, clock.NewDefaultClock())
+	for range 2 {
+		got, err := store.GetVTXO(ctx, asset.Outpoint)
+		require.NoError(t, err)
+		require.Equal(t, asset.TaprootAssetRoot, got.TaprootAssetRoot)
+		require.Equal(t, asset.TaprootAssetRef, got.TaprootAssetRef)
+		require.Equal(t, uint64(math.MaxUint64), got.TaprootAssetAmount)
+		require.Equal(t, asset.Amount, got.Amount)
+		require.Equal(
+			t, asset.TaprootAssetSealedPackage,
+			got.TaprootAssetSealedPackage,
+		)
+		require.Nil(t, got.TapScript)
+		script, err := got.EffectivePkScript()
+		require.NoError(t, err)
+		require.Equal(t, asset.PkScript, script)
+		got.TaprootAssetSealedPackage[0] ^= 1
+	}
+	live, err := store.ListLiveVTXOs(ctx)
+	require.NoError(t, err)
+	require.Len(t, live, 2)
+	byStatus, err := store.ListVTXOsByStatus(ctx, vtxo.VTXOStatusLive)
+	require.NoError(t, err)
+	require.Len(t, byStatus, 2)
+	candidates, err := store.ListSelectionCandidatesByStatus(
+		ctx, vtxo.VTXOStatusLive,
+	)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, bitcoin.Outpoint, candidates[0].Outpoint)
+}
+
+// TestAssetVTXOReplay rejects contradictory identity and package writes while
+// preserving the asset marker when an earlier minimal descriptor is replayed.
+func TestAssetVTXOReplay(t *testing.T) {
+	t.Parallel()
+	store, _, _ := newVTXOStoreForTest(t)
+	ctx := t.Context()
+	asset := testAssetDescriptor(t, 1)
+	minimal := *asset
+	minimal.TaprootAssetRoot = nil
+	minimal.TaprootAssetRef = ""
+	minimal.TaprootAssetAmount = 0
+	minimal.TaprootAssetSealedPackage = nil
+	require.NoError(t, store.SaveVTXO(ctx, &minimal))
+	_, err := store.GetVTXO(ctx, asset.Outpoint)
+	require.NoError(t, err)
+	require.NoError(t, store.SaveVTXO(ctx, asset))
+	require.NoError(t, store.SaveVTXO(ctx, &minimal))
+	got, err := store.GetVTXO(ctx, asset.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, asset.TaprootAssetAmount, got.TaprootAssetAmount)
+	require.Nil(t, got.TapScript)
+	tests := []struct {
+		name   string
+		mutate func(*vtxo.Descriptor)
+	}{
+		{
+			"amount",
+			func(d *vtxo.Descriptor) {
+				d.TaprootAssetAmount--
+			},
+		},
+		{
+			"reference",
+			func(d *vtxo.Descriptor) {
+				d.TaprootAssetRef = "other"
+			},
+		},
+		{
+			"package",
+			func(d *vtxo.Descriptor) {
+				d.TaprootAssetSealedPackage = []byte{
+					9,
+				}
+			},
+		},
+		{
+			"script",
+			func(d *vtxo.Descriptor) {
+				d.PkScript = []byte{
+					0,
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			changed := *asset
+			test.mutate(&changed)
+			require.Error(t, store.SaveVTXO(ctx, &changed))
+			got, err := store.GetVTXO(ctx, asset.Outpoint)
+			require.NoError(t, err)
+			require.Equal(
+				t, asset.TaprootAssetAmount,
+				got.TaprootAssetAmount,
+			)
+			require.Equal(
+				t, asset.TaprootAssetSealedPackage,
+				got.TaprootAssetSealedPackage,
+			)
+		})
+	}
+}
+
+// TestAssetVTXOInvalidState rejects incomplete, oversized, and script-unbound
+// metadata at the persistence boundary, including malformed database rows.
+func TestAssetVTXOInvalidState(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*vtxo.Descriptor)
+	}{
+		{
+			"missing root",
+			func(d *vtxo.Descriptor) {
+				d.TaprootAssetRoot = nil
+			},
+		},
+		{
+			"missing reference",
+			func(d *vtxo.Descriptor) {
+				d.TaprootAssetRef = ""
+			},
+		},
+		{
+			"zero units",
+			func(d *vtxo.Descriptor) {
+				d.TaprootAssetAmount = 0
+			},
+		},
+		{
+			"oversized reference",
+			func(d *vtxo.Descriptor) {
+				d.TaprootAssetRef = string(
+					bytes.Repeat(
+						[]byte{1}, 513,
+					),
+				)
+			},
+		},
+		{
+			"wrong script",
+			func(d *vtxo.Descriptor) {
+				d.PkScript = []byte{
+					0,
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store, _, _ := newVTXOStoreForTest(t)
+			desc := testAssetDescriptor(t, 1)
+			test.mutate(desc)
+			require.Error(t, store.SaveVTXO(t.Context(), desc))
+			_, err := store.GetVTXO(t.Context(), desc.Outpoint)
+			require.Error(t, err)
+		})
+	}
+	rows := []VTXORow{
+		{
+			TaprootAssetRoot: []byte{},
+		},
+		{
+			TaprootAssetRoot: make([]byte, 31),
+		},
+		{
+			TaprootAssetRoot: make([]byte, 32),
+		},
+		{
+			TaprootAssetAmount: []byte{
+				1,
+			},
+		},
+		{
+			TaprootAssetRef: sql.NullString{
+				Valid: true,
+			},
+		},
+		{
+			TaprootAssetSealedPackage: []byte{
+				1,
+			},
+		},
+	}
+	for _, row := range rows {
+		_, err := decodeAssetVTXOState(row)
+		require.Error(t, err)
+	}
+}

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -940,6 +940,17 @@ func (s *VTXOPersistenceStore) descriptorToInsertParams(ctx context.Context,
 		operatorPubkey = desc.OperatorKey.SerializeCompressed()
 	}
 
+	assetRef, assetAmount, err := encodeTaprootAssetMetadata(desc)
+	if err != nil {
+		return InsertVTXOParams{}, err
+	}
+	if err := validateAssetVTXOReplay(ctx, q, desc); err != nil {
+		return InsertVTXOParams{}, err
+	}
+	var assetRoot []byte
+	if desc.TaprootAssetRoot != nil {
+		assetRoot = desc.TaprootAssetRoot.CloneBytes()
+	}
 	nowUnix := s.clock.Now().Unix()
 
 	// Register the local-ownership (client) key in the shared internal_keys
@@ -983,6 +994,12 @@ func (s *VTXOPersistenceStore) descriptorToInsertParams(ctx context.Context,
 		// immutable, so the InsertVTXO upsert never updates it on
 		// conflict.
 		ConstructionVersion: int32(desc.ConstructionVersion),
+		TaprootAssetRoot:    assetRoot,
+		TaprootAssetRef:     assetRef,
+		TaprootAssetAmount:  assetAmount,
+		TaprootAssetSealedPackage: bytes.Clone(
+			desc.TaprootAssetSealedPackage,
+		),
 	}, nil
 }
 
@@ -1009,6 +1026,11 @@ func (s *VTXOPersistenceStore) rowToDescriptor(ctx context.Context,
 		Index: uint32(row.OutpointIndex),
 	}
 
+	assetDesc, assetErr := decodeAssetVTXOState(row)
+	if assetErr != nil {
+		return nil, assetErr
+	}
+
 	// Hydrate the client key descriptor (pubkey + locator) from the
 	// internal_keys registry via the client_key_id FK. The FK is NULL on a
 	// minimal round-created row the VTXO manager has not yet healed; in
@@ -1032,7 +1054,7 @@ func (s *VTXOPersistenceStore) rowToDescriptor(ctx context.Context,
 	// map to different derived values; only the mutable row state below
 	// is read fresh on every call.
 	derived, ok := s.descriptorCache.get(outpoint)
-	if !ok {
+	if !ok || assetDesc.TaprootAssetRoot != nil {
 		var err error
 		derived, err = s.deriveDescriptorParts(ctx, row, outpoint)
 		if err != nil {
@@ -1084,10 +1106,15 @@ func (s *VTXOPersistenceStore) rowToDescriptor(ctx context.Context,
 	}
 
 	return &vtxo.Descriptor{
-		Outpoint:       outpoint,
-		Amount:         btcutil.Amount(row.Amount),
-		PolicyTemplate: derived.policyTemplate,
-		PkScript:       row.PkScript,
+		Outpoint:                  outpoint,
+		Amount:                    btcutil.Amount(row.Amount),
+		PolicyTemplate:            derived.policyTemplate,
+		PkScript:                  row.PkScript,
+		TaprootAssetRoot:          assetDesc.TaprootAssetRoot,
+		TaprootAssetRef:           assetDesc.TaprootAssetRef,
+		TaprootAssetAmount:        assetDesc.TaprootAssetAmount,
+		TaprootAssetSealedPackage: assetDesc.TaprootAssetSealedPackage,
+
 		ClientKey:      clientKey,
 		OperatorKey:    derived.operatorPubkey,
 		TapScript:      derived.tapscript,
@@ -1134,7 +1161,7 @@ func (s *VTXOPersistenceStore) deriveDescriptorParts(ctx context.Context,
 	// policies keep TapScript nil and rely on explicit spend
 	// paths instead.
 	var tapscript *waddrmgr.Tapscript
-	if len(policyTemplate) > 0 {
+	if len(policyTemplate) > 0 && row.TaprootAssetRoot == nil {
 		desc := &vtxo.Descriptor{PolicyTemplate: policyTemplate}
 		ts, err := desc.StandardTapScript()
 		if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,6 @@ require (
 	github.com/lightninglabs/loop v0.33.0-beta
 	github.com/lightninglabs/neutrino v0.18.0
 	github.com/lightninglabs/neutrino/cache v1.1.4
-	github.com/lightninglabs/taproot-assets v0.7.1-0.20260729123750-e798aabc7f20
-	github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260729123750-e798aabc7f20
 	github.com/lightninglabs/wavelength/baselib v0.0.0-00010101000000-000000000000
 	github.com/lightningnetwork/lightning-onion v1.4.0
 	github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260630214209-40c64f9db30d
@@ -147,6 +145,8 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182311-2f1d46ef18b7 // indirect
+	github.com/lightninglabs/taproot-assets v0.7.1-0.20260729123750-e798aabc7f20 // indirect
+	github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260729123750-e798aabc7f20 // indirect
 	github.com/lightningnetwork/lnd/actor v0.0.6 // indirect
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/healthcheck v1.2.6 // indirect

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -35,7 +35,8 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/lndclient"
-	"github.com/lightninglabs/taproot-assets/taprpc"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	tapgrpc "github.com/lightninglabs/tap-sdk/grpc"
 	"github.com/lightninglabs/wavelength/chain"
 	lnrpc "github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
@@ -368,7 +369,7 @@ func DefaultOptions() Options {
 		LNDImage: "mirror.gcr.io/lightninglabs/lnd:" +
 			"daily-testing-20260701",
 		TapdImage: "mirror.gcr.io/lightninglabs/taproot-assets:" +
-			"v0.7.0-rc1",
+			"v0.8.3",
 		ArtifactsBaseDir:    artifactsBaseDir,
 		HarnessLogStdOut:    *harnessLogStdOut,
 		AlwaysKeepArtifacts: true,
@@ -2936,47 +2937,6 @@ func GetLNDClientConn(ctx context.Context, addr, tlsPath,
 	return conn, nil
 }
 
-// getTapdClientConn creates a gRPC connection to tapd using TLS and macaroon
-// authentication.
-func getTapdClientConn(ctx context.Context, addr, tlsPath,
-	macaroonPath string) (*grpc.ClientConn, error) {
-
-	// Load TLS credentials.
-	creds, err := credentials.NewClientTLSFromFile(tlsPath, "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to load TLS cert: %w", err)
-	}
-
-	// Load macaroon.
-	macBytes, err := os.ReadFile(macaroonPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read macaroon: %w", err)
-	}
-	mac := &macaroon.Macaroon{}
-	if err := mac.UnmarshalBinary(macBytes); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal macaroon: %w", err)
-	}
-
-	macaroonCred, err := macaroons.NewMacaroonCredential(mac)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create macaroon "+
-			"credential: %w", err)
-	}
-
-	// Create dial options with TLS and macaroon credentials.
-	opts := []grpc.DialOption{
-		grpc.WithTransportCredentials(creds),
-		grpc.WithPerRPCCredentials(macaroonCred),
-	}
-
-	conn, err := grpc.NewClient(addr, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial tapd: %w", err)
-	}
-
-	return conn, nil
-}
-
 // waitForTapdReady waits until tapd's GetInfo RPC responds and reports that
 // tapd is synced to chain.
 func (h *Harness) waitForTapdReady() {
@@ -2999,23 +2959,24 @@ func (h *Harness) waitForTapdReady() {
 		defer cancel()
 
 		addr := net.JoinHostPort("127.0.0.1", h.TapdGRPCPort)
-		conn, err := getTapdClientConn(
-			ctx, addr, h.tapdTLSCert, h.tapdMacaroon,
-		)
+		client, err := tapgrpc.NewClient(&tapgrpc.Config{
+			Host:       addr,
+			Network:    tapsdk.NetworkRegtest,
+			TLS:        tapgrpc.TLSFromPath(h.tapdTLSCert),
+			Macaroon:   tapsdk.MacaroonFromPath(h.tapdMacaroon),
+			RPCTimeout: checkTimeout,
+		})
 		if err != nil {
 			return false
 		}
-		defer conn.Close()
-
-		// Call GetInfo to check if tapd is ready and synced.
-		client := taprpc.NewTaprootAssetsClient(conn)
-		resp, err := client.GetInfo(ctx, &taprpc.GetInfoRequest{})
+		defer client.Close()
+		resp, err := client.GetInfo(ctx)
 		if err != nil {
 			return false
 		}
 
 		// Check if tapd is synced to chain.
-		return resp.SyncToChain
+		return resp.SyncedToChain
 	}, defaultTimeout, time.Second, "tapd not ready or not synced")
 }
 

--- a/harness/tapd_harness.go
+++ b/harness/tapd_harness.go
@@ -9,7 +9,8 @@ import (
 	"time"
 
 	"github.com/lightninglabs/lndclient"
-	"github.com/lightninglabs/taproot-assets/taprpc"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	tapgrpc "github.com/lightninglabs/tap-sdk/grpc"
 	lnrpc "github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
@@ -520,21 +521,23 @@ func (th *TapdHarness) waitForTapdReady() {
 		defer cancel()
 
 		addr := net.JoinHostPort("127.0.0.1", th.TapdGRPCPort)
-		conn, err := getTapdClientConn(
-			ctx, addr, th.TapdTLSCert, th.TapdMacaroon,
-		)
+		client, err := tapgrpc.NewClient(&tapgrpc.Config{
+			Host:       addr,
+			Network:    tapsdk.NetworkRegtest,
+			TLS:        tapgrpc.TLSFromPath(th.TapdTLSCert),
+			Macaroon:   tapsdk.MacaroonFromPath(th.TapdMacaroon),
+			RPCTimeout: checkTimeout,
+		})
 		if err != nil {
 			return false
 		}
-		defer conn.Close()
-
-		client := taprpc.NewTaprootAssetsClient(conn)
-		resp, err := client.GetInfo(ctx, &taprpc.GetInfoRequest{})
+		defer client.Close()
+		resp, err := client.GetInfo(ctx)
 		if err != nil {
 			return false
 		}
 
-		return resp.SyncToChain
+		return resp.SyncedToChain
 	}, defaultTimeout, time.Second, th.Name+" tapd not ready or not synced")
 }
 

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -26,7 +26,7 @@ server during round participation. These types are used across `round`, `vtxo`,
   absorbs the server fee residual; serialized into `JoinRoundAuth`.
 - `BoardingRequest` — Describes a boarding input: `Outpoint`,
   `PolicyTemplate` (authoritative join-round policy), `ClientKey` /
-  `OperatorKey`, and `ExitDelay`. `TxProof fn.Option[proof.TxProof]` carries
+  `OperatorKey`, and `ExitDelay`. `TxProof fn.Option[TxProof]` carries
   an optional SPV merkle inclusion proof for server-side verification of
   boarding UTXOs without requiring the server's own chain source.
 - `OperatorTerms` — Server-published round parameters (fee rates, expiry

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -26,7 +26,7 @@ server during round participation. These types are used across `round`, `vtxo`,
   absorbs the server fee residual; serialized into `JoinRoundAuth`.
 - `BoardingRequest` — Describes a boarding input: `Outpoint`,
   `PolicyTemplate` (authoritative join-round policy), `ClientKey` /
-  `OperatorKey`, and `ExitDelay`. `TxProof fn.Option[proof.TxProof]` carries
+  `OperatorKey`, and `ExitDelay`. `TxProof fn.Option[TxProof]` carries
   an optional SPV merkle inclusion proof for server-side verification of
   boarding UTXOs without requiring the server's own chain source.
 - `OperatorTerms` — Server-published round parameters (fee rates, expiry

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -7,7 +7,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/wire/v2"
-	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/lib/tree"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -402,7 +401,7 @@ type BoardingRequest struct {
 	// builds it inline (see wallet.processUtxo) and the
 	// maybeRebuildBoardingProof recovery path reconstructs it from the
 	// chain backend for any persisted intent that lacks one.
-	TxProof fn.Option[proof.TxProof]
+	TxProof fn.Option[TxProof]
 }
 
 // BoardingInputSignature represents the client's signature for a boarding

--- a/lib/types/proof_codec.go
+++ b/lib/types/proof_codec.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/wire/v2"
-	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -164,7 +163,7 @@ func txProofBlockHeaderDecoder(r io.Reader, val interface{}, _ *[8]byte,
 }
 
 type txProofMerkleProofRecord struct {
-	Proof proof.TxMerkleProof
+	Proof TxMerkleProof
 }
 
 func (t *txProofMerkleProofRecord) Record() tlv.Record {
@@ -215,8 +214,8 @@ type tlvTxProof struct {
 	MerkleRoot    tlv.RecordT[tlvTxProofMerkleRoot, []byte]
 }
 
-// SerializeTxProof serializes a proof.TxProof to TLV-encoded bytes.
-func SerializeTxProof(p *proof.TxProof) ([]byte, error) {
+// SerializeTxProof serializes a TxProof to TLV-encoded bytes.
+func SerializeTxProof(p *TxProof) ([]byte, error) {
 	if p == nil {
 		return nil, nil
 	}
@@ -276,8 +275,8 @@ func SerializeTxProof(p *proof.TxProof) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// DeserializeTxProof deserializes a proof.TxProof from TLV-encoded bytes.
-func DeserializeTxProof(data []byte) (*proof.TxProof, error) {
+// DeserializeTxProof deserializes a TxProof from TLV-encoded bytes.
+func DeserializeTxProof(data []byte) (*TxProof, error) {
 	if len(data) == 0 {
 		return nil, nil
 	}
@@ -313,7 +312,7 @@ func DeserializeTxProof(data []byte) (*proof.TxProof, error) {
 	}
 
 	// Reconstruct the TxProof from decoded TLV fields.
-	p := &proof.TxProof{
+	p := &TxProof{
 		BlockHeader:     t.BlockHeader.Val.Header,
 		BlockHeight:     t.BlockHeight.Val,
 		MerkleProof:     t.MerkleProof.Val.Proof,

--- a/lib/types/proof_codec_test.go
+++ b/lib/types/proof_codec_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
-	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +14,7 @@ import (
 // testTxProof builds a small but structurally complete TxProof so the
 // codec tests can round-trip a realistic value and seed the fuzzer with
 // one.
-func testTxProof(t testing.TB) *proof.TxProof {
+func testTxProof(t testing.TB) *TxProof {
 	t.Helper()
 
 	tx := wire.NewMsgTx(2)
@@ -30,13 +29,13 @@ func testTxProof(t testing.TB) *proof.TxProof {
 		PkScript: []byte{0x51, 0x20, 0x03, 0x04},
 	})
 
-	merkleProof, err := proof.NewTxMerkleProof([]*wire.MsgTx{tx}, 0)
+	merkleProof, err := NewTxMerkleProof([]*wire.MsgTx{tx}, 0)
 	require.NoError(t, err)
 
 	priv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	return &proof.TxProof{
+	return &TxProof{
 		MsgTx: *tx,
 		BlockHeader: wire.BlockHeader{
 			Version:   4,

--- a/lib/types/tx_proof.go
+++ b/lib/types/tx_proof.go
@@ -1,0 +1,239 @@
+package types
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// MaxTxMerkleProofNodes bounds Bitcoin transaction inclusion proofs. Fifteen
+// levels cover the maximum number of transactions in a consensus-valid block.
+const MaxTxMerkleProofNodes = 15
+
+// HeaderVerifier authenticates a block header at its claimed chain height.
+type HeaderVerifier func(wire.BlockHeader, uint32) error
+
+// MerkleVerifier authenticates a transaction against a block's merkle root.
+type MerkleVerifier func(*wire.MsgTx, *TxMerkleProof, [32]byte) error
+
+// TxMerkleProof proves the inclusion of one transaction in a Bitcoin block.
+// The encoding is the existing boarding protocol's node count, sibling hashes,
+// and packed direction bits, in that order.
+type TxMerkleProof struct {
+	// Nodes contains the siblings from the transaction up to the root.
+	Nodes []chainhash.Hash
+
+	// Bits is true when the corresponding sibling is on the right.
+	Bits []bool
+}
+
+// NewTxMerkleProof constructs an inclusion proof using Bitcoin's duplicate-last
+// rule for levels with an odd number of nodes.
+func NewTxMerkleProof(txs []*wire.MsgTx, txIdx int) (*TxMerkleProof, error) {
+	if txIdx < 0 || txIdx >= len(txs) {
+		return nil, fmt.Errorf("transaction index %d is out of range",
+			txIdx)
+	}
+	if len(txs) > 1<<MaxTxMerkleProofNodes {
+		return nil, fmt.Errorf("too many transactions for inclusion " +
+			"proof")
+	}
+
+	level := make([]chainhash.Hash, len(txs))
+	for idx, txn := range txs {
+		if txn == nil {
+			return nil, fmt.Errorf("transaction %d is nil", idx)
+		}
+		level[idx] = txn.TxHash()
+	}
+
+	proof := &TxMerkleProof{
+		Nodes: make([]chainhash.Hash, 0),
+		Bits:  make([]bool, 0),
+	}
+	for len(level) > 1 {
+		sibling := txIdx ^ 1
+		if sibling >= len(level) {
+			sibling = txIdx
+		}
+		proof.Nodes = append(proof.Nodes, level[sibling])
+		proof.Bits = append(proof.Bits, txIdx%2 == 0)
+
+		next := make([]chainhash.Hash, (len(level)+1)/2)
+		for idx := range next {
+			left, right := 2*idx, 2*idx+1
+			if right == len(level) {
+				right = left
+			}
+			next[idx] = hashMerklePair(level[left], level[right])
+		}
+		level = next
+		txIdx /= 2
+	}
+
+	return proof, nil
+}
+
+// hashMerklePair hashes a left and right child in Bitcoin's merkle tree.
+func hashMerklePair(left, right chainhash.Hash) chainhash.Hash {
+	var pair [2 * chainhash.HashSize]byte
+	copy(pair[:chainhash.HashSize], left[:])
+	copy(pair[chainhash.HashSize:], right[:])
+
+	return chainhash.DoubleHashH(pair[:])
+}
+
+// Verify checks the transaction's inclusion in the supplied merkle root.
+func (p *TxMerkleProof) Verify(txn *wire.MsgTx, root chainhash.Hash) bool {
+	if p == nil || txn == nil || len(p.Nodes) != len(p.Bits) ||
+		len(p.Nodes) > MaxTxMerkleProofNodes {
+		return false
+	}
+
+	current := txn.TxHash()
+	for idx, sibling := range p.Nodes {
+		if p.Bits[idx] {
+			current = hashMerklePair(current, sibling)
+		} else {
+			current = hashMerklePair(sibling, current)
+		}
+	}
+
+	return current == root
+}
+
+// Encode writes the boarding protocol's transaction inclusion proof encoding.
+func (p *TxMerkleProof) Encode(w io.Writer) error {
+	if p == nil || len(p.Nodes) != len(p.Bits) ||
+		len(p.Nodes) > MaxTxMerkleProofNodes {
+		return fmt.Errorf("invalid transaction merkle proof shape")
+	}
+	var scratch [8]byte
+	if err := tlv.WriteVarInt(
+		w,
+		uint64(
+			len(p.Nodes),
+		),
+		&scratch,
+	); err != nil {
+		return err
+	}
+	for _, node := range p.Nodes {
+		if _, err := w.Write(node[:]); err != nil {
+			return err
+		}
+	}
+
+	packed := make([]byte, (len(p.Bits)+7)/8)
+	for idx, right := range p.Bits {
+		if right {
+			packed[idx/8] |= 1 << (idx % 8)
+		}
+	}
+	_, err := w.Write(packed)
+
+	return err
+}
+
+// Decode reads a bounded inclusion proof without replacing the receiver when
+// the input is truncated or malformed.
+func (p *TxMerkleProof) Decode(r io.Reader) error {
+	var scratch [8]byte
+	count, err := tlv.ReadVarInt(r, &scratch)
+	if err != nil {
+		return err
+	}
+	if count > MaxTxMerkleProofNodes {
+		return tlv.ErrRecordTooLarge
+	}
+
+	nodes := make([]chainhash.Hash, int(count))
+	for idx := range nodes {
+		if _, err := io.ReadFull(r, nodes[idx][:]); err != nil {
+			return err
+		}
+	}
+	packed := make([]byte, (count+7)/8)
+	if _, err := io.ReadFull(r, packed); err != nil {
+		return err
+	}
+	bits := make([]bool, int(count))
+	for idx := range bits {
+		bits[idx] = packed[idx/8]&(1<<(idx%8)) != 0
+	}
+	p.Nodes, p.Bits = nodes, bits
+
+	return nil
+}
+
+// TxProof binds a boarding outpoint to a transaction, a block, and the Taproot
+// construction of the claimed output. It contains no Taproot Asset state.
+type TxProof struct {
+	MsgTx           wire.MsgTx
+	BlockHeader     wire.BlockHeader
+	BlockHeight     uint32
+	MerkleProof     TxMerkleProof
+	ClaimedOutPoint wire.OutPoint
+	InternalKey     btcec.PublicKey
+	MerkleRoot      []byte
+}
+
+// Verify authenticates the claimed output, merkle inclusion, and block header.
+func (p *TxProof) Verify(headerVerifier HeaderVerifier,
+	merkleVerifier MerkleVerifier) error {
+
+	if p == nil || headerVerifier == nil || merkleVerifier == nil {
+		return errors.New("transaction proof and verifiers are " +
+			"required")
+	}
+	if p.ClaimedOutPoint.Hash != p.MsgTx.TxHash() {
+		return errors.New("outpoint hash does not match transaction " +
+			"hash")
+	}
+	if p.ClaimedOutPoint.Index >= uint32(len(p.MsgTx.TxOut)) {
+		return errors.New("claimed output index is out of range")
+	}
+	if len(p.MerkleRoot) != 0 && len(p.MerkleRoot) != chainhash.HashSize {
+		return errors.New("invalid Taproot merkle root length")
+	}
+	if !p.InternalKey.IsOnCurve() {
+		return errors.New("invalid Taproot internal key")
+	}
+	outputKey := txscript.ComputeTaprootOutputKey(
+		&p.InternalKey, p.MerkleRoot,
+	)
+	expected, err := txscript.PayToTaprootScript(outputKey)
+	if err != nil {
+		return err
+	}
+	output := p.MsgTx.TxOut[p.ClaimedOutPoint.Index]
+	if output == nil || !bytes.Equal(output.PkScript, expected) {
+		return errors.New("claimed output does not match Taproot " +
+			"construction")
+	}
+	if err := merkleVerifier(
+		&p.MsgTx, &p.MerkleProof, p.BlockHeader.MerkleRoot,
+	); err != nil {
+		return err
+	}
+
+	return headerVerifier(p.BlockHeader, p.BlockHeight)
+}
+
+// DefaultMerkleVerifier checks Bitcoin transaction inclusion against a root.
+func DefaultMerkleVerifier(txn *wire.MsgTx, proof *TxMerkleProof,
+	root [32]byte) error {
+
+	if proof == nil || !proof.Verify(txn, root) {
+		return errors.New("invalid transaction merkle proof")
+	}
+
+	return nil
+}

--- a/lib/types/tx_proof_test.go
+++ b/lib/types/tx_proof_test.go
@@ -1,0 +1,182 @@
+package types
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTxMerkleProof checks every position across balanced and unbalanced trees
+// against btcd's independently constructed block merkle root.
+func TestTxMerkleProof(t *testing.T) {
+	t.Parallel()
+
+	var txs []*wire.MsgTx
+	var blockTxs []*btcutil.Tx
+	for count := 1; count <= 40; count++ {
+		txn := wire.NewMsgTx(2)
+		txn.AddTxIn(
+			wire.NewTxIn(
+				&wire.OutPoint{
+					Hash: chainhash.Hash{byte(count)},
+				},
+				nil,
+				nil,
+			),
+		)
+		txn.AddTxOut(
+			wire.NewTxOut(
+				int64(count), []byte{txscript.OP_TRUE},
+			),
+		)
+		txs = append(txs, txn)
+		blockTxs = append(blockTxs, btcutil.NewTx(txn))
+		tree := blockchain.BuildMerkleTreeStore(blockTxs, false)
+		root := *tree[len(tree)-1]
+		for idx := range txs {
+			proof, err := NewTxMerkleProof(txs, idx)
+			require.NoError(t, err)
+			require.True(t, proof.Verify(txs[idx], root))
+			require.False(
+				t,
+				proof.Verify(
+					txs[idx], chainhash.Hash{},
+				),
+			)
+
+			var encoded bytes.Buffer
+			require.NoError(t, proof.Encode(&encoded))
+			var decoded TxMerkleProof
+			require.NoError(t, decoded.Decode(&encoded))
+			require.Equal(t, *proof, decoded)
+		}
+	}
+}
+
+// TestTxMerkleProofWireEncoding pins the pre-existing boarding proof format.
+func TestTxMerkleProofWireEncoding(t *testing.T) {
+	t.Parallel()
+
+	proof := TxMerkleProof{
+		Nodes: []chainhash.Hash{
+			{
+				1,
+			},
+			{
+				2,
+			},
+		},
+		Bits: []bool{
+			true,
+			false,
+		},
+	}
+	want, err := hex.DecodeString(
+		"02010000000000000000000000000000000000000000000000000000000" +
+			"000000002000000000000000000000000000000000000000000" +
+			"0000000000000000000001",
+	)
+	require.NoError(t, err)
+	var encoded bytes.Buffer
+	require.NoError(t, proof.Encode(&encoded))
+	require.Equal(t, want, encoded.Bytes())
+
+	for end := range want {
+		decoded := TxMerkleProof{
+			Nodes: []chainhash.Hash{
+				{
+					9,
+				},
+			},
+			Bits: []bool{
+				false,
+			},
+		}
+		original := decoded
+		require.Error(t, decoded.Decode(bytes.NewReader(want[:end])))
+		require.Equal(t, original, decoded)
+	}
+	var decoded TxMerkleProof
+	require.ErrorIs(
+		t,
+		decoded.Decode(
+			bytes.NewReader(
+				[]byte{16},
+			),
+		),
+		tlv.ErrRecordTooLarge,
+	)
+
+	proof.Bits = nil
+	require.Error(t, proof.Encode(&encoded))
+	require.False(t, proof.Verify(wire.NewMsgTx(2), chainhash.Hash{}))
+	_, err = NewTxMerkleProof([]*wire.MsgTx{wire.NewMsgTx(2)}, -1)
+	require.Error(t, err)
+	_, err = NewTxMerkleProof([]*wire.MsgTx{nil}, 0)
+	require.Error(t, err)
+}
+
+// TestTxProofVerification checks that inclusion cannot authenticate a different
+// output or bypass the caller's chain-header verifier.
+func TestTxProofVerification(t *testing.T) {
+	t.Parallel()
+
+	key, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	script, err := txscript.PayToTaprootScript(
+		txscript.ComputeTaprootKeyNoScript(
+			key.PubKey(),
+		),
+	)
+	require.NoError(t, err)
+	txn := wire.NewMsgTx(2)
+	txn.AddTxIn(
+		wire.NewTxIn(
+			&wire.OutPoint{
+				Hash: chainhash.Hash{1},
+			},
+			nil,
+			nil,
+		),
+	)
+	txn.AddTxOut(wire.NewTxOut(1_000, script))
+	proof := &TxProof{
+		MsgTx: *txn,
+		BlockHeader: wire.BlockHeader{
+			MerkleRoot: txn.TxHash(),
+		},
+		BlockHeight: 42,
+		ClaimedOutPoint: wire.OutPoint{
+			Hash: txn.TxHash(),
+		},
+		InternalKey: *key.PubKey(),
+	}
+	headerChecked := false
+	verifyHeader := func(header wire.BlockHeader, height uint32) error {
+		headerChecked = true
+		require.EqualValues(t, 42, height)
+		require.Equal(t, txn.TxHash(), header.MerkleRoot)
+
+		return nil
+	}
+	require.NoError(t, proof.Verify(verifyHeader, DefaultMerkleVerifier))
+	require.True(t, headerChecked)
+
+	headerChecked = false
+	proof.ClaimedOutPoint.Hash[0] ^= 1
+	require.Error(t, proof.Verify(verifyHeader, DefaultMerkleVerifier))
+	require.False(t, headerChecked)
+	proof.ClaimedOutPoint.Hash = txn.TxHash()
+	proof.BlockHeader.MerkleRoot[0] ^= 1
+	require.Error(t, proof.Verify(verifyHeader, DefaultMerkleVerifier))
+	require.False(t, headerChecked)
+}

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -338,3 +338,10 @@ state transitions and validation rules live under [Invariants](#invariants).
 - [round/README.md](README.md) — Full state machine walkthrough with
   diagrams.
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+
+## Asset leaf persistence
+
+Locally owned asset leaves retain their verified reference, amount,
+commitment root, and sealed package in `ClientVTXO`. Confirmation writes persist that identity before notifying the VTXO
+manager, and both round recovery and manager notification preserve it. Missing or mismatched tree
+metadata prevents a leaf from entering wallet inventory.

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -338,3 +338,10 @@ state transitions and validation rules live under [Invariants](#invariants).
 - [round/README.md](README.md) — Full state machine walkthrough with
   diagrams.
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+
+## Asset leaf persistence
+
+Locally owned asset leaves retain their verified reference, amount,
+commitment root, and sealed package in `ClientVTXO`. Confirmation writes persist that identity before notifying the VTXO
+manager, and both round recovery and manager notification preserve it. Missing or mismatched tree
+metadata prevents a leaf from entering wallet inventory.

--- a/round/asset_vtxo_state.go
+++ b/round/asset_vtxo_state.go
@@ -1,0 +1,52 @@
+package round
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/types"
+)
+
+// setClientVTXOAssetState retains the verified transition with its leaf. A
+// missing marker would let a restarted wallet treat carrier sats as Bitcoin.
+func setClientVTXOAssetState(cv *ClientVTXO, req types.VTXORequest,
+	clientTree *tree.Tree, leaf *tree.Node) error {
+
+	assetContext := clientTree.AssetContext
+	if req.AssetRef == "" {
+		if assetContext != nil {
+			return fmt.Errorf("Bitcoin VTXO request has an asset " +
+				"tree")
+		}
+
+		return nil
+	}
+	if assetContext == nil {
+		return fmt.Errorf("asset VTXO is missing tree context")
+	}
+	if err := assetContext.Validate(clientTree.Root); err != nil {
+		return fmt.Errorf("asset VTXO tree context: %w", err)
+	}
+	if assetContext.AssetRef() != req.AssetRef ||
+		assetContext.NodeAssetAmount(leaf) != req.AssetAmount {
+		return fmt.Errorf("asset VTXO identity does not match request")
+	}
+	rootBytes := assetContext.LeafAssetRoot(leaf.Input)
+	if len(rootBytes) != chainhash.HashSize {
+		return fmt.Errorf("asset VTXO is missing leaf commitment root")
+	}
+	sealedPackage := assetContext.SealedPackage(leaf.Input)
+	if len(sealedPackage) == 0 {
+		return fmt.Errorf("asset VTXO is missing sealed leaf package")
+	}
+	var root chainhash.Hash
+	copy(root[:], rootBytes)
+	cv.TaprootAssetRoot = &root
+	cv.TaprootAssetRef = req.AssetRef
+	cv.TaprootAssetAmount = req.AssetAmount
+	cv.TaprootAssetSealedPackage = bytes.Clone(sealedPackage)
+
+	return nil
+}

--- a/round/asset_vtxo_state_test.go
+++ b/round/asset_vtxo_state_test.go
@@ -1,0 +1,77 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildClientAssetVTXORejectsMissingState prevents incomplete restart
+// evidence from being persisted as an ordinary Bitcoin leaf.
+func TestBuildClientAssetVTXORejectsMissingState(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*boundAssetVTXOFixture)
+	}{
+		{
+			"missing context",
+			func(f *boundAssetVTXOFixture) {
+				f.tree.AssetContext = nil
+			},
+		},
+		{
+			"missing package",
+			func(f *boundAssetVTXOFixture) {
+				f.tree.AssetContext.SetSealedPackage(
+					f.tree.Root.Input, nil,
+				)
+			},
+		},
+		{
+			"wrong reference",
+			func(f *boundAssetVTXOFixture) {
+				f.request.AssetRef = "other"
+			},
+		},
+		{
+			"wrong units",
+			func(f *boundAssetVTXOFixture) {
+				f.request.AssetAmount++
+			},
+		},
+		{
+			"Bitcoin request",
+			func(f *boundAssetVTXOFixture) {
+				f.request.AssetRef = ""
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			h := newTestHarness(t)
+			fixture := newBoundAssetVTXOFixture(t, h)
+			fixture.tree.AssetContext.SetSealedPackage(
+				fixture.tree.Root.Input, fixture.sealedPackage,
+			)
+			test.mutate(fixture)
+			signerKey := NewSignerKey(
+				fixture.request.SigningKey.PubKey,
+			)
+			vtxos, err := buildClientVTXOs(
+				t.Context(), nil, Intents{
+					VTXOs: []types.VTXORequest{
+						fixture.request,
+					},
+				}, map[SignerKey]*tree.Tree{
+					signerKey: fixture.tree,
+				},
+				RoundID{1},
+			)
+			require.Error(t, err)
+			require.Empty(t, vtxos)
+		})
+	}
+}

--- a/round/asset_vtxo_validation_test.go
+++ b/round/asset_vtxo_validation_test.go
@@ -231,6 +231,23 @@ func TestCommitmentTxReceivedVerifiesAssetVTXO(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, vtxos, 1)
 	require.Equal(t, leafOutput.PkScript, vtxos[0].PkScript)
+	require.Equal(t, fixture.request.AssetRef, vtxos[0].TaprootAssetRef)
+	require.Equal(
+		t, fixture.request.AssetAmount, vtxos[0].TaprootAssetAmount,
+	)
+	require.Equal(
+		t, clientTree.AssetContext.LeafAssetRoot(leaf.Input),
+		vtxos[0].TaprootAssetRoot[:],
+	)
+	require.Equal(
+		t, fixture.sealedPackage, vtxos[0].TaprootAssetSealedPackage,
+	)
+	vtxos[0].TaprootAssetSealedPackage[0] ^= 1
+	require.Equal(
+		t, fixture.sealedPackage,
+		clientTree.AssetContext.SealedPackage(leaf.Input),
+	)
+
 }
 
 func TestValidateRequestedAssetVTXO(t *testing.T) {

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -501,6 +501,21 @@ type ClientVTXO struct {
 
 	PkScript []byte
 
+	// TaprootAssetRoot is the commitment composed beside this leaf's
+	// policy.
+	TaprootAssetRoot *chainhash.Hash
+
+	// TaprootAssetRef identifies the asset independently of carrier
+	// satoshis.
+	TaprootAssetRef string
+
+	// TaprootAssetAmount counts asset units, separately from Amount.
+	TaprootAssetAmount uint64
+
+	// TaprootAssetSealedPackage preserves the verified leaf transition for
+	// subsequent asset spends and claims after restart.
+	TaprootAssetSealedPackage []byte
+
 	// Expiry is the CSV delay for the unilateral exit path.
 	Expiry uint32
 

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
-	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/lib/tree"
@@ -297,7 +296,7 @@ func (m *JoinRoundRequest) ToProto() fn.Result[proto.Message] {
 		}
 
 		// Serialize the TxProof inline if present.
-		req.TxProof.WhenSome(func(tp proof.TxProof) {
+		req.TxProof.WhenSome(func(tp types.TxProof) {
 			data, err := types.SerializeTxProof(&tp)
 			if err == nil {
 				br.TxProof = data

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -4767,6 +4767,11 @@ func buildClientVTXOs(ctx context.Context, checker OwnedScriptChecker,
 			RoundID:        fn.Some(roundID),
 			Origin:         req.Origin,
 		}
+		if err := setClientVTXOAssetState(
+			vtxo, req, clientTree, leaf,
+		); err != nil {
+			return nil, err
+		}
 		if isStandard {
 			vtxo.Expiry = params.ExitDelay
 			vtxo.OperatorKey = params.OperatorKey

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -355,3 +355,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - [lib/recovery/CLAUDE.md](../lib/recovery/CLAUDE.md) — immutable
   proof graph.
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — system-wide package map.
+
+## Asset carrier safety
+
+Asset-bearing VTXOs require an asset-aware transition. Bitcoin spending,
+forfeit signing, automatic refresh, and expired reclaim refuse them. An
+unroll can materialize its presigned path, but its final Bitcoin sweep is
+withheld, including a sweep restored from a checkpoint.

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -355,3 +355,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 - [lib/recovery/CLAUDE.md](../lib/recovery/CLAUDE.md) — immutable
   proof graph.
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — system-wide package map.
+
+## Asset carrier safety
+
+Asset-bearing VTXOs require an asset-aware transition. Bitcoin spending,
+forfeit signing, automatic refresh, and expired reclaim refuse them. An
+unroll can materialize its presigned path, but its final Bitcoin sweep is
+withheld, including a sweep restored from a checkpoint.

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -553,6 +553,12 @@ func (b *behavior) driveEvent(ctx context.Context, ax actor.Exec[unrollTx],
 func (b *behavior) startSweep(ctx context.Context,
 	ax actor.Exec[unrollTx]) error {
 
+	// Check before adopting any staged sweep: a restored Bitcoin sweep
+	// must never consume an output now known to carry assets.
+	if b.desc != nil && b.desc.TaprootAssetRoot != nil {
+		return vtxo.ErrAssetVTXORequiresTransition
+	}
+
 	// Idempotency guard against a lost-in-memory sweep. Before deriving a
 	// fresh sweep -- which burns a new BIP32 wallet address and yields a
 	// new txid -- reconcile against the durably Staged checkpoint via a
@@ -803,6 +809,10 @@ func (b *behavior) currentHeightHint() uint32 {
 // resolveExitSpendPolicy reconstructs the exit policy for this job.
 func (b *behavior) resolveExitSpendPolicy(ctx context.Context) (ExitSpendPolicy,
 	error) {
+
+	if b.desc != nil && b.desc.TaprootAssetRoot != nil {
+		return nil, vtxo.ErrAssetVTXORequiresTransition
+	}
 
 	req := ExitSpendPolicyRequest{
 		Kind:               b.exitPolicyKind(),

--- a/unroll/asset_safety_test.go
+++ b/unroll/asset_safety_test.go
@@ -1,0 +1,48 @@
+package unroll
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAssetUnrollWithholdsBitcoinSweep still materializes the presigned path
+// while refusing both fresh and checkpoint-restored Bitcoin sweeps.
+func TestAssetUnrollWithholdsBitcoinSweep(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	root := chainhash.Hash{1}
+	desc.TaprootAssetRoot = &root
+	unrollActor, behavior, txconfirmRef, _, exec := newActorHarnessExec(
+		t, proof, desc,
+	)
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height: 100, Trigger: TriggerManual,
+	})
+	require.Equal(t, 1, txconfirmRef.requestCount())
+	require.Equal(
+		t, proof.RootTxids()[0],
+		txconfirmRef.lastRequest(t).Tx.TxHash(),
+	)
+	_, err := behavior.resolveExitSpendPolicy(t.Context())
+	require.ErrorIs(t, err, vtxo.ErrAssetVTXORequiresTransition)
+	require.ErrorIs(
+		t,
+		behavior.startSweep(
+			t.Context(), exec,
+		),
+		vtxo.ErrAssetVTXORequiresTransition,
+	)
+	behavior.sweepTx = wire.NewMsgTx(2)
+	require.ErrorIs(
+		t,
+		behavior.startSweep(
+			t.Context(), exec,
+		),
+		vtxo.ErrAssetVTXORequiresTransition,
+	)
+	require.Equal(t, 1, txconfirmRef.requestCount())
+}

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -235,3 +235,10 @@ when the local wallet owns the receive script.
 ## Deep Docs
 
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+
+## Asset carrier safety
+
+Asset-bearing VTXOs require an asset-aware transition. Bitcoin spending,
+forfeit signing, automatic refresh, and expired reclaim refuse them. An
+unroll can materialize its presigned path, but its final Bitcoin sweep is
+withheld, including a sweep restored from a checkpoint.

--- a/vtxo/CLAUDE.md
+++ b/vtxo/CLAUDE.md
@@ -235,3 +235,10 @@ when the local wallet owns the receive script.
 ## Deep Docs
 
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+
+## Asset carrier safety
+
+Asset-bearing VTXOs require an asset-aware transition. Bitcoin spending,
+forfeit signing, automatic refresh, and expired reclaim refuse them. An
+unroll can materialize its presigned path, but its final Bitcoin sweep is
+withheld, including a sweep restored from a checkpoint.

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -284,7 +284,7 @@ func (a *VTXOActor) preflightAutoRefresh(ctx context.Context, event VTXOEvent) (
 	}
 
 	liveState, ok := a.state.(*LiveState)
-	if !ok {
+	if !ok || liveState.VTXO.TaprootAssetRoot != nil {
 		return nil, false, nil
 	}
 
@@ -345,6 +345,12 @@ func (a *VTXOActor) preflightCriticalExit(ctx context.Context,
 		desc = state.VTXO
 
 	default:
+		return event
+	}
+
+	// Asset exits materialize the leaf without a Bitcoin sweep. Its
+	// carrier cannot be assessed against the Bitcoin sweep fee budget.
+	if desc.TaprootAssetRoot != nil {
 		return event
 	}
 

--- a/vtxo/admission_errors.go
+++ b/vtxo/admission_errors.go
@@ -3,6 +3,11 @@ package vtxo
 import "errors"
 
 var (
+	// ErrAssetVTXORequiresTransition rejects Bitcoin operations on asset
+	// carriers.
+	ErrAssetVTXORequiresTransition = errors.New("asset VTXO requires an " +
+		"asset-aware transition")
+
 	// ErrInsufficientSpendableFunds means live VTXOs cannot cover the
 	// requested amount.
 	ErrInsufficientSpendableFunds = errors.New("insufficient spendable " +

--- a/vtxo/asset_safety_test.go
+++ b/vtxo/asset_safety_test.go
@@ -118,3 +118,17 @@ func TestAssetCriticalExpiryBypassesBitcoinFeeAssessment(t *testing.T) {
 	event := &BlockEpochEvent{Height: desc.BatchExpiry - 1}
 	require.Same(t, event, a.preflightCriticalExit(h.ctx, event))
 }
+
+// TestPendingAssetVTXORejectsForfeit protects recovered pending descriptors
+// even when their reservation predates the current process.
+func TestPendingAssetVTXORejectsForfeit(t *testing.T) {
+	t.Parallel()
+	h := newVTXOTestHarness(t)
+	desc := h.newTestDescriptor()
+	root := chainhash.Hash{1}
+	desc.TaprootAssetRoot = &root
+	h.withState(&PendingForfeitState{VTXO: desc})
+	_, err := h.sendEvent(&ForfeitRequestEvent{})
+	require.ErrorIs(t, err, ErrAssetVTXORequiresTransition)
+	require.Empty(t, h.outboxMessages)
+}

--- a/vtxo/asset_safety_test.go
+++ b/vtxo/asset_safety_test.go
@@ -1,0 +1,120 @@
+package vtxo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAssetVTXORejectsBitcoinOperations refuses direct admission and signing
+// requests before the actor emits a reservation or a signature.
+func TestAssetVTXORejectsBitcoinOperations(t *testing.T) {
+	t.Parallel()
+	for _, event := range []VTXOEvent{
+		&SpendReserveEvent{},
+		&PendingForfeitEvent{},
+		&ForfeitRequestEvent{},
+	} {
+		h := newVTXOTestHarness(t)
+		desc := h.newTestDescriptor()
+		root := chainhash.Hash{1}
+		desc.TaprootAssetRoot = &root
+		h.withState(&LiveState{VTXO: desc})
+		_, err := h.sendEvent(event)
+		require.ErrorIs(t, err, ErrAssetVTXORequiresTransition)
+		assertState[*LiveState](h)
+		require.Empty(t, h.outboxMessages)
+	}
+}
+
+// TestAssetVTXOSkipsAutomaticRefresh exercises threshold, cohort, critical
+// fallback, and expired-reclaim triggers. None may request a Bitcoin round.
+func TestAssetVTXOSkipsAutomaticRefresh(t *testing.T) {
+	t.Parallel()
+	for _, event := range []VTXOEvent{
+		&BlockEpochEvent{
+			Height: 850,
+		},
+		&CohortRefreshEvent{
+			Height:      850,
+			BatchExpiry: 1000,
+		},
+		&criticalRefreshEvent{
+			Height: 990,
+		},
+	} {
+		h := newVTXOTestHarness(t)
+		desc := h.newTestDescriptor()
+		root := chainhash.Hash{1}
+		desc.TaprootAssetRoot = &root
+		desc.BatchExpiry = 1000
+		h.withExpiryConfig(&ExpiryConfig{
+			RefreshThresholdBlocks:  200,
+			CriticalThresholdBlocks: 50,
+		})
+		h.withState(&LiveState{VTXO: desc})
+		_, err := h.sendEvent(event)
+		require.NoError(t, err)
+		assertState[*LiveState](h)
+		require.Empty(t, h.outboxMessages)
+	}
+	h := newVTXOTestHarness(t)
+	desc := h.newTestDescriptor()
+	root := chainhash.Hash{1}
+	desc.TaprootAssetRoot = &root
+	desc.BatchExpiry = 1000
+	h.withState(&ExpiredState{VTXO: desc, ObservedHeight: 1001})
+	_, err := h.sendEvent(&BlockEpochEvent{Height: 1002})
+	require.NoError(t, err)
+	assertState[*ExpiredState](h)
+	require.Empty(t, h.outboxMessages)
+	_, err = h.sendEvent(&PendingForfeitEvent{})
+	require.ErrorIs(t, err, ErrAssetVTXORequiresTransition)
+}
+
+// TestAssetVTXOCarrierBalance reports asset carriers in total holdings while
+// excluding them from the Bitcoin spendable balance.
+func TestAssetVTXOCarrierBalance(t *testing.T) {
+	t.Parallel()
+	root := chainhash.Hash{1}
+	descs := []*Descriptor{
+		{
+			Amount:           1000,
+			Status:           VTXOStatusLive,
+			TaprootAssetRoot: &root,
+		},
+		{
+			Amount: 2000,
+			Status: VTXOStatusLive,
+		},
+		{
+			Amount: 3000,
+			Status: VTXOStatusSpending,
+		},
+	}
+	require.EqualValues(t, 6000, SumBalance(descs))
+	require.EqualValues(t, 2000, SumSpendableBalance(descs))
+}
+
+// TestAssetCriticalExpiryBypassesBitcoinFeeAssessment prevents a small
+// carrier from being routed back into the unsupported Bitcoin refresh path.
+func TestAssetCriticalExpiryBypassesBitcoinFeeAssessment(t *testing.T) {
+	t.Parallel()
+	h := newVTXOTestHarness(t)
+	desc := h.newTestDescriptor()
+	root := chainhash.Hash{1}
+	desc.TaprootAssetRoot = &root
+	manager := newMockManagerRef(t)
+	a := newRefreshTestActor(h, desc, manager, nil)
+	a.cfg.CriticalExitAssessor = func(context.Context, *Descriptor) (
+		CriticalExitAssessment, error) {
+
+		t.Fatal("asset exit must not assess a Bitcoin sweep")
+
+		return CriticalExitAssessment{}, nil
+	}
+	event := &BlockEpochEvent{Height: desc.BatchExpiry - 1}
+	require.Same(t, event, a.preflightCriticalExit(h.ctx, event))
+}

--- a/vtxo/filter.go
+++ b/vtxo/filter.go
@@ -59,7 +59,8 @@ func SumBalance(descs []*Descriptor) btcutil.Amount {
 // spendable subset of descriptors. Only Live VTXOs can fund a spend;
 // the other non-terminal states (PendingForfeit, Forfeiting, Spending)
 // are still "live" for actor-recovery purposes but cannot back a spend,
-// so they are excluded here. Callers reporting a spendable balance must
+// so they are excluded here. Asset carriers are also excluded because
+// they cannot fund Bitcoin payments. Callers reporting a spendable balance must
 // use this rather than SumBalance over a recovery-oriented VTXO set,
 // otherwise the figure overstates spendable liquidity.
 func SumSpendableBalance(descs []*Descriptor) btcutil.Amount {
@@ -68,7 +69,14 @@ func SumSpendableBalance(descs []*Descriptor) btcutil.Amount {
 		StatusSet: true,
 	})
 
-	return SumBalance(spendable)
+	var total btcutil.Amount
+	for _, desc := range spendable {
+		if desc.TaprootAssetRoot == nil {
+			total += desc.Amount
+		}
+	}
+
+	return total
 }
 
 // SumPendingBalance sums VTXOs in a non-terminal, non-spendable state

--- a/vtxo/interfaces.go
+++ b/vtxo/interfaces.go
@@ -357,6 +357,9 @@ func (s VTXOStatus) String() string {
 // alias keeps the legacy vtxo.Ancestry symbol working for callers.
 type Ancestry = types.Ancestry
 
+// MaxTaprootAssetRefBytes bounds the opaque asset reference in storage.
+const MaxTaprootAssetRefBytes = 512
+
 // Descriptor contains all information needed to track and spend a VTXO. This
 // is the canonical representation persisted to storage and passed between
 // actors.
@@ -376,6 +379,27 @@ type Descriptor struct {
 	// PkScript is the output script for this VTXO (taproot with
 	// collaborative and timeout spend paths).
 	PkScript []byte
+
+	// TaprootAssetRoot is the optional root of the Taproot Asset commitment
+	// composed beside PolicyTemplate. When set, PkScript commits to
+	// TapBranch(policy_root, taproot_asset_root), and all Ark spend paths
+	// must include this root as the final control-block sibling.
+	TaprootAssetRoot *chainhash.Hash
+
+	// TaprootAssetRef is the opaque tap-sdk asset identity carried by this
+	// VTXO. It is intentionally a string so the wallet domain does not
+	// depend on tap-sdk or taproot-assets types.
+	TaprootAssetRef string
+
+	// TaprootAssetAmount is the number of Taproot Asset units carried by
+	// this VTXO. Amount remains the separate Bitcoin carrier value.
+	TaprootAssetAmount uint64
+
+	// TaprootAssetSealedPackage is the sealed tap-sdk package that
+	// created this VTXO, present only for an asset leaf received from a
+	// round. Spending it out of round rebuilds the compact proof path
+	// and the OP_TRUE witness from it.
+	TaprootAssetSealedPackage []byte
 
 	// ClientKey is the client's key descriptor for this VTXO.
 	ClientKey keychain.KeyDescriptor

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -1649,6 +1649,7 @@ func (m *Manager) coordinateAutoRefreshCohort(ctx context.Context,
 	addCandidates := func(candidates []*Descriptor, pending bool) {
 		for _, candidate := range candidates {
 			if candidate == nil ||
+				candidate.TaprootAssetRoot != nil ||
 				candidate.Outpoint == req.VTXOOutpoint ||
 				candidate.BatchExpiry != req.BatchExpiry ||
 				m.isReserved(candidate.Outpoint) {
@@ -2266,6 +2267,10 @@ func (m *Manager) exactSpendUnavailableError(ctx context.Context,
 			err)
 	}
 
+	if desc.TaprootAssetRoot != nil {
+		return ErrAssetVTXORequiresTransition
+	}
+
 	switch desc.Status {
 	case VTXOStatusLive, VTXOStatusPendingForfeit,
 		VTXOStatusForfeiting, VTXOStatusSpending:
@@ -2298,7 +2303,7 @@ func (m *Manager) insufficientLiquidityError(ctx context.Context,
 
 	var lockedTotal btcutil.Amount
 	for _, desc := range nonTerminal {
-		if desc == nil {
+		if desc == nil || desc.TaprootAssetRoot != nil {
 			continue
 		}
 
@@ -3311,6 +3316,9 @@ func (m *Manager) customForfeitInputStoredMatch(ctx context.Context,
 	if desc == nil {
 		return false, false, fmt.Errorf("load existing custom forfeit "+
 			"input %s: nil descriptor", input.Outpoint)
+	}
+	if desc.TaprootAssetRoot != nil {
+		return false, false, ErrAssetVTXORequiresTransition
 	}
 	synthetic := desc.Status == VTXOStatusPendingForfeit
 	if desc.Amount != input.Amount {

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -3572,7 +3572,7 @@ func clientVTXOToDescriptor(cv *round.ClientVTXO,
 	// carry their semantic template and explicit spend paths
 	// instead of a derived standard tapscript.
 	var tapscript *waddrmgr.Tapscript
-	if len(cv.PolicyTemplate) > 0 {
+	if len(cv.PolicyTemplate) > 0 && cv.TaprootAssetRoot == nil {
 		desc := &Descriptor{PolicyTemplate: cv.PolicyTemplate}
 		ts, err := desc.StandardTapScript()
 		if err == nil {
@@ -3590,11 +3590,23 @@ func clientVTXOToDescriptor(cv *round.ClientVTXO,
 	ancestry := make([]Ancestry, len(cv.Ancestry))
 	copy(ancestry, cv.Ancestry)
 
+	var assetRoot *chainhash.Hash
+	if cv.TaprootAssetRoot != nil {
+		root := *cv.TaprootAssetRoot
+		assetRoot = &root
+	}
+
 	return fn.Ok(&Descriptor{
-		Outpoint:       cv.Outpoint,
-		Amount:         cv.Amount,
-		PolicyTemplate: cv.PolicyTemplate,
-		PkScript:       cv.PkScript,
+		Outpoint:           cv.Outpoint,
+		Amount:             cv.Amount,
+		PolicyTemplate:     cv.PolicyTemplate,
+		PkScript:           cv.PkScript,
+		TaprootAssetRoot:   assetRoot,
+		TaprootAssetRef:    cv.TaprootAssetRef,
+		TaprootAssetAmount: cv.TaprootAssetAmount,
+		TaprootAssetSealedPackage: bytes.Clone(
+			cv.TaprootAssetSealedPackage,
+		),
 		ClientKey:      cv.OwnerKey,
 		OperatorKey:    cv.OperatorKey,
 		TapScript:      tapscript,

--- a/vtxo/policy.go
+++ b/vtxo/policy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 )
@@ -52,7 +53,28 @@ func (d *Descriptor) EffectivePkScript() ([]byte, error) {
 		return nil, err
 	}
 
-	return template.PkScript()
+	if d.TaprootAssetRoot == nil {
+		return template.PkScript()
+	}
+
+	compiled, err := template.Compile()
+	if err != nil {
+		return nil, fmt.Errorf("compile VTXO policy: %w", err)
+	}
+
+	composed, err := arkscript.ComposeWithSiblingRoot(
+		compiled, *d.TaprootAssetRoot,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("compose Taproot Asset root: %w", err)
+	}
+
+	pkScript, err := txscript.PayToTaprootScript(composed.OutputKey())
+	if err != nil {
+		return nil, fmt.Errorf("derive composed VTXO pkscript: %w", err)
+	}
+
+	return pkScript, nil
 }
 
 // DecodeStandardPolicyTemplate extracts the standard VTXO parameters when this
@@ -120,6 +142,10 @@ func (d *Descriptor) RefreshOutputTemplate(
 // StandardTapScript derives the standard tapscript for descriptors that use
 // the default Ark policy shape.
 func (d *Descriptor) StandardTapScript() (*waddrmgr.Tapscript, error) {
+	if d != nil && d.TaprootAssetRoot != nil {
+		return nil, fmt.Errorf("asset VTXO requires a composed spend " +
+			"path")
+	}
 	params, err := d.DecodeStandardPolicyTemplate()
 	if err != nil {
 		return nil, err

--- a/vtxo/round_asset_state_test.go
+++ b/vtxo/round_asset_state_test.go
@@ -1,0 +1,40 @@
+package vtxo
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/round"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRoundAssetDescriptor retains independent asset state when a confirmed
+// round hands its leaves to the VTXO manager.
+func TestRoundAssetDescriptor(t *testing.T) {
+	t.Parallel()
+	root := chainhash.Hash{1}
+	cv := &round.ClientVTXO{
+		TaprootAssetRoot:   &root,
+		TaprootAssetRef:    "asset",
+		TaprootAssetAmount: 100,
+		TaprootAssetSealedPackage: []byte{
+			1,
+			2,
+		},
+	}
+	desc, err := clientVTXOToDescriptor(
+		cv, &round.VTXOCreatedNotification{},
+	).Unpack()
+	require.NoError(t, err)
+	require.Equal(t, cv.TaprootAssetRoot, desc.TaprootAssetRoot)
+	require.Equal(t, cv.TaprootAssetRef, desc.TaprootAssetRef)
+	require.Equal(t, cv.TaprootAssetAmount, desc.TaprootAssetAmount)
+	require.Equal(
+		t, cv.TaprootAssetSealedPackage, desc.TaprootAssetSealedPackage,
+	)
+	require.Nil(t, desc.TapScript)
+	cv.TaprootAssetRoot[0] = 2
+	cv.TaprootAssetSealedPackage[0] = 3
+	require.EqualValues(t, 1, desc.TaprootAssetRoot[0])
+	require.EqualValues(t, 1, desc.TaprootAssetSealedPackage[0])
+}

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -166,6 +166,11 @@ func (s *LiveState) handleCohortRefresh(evt *CohortRefreshEvent,
 func (s *LiveState) autoRefreshTransition(height int32,
 	cohortMember bool) *VTXOStateTransition {
 
+	// A Bitcoin refresh would discard the asset commitment.
+	if s.VTXO.TaprootAssetRoot != nil {
+		return &VTXOStateTransition{NextState: s}
+	}
+
 	outbox := []VTXOOutMsg{
 		&ForfeitRequest{
 			VTXOOutpoint:      s.VTXO.Outpoint,
@@ -194,6 +199,10 @@ func (s *LiveState) autoRefreshTransition(height int32,
 func (s *LiveState) handlePendingForfeit(_ context.Context,
 	_ *VTXOEnvironment) (*VTXOStateTransition, error) {
 
+	if s.VTXO.TaprootAssetRoot != nil {
+		return nil, ErrAssetVTXORequiresTransition
+	}
+
 	return &VTXOStateTransition{
 		NextState: &PendingForfeitState{
 			VTXO:              s.VTXO,
@@ -215,6 +224,10 @@ func (s *LiveState) handlePendingForfeit(_ context.Context,
 // until the spend completes or is released.
 func (s *LiveState) handleSpendReserve(_ context.Context, _ *VTXOEnvironment) (
 	*VTXOStateTransition, error) {
+
+	if s.VTXO.TaprootAssetRoot != nil {
+		return nil, ErrAssetVTXORequiresTransition
+	}
 
 	return &VTXOStateTransition{
 		NextState: &SpendingState{
@@ -391,6 +404,10 @@ func (s *LiveState) handleBlockEpoch(ctx context.Context, evt *BlockEpochEvent,
 func (s *LiveState) handleForfeitRequest(ctx context.Context,
 	evt *ForfeitRequestEvent, env *VTXOEnvironment) (*VTXOStateTransition,
 	error) {
+
+	if s.VTXO.TaprootAssetRoot != nil {
+		return nil, ErrAssetVTXORequiresTransition
+	}
 
 	forfeitSpend, err := resolveForfeitSpendPath(s.VTXO, evt)
 	if err != nil {
@@ -1644,6 +1661,10 @@ func (s *ExpiredState) ProcessEvent(ctx context.Context, event VTXOEvent,
 			), nil
 		}
 
+		if s.VTXO.TaprootAssetRoot != nil {
+			return &VTXOStateTransition{NextState: s}, nil
+		}
+
 		// The VTXO is still expired, so recover it through the ordinary
 		// refresh path. The server admits the input from its effective
 		// batch expiry and the normal connector-bound forfeit protects
@@ -1668,6 +1689,9 @@ func (s *ExpiredState) ProcessEvent(ctx context.Context, event VTXOEvent,
 		}, nil
 
 	case *PendingForfeitEvent:
+		if s.VTXO.TaprootAssetRoot != nil {
+			return nil, ErrAssetVTXORequiresTransition
+		}
 		// The reclaim path: the wallet has committed this expired
 		// VTXO to a round. From here it follows the ordinary forfeit
 		// choreography, because a reclaim IS an ordinary refresh whose

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -491,6 +491,10 @@ func (s *LiveState) handleForfeitRequest(ctx context.Context,
 func resolveForfeitSpendPath(vtxo *Descriptor,
 	evt *ForfeitRequestEvent) (*arkscript.SpendPath, error) {
 
+	if vtxo.TaprootAssetRoot != nil {
+		return nil, ErrAssetVTXORequiresTransition
+	}
+
 	if evt != nil && evt.ForfeitSpend != nil {
 		err := evt.ForfeitSpend.Validate()
 		if err != nil {

--- a/wallet/interfaces.go
+++ b/wallet/interfaces.go
@@ -9,7 +9,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
-	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/wavelength/lib/types"
 	"github.com/lightninglabs/wavelength/walletcore"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -316,7 +316,7 @@ type BoardingChainInfo struct {
 	// output construction details needed for server verification without
 	// querying its own chain source. None if the proof hasn't been
 	// constructed yet (e.g., block data not available).
-	TxProof fn.Option[proof.TxProof]
+	TxProof fn.Option[types.TxProof]
 }
 
 // BoardingIntent captures one confirmed boarding input. Intents are only

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -16,7 +16,6 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
-	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/lightninglabs/wavelength/build"
 	"github.com/lightninglabs/wavelength/chainsource"
@@ -2536,7 +2535,7 @@ func sumBoardingAmounts(amounts []btcutil.Amount) btcutil.Amount {
 func (a *Ark) buildBoardingTxProof(ctx context.Context,
 	blockHash chainhash.Hash, blockHeight int32, confTx *wire.MsgTx,
 	outpoint wire.OutPoint,
-	addr *BoardingAddress) fn.Option[proof.TxProof] {
+	addr *BoardingAddress) fn.Option[types.TxProof] {
 
 	// Fetch the full block to compute the merkle proof.
 	block, err := a.backend.GetBlock(ctx, blockHash)
@@ -2546,7 +2545,7 @@ func (a *Ark) buildBoardingTxProof(ctx context.Context,
 			btclog.Fmt("block_hash", "%v", blockHash),
 		)
 
-		return fn.None[proof.TxProof]()
+		return fn.None[types.TxProof]()
 	}
 
 	// Find the transaction index within the block.
@@ -2565,11 +2564,11 @@ func (a *Ark) buildBoardingTxProof(ctx context.Context,
 			btclog.Fmt("block_hash", "%v", blockHash),
 		)
 
-		return fn.None[proof.TxProof]()
+		return fn.None[types.TxProof]()
 	}
 
 	// Compute the merkle inclusion proof.
-	merkleProof, err := proof.NewTxMerkleProof(
+	merkleProof, err := types.NewTxMerkleProof(
 		block.Transactions, txIdx,
 	)
 	if err != nil {
@@ -2578,7 +2577,7 @@ func (a *Ark) buildBoardingTxProof(ctx context.Context,
 			btclog.Fmt("txid", "%v", txHash),
 		)
 
-		return fn.None[proof.TxProof]()
+		return fn.None[types.TxProof]()
 	}
 
 	// Extract the internal key and tapscript root hash from the boarding
@@ -2593,7 +2592,7 @@ func (a *Ark) buildBoardingTxProof(ctx context.Context,
 			nil,
 		)
 
-		return fn.None[proof.TxProof]()
+		return fn.None[types.TxProof]()
 	}
 	internalKey := addr.Tapscript.ControlBlock.InternalKey
 	merkleRoot := addr.Tapscript.RootHash
@@ -2603,7 +2602,7 @@ func (a *Ark) buildBoardingTxProof(ctx context.Context,
 		slog.Int("block_height", int(blockHeight)),
 	)
 
-	return fn.Some(proof.TxProof{
+	return fn.Some(types.TxProof{
 		MsgTx:           *confTx,
 		BlockHeader:     block.Header,
 		BlockHeight:     uint32(blockHeight),

--- a/waved/rpc_oor_custom_input_test.go
+++ b/waved/rpc_oor_custom_input_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/chainsource"
-	"github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
 	"github.com/lightninglabs/wavelength/oor"
@@ -65,6 +64,7 @@ func newCustomOORRPCFixture(t *testing.T) *customOORRPCFixture {
 		},
 	}
 
+	vtxoStore, _, _, _, _ := newSendOORTestStores(t)
 	server := &Server{
 		cfg: &Config{
 			Wallet: &WalletConfig{
@@ -72,7 +72,7 @@ func newCustomOORRPCFixture(t *testing.T) *customOORRPCFixture {
 			},
 		},
 		walletReady: ready,
-		vtxoStore:   &db.VTXOPersistenceStore{},
+		vtxoStore:   vtxoStore,
 		clientKeyDesc: keychain.KeyDescriptor{
 			PubKey: receiverPriv.PubKey(),
 			KeyLocator: keychain.KeyLocator{

--- a/waved/wallet_ops.go
+++ b/waved/wallet_ops.go
@@ -136,6 +136,10 @@ func BuildTransferInputs(ctx context.Context, store vtxo.VTXOStore,
 			return nil, fmt.Errorf("look up VTXO %s: %w", op, err)
 		}
 
+		if desc.TaprootAssetRoot != nil {
+			return nil, vtxo.ErrAssetVTXORequiresTransition
+		}
+
 		// The checkpoint output collab path is a 2-of-2 multisig
 		// between the VTXO owner and the operator, matching the
 		// VTXO's own collaborative spend path. This ensures both

--- a/waved/wallet_ops.go
+++ b/waved/wallet_ops.go
@@ -3,6 +3,7 @@ package waved
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -195,6 +196,22 @@ func BuildCustomTransferInputs(ctx context.Context, store vtxo.VTXOStore,
 
 		var desc *vtxo.Descriptor
 
+		// Caller-supplied fields must not hide an asset marker already
+		// known to this wallet. A lookup failure other than absence
+		// fails closed.
+		if store != nil {
+			stored, lookupErr := store.GetVTXO(ctx, outpoint)
+			if lookupErr != nil &&
+				!errors.Is(lookupErr, vtxo.ErrVTXONotFound) {
+				return nil, fmt.Errorf("look up custom VTXO "+
+					"%s: %w", outpoint, lookupErr)
+			}
+			if stored != nil && stored.TaprootAssetRoot != nil {
+				return nil, vtxo.ErrAssetVTXORequiresTransition
+			}
+			desc = stored
+		}
+
 		// If the caller provided amount and pkscript, build
 		// the descriptor directly (for VTXOs not in the local
 		// store, e.g., received via OOR).
@@ -210,13 +227,9 @@ func BuildCustomTransferInputs(ctx context.Context, store vtxo.VTXOStore,
 				OperatorKey:    operatorKey,
 				RelativeExpiry: exitDelay,
 			}
-		} else {
-			// Fall back to store lookup.
-			desc, err = store.GetVTXO(ctx, outpoint)
-			if err != nil {
-				return nil, fmt.Errorf("look up VTXO %s: %w",
-					outpoint, err)
-			}
+		} else if desc == nil {
+			return nil, fmt.Errorf("look up VTXO %s: %w", outpoint,
+				vtxo.ErrVTXONotFound)
 		}
 
 		var (

--- a/waved/wallet_ops_test.go
+++ b/waved/wallet_ops_test.go
@@ -530,3 +530,18 @@ func TestFindSettlementOwnerLeafWithConditions(t *testing.T) {
 	require.Equal(t, claimPath.WitnessScript, ownerLeaf)
 	require.NotEmpty(t, ownerLeafPolicy)
 }
+
+// TestBuildTransferInputsRejectsAssetCarrier refuses explicit Bitcoin sends
+// even when the caller bypasses wallet coin selection.
+func TestBuildTransferInputsRejectsAssetCarrier(t *testing.T) {
+	t.Parallel()
+	root := chainhash.Hash{1}
+	store := &testCustomInputStore{desc: &vtxo.Descriptor{
+		TaprootAssetRoot: &root,
+	}}
+	inputs, err := BuildTransferInputs(
+		t.Context(), store, []wire.OutPoint{{}},
+	)
+	require.ErrorIs(t, err, vtxo.ErrAssetVTXORequiresTransition)
+	require.Empty(t, inputs)
+}

--- a/waved/wallet_ops_test.go
+++ b/waved/wallet_ops_test.go
@@ -37,7 +37,7 @@ func (s *testCustomInputStore) GetVTXO(_ context.Context,
 	s.lookups = append(s.lookups, outpoint)
 
 	if s.desc == nil {
-		return nil, fmt.Errorf("vtxo not found")
+		return nil, vtxo.ErrVTXONotFound
 	}
 
 	return s.desc, nil
@@ -190,7 +190,7 @@ func TestBuildCustomTransferInputsExternalVHTLCClaim(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, inputs, 1)
-	require.Empty(t, store.lookups)
+	require.Equal(t, []wire.OutPoint{outpoint}, store.lookups)
 
 	input := inputs[0]
 	require.Equal(t, outpoint, input.VTXO.Outpoint)
@@ -544,4 +544,29 @@ func TestBuildTransferInputsRejectsAssetCarrier(t *testing.T) {
 	)
 	require.ErrorIs(t, err, vtxo.ErrAssetVTXORequiresTransition)
 	require.Empty(t, inputs)
+}
+
+// TestCustomTransferInputsCannotHideAssetState rejects a known asset whether
+// the custom request resolves its descriptor or supplies replacement fields.
+func TestCustomTransferInputsCannotHideAssetState(t *testing.T) {
+	t.Parallel()
+	root := chainhash.Hash{1}
+	for _, supplied := range []bool{false, true} {
+		store := &testCustomInputStore{desc: &vtxo.Descriptor{
+			TaprootAssetRoot: &root,
+		}}
+		ci := &waverpc.CustomOORInput{
+			Outpoint: testWalletOpsOutpoint(1).String(),
+		}
+		if supplied {
+			ci.AmountSat = 1000
+			ci.PkScript = []byte{1}
+		}
+		inputs, err := BuildCustomTransferInputs(
+			t.Context(), store, []*waverpc.CustomOORInput{ci},
+			keychain.KeyDescriptor{}, nil, 0,
+		)
+		require.ErrorIs(t, err, vtxo.ErrAssetVTXORequiresTransition)
+		require.Empty(t, inputs)
+	}
 }


### PR DESCRIPTION
Persist asset identity, amounts, composed scripts, and sealed transition packages across VTXO and round recovery. Validate recovered asset state and reject Bitcoin-only operations that would discard asset commitments.

Bitcoin inclusion proofs now use Wavelength-owned types with unchanged wire encoding, and tapd harness access uses tap-sdk, removing direct Taproot Assets and taprpc imports.