### PR TITLE
round: persist verified asset leaf state

### DIFF
--- a/db/round_asset_state_test.go
+++ b/db/round_asset_state_test.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/wavelength/round"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRoundAssetVTXOState persists the asset marker in the round transaction,
+// before any manager notification, and preserves it through both read APIs.
+func TestRoundAssetVTXOState(t *testing.T) {
+	t.Parallel()
+	vtxoStore, roundStore, _ := newVTXOStoreForTest(t)
+	ctx := t.Context()
+	roundID := round.RoundID{1}
+	require.NoError(
+		t,
+		roundStore.CommitState(
+			ctx, createTestRound(t, roundID),
+			&round.InputSigSentState{
+				RoundID: roundID,
+			},
+		),
+	)
+	desc := testAssetDescriptor(t, 1)
+	cv := &round.ClientVTXO{
+		Outpoint:                  desc.Outpoint,
+		Amount:                    desc.Amount,
+		PolicyTemplate:            desc.PolicyTemplate,
+		PkScript:                  desc.PkScript,
+		OwnerKey:                  desc.ClientKey,
+		OperatorKey:               desc.OperatorKey,
+		Expiry:                    desc.RelativeExpiry,
+		RoundID:                   fn.Some(roundID),
+		TaprootAssetRoot:          desc.TaprootAssetRoot,
+		TaprootAssetRef:           desc.TaprootAssetRef,
+		TaprootAssetAmount:        desc.TaprootAssetAmount,
+		TaprootAssetSealedPackage: desc.TaprootAssetSealedPackage,
+	}
+	require.NoError(t, roundStore.SaveVTXOs(ctx, []*round.ClientVTXO{cv}))
+	got, err := vtxoStore.GetVTXO(ctx, desc.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, desc.TaprootAssetAmount, got.TaprootAssetAmount)
+	require.Equal(
+		t, desc.TaprootAssetSealedPackage,
+		got.TaprootAssetSealedPackage,
+	)
+	require.Nil(t, got.TapScript)
+	fromRound, err := roundStore.GetVTXO(ctx, desc.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, cv.TaprootAssetRoot, fromRound.TaprootAssetRoot)
+	require.Equal(t, cv.TaprootAssetRef, fromRound.TaprootAssetRef)
+	require.Equal(t, cv.TaprootAssetAmount, fromRound.TaprootAssetAmount)
+	require.Equal(
+		t, cv.TaprootAssetSealedPackage,
+		fromRound.TaprootAssetSealedPackage,
+	)
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, desc))
+	cv.TaprootAssetAmount--
+	require.Error(t, roundStore.SaveVTXOs(ctx, []*round.ClientVTXO{cv}))
+}

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lightninglabs/wavelength/lib/types"
 	"github.com/lightninglabs/wavelength/round"
 	"github.com/lightninglabs/wavelength/rpc/roundpb"
+	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -1719,16 +1720,16 @@ func dbVtxoRequestRowToVTXORequest(ctx context.Context, q RoundStore,
 // upsertRoundClientVTXOAncestry alongside InsertVTXO inside the same
 // transaction.
 func (s *RoundPersistenceStore) domainVTXOToInsertParams(ctx context.Context,
-	q RoundStore, vtxo *round.ClientVTXO) (InsertVTXOParams, error) {
+	q RoundStore, cv *round.ClientVTXO) (InsertVTXOParams, error) {
 
 	roundIDStr := ""
-	vtxo.RoundID.WhenSome(func(rid round.RoundID) {
+	cv.RoundID.WhenSome(func(rid round.RoundID) {
 		roundIDStr = rid.String()
 	})
 
 	var operatorPubkey []byte
-	if vtxo.OperatorKey != nil {
-		operatorPubkey = vtxo.OperatorKey.SerializeCompressed()
+	if cv.OperatorKey != nil {
+		operatorPubkey = cv.OperatorKey.SerializeCompressed()
 	}
 
 	nowUnix := s.clock.Now().Unix()
@@ -1738,8 +1739,8 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(ctx context.Context,
 	// owner pubkey yet; in that case the FK stays NULL until the VTXO
 	// manager heals the row with the full descriptor.
 	var clientKeyID sql.NullInt64
-	if vtxo.OwnerKey.PubKey != nil {
-		id, err := RegisterInternalKeyTx(ctx, q, nowUnix, vtxo.OwnerKey)
+	if cv.OwnerKey.PubKey != nil {
+		id, err := RegisterInternalKeyTx(ctx, q, nowUnix, cv.OwnerKey)
 		if err != nil {
 			return InsertVTXOParams{}, fmt.Errorf("register "+
 				"owner key: %w", err)
@@ -1748,12 +1749,12 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(ctx context.Context,
 		clientKeyID = sql.NullInt64{Int64: id, Valid: true}
 	}
 
-	policyTemplate := bytes.Clone(vtxo.PolicyTemplate)
-	if len(policyTemplate) == 0 && vtxo.OwnerKey.PubKey != nil &&
-		vtxo.OperatorKey != nil && vtxo.Expiry != 0 {
+	policyTemplate := bytes.Clone(cv.PolicyTemplate)
+	if len(policyTemplate) == 0 && cv.OwnerKey.PubKey != nil &&
+		cv.OperatorKey != nil && cv.Expiry != 0 {
 
 		encodedPolicy, err := arkscript.EncodeStandardVTXOTemplate(
-			vtxo.OwnerKey.PubKey, vtxo.OperatorKey, vtxo.Expiry,
+			cv.OwnerKey.PubKey, cv.OperatorKey, cv.Expiry,
 		)
 		if err != nil {
 			return InsertVTXOParams{}, fmt.Errorf("encode client "+
@@ -1763,20 +1764,41 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(ctx context.Context,
 		policyTemplate = encodedPolicy
 	}
 
+	assetDesc := &vtxo.Descriptor{
+		Outpoint:                  cv.Outpoint,
+		PolicyTemplate:            policyTemplate,
+		PkScript:                  cv.PkScript,
+		TaprootAssetRoot:          cv.TaprootAssetRoot,
+		TaprootAssetRef:           cv.TaprootAssetRef,
+		TaprootAssetAmount:        cv.TaprootAssetAmount,
+		TaprootAssetSealedPackage: cv.TaprootAssetSealedPackage,
+	}
+	assetRef, assetAmount, err := encodeTaprootAssetMetadata(assetDesc)
+	if err != nil {
+		return InsertVTXOParams{}, err
+	}
+	if err := validateAssetVTXOReplay(ctx, q, assetDesc); err != nil {
+		return InsertVTXOParams{}, err
+	}
+	var assetRoot []byte
+	if cv.TaprootAssetRoot != nil {
+		assetRoot = cv.TaprootAssetRoot.CloneBytes()
+	}
+
 	return InsertVTXOParams{
-		OutpointHash:   vtxo.Outpoint.Hash[:],
-		OutpointIndex:  int32(vtxo.Outpoint.Index),
+		OutpointHash:   cv.Outpoint.Hash[:],
+		OutpointIndex:  int32(cv.Outpoint.Index),
 		RoundID:        roundIDStr,
-		Amount:         int64(vtxo.Amount),
-		PkScript:       vtxo.PkScript,
-		Expiry:         int32(vtxo.Expiry),
+		Amount:         int64(cv.Amount),
+		PkScript:       cv.PkScript,
+		Expiry:         int32(cv.Expiry),
 		PolicyTemplate: policyTemplate,
 		ClientKeyID:    clientKeyID,
 		OperatorPubkey: operatorPubkey,
-		BatchExpiry:    vtxo.BatchExpiry,
+		BatchExpiry:    cv.BatchExpiry,
 		ChainDepth:     0,
-		CreatedHeight:  vtxo.CreatedHeight,
-		CommitmentTxid: vtxo.CommitmentTxID[:],
+		CreatedHeight:  cv.CreatedHeight,
+		CommitmentTxid: cv.CommitmentTxID[:],
 		Spent:          false,
 		CreationTime:   nowUnix,
 		LastUpdateTime: nowUnix,
@@ -1787,6 +1809,12 @@ func (s *RoundPersistenceStore) domainVTXOToInsertParams(ctx context.Context,
 		// descriptor-heal path so the write-once construction_version
 		// is set deliberately at creation rather than defaulted.
 		ConstructionVersion: int32(arkrpc.ConstructionVersionV1),
+		TaprootAssetRoot:    assetRoot,
+		TaprootAssetRef:     assetRef,
+		TaprootAssetAmount:  assetAmount,
+		TaprootAssetSealedPackage: bytes.Clone(
+			cv.TaprootAssetSealedPackage,
+		),
 	}, nil
 }
 
@@ -1931,19 +1959,28 @@ func (s *RoundPersistenceStore) dbVTXOToDomainVTXO(ctx context.Context,
 		copy(commitmentTxID[:], dbVTXO.CommitmentTxid)
 	}
 
+	assetDesc, assetErr := decodeAssetVTXOState(dbVTXO)
+	if assetErr != nil {
+		return nil, assetErr
+	}
+
 	return &round.ClientVTXO{
-		Outpoint:       outpoint,
-		Amount:         btcutil.Amount(dbVTXO.Amount),
-		PolicyTemplate: policyTemplate,
-		PkScript:       dbVTXO.PkScript,
-		Expiry:         expiry,
-		OwnerKey:       ownerKey,
-		OperatorKey:    operatorPubkey,
-		Ancestry:       ancestry,
-		RoundID:        roundIDOpt,
-		CommitmentTxID: commitmentTxID,
-		BatchExpiry:    dbVTXO.BatchExpiry,
-		CreatedHeight:  dbVTXO.CreatedHeight,
+		Outpoint:                  outpoint,
+		Amount:                    btcutil.Amount(dbVTXO.Amount),
+		PolicyTemplate:            policyTemplate,
+		PkScript:                  dbVTXO.PkScript,
+		TaprootAssetRoot:          assetDesc.TaprootAssetRoot,
+		TaprootAssetRef:           assetDesc.TaprootAssetRef,
+		TaprootAssetAmount:        assetDesc.TaprootAssetAmount,
+		TaprootAssetSealedPackage: assetDesc.TaprootAssetSealedPackage,
+		Expiry:                    expiry,
+		OwnerKey:                  ownerKey,
+		OperatorKey:               operatorPubkey,
+		Ancestry:                  ancestry,
+		RoundID:                   roundIDOpt,
+		CommitmentTxID:            commitmentTxID,
+		BatchExpiry:               dbVTXO.BatchExpiry,
+		CreatedHeight:             dbVTXO.CreatedHeight,
 	}, nil
 }
 

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -338,3 +338,10 @@ state transitions and validation rules live under [Invariants](#invariants).
 - [round/README.md](README.md) — Full state machine walkthrough with
   diagrams.
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+
+## Asset leaf persistence
+
+Locally owned asset leaves retain their verified reference, amount,
+commitment root, and sealed package in `ClientVTXO`. Confirmation writes persist that identity before notifying the VTXO
+manager, and both round recovery and manager notification preserve it. Missing or mismatched tree
+metadata prevents a leaf from entering wallet inventory.

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -338,3 +338,10 @@ state transitions and validation rules live under [Invariants](#invariants).
 - [round/README.md](README.md) — Full state machine walkthrough with
   diagrams.
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+
+## Asset leaf persistence
+
+Locally owned asset leaves retain their verified reference, amount,
+commitment root, and sealed package in `ClientVTXO`. Confirmation writes persist that identity before notifying the VTXO
+manager, and both round recovery and manager notification preserve it. Missing or mismatched tree
+metadata prevents a leaf from entering wallet inventory.

--- a/round/asset_vtxo_state.go
+++ b/round/asset_vtxo_state.go
@@ -1,0 +1,52 @@
+package round
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/types"
+)
+
+// setClientVTXOAssetState retains the verified transition with its leaf. A
+// missing marker would let a restarted wallet treat carrier sats as Bitcoin.
+func setClientVTXOAssetState(cv *ClientVTXO, req types.VTXORequest,
+	clientTree *tree.Tree, leaf *tree.Node) error {
+
+	assetContext := clientTree.AssetContext
+	if req.AssetRef == "" {
+		if assetContext != nil {
+			return fmt.Errorf("Bitcoin VTXO request has an asset " +
+				"tree")
+		}
+
+		return nil
+	}
+	if assetContext == nil {
+		return fmt.Errorf("asset VTXO is missing tree context")
+	}
+	if err := assetContext.Validate(clientTree.Root); err != nil {
+		return fmt.Errorf("asset VTXO tree context: %w", err)
+	}
+	if assetContext.AssetRef() != req.AssetRef ||
+		assetContext.NodeAssetAmount(leaf) != req.AssetAmount {
+		return fmt.Errorf("asset VTXO identity does not match request")
+	}
+	rootBytes := assetContext.LeafAssetRoot(leaf.Input)
+	if len(rootBytes) != chainhash.HashSize {
+		return fmt.Errorf("asset VTXO is missing leaf commitment root")
+	}
+	sealedPackage := assetContext.SealedPackage(leaf.Input)
+	if len(sealedPackage) == 0 {
+		return fmt.Errorf("asset VTXO is missing sealed leaf package")
+	}
+	var root chainhash.Hash
+	copy(root[:], rootBytes)
+	cv.TaprootAssetRoot = &root
+	cv.TaprootAssetRef = req.AssetRef
+	cv.TaprootAssetAmount = req.AssetAmount
+	cv.TaprootAssetSealedPackage = bytes.Clone(sealedPackage)
+
+	return nil
+}

--- a/round/asset_vtxo_state_test.go
+++ b/round/asset_vtxo_state_test.go
@@ -1,0 +1,77 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildClientAssetVTXORejectsMissingState prevents incomplete restart
+// evidence from being persisted as an ordinary Bitcoin leaf.
+func TestBuildClientAssetVTXORejectsMissingState(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*boundAssetVTXOFixture)
+	}{
+		{
+			"missing context",
+			func(f *boundAssetVTXOFixture) {
+				f.tree.AssetContext = nil
+			},
+		},
+		{
+			"missing package",
+			func(f *boundAssetVTXOFixture) {
+				f.tree.AssetContext.SetSealedPackage(
+					f.tree.Root.Input, nil,
+				)
+			},
+		},
+		{
+			"wrong reference",
+			func(f *boundAssetVTXOFixture) {
+				f.request.AssetRef = "other"
+			},
+		},
+		{
+			"wrong units",
+			func(f *boundAssetVTXOFixture) {
+				f.request.AssetAmount++
+			},
+		},
+		{
+			"Bitcoin request",
+			func(f *boundAssetVTXOFixture) {
+				f.request.AssetRef = ""
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			h := newTestHarness(t)
+			fixture := newBoundAssetVTXOFixture(t, h)
+			fixture.tree.AssetContext.SetSealedPackage(
+				fixture.tree.Root.Input, fixture.sealedPackage,
+			)
+			test.mutate(fixture)
+			signerKey := NewSignerKey(
+				fixture.request.SigningKey.PubKey,
+			)
+			vtxos, err := buildClientVTXOs(
+				t.Context(), nil, Intents{
+					VTXOs: []types.VTXORequest{
+						fixture.request,
+					},
+				}, map[SignerKey]*tree.Tree{
+					signerKey: fixture.tree,
+				},
+				RoundID{1},
+			)
+			require.Error(t, err)
+			require.Empty(t, vtxos)
+		})
+	}
+}

--- a/round/asset_vtxo_validation_test.go
+++ b/round/asset_vtxo_validation_test.go
@@ -231,6 +231,23 @@ func TestCommitmentTxReceivedVerifiesAssetVTXO(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, vtxos, 1)
 	require.Equal(t, leafOutput.PkScript, vtxos[0].PkScript)
+	require.Equal(t, fixture.request.AssetRef, vtxos[0].TaprootAssetRef)
+	require.Equal(
+		t, fixture.request.AssetAmount, vtxos[0].TaprootAssetAmount,
+	)
+	require.Equal(
+		t, clientTree.AssetContext.LeafAssetRoot(leaf.Input),
+		vtxos[0].TaprootAssetRoot[:],
+	)
+	require.Equal(
+		t, fixture.sealedPackage, vtxos[0].TaprootAssetSealedPackage,
+	)
+	vtxos[0].TaprootAssetSealedPackage[0] ^= 1
+	require.Equal(
+		t, fixture.sealedPackage,
+		clientTree.AssetContext.SealedPackage(leaf.Input),
+	)
+
 }
 
 func TestValidateRequestedAssetVTXO(t *testing.T) {

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -501,6 +501,21 @@ type ClientVTXO struct {
 
 	PkScript []byte
 
+	// TaprootAssetRoot is the commitment composed beside this leaf's
+	// policy.
+	TaprootAssetRoot *chainhash.Hash
+
+	// TaprootAssetRef identifies the asset independently of carrier
+	// satoshis.
+	TaprootAssetRef string
+
+	// TaprootAssetAmount counts asset units, separately from Amount.
+	TaprootAssetAmount uint64
+
+	// TaprootAssetSealedPackage preserves the verified leaf transition for
+	// subsequent asset spends and claims after restart.
+	TaprootAssetSealedPackage []byte
+
 	// Expiry is the CSV delay for the unilateral exit path.
 	Expiry uint32
 

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -4767,6 +4767,11 @@ func buildClientVTXOs(ctx context.Context, checker OwnedScriptChecker,
 			RoundID:        fn.Some(roundID),
 			Origin:         req.Origin,
 		}
+		if err := setClientVTXOAssetState(
+			vtxo, req, clientTree, leaf,
+		); err != nil {
+			return nil, err
+		}
 		if isStandard {
 			vtxo.Expiry = params.ExitDelay
 			vtxo.OperatorKey = params.OperatorKey

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -3572,7 +3572,7 @@ func clientVTXOToDescriptor(cv *round.ClientVTXO,
 	// carry their semantic template and explicit spend paths
 	// instead of a derived standard tapscript.
 	var tapscript *waddrmgr.Tapscript
-	if len(cv.PolicyTemplate) > 0 {
+	if len(cv.PolicyTemplate) > 0 && cv.TaprootAssetRoot == nil {
 		desc := &Descriptor{PolicyTemplate: cv.PolicyTemplate}
 		ts, err := desc.StandardTapScript()
 		if err == nil {
@@ -3590,11 +3590,23 @@ func clientVTXOToDescriptor(cv *round.ClientVTXO,
 	ancestry := make([]Ancestry, len(cv.Ancestry))
 	copy(ancestry, cv.Ancestry)
 
+	var assetRoot *chainhash.Hash
+	if cv.TaprootAssetRoot != nil {
+		root := *cv.TaprootAssetRoot
+		assetRoot = &root
+	}
+
 	return fn.Ok(&Descriptor{
-		Outpoint:       cv.Outpoint,
-		Amount:         cv.Amount,
-		PolicyTemplate: cv.PolicyTemplate,
-		PkScript:       cv.PkScript,
+		Outpoint:           cv.Outpoint,
+		Amount:             cv.Amount,
+		PolicyTemplate:     cv.PolicyTemplate,
+		PkScript:           cv.PkScript,
+		TaprootAssetRoot:   assetRoot,
+		TaprootAssetRef:    cv.TaprootAssetRef,
+		TaprootAssetAmount: cv.TaprootAssetAmount,
+		TaprootAssetSealedPackage: bytes.Clone(
+			cv.TaprootAssetSealedPackage,
+		),
 		ClientKey:      cv.OwnerKey,
 		OperatorKey:    cv.OperatorKey,
 		TapScript:      tapscript,

--- a/vtxo/round_asset_state_test.go
+++ b/vtxo/round_asset_state_test.go
@@ -1,0 +1,40 @@
+package vtxo
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/round"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRoundAssetDescriptor retains independent asset state when a confirmed
+// round hands its leaves to the VTXO manager.
+func TestRoundAssetDescriptor(t *testing.T) {
+	t.Parallel()
+	root := chainhash.Hash{1}
+	cv := &round.ClientVTXO{
+		TaprootAssetRoot:   &root,
+		TaprootAssetRef:    "asset",
+		TaprootAssetAmount: 100,
+		TaprootAssetSealedPackage: []byte{
+			1,
+			2,
+		},
+	}
+	desc, err := clientVTXOToDescriptor(
+		cv, &round.VTXOCreatedNotification{},
+	).Unpack()
+	require.NoError(t, err)
+	require.Equal(t, cv.TaprootAssetRoot, desc.TaprootAssetRoot)
+	require.Equal(t, cv.TaprootAssetRef, desc.TaprootAssetRef)
+	require.Equal(t, cv.TaprootAssetAmount, desc.TaprootAssetAmount)
+	require.Equal(
+		t, cv.TaprootAssetSealedPackage, desc.TaprootAssetSealedPackage,
+	)
+	require.Nil(t, desc.TapScript)
+	cv.TaprootAssetRoot[0] = 2
+	cv.TaprootAssetSealedPackage[0] = 3
+	require.EqualValues(t, 1, desc.TaprootAssetRoot[0])
+	require.EqualValues(t, 1, desc.TaprootAssetSealedPackage[0])
+}


### PR DESCRIPTION
Carry each verified asset leaf's reference, amount, commitment root, and sealed transition package into `ClientVTXO`, confirmation-time storage, and the VTXO manager. Both round and wallet reads restore that identity before the leaf can participate in wallet operations.

Reject missing packages and mismatched tree metadata during leaf construction, preserve independent copies across manager notifications, and apply the same composed-script and replay checks to round-created rows as to wallet writes.
