### PR TITLE
multi: list every unconsumed VTXO by default and accept status lists in ListVTXOs

### DIFF
--- a/.claude/skills/waved.md
+++ b/.claude/skills/waved.md
@@ -190,7 +190,8 @@ wavecli --network=regtest activity                            # all activity
 wavecli --network=regtest activity --pending --kind send,recv # filter
 wavecli --network=regtest activity --format json              # JSON output
 # VTXO inventory and on-chain history are not part of the activity feed;
-# use the `ark` subtree: `ark vtxos list` (live VTXOs),
+# use the `ark` subtree: `ark vtxos list` (inventory; `--status live` for
+# spendable, `--all` for every status),
 # `ark listtransactions` (raw tx / onchain history),
 # `ark sweep list` (boarding-timeout sweep records).
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -175,7 +175,7 @@ wavecli-bob ark vtxos list   # bob's new VTXO appears within seconds
 ### Unilateral exit
 
 ```bash
-VTXO=$(wavecli ark vtxos list | jq -r '.vtxos[0].outpoint')
+VTXO=$(wavecli ark vtxos list --status live | jq -r '.vtxos[0].outpoint')
 wavecli exit --outpoint "$VTXO"
 # mine through the CSV delay
 wavecli exit status --outpoint "$VTXO"   # eventually COMPLETED

--- a/cmd/wavecli/waveclicommands/cmd_mcp.go
+++ b/cmd/wavecli/waveclicommands/cmd_mcp.go
@@ -250,29 +250,44 @@ func registerMCPTools(s *mcp.Server, client waverpc.DaemonServiceClient) {
 
 	// vtxos_list — with optional filters.
 	type vtxosListArgs struct {
-		StatusFilter string `json:"status_filter,omitempty" jsonschema:"VTXO status filter (live, pending_forfeit, unilateral_exit, etc.)"` //nolint:ll
-		MinAmountSat int64  `json:"min_amount_sat,omitempty" jsonschema:"minimum amount in sats"`                                           //nolint:ll
+		StatusFilter string   `json:"status_filter,omitempty" jsonschema:"single VTXO status"`                                                    //nolint:ll
+		Statuses     []string `json:"statuses,omitempty" jsonschema:"VTXO statuses to list; empty lists every status except forfeited and spent"` //nolint:ll
+		All          bool     `json:"all,omitempty" jsonschema:"list every status"`                                                               //nolint:ll
+		MinAmountSat int64    `json:"min_amount_sat,omitempty" jsonschema:"minimum amount in sats"`                                               //nolint:ll
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "ark.vtxos.list",
-		Description: "List VTXOs with optional filters",
+		Description: "List VTXOs with optional status filters",
 	}, func(ctx context.Context, req *mcp.CallToolRequest,
 		args vtxosListArgs) (*mcp.CallToolResult, any, error) {
 
-		rpcReq := &waverpc.ListVTXOsRequest{
-			MinAmountSat: args.MinAmountSat,
+		names := args.Statuses
+		if args.StatusFilter != "" {
+			names = append(names, args.StatusFilter)
 		}
 
-		if args.StatusFilter != "" {
-			status, ok := parseVTXOStatus(
-				args.StatusFilter,
-			)
+		if args.All && len(names) > 0 {
+			return nil, nil, fmt.Errorf("all and statuses are " +
+				"mutually exclusive")
+		}
+
+		rpcReq := &waverpc.ListVTXOsRequest{
+			MinAmountSat:           args.MinAmountSat,
+			ExcludeCheckpointPsbts: args.All,
+		}
+
+		for _, name := range names {
+			status, ok := parseVTXOStatus(name)
 			if !ok {
 				return nil, nil, fmt.Errorf("invalid "+
-					"status: %s", args.StatusFilter)
+					"status: %s", name)
 			}
 
-			rpcReq.StatusFilter = status
+			rpcReq.Statuses = append(rpcReq.Statuses, status)
+		}
+
+		if args.All {
+			rpcReq.Statuses = allVTXOStatuses()
 		}
 
 		resp, err := client.ListVTXOs(ctx, rpcReq)

--- a/cmd/wavecli/waveclicommands/cmd_vtxos.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/lightninglabs/wavelength/waverpc"
@@ -38,23 +39,30 @@ func newVTXOsCmd() *cobra.Command {
 var validStatuses = []string{
 	"live", "pending_forfeit", "forfeiting",
 	"forfeited", "spent", "unilateral_exit", "failed",
-	"spending",
+	"spending", "pending_round", "expired",
 }
+
+// checkpointPSBTsField is the --fields name of the OOR checkpoint PSBTs.
+const checkpointPSBTsField = "oor_final_checkpoint_psbts"
 
 // newVTXOsListCmd creates the vtxos list subcommand.
 func newVTXOsListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List VTXOs",
-		Long: "Returns VTXOs known to the wallet, " +
-			"optionally filtered by status and " +
-			"minimum amount.",
+		Long: "Returns VTXOs known to the wallet, newest first. " +
+			"Without --status, every VTXO except forfeited and " +
+			"spent ones is listed.",
 		RunE: vtxosList,
 	}
 
-	cmd.Flags().String("status", "",
-		"filter by status: "+
+	cmd.Flags().StringSlice("status", nil,
+		"filter by status, repeatable: "+
 			strings.Join(validStatuses, ", "))
+
+	cmd.Flags().Bool("all", false,
+		"list every status; checkpoint PSBTs only with --fields "+
+			checkpointPSBTsField)
 
 	cmd.Flags().Int64("min-amount", 0,
 		"minimum amount in sats")
@@ -74,13 +82,19 @@ func vtxosList(cmd *cobra.Command, _ []string) error {
 
 	req := &waverpc.ListVTXOsRequest{}
 	if err := parseRequest(cmd, req, func() error {
-		statusStr, _ := cmd.Flags().GetString("status")
+		statusStrs, _ := cmd.Flags().GetStringSlice("status")
+		all, _ := cmd.Flags().GetBool("all")
 		minAmount, _ := cmd.Flags().GetInt64("min-amount")
 
-		if statusStr != "" {
-			statusFilter, ok := parseVTXOStatus(
-				statusStr,
+		if all && len(statusStrs) > 0 {
+			return PrintError(
+				"INVALID_ARGS",
+				"--all and --status are mutually exclusive",
 			)
+		}
+
+		for _, statusStr := range statusStrs {
+			statusFilter, ok := parseVTXOStatus(statusStr)
 			if !ok {
 				return PrintError(
 					"INVALID_STATUS",
@@ -93,10 +107,15 @@ func vtxosList(cmd *cobra.Command, _ []string) error {
 				)
 			}
 
-			req.StatusFilter = statusFilter
+			req.Statuses = append(req.Statuses, statusFilter)
+		}
+
+		if all {
+			req.Statuses = allVTXOStatuses()
 		}
 
 		req.MinAmountSat = minAmount
+		req.ExcludeCheckpointPsbts = !wantsCheckpointPSBTs(cmd, all)
 
 		return nil
 	}); err != nil {
@@ -119,7 +138,25 @@ func vtxosList(cmd *cobra.Command, _ []string) error {
 	return renderListOutput(cmd, resp, items)
 }
 
-// parseVTXOStatus converts a status string to the proto enum.
+// wantsCheckpointPSBTs reports whether to request OOR checkpoint PSBTs: when
+// --fields names them, or when neither --fields nor --all is set.
+func wantsCheckpointPSBTs(cmd *cobra.Command, all bool) bool {
+	fieldsStr, _ := cmd.Flags().GetString("fields")
+	if fieldsStr == "" {
+		return !all
+	}
+
+	for _, field := range strings.Split(fieldsStr, ",") {
+		if strings.TrimSpace(field) == checkpointPSBTsField {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseVTXOStatus converts a status string to the proto enum, rejecting
+// UNSPECIFIED.
 func parseVTXOStatus(s string) (waverpc.VTXOStatus, bool) {
 	normalized := strings.ToUpper(s)
 	if !strings.HasPrefix(normalized, "VTXO_STATUS_") {
@@ -127,11 +164,29 @@ func parseVTXOStatus(s string) (waverpc.VTXOStatus, bool) {
 	}
 
 	val, ok := waverpc.VTXOStatus_value[normalized]
-	if !ok {
+	if !ok || val == int32(waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED) {
 		return 0, false
 	}
 
 	return waverpc.VTXOStatus(val), true
+}
+
+// allVTXOStatuses returns every status except UNSPECIFIED in enum order.
+func allVTXOStatuses() []waverpc.VTXOStatus {
+	values := make([]int32, 0, len(waverpc.VTXOStatus_name))
+	for val := range waverpc.VTXOStatus_name {
+		if val != int32(waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED) {
+			values = append(values, val)
+		}
+	}
+	slices.Sort(values)
+
+	statuses := make([]waverpc.VTXOStatus, len(values))
+	for i, val := range values {
+		statuses[i] = waverpc.VTXOStatus(val)
+	}
+
+	return statuses
 }
 
 // newVTXOsRefreshCmd creates the vtxos refresh subcommand.

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_test.go
@@ -1,0 +1,99 @@
+package waveclicommands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidStatusesMatchEnum pins validStatuses to the proto enum.
+func TestValidStatusesMatchEnum(t *testing.T) {
+	t.Parallel()
+
+	all := allVTXOStatuses()
+	require.NotContains(
+		t, all, waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED,
+	)
+	require.IsIncreasing(t, all)
+
+	expected := make([]string, 0, len(all))
+	for _, vtxoStatus := range all {
+		expected = append(
+			expected,
+			strings.ToLower(
+				strings.TrimPrefix(
+					vtxoStatus.String(),
+					"VTXO_STATUS_",
+				),
+			),
+		)
+	}
+	require.ElementsMatch(t, expected, validStatuses)
+}
+
+// TestParseVTXOStatus checks accepted and rejected status names.
+func TestParseVTXOStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range validStatuses {
+		_, ok := parseVTXOStatus(name)
+		require.True(t, ok, name)
+	}
+
+	for _, name := range []string{"unspecified", "bogus", ""} {
+		_, ok := parseVTXOStatus(name)
+		require.False(t, ok, name)
+	}
+}
+
+// TestWantsCheckpointPSBTs covers the --fields and --all combinations.
+func TestWantsCheckpointPSBTs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		fields string
+		all    bool
+		want   bool
+	}{
+		{
+			name: "full projection",
+			want: true,
+		},
+		{
+			name: "all without fields",
+			all:  true,
+			want: false,
+		},
+		{
+			name:   "fields omit psbts",
+			fields: "outpoint,amount_sat",
+			want:   false,
+		},
+		{
+			name:   "fields name psbts under all",
+			fields: "outpoint, " + checkpointPSBTsField,
+			all:    true,
+			want:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := newVTXOsListCmd()
+			if tc.fields != "" {
+				require.NoError(
+					t, cmd.Flags().Set("fields", tc.fields),
+				)
+			}
+
+			require.Equal(
+				t, tc.want, wantsCheckpointPSBTs(cmd, tc.all),
+			)
+		})
+	}
+}

--- a/cmd/wavecli/waveclicommands/schema_registry.go
+++ b/cmd/wavecli/waveclicommands/schema_registry.go
@@ -839,12 +839,14 @@ func arkVTXOMethodRegistry() []schemaMethod {
 	return []schemaMethod{
 		{
 			Method:      "ark.vtxos.list",
-			Description: "List VTXOs with optional filters",
+			Description: "List VTXOs with optional status filters",
 			Params: append([]schemaParam{
 				{
-					Name:        "status",
-					Type:        "enum",
-					Description: "filter by VTXO status",
+					Name:     "status",
+					Type:     "enum",
+					FlagType: "stringSlice",
+					Description: "filter by VTXO status, " +
+						"repeatable",
 					Values: []string{
 						"live",
 						"pending_forfeit",
@@ -854,7 +856,16 @@ func arkVTXOMethodRegistry() []schemaMethod {
 						"unilateral_exit",
 						"failed",
 						"spending",
+						"pending_round",
+						"expired",
 					},
+				},
+				{
+					Name: "all",
+					Type: "bool",
+					Description: "list every status; " +
+						"checkpoint PSBTs only with " +
+						"--fields",
 				},
 				{
 					Name:        "min-amount",

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -2,11 +2,13 @@ package db
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
@@ -594,6 +596,71 @@ func (s *VTXOPersistenceStore) ListVTXOsByStatusLight(ctx context.Context,
 
 		// A non-nil empty index keeps rowToDescriptor on the preloaded
 		// (zero ancestry) path, matching rowsToDescriptorsNoAncestry.
+		noAncestry := map[wire.OutPoint][]vtxo.Ancestry{}
+		descs, err := s.byStatusRowsToDescriptors(
+			ctx, q, rows, noAncestry,
+		)
+		if err != nil {
+			return err
+		}
+
+		result = descs
+
+		return nil
+	})
+
+	return result, err
+}
+
+// ListVTXOsByStatusesLight returns the descriptors in any of the given
+// statuses, newest first, without ancestry. One indexed query per status runs
+// inside a single read transaction; a parameterised IN list is not portable
+// across SQLite and Postgres.
+func (s *VTXOPersistenceStore) ListVTXOsByStatusesLight(ctx context.Context,
+	statuses []vtxo.VTXOStatus) ([]*vtxo.Descriptor, error) {
+
+	readTxOpts := ReadTxOption()
+
+	var result []*vtxo.Descriptor
+
+	err := s.db.ExecTx(ctx, readTxOpts, func(q RoundStore) error {
+		var rows []sqlc.ListVTXOsByStatusRow
+		seen := make(map[vtxo.VTXOStatus]struct{}, len(statuses))
+		for _, status := range statuses {
+			if _, dup := seen[status]; dup {
+				continue
+			}
+			seen[status] = struct{}{}
+
+			statusRows, err := q.ListVTXOsByStatus(
+				ctx, int32(status),
+			)
+			if err != nil {
+				return fmt.Errorf("list VTXOs by status: %w",
+					err)
+			}
+
+			rows = append(rows, statusRows...)
+		}
+
+		// Legacy rows flagged spent stay hidden under other statuses.
+		rows = slices.DeleteFunc(
+			rows, func(row sqlc.ListVTXOsByStatusRow) bool {
+				return row.Vtxo.Spent &&
+					vtxo.VTXOStatus(row.Vtxo.Status) !=
+						vtxo.VTXOStatusSpent
+			},
+		)
+
+		slices.SortStableFunc(
+			rows, func(a, b sqlc.ListVTXOsByStatusRow) int {
+				return cmp.Compare(
+					b.Vtxo.CreationTime,
+					a.Vtxo.CreationTime,
+				)
+			},
+		)
+
 		noAncestry := map[wire.OutPoint][]vtxo.Ancestry{}
 		descs, err := s.byStatusRowsToDescriptors(
 			ctx, q, rows, noAncestry,

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -546,41 +546,10 @@ func (s *VTXOPersistenceStore) ListVTXOsByStatus(ctx context.Context,
 	return result, err
 }
 
-// ListLiveVTXOsLight returns the same descriptors as ListLiveVTXOs with a
-// nil Ancestry on every entry. The ancestry side table's TLV tree fragments
-// grow with OOR chain depth, and the batched join sorts those blobs through
-// SQLite's external sorter on every call, so consumers that never walk the
-// lineage (the ListVTXOs RPC response carries no ancestry) skip the side
-// table entirely.
-func (s *VTXOPersistenceStore) ListLiveVTXOsLight(ctx context.Context) (
-	[]*vtxo.Descriptor, error) {
-
-	readTxOpts := ReadTxOption()
-
-	var result []*vtxo.Descriptor
-
-	err := s.db.ExecTx(ctx, readTxOpts, func(q RoundStore) error {
-		rows, err := q.ListLiveVTXOs(ctx)
-		if err != nil {
-			return fmt.Errorf("list live VTXOs: %w", err)
-		}
-
-		descs, err := s.rowsToDescriptorsNoAncestry(ctx, q, rows)
-		if err != nil {
-			return err
-		}
-
-		result = descs
-
-		return nil
-	})
-
-	return result, err
-}
-
 // ListVTXOsByStatusLight returns the same descriptors as ListVTXOsByStatus
-// with a nil Ancestry on every entry. See ListLiveVTXOsLight for why
-// listing-only consumers skip the ancestry side table.
+// without ancestry. The ancestry side table's TLV blobs grow with OOR chain
+// depth and sort through SQLite's external sorter, so listings that never
+// walk the lineage skip it.
 func (s *VTXOPersistenceStore) ListVTXOsByStatusLight(ctx context.Context,
 	status vtxo.VTXOStatus) ([]*vtxo.Descriptor, error) {
 

--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -786,10 +786,6 @@ func TestListVTXOsLightSkipsAncestry(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assertLight(light)
-
-	liveLight, err := vtxoStore.ListLiveVTXOsLight(ctx)
-	require.NoError(t, err)
-	assertLight(liveLight)
 }
 
 // addAncestryFragment appends a synthetic ancestry fragment to a

--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
@@ -2336,5 +2337,154 @@ func TestVTXOStoreExpiredExcludedFromLiveSet(t *testing.T) {
 		outpoints(recoverable),
 		"an expired VTXO's actor must still be restored so its "+
 			"value can be reclaimed",
+	)
+}
+
+// TestVTXOPersistenceStoreListVTXOsByStatusesLight covers status selection,
+// cross-status ordering, deduplication, the spent-flag guard and settlement
+// stamping.
+func TestVTXOPersistenceStoreListVTXOsByStatusesLight(t *testing.T) {
+	t.Parallel()
+
+	testDB := NewTestDB(t)
+	roundDB := NewTransactionExecutor(
+		testDB.BaseDB,
+		func(tx *sql.Tx) RoundStore {
+			return testDB.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	roundStore := NewRoundPersistenceStore(
+		roundDB, &chaincfg.RegressionNetParams, clock.NewDefaultClock(),
+	)
+	testClock := clock.NewTestClock(time.Unix(1_700_000_000, 0))
+	vtxoStore := NewVTXOPersistenceStore(roundDB, testClock)
+	ctx := t.Context()
+
+	commitRound := func(id round.RoundID) {
+		r := createTestRound(t, id)
+		state := &round.InputSigSentState{
+			RoundID:     r.RoundID,
+			ClientTrees: make(map[round.SignerKey]*tree.Tree),
+		}
+		require.NoError(t, roundStore.CommitState(ctx, r, state))
+	}
+
+	createRoundID := testRoundIDDB("by-statuses-create-round")
+	commitRound(createRoundID)
+
+	// The confirmed round the forfeiting VTXO settles in.
+	settleRoundID := testRoundIDDB("by-statuses-settle-round")
+	commitRound(settleRoundID)
+	settlementTxid := chainhash.HashH([]byte("by-statuses-settlement"))
+	const settlementHeight = int32(812345)
+	require.NoError(
+		t,
+		roundStore.FinalizeRound(
+			ctx, settleRoundID, settlementTxid, round.ConfInfo{
+				Height: settlementHeight,
+				BlockHash: chainhash.HashH(
+					[]byte("by-statuses-block"),
+				),
+			},
+		),
+	)
+
+	// One VTXO per status, saved a second apart.
+	statuses := []vtxo.VTXOStatus{
+		vtxo.VTXOStatusLive, vtxo.VTXOStatusPendingForfeit,
+		vtxo.VTXOStatusForfeiting, vtxo.VTXOStatusForfeited,
+		vtxo.VTXOStatusSpent, vtxo.VTXOStatusUnilateralExit,
+		vtxo.VTXOStatusFailed, vtxo.VTXOStatusSpending,
+		vtxo.VTXOStatusExpired,
+	}
+	byStatus := make(map[vtxo.VTXOStatus]wire.OutPoint, len(statuses))
+	for i, status := range statuses {
+		testClock.SetTime(testClock.Now().Add(time.Second))
+		desc := createTestVTXODescriptor(t, createRoundID, i+1)
+		require.NoError(t, vtxoStore.SaveVTXO(ctx, desc))
+
+		if status == vtxo.VTXOStatusForfeiting {
+			require.NoError(
+				t,
+				vtxoStore.MarkForfeiting(
+					ctx, desc.Outpoint,
+					settleRoundID.String(), nil,
+				),
+			)
+		} else {
+			require.NoError(
+				t, vtxoStore.UpdateVTXOStatus(
+					ctx, desc.Outpoint, status,
+				),
+			)
+		}
+
+		byStatus[status] = desc.Outpoint
+	}
+
+	outpoints := func(descs []*vtxo.Descriptor) []wire.OutPoint {
+		out := make([]wire.OutPoint, len(descs))
+		for i, d := range descs {
+			out[i] = d.Outpoint
+		}
+
+		return out
+	}
+
+	inventory, err := vtxoStore.ListVTXOsByStatusesLight(
+		ctx, vtxo.InventoryStatuses(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, []wire.OutPoint{
+		byStatus[vtxo.VTXOStatusExpired],
+		byStatus[vtxo.VTXOStatusSpending],
+		byStatus[vtxo.VTXOStatusFailed],
+		byStatus[vtxo.VTXOStatusUnilateralExit],
+		byStatus[vtxo.VTXOStatusForfeiting],
+		byStatus[vtxo.VTXOStatusPendingForfeit],
+		byStatus[vtxo.VTXOStatusLive],
+	}, outpoints(inventory))
+
+	for _, desc := range inventory {
+		require.Nil(t, desc.Ancestry)
+
+		if desc.Status != vtxo.VTXOStatusForfeiting {
+			require.True(t, desc.Settlement.IsNone(), desc.Status)
+
+			continue
+		}
+
+		settle := desc.Settlement.UnwrapOrFail(t)
+		require.Equal(t, settlementTxid, settle.TxID)
+		require.Equal(t, settlementHeight, settle.Height)
+	}
+
+	consumed, err := vtxoStore.ListVTXOsByStatusesLight(
+		ctx, []vtxo.VTXOStatus{
+			vtxo.VTXOStatusSpent, vtxo.VTXOStatusForfeited,
+			vtxo.VTXOStatusSpent,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []wire.OutPoint{
+		byStatus[vtxo.VTXOStatusSpent],
+		byStatus[vtxo.VTXOStatusForfeited],
+	}, outpoints(consumed))
+
+	// A status rewrite keeps the spent flag; the row stays hidden.
+	require.NoError(
+		t, vtxoStore.UpdateVTXOStatus(
+			ctx, byStatus[vtxo.VTXOStatusSpent],
+			vtxo.VTXOStatusLive,
+		),
+	)
+	live, err := vtxoStore.ListVTXOsByStatusesLight(
+		ctx, []vtxo.VTXOStatus{vtxo.VTXOStatusLive},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, []wire.OutPoint{byStatus[vtxo.VTXOStatusLive]},
+		outpoints(live),
 	)
 }

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -476,21 +476,30 @@ List VTXOs known to the wallet with optional filters.
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `--status` | string | Filter: live, pending_forfeit, forfeiting, forfeited, spent, unilateral_exit, failed, spending |
+| `--status` | string, repeatable | Filter by status: live, pending_forfeit, forfeiting, forfeited, spent, unilateral_exit, failed, spending, pending_round, expired. Default: every status except forfeited and spent |
+| `--all` | bool | List every status; checkpoint PSBTs only with `--fields oor_final_checkpoint_psbts` |
 | `--min-amount` | int64 | Minimum amount in sats |
 | `--fields` | string | Comma-separated field names to include |
 | `--ndjson` | bool | Emit one JSON object per VTXO (newline-delimited) |
 
+Only live VTXOs are spendable; use `balance` for balances.
+
 ```bash
-# All VTXOs
+# VTXO inventory: every status except forfeited and spent
 wavecli ark vtxos list
+
+# Every VTXO the wallet has ever held
+wavecli ark vtxos list --all
 
 # Live VTXOs above 10k sats, only outpoint and amount
 wavecli ark vtxos list --status live --min-amount 10000 \
   --fields outpoint,amount_sat
 
+# Consumed VTXOs only
+wavecli ark vtxos list --status forfeited,spent
+
 # Streaming NDJSON for piping to jq
-wavecli ark vtxos list --ndjson | jq '.amount_sat'
+wavecli ark vtxos list --status live --ndjson | jq '.amount_sat'
 ```
 
 ### `ark vtxos refresh`
@@ -736,7 +745,7 @@ The VTXO inventory and onchain history are not part of the activity feed.
 Use the `ark` subtree for those:
 
 ```bash
-wavecli ark vtxos list          # live VTXO inventory
+wavecli ark vtxos list          # VTXO inventory (all but forfeited/spent)
 wavecli ark listtransactions    # raw transaction / onchain history
 wavecli ark sweep list          # boarding-timeout sweep records
 ```

--- a/docs/wavewalletrpc_build.md
+++ b/docs/wavewalletrpc_build.md
@@ -73,7 +73,7 @@ When the daemon is started from a `wavewalletrpc`-tagged build:
 - The CLI exposes top-level wallet verbs: `send`, `recv`, `activity`,
   `balance`, `create`, `unlock`, `exit`, `wallet-sweep`, and `mcp serve`.
   Raw transaction / onchain
-  history is available via `ark listtransactions`, the live VTXO set via
+  history is available via `ark listtransactions`, the VTXO inventory via
   `ark vtxos list`, and boarding-timeout sweep records via `ark sweep list`.
   Subscriptions are available from the
   `wavewalletrpc.WalletService.SubscribeWallet` RPC.

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -645,7 +645,8 @@ func (c *Client) GetBalance(ctx context.Context) (*waverpc.GetBalanceResponse,
 }
 
 // ListVTXOs returns the daemon's known VTXOs using the supplied filter
-// request. Passing nil uses the daemon defaults with no extra filters.
+// request. Passing nil lists the inventory set: every VTXO except forfeited
+// and spent ones, newest first, of which only live entries are spendable.
 func (c *Client) ListVTXOs(ctx context.Context, req *waverpc.ListVTXOsRequest) (
 	*waverpc.ListVTXOsResponse, error) {
 

--- a/systest/list_vtxos_test.go
+++ b/systest/list_vtxos_test.go
@@ -1,0 +1,128 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestListVTXOs drives the ListVTXOs status selection
+// through a full daemon: the default listing hides forfeited and spent rows,
+// status lists select any set, and the spendable balance ignores the extra
+// rows.
+func TestListVTXOs(t *testing.T) {
+	ParallelN(t)
+
+	fixture := newDirectedSendFixture(t)
+
+	// The fake operator never completes a round or an OOR spend, so the
+	// terminal rows are seeded while the daemon is stopped.
+	fixture.shutdown()
+	seeded := map[vtxo.VTXOStatus]wire.OutPoint{
+		vtxo.VTXOStatusLive: fixture.seededOutpoint,
+	}
+	for label, vtxoStatus := range map[string]vtxo.VTXOStatus{
+		"forfeited": vtxo.VTXOStatusForfeited,
+		"spent":     vtxo.VTXOStatusSpent,
+		"failed":    vtxo.VTXOStatusFailed,
+	} {
+		seeded[vtxoStatus] = seedVTXO(
+			t, fixture.cfg, fixture.operatorKey,
+			btcutil.Amount(testSeededAmountSat), label, vtxoStatus,
+		)
+	}
+	fixture.launch()
+
+	list := func(req *waverpc.ListVTXOsRequest) ([]*waverpc.VTXO, error) {
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+
+		resp, err := fixture.client.ListVTXOs(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		return resp.Vtxos, nil
+	}
+	outpoints := func(vtxos []*waverpc.VTXO) []string {
+		out := make([]string, 0, len(vtxos))
+		for _, v := range vtxos {
+			out = append(out, v.Outpoint)
+		}
+
+		return out
+	}
+	expect := func(statuses ...vtxo.VTXOStatus) []string {
+		out := make([]string, 0, len(statuses))
+		for _, s := range statuses {
+			out = append(out, outpointString(seeded[s]))
+		}
+
+		return out
+	}
+
+	inventory, err := list(&waverpc.ListVTXOsRequest{})
+	require.NoError(t, err)
+	require.ElementsMatch(
+		t, expect(vtxo.VTXOStatusLive, vtxo.VTXOStatusFailed),
+		outpoints(inventory),
+	)
+
+	consumed, err := list(&waverpc.ListVTXOsRequest{
+		Statuses: []waverpc.VTXOStatus{
+			waverpc.VTXOStatus_VTXO_STATUS_FORFEITED,
+			waverpc.VTXOStatus_VTXO_STATUS_SPENT,
+		},
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(
+		t, expect(vtxo.VTXOStatusForfeited, vtxo.VTXOStatusSpent),
+		outpoints(consumed),
+	)
+
+	live, err := list(&waverpc.ListVTXOsRequest{
+		StatusFilter: waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expect(vtxo.VTXOStatusLive), outpoints(live))
+
+	// The full enum is what the CLI sends for --all; pending_round hits
+	// the live round actor and contributes nothing here.
+	all, err := list(&waverpc.ListVTXOsRequest{
+		Statuses: []waverpc.VTXOStatus{
+			waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+			waverpc.VTXOStatus_VTXO_STATUS_PENDING_FORFEIT,
+			waverpc.VTXOStatus_VTXO_STATUS_FORFEITING,
+			waverpc.VTXOStatus_VTXO_STATUS_FORFEITED,
+			waverpc.VTXOStatus_VTXO_STATUS_SPENT,
+			waverpc.VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT,
+			waverpc.VTXOStatus_VTXO_STATUS_FAILED,
+			waverpc.VTXOStatus_VTXO_STATUS_SPENDING,
+			waverpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND,
+			waverpc.VTXOStatus_VTXO_STATUS_EXPIRED,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, all, len(seeded))
+
+	_, err = list(&waverpc.ListVTXOsRequest{
+		Statuses: []waverpc.VTXOStatus{
+			waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED,
+		},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	require.Equal(
+		t, testSeededAmountSat, vtxoBalanceSat(t, fixture.client),
+	)
+}

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -822,6 +822,18 @@ func newLoopbackAddr(t *testing.T) string {
 func seedLiveVTXO(t *testing.T, cfg *waved.Config, operatorKey *btcec.PublicKey,
 	amount btcutil.Amount) wire.OutPoint {
 
+	return seedVTXO(
+		t, cfg, operatorKey, amount, "seeded-vtxo", vtxo.VTXOStatusLive,
+	)
+}
+
+// seedVTXO inserts one VTXO with the given status into the daemon database
+// while the daemon is not running. The label keeps outpoints distinct across
+// calls.
+func seedVTXO(t *testing.T, cfg *waved.Config, operatorKey *btcec.PublicKey,
+	amount btcutil.Amount, label string,
+	status vtxo.VTXOStatus) wire.OutPoint {
+
 	t.Helper()
 
 	networkDir := cfg.NetworkDir()
@@ -861,10 +873,12 @@ func seedLiveVTXO(t *testing.T, cfg *waved.Config, operatorKey *btcec.PublicKey,
 	require.NoError(t, err)
 
 	outpoint := wire.OutPoint{
-		Hash:  chainhash.HashH([]byte(t.Name() + "-seeded-vtxo")),
+		Hash:  chainhash.HashH([]byte(t.Name() + "-" + label)),
 		Index: 0,
 	}
-	commitmentTxID := chainhash.HashH([]byte(t.Name() + "-commitment"))
+	commitmentTxID := chainhash.HashH(
+		[]byte(t.Name() + "-" + label + "-commitment"),
+	)
 	treePath := &tree.Tree{
 		BatchOutpoint: outpoint,
 		Root: &tree.Node{
@@ -906,8 +920,10 @@ func seedLiveVTXO(t *testing.T, cfg *waved.Config, operatorKey *btcec.PublicKey,
 		roundID,
 		commitmentTx.TxHash(),
 		round.ConfInfo{
-			Height:    1,
-			BlockHash: chainhash.HashH([]byte(t.Name() + "-block")),
+			Height: 1,
+			BlockHash: chainhash.HashH(
+				[]byte(t.Name() + "-" + label + "-block"),
+			),
 		},
 	)
 	require.NoError(t, err)
@@ -939,6 +955,11 @@ func seedLiveVTXO(t *testing.T, cfg *waved.Config, operatorKey *btcec.PublicKey,
 		Status:         vtxo.VTXOStatusLive,
 	})
 	require.NoError(t, err)
+
+	if status != vtxo.VTXOStatusLive {
+		err = vtxoStore.UpdateVTXOStatus(t.Context(), outpoint, status)
+		require.NoError(t, err)
+	}
 
 	return outpoint
 }

--- a/vtxo/filter.go
+++ b/vtxo/filter.go
@@ -93,3 +93,14 @@ func SumPendingBalance(descs []*Descriptor) btcutil.Amount {
 
 	return total
 }
+
+// InventoryStatuses returns the statuses a listing covers without a filter:
+// every status except Forfeited and Spent, whose value has moved to another
+// output.
+func InventoryStatuses() []VTXOStatus {
+	return []VTXOStatus{
+		VTXOStatusLive, VTXOStatusPendingForfeit, VTXOStatusForfeiting,
+		VTXOStatusSpending, VTXOStatusUnilateralExit, VTXOStatusFailed,
+		VTXOStatusExpired,
+	}
+}

--- a/vtxo/filter_test.go
+++ b/vtxo/filter_test.go
@@ -165,3 +165,24 @@ func TestSumPendingBalanceEmpty(t *testing.T) {
 	require.Zero(t, SumPendingBalance(nil))
 	require.Zero(t, SumPendingBalance([]*Descriptor{}))
 }
+
+// TestInventoryStatusesHidesConsumedOnly verifies that only Forfeited and
+// Spent are missing from the inventory set.
+func TestInventoryStatusesHidesConsumedOnly(t *testing.T) {
+	t.Parallel()
+
+	hidden := map[VTXOStatus]bool{
+		VTXOStatusForfeited: true,
+		VTXOStatusSpent:     true,
+	}
+
+	listed := make(map[VTXOStatus]bool)
+	for _, s := range InventoryStatuses() {
+		require.False(t, listed[s], "duplicate status %v", s)
+		listed[s] = true
+	}
+
+	for s := VTXOStatusLive; s <= VTXOStatusExpired; s++ {
+		require.Equal(t, !hidden[s], listed[s], "status %v", s)
+	}
+}

--- a/waved/rpc_list_vtxos_test.go
+++ b/waved/rpc_list_vtxos_test.go
@@ -1,0 +1,210 @@
+package waved
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/google/uuid"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/lightninglabs/wavelength/round"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// newListVTXOsStore returns an empty SQL-backed VTXO store.
+func newListVTXOsStore(t *testing.T) *db.VTXOPersistenceStore {
+	t.Helper()
+
+	sqlDB := db.NewTestDB(t)
+	roundDB := db.NewTransactionExecutor(
+		sqlDB.BaseDB,
+		func(tx *sql.Tx) db.RoundStore {
+			return sqlDB.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+
+	return db.NewVTXOPersistenceStore(roundDB, clock.NewDefaultClock())
+}
+
+// newListVTXOsServer returns a wallet-ready RPC server.
+func newListVTXOsServer(store *db.VTXOPersistenceStore,
+	system *actor.ActorSystem) *RPCServer {
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+
+	return &RPCServer{server: &Server{
+		actorSystem: system,
+		walletReady: walletReady,
+		vtxoStore:   store,
+	}}
+}
+
+// responseStatuses projects the status of every returned VTXO.
+func responseStatuses(resp *waverpc.ListVTXOsResponse) []waverpc.VTXOStatus {
+	statuses := make([]waverpc.VTXOStatus, 0, len(resp.Vtxos))
+	for _, v := range resp.Vtxos {
+		statuses = append(statuses, v.Status)
+	}
+
+	return statuses
+}
+
+// TestListVTXOsStatusSelection covers the default inventory set, explicit
+// status lists, the status_filter union and the UNSPECIFIED rejection.
+func TestListVTXOsStatusSelection(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	vtxoStore := newListVTXOsStore(t)
+
+	seeded := map[vtxo.VTXOStatus]*vtxo.Descriptor{
+		vtxo.VTXOStatusLive: newRefreshEstimateVTXO(
+			t, 0x01, 10_000, 900,
+		),
+		vtxo.VTXOStatusForfeited: newRefreshEstimateVTXO(
+			t, 0x02, 10_000, 900,
+		),
+		vtxo.VTXOStatusSpent: newRefreshEstimateVTXO(
+			t, 0x03, 10_000, 900,
+		),
+		vtxo.VTXOStatusUnilateralExit: newRefreshEstimateVTXO(
+			t, 0x04, 10_000, 900,
+		),
+		vtxo.VTXOStatusExpired: newRefreshEstimateVTXO(
+			t, 0x05, 10_000, 900,
+		),
+		vtxo.VTXOStatusSpending: newRefreshEstimateVTXO(
+			t, 0x06, 10_000, 900,
+		),
+	}
+	for vtxoStatus, desc := range seeded {
+		require.NoError(t, vtxoStore.SaveVTXO(ctx, desc))
+		require.NoError(
+			t, vtxoStore.UpdateVTXOStatus(
+				ctx, desc.Outpoint, vtxoStatus,
+			),
+		)
+	}
+
+	srv := newListVTXOsServer(vtxoStore, nil)
+
+	inventory, err := srv.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []waverpc.VTXOStatus{
+		waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+		waverpc.VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT,
+		waverpc.VTXOStatus_VTXO_STATUS_EXPIRED,
+		waverpc.VTXOStatus_VTXO_STATUS_SPENDING,
+	}, responseStatuses(inventory))
+
+	consumed, err := srv.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{
+		Statuses: []waverpc.VTXOStatus{
+			waverpc.VTXOStatus_VTXO_STATUS_FORFEITED,
+			waverpc.VTXOStatus_VTXO_STATUS_SPENT,
+		},
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []waverpc.VTXOStatus{
+		waverpc.VTXOStatus_VTXO_STATUS_FORFEITED,
+		waverpc.VTXOStatus_VTXO_STATUS_SPENT,
+	}, responseStatuses(consumed))
+
+	union, err := srv.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{
+		StatusFilter: waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+		Statuses: []waverpc.VTXOStatus{
+			waverpc.VTXOStatus_VTXO_STATUS_SPENT,
+		},
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []waverpc.VTXOStatus{
+		waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+		waverpc.VTXOStatus_VTXO_STATUS_SPENT,
+	}, responseStatuses(union))
+
+	single, err := srv.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{
+		StatusFilter: waverpc.VTXOStatus_VTXO_STATUS_SPENT,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []waverpc.VTXOStatus{
+		waverpc.VTXOStatus_VTXO_STATUS_SPENT,
+	}, responseStatuses(single))
+
+	_, err = srv.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{
+		Statuses: []waverpc.VTXOStatus{
+			waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED,
+		},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestListVTXOsPendingRoundCombinesWithStored verifies that pending-round
+// projections precede stored rows when both are requested and are absent
+// from the default listing.
+func TestListVTXOsPendingRoundCombinesWithStored(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	roundID := round.RoundID(uuid.New())
+	state := &round.InputSigSentState{
+		RoundID: roundID,
+		Intents: round.Intents{
+			VTXOs: []types.VTXORequest{{
+				Amount:   btcutil.Amount(50_000),
+				OwnerKey: localOwnerKey(t),
+			}},
+		},
+	}
+	system := newRoundActorWithStates(t,
+		map[string]round.FSMStateInfo{
+			roundID.String(): {
+				State:   state,
+				RoundID: roundID,
+			},
+		},
+	)
+	defer func() {
+		require.NoError(t, system.Shutdown(ctx))
+	}()
+
+	vtxoStore := newListVTXOsStore(t)
+	live := newRefreshEstimateVTXO(t, 0x01, 10_000, 900)
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, live))
+
+	srv := newListVTXOsServer(vtxoStore, system)
+
+	combined, err := srv.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{
+		Statuses: []waverpc.VTXOStatus{
+			waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+			waverpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, combined.Vtxos, 2)
+	require.Equal(
+		t, waverpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND,
+		combined.Vtxos[0].Status,
+	)
+	require.Equal(t, roundID.String(), combined.Vtxos[0].RoundId)
+	require.Equal(
+		t, waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+		combined.Vtxos[1].Status,
+	)
+	require.Equal(t, live.Outpoint.String(), combined.Vtxos[1].Outpoint)
+
+	inventory, err := srv.ListVTXOs(ctx, &waverpc.ListVTXOsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, []waverpc.VTXOStatus{
+		waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+	}, responseStatuses(inventory))
+}

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -1477,6 +1477,9 @@ func protoStatusToDomain(s waverpc.VTXOStatus) (vtxo.VTXOStatus, error) {
 	case waverpc.VTXOStatus_VTXO_STATUS_FAILED:
 		return vtxo.VTXOStatusFailed, nil
 
+	case waverpc.VTXOStatus_VTXO_STATUS_SPENDING:
+		return vtxo.VTXOStatusSpending, nil
+
 	case waverpc.VTXOStatus_VTXO_STATUS_EXPIRED:
 		return vtxo.VTXOStatusExpired, nil
 

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -1426,9 +1426,14 @@ func (r *RPCServer) listStoredVTXOs(ctx context.Context,
 				ctx, packageStore, v, protoVTXO,
 			)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal,
-					"populate package checkpoint psbts: %v",
-					err)
+				// An unreadable package only costs this entry
+				// its PSBTs.
+				r.server.log.DebugS(ctx, "Skipping checkpoint "+
+					"PSBTs for VTXO",
+					slog.String(
+						"outpoint", v.Outpoint.String(),
+					),
+					btclog.Fmt("err", "%v", err))
 			}
 		}
 

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -1288,12 +1288,10 @@ func roundStateLabel(s waverpc.RoundState) string {
 	return strings.ToLower(strings.TrimPrefix(s.String(), "ROUND_STATE_"))
 }
 
-// ListVTXOs returns the set of VTXOs known to the wallet, optionally
-// filtered by status and minimum amount. The VTXO_STATUS_PENDING_ROUND
-// filter is special: it bypasses the on-disk store and projects each
-// upcoming VTXO from the live round actor as a synthetic VTXO entry,
-// giving callers a way to see the outputs they have signed for but
-// which have not yet been created by an on-chain commitment.
+// ListVTXOs returns the VTXOs known to the wallet, newest first, in the
+// requested statuses or in vtxo.InventoryStatuses when none are given.
+// VTXO_STATUS_PENDING_ROUND entries are projected from the live round actor
+// instead of read from the store.
 func (r *RPCServer) ListVTXOs(ctx context.Context,
 	req *waverpc.ListVTXOsRequest) (*waverpc.ListVTXOsResponse, error) {
 
@@ -1301,46 +1299,89 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 		return nil, err
 	}
 
-	if req.StatusFilter ==
-		waverpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND {
-		return r.listPendingRoundVTXOs(ctx, req)
+	persisted, includePending, err := requestedVTXOStatuses(req)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
+
+	protoVTXOs := make([]*waverpc.VTXO, 0)
+	if includePending {
+		pending, err := r.listPendingRoundVTXOs(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		protoVTXOs = append(protoVTXOs, pending...)
+	}
+
+	if len(persisted) > 0 {
+		stored, err := r.listStoredVTXOs(ctx, req, persisted)
+		if err != nil {
+			return nil, err
+		}
+
+		protoVTXOs = append(protoVTXOs, stored...)
+	}
+
+	return &waverpc.ListVTXOsResponse{
+		Vtxos: protoVTXOs,
+	}, nil
+}
+
+// requestedVTXOStatuses returns the persisted statuses to read and whether
+// pending-round projections are wanted.
+func requestedVTXOStatuses(req *waverpc.ListVTXOsRequest) ([]vtxo.VTXOStatus,
+	bool, error) {
+
+	selected := make([]waverpc.VTXOStatus, 0, len(req.Statuses)+1)
+	selected = append(selected, req.Statuses...)
+	if req.StatusFilter != waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED {
+		selected = append(selected, req.StatusFilter)
+	}
+
+	if len(selected) == 0 {
+		return vtxo.InventoryStatuses(), false, nil
+	}
+
+	var (
+		persisted      []vtxo.VTXOStatus
+		includePending bool
+	)
+	for _, s := range selected {
+		if s == waverpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND {
+			includePending = true
+
+			continue
+		}
+
+		domainStatus, err := protoStatusToDomain(s)
+		if err != nil {
+			return nil, false, fmt.Errorf("invalid status "+
+				"filter: %w", err)
+		}
+
+		persisted = append(persisted, domainStatus)
+	}
+
+	return persisted, includePending, nil
+}
+
+// listStoredVTXOs lists the persisted VTXOs in the given statuses.
+func (r *RPCServer) listStoredVTXOs(ctx context.Context,
+	req *waverpc.ListVTXOsRequest, statuses []vtxo.VTXOStatus) (
+	[]*waverpc.VTXO, error) {
 
 	if r.server.vtxoStore == nil {
 		return nil, status.Errorf(codes.Internal, "vtxo store not "+
 			"initialized")
 	}
 
-	// Fetch VTXOs from the store. When a specific status filter
-	// is provided, query the DB directly for that status so
-	// terminal states (spent, forfeited) are reachable. When
-	// unspecified, return all non-terminal (live) VTXOs.
-	var (
-		dbVTXOs []*vtxo.Descriptor
-		err     error
+	// The listing response never carries ancestry, so the light variant
+	// skips the ancestry side-table join (whose TLV tree fragments grow
+	// with OOR chain depth) entirely.
+	dbVTXOs, err := r.server.vtxoStore.ListVTXOsByStatusesLight(
+		ctx, statuses,
 	)
-
-	if req.StatusFilter !=
-		waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED {
-
-		domainStatus, sErr := protoStatusToDomain(
-			req.StatusFilter,
-		)
-		if sErr != nil {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"invalid status filter: %v", sErr)
-		}
-
-		// The listing response never carries ancestry, so the light
-		// variants skip the ancestry side-table join (whose TLV tree
-		// fragments grow with OOR chain depth) entirely.
-		dbVTXOs, err = r.server.vtxoStore.ListVTXOsByStatusLight(
-			ctx, domainStatus,
-		)
-	} else {
-		dbVTXOs, err = r.server.vtxoStore.ListLiveVTXOsLight(ctx)
-	}
-
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to list "+
 			"VTXOs: %v", err)
@@ -1394,9 +1435,7 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 		protoVTXOs = append(protoVTXOs, protoVTXO)
 	}
 
-	return &waverpc.ListVTXOsResponse{
-		Vtxos: protoVTXOs,
-	}, nil
+	return protoVTXOs, nil
 }
 
 // listPendingRoundVTXOs projects the upcoming VTXOs from every live
@@ -1407,7 +1446,7 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 // precise leaf outpoint inside the VTXO tree is not finalised until
 // the commitment transaction confirms.
 func (r *RPCServer) listPendingRoundVTXOs(ctx context.Context,
-	req *waverpc.ListVTXOsRequest) (*waverpc.ListVTXOsResponse, error) {
+	req *waverpc.ListVTXOsRequest) ([]*waverpc.VTXO, error) {
 
 	rounds, err := r.queryRoundStates(ctx)
 	if err != nil {
@@ -1445,9 +1484,7 @@ func (r *RPCServer) listPendingRoundVTXOs(ctx context.Context,
 		}
 	}
 
-	return &waverpc.ListVTXOsResponse{
-		Vtxos: protoVTXOs,
-	}, nil
+	return protoVTXOs, nil
 }
 
 // protoStatusToDomain converts a proto VTXOStatus enum to the domain

--- a/waved/rpc_server_test.go
+++ b/waved/rpc_server_test.go
@@ -1739,3 +1739,30 @@ func TestAutomaticExitDecisionReason(t *testing.T) {
 		})
 	}
 }
+
+// TestVTXOStatusProtoRoundTrip verifies that every persisted status maps
+// between the proto and domain enums in both directions.
+func TestVTXOStatusProtoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	unmapped := map[waverpc.VTXOStatus]bool{
+		waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED:   true,
+		waverpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND: true,
+	}
+
+	for val, name := range waverpc.VTXOStatus_name {
+		protoStatus := waverpc.VTXOStatus(val)
+		if unmapped[protoStatus] {
+			_, err := protoStatusToDomain(protoStatus)
+			require.Error(t, err, name)
+
+			continue
+		}
+
+		domainStatus, err := protoStatusToDomain(protoStatus)
+		require.NoError(t, err, name)
+		require.Equal(
+			t, protoStatus, vtxoStatusToProto(domainStatus), name,
+		)
+	}
+}

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -2145,8 +2145,8 @@ func (x *VTXOSettlement) GetFeeSat() int64 {
 
 type ListVTXOsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// status_filter restricts the response to VTXOs matching this status.
-	// If VTXO_STATUS_UNSPECIFIED (default), all statuses are returned.
+	// status_filter restricts the response to VTXOs in this status. It is
+	// equivalent to a single entry in statuses.
 	StatusFilter VTXOStatus `protobuf:"varint,1,opt,name=status_filter,json=statusFilter,proto3,enum=waverpc.VTXOStatus" json:"status_filter,omitempty"`
 	// min_amount_sat excludes VTXOs below this value.
 	MinAmountSat int64 `protobuf:"varint,2,opt,name=min_amount_sat,json=minAmountSat,proto3" json:"min_amount_sat,omitempty"`
@@ -2156,8 +2156,13 @@ type ListVTXOsRequest struct {
 	// consumers (balance views, coin selection) that never inspect the
 	// PSBTs. The default keeps the full response for compatibility.
 	ExcludeCheckpointPsbts bool `protobuf:"varint,3,opt,name=exclude_checkpoint_psbts,json=excludeCheckpointPsbts,proto3" json:"exclude_checkpoint_psbts,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// statuses restricts the response to VTXOs in any of these statuses.
+	// When empty, every VTXO except VTXO_STATUS_FORFEITED and
+	// VTXO_STATUS_SPENT is returned. VTXO_STATUS_PENDING_ROUND entries are
+	// only included when listed.
+	Statuses      []VTXOStatus `protobuf:"varint,4,rep,packed,name=statuses,proto3,enum=waverpc.VTXOStatus" json:"statuses,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListVTXOsRequest) Reset() {
@@ -2209,6 +2214,13 @@ func (x *ListVTXOsRequest) GetExcludeCheckpointPsbts() bool {
 		return x.ExcludeCheckpointPsbts
 	}
 	return false
+}
+
+func (x *ListVTXOsRequest) GetStatuses() []VTXOStatus {
+	if x != nil {
+		return x.Statuses
+	}
+	return nil
 }
 
 type ListVTXOsResponse struct {
@@ -10829,11 +10841,12 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0eVTXOSettlement\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x16\n" +
 	"\x06height\x18\x02 \x01(\x05R\x06height\x12\x17\n" +
-	"\afee_sat\x18\x03 \x01(\x03R\x06feeSat\"\xac\x01\n" +
+	"\afee_sat\x18\x03 \x01(\x03R\x06feeSat\"\xdd\x01\n" +
 	"\x10ListVTXOsRequest\x128\n" +
 	"\rstatus_filter\x18\x01 \x01(\x0e2\x13.waverpc.VTXOStatusR\fstatusFilter\x12$\n" +
 	"\x0emin_amount_sat\x18\x02 \x01(\x03R\fminAmountSat\x128\n" +
-	"\x18exclude_checkpoint_psbts\x18\x03 \x01(\bR\x16excludeCheckpointPsbts\"8\n" +
+	"\x18exclude_checkpoint_psbts\x18\x03 \x01(\bR\x16excludeCheckpointPsbts\x12/\n" +
+	"\bstatuses\x18\x04 \x03(\x0e2\x13.waverpc.VTXOStatusR\bstatuses\"8\n" +
 	"\x11ListVTXOsResponse\x12#\n" +
 	"\x05vtxos\x18\x01 \x03(\v2\r.waverpc.VTXOR\x05vtxos\"\x13\n" +
 	"\x11NewAddressRequest\".\n" +
@@ -11766,175 +11779,176 @@ var file_daemon_proto_depIdxs = []int32{
 	22,  // 4: waverpc.VTXO.expiry_info:type_name -> waverpc.VTXOExpiryInfo
 	24,  // 5: waverpc.VTXO.settlement:type_name -> waverpc.VTXOSettlement
 	1,   // 6: waverpc.ListVTXOsRequest.status_filter:type_name -> waverpc.VTXOStatus
-	23,  // 7: waverpc.ListVTXOsResponse.vtxos:type_name -> waverpc.VTXO
-	1,   // 8: waverpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> waverpc.VTXOStatus
-	23,  // 9: waverpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> waverpc.VTXO
-	1,   // 10: waverpc.GetVTXOExpiryInfoRequest.status_filter:type_name -> waverpc.VTXOStatus
-	22,  // 11: waverpc.GetVTXOExpiryInfoResponse.expiry_info:type_name -> waverpc.VTXOExpiryInfo
-	23,  // 12: waverpc.GetVTXOExpiryInfoResponse.vtxo:type_name -> waverpc.VTXO
-	45,  // 13: waverpc.SendVTXORequest.recipients:type_name -> waverpc.Output
-	45,  // 14: waverpc.SendOORRequest.recipients:type_name -> waverpc.Output
-	49,  // 15: waverpc.SendOORRequest.custom_inputs:type_name -> waverpc.CustomOORInput
-	50,  // 16: waverpc.CustomOORInput.external_signatures:type_name -> waverpc.TaprootScriptSignature
-	45,  // 17: waverpc.PrepareOORRequest.recipient:type_name -> waverpc.Output
-	49,  // 18: waverpc.PrepareOORRequest.custom_inputs:type_name -> waverpc.CustomOORInput
-	53,  // 19: waverpc.PrepareOORResponse.custom_inputs:type_name -> waverpc.PreparedOORCustomInput
-	49,  // 20: waverpc.SignOORCustomInputRequest.custom_input:type_name -> waverpc.CustomOORInput
-	50,  // 21: waverpc.SignOORCustomInputResponse.signature:type_name -> waverpc.TaprootScriptSignature
-	3,   // 22: waverpc.ForfeitSigningContext.signing_route:type_name -> waverpc.ForfeitSigningRoute
-	60,  // 23: waverpc.RefreshVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
-	63,  // 24: waverpc.RefreshVTXOsResponse.fee_estimate:type_name -> waverpc.RefreshFeeEstimate
-	64,  // 25: waverpc.RefreshFeeEstimate.outpoints:type_name -> waverpc.OutpointFeeEstimate
-	59,  // 26: waverpc.CustomRefreshVTXOInput.forfeit_signing_context:type_name -> waverpc.ForfeitSigningContext
-	65,  // 27: waverpc.RefreshCustomVTXOsRequest.inputs:type_name -> waverpc.CustomRefreshVTXOInput
-	66,  // 28: waverpc.RefreshCustomVTXOsRequest.outputs:type_name -> waverpc.CustomRefreshVTXOOutput
-	3,   // 29: waverpc.PendingForfeitParticipantSignatureRequest.signing_route:type_name -> waverpc.ForfeitSigningRoute
-	69,  // 30: waverpc.ListPendingForfeitParticipantSignatureRequestsResponse.requests:type_name -> waverpc.PendingForfeitParticipantSignatureRequest
-	72,  // 31: waverpc.SubmitForfeitParticipantSignaturesRequest.signatures:type_name -> waverpc.ForfeitParticipantSignature
-	60,  // 32: waverpc.LeaveVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
-	75,  // 33: waverpc.LeaveVTXOsRequest.default_destination:type_name -> waverpc.LeaveDestination
-	140, // 34: waverpc.LeaveVTXOsRequest.destinations:type_name -> waverpc.LeaveVTXOsRequest.DestinationsEntry
-	75,  // 35: waverpc.SendOnChainRequest.destination:type_name -> waverpc.LeaveDestination
-	85,  // 36: waverpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> waverpc.BoardingSweepOutput
-	88,  // 37: waverpc.BoardingSweep.inputs:type_name -> waverpc.BoardingSweepInput
-	89,  // 38: waverpc.ListBoardingSweepsResponse.sweeps:type_name -> waverpc.BoardingSweep
-	4,   // 39: waverpc.RoundInfo.state:type_name -> waverpc.RoundState
-	91,  // 40: waverpc.RoundInfo.vtxos:type_name -> waverpc.RoundVTXOInfo
-	4,   // 41: waverpc.ListRoundsRequest.state_filter:type_name -> waverpc.RoundState
-	92,  // 42: waverpc.GetRoundResponse.round:type_name -> waverpc.RoundInfo
-	92,  // 43: waverpc.ListRoundsResponse.rounds:type_name -> waverpc.RoundInfo
-	92,  // 44: waverpc.WatchRoundsResponse.round:type_name -> waverpc.RoundInfo
-	5,   // 45: waverpc.OORSessionInfo.direction:type_name -> waverpc.OORSessionDirection
-	6,   // 46: waverpc.OORSessionInfo.status:type_name -> waverpc.OORSessionStatus
-	5,   // 47: waverpc.ListOORSessionsRequest.direction_filter:type_name -> waverpc.OORSessionDirection
-	6,   // 48: waverpc.ListOORSessionsRequest.status_filter:type_name -> waverpc.OORSessionStatus
-	99,  // 49: waverpc.ListOORSessionsResponse.sessions:type_name -> waverpc.OORSessionInfo
-	99,  // 50: waverpc.GetOORSessionResponse.session:type_name -> waverpc.OORSessionInfo
-	107, // 51: waverpc.GetFeeHistoryResponse.entries:type_name -> waverpc.FeeHistoryEntry
-	110, // 52: waverpc.ListTransactionsResponse.transactions:type_name -> waverpc.TransactionHistoryEntry
-	7,   // 53: waverpc.GetUnrollStatusResponse.status:type_name -> waverpc.UnrollJobStatus
-	115, // 54: waverpc.GetUnrollStatusResponse.progress:type_name -> waverpc.UnrollProgress
-	116, // 55: waverpc.GetUnrollStatusResponse.csv:type_name -> waverpc.UnrollCSV
-	117, // 56: waverpc.GetUnrollStatusResponse.fees:type_name -> waverpc.UnrollFees
-	8,   // 57: waverpc.ArmVHTLCRecoveryRequest.direction:type_name -> waverpc.VHTLCRecoveryDirection
-	9,   // 58: waverpc.ArmVHTLCRecoveryRequest.action:type_name -> waverpc.VHTLCRecoveryAction
-	129, // 59: waverpc.ArmVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
-	129, // 60: waverpc.EscalateVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
-	129, // 61: waverpc.CancelVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
-	129, // 62: waverpc.GetVHTLCRecoveryStatusResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
-	129, // 63: waverpc.ListVHTLCRecoveriesResponse.statuses:type_name -> waverpc.VHTLCRecoveryStatus
-	8,   // 64: waverpc.VHTLCRecoveryStatus.direction:type_name -> waverpc.VHTLCRecoveryDirection
-	9,   // 65: waverpc.VHTLCRecoveryStatus.action:type_name -> waverpc.VHTLCRecoveryAction
-	10,  // 66: waverpc.VHTLCRecoveryStatus.state:type_name -> waverpc.VHTLCRecoveryState
-	7,   // 67: waverpc.VHTLCRecoveryStatus.unroll_status:type_name -> waverpc.UnrollJobStatus
-	134, // 68: waverpc.BakeMacaroonRequest.permissions:type_name -> waverpc.MacaroonPermission
-	134, // 69: waverpc.MacaroonPermissionList.permissions:type_name -> waverpc.MacaroonPermission
-	141, // 70: waverpc.ListPermissionsResponse.method_permissions:type_name -> waverpc.ListPermissionsResponse.MethodPermissionsEntry
-	75,  // 71: waverpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> waverpc.LeaveDestination
-	137, // 72: waverpc.ListPermissionsResponse.MethodPermissionsEntry.value:type_name -> waverpc.MacaroonPermissionList
-	11,  // 73: waverpc.DaemonService.GetInfo:input_type -> waverpc.GetInfoRequest
-	14,  // 74: waverpc.DaemonService.GenSeed:input_type -> waverpc.GenSeedRequest
-	16,  // 75: waverpc.DaemonService.InitWallet:input_type -> waverpc.InitWalletRequest
-	18,  // 76: waverpc.DaemonService.UnlockWallet:input_type -> waverpc.UnlockWalletRequest
-	20,  // 77: waverpc.DaemonService.GetBalance:input_type -> waverpc.GetBalanceRequest
-	25,  // 78: waverpc.DaemonService.ListVTXOs:input_type -> waverpc.ListVTXOsRequest
-	27,  // 79: waverpc.DaemonService.NewAddress:input_type -> waverpc.NewAddressRequest
-	29,  // 80: waverpc.DaemonService.NewReceiveScript:input_type -> waverpc.NewReceiveScriptRequest
-	31,  // 81: waverpc.DaemonService.ReceiveAuthKey:input_type -> waverpc.ReceiveAuthKeyRequest
-	33,  // 82: waverpc.DaemonService.SignReceiveAuthMessage:input_type -> waverpc.SignReceiveAuthMessageRequest
-	35,  // 83: waverpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> waverpc.SignReceiveAuthMessageCompactRequest
-	37,  // 84: waverpc.DaemonService.ReceiveAuthECDH:input_type -> waverpc.ReceiveAuthECDHRequest
-	39,  // 85: waverpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> waverpc.GetIndexedVTXOByPkScriptRequest
-	41,  // 86: waverpc.DaemonService.GetVTXOExpiryInfo:input_type -> waverpc.GetVTXOExpiryInfoRequest
-	43,  // 87: waverpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> waverpc.GetIndexedOORSessionByTxidRequest
-	46,  // 88: waverpc.DaemonService.SendVTXO:input_type -> waverpc.SendVTXORequest
-	48,  // 89: waverpc.DaemonService.SendOOR:input_type -> waverpc.SendOORRequest
-	52,  // 90: waverpc.DaemonService.PrepareOOR:input_type -> waverpc.PrepareOORRequest
-	55,  // 91: waverpc.DaemonService.SignOORCustomInput:input_type -> waverpc.SignOORCustomInputRequest
-	57,  // 92: waverpc.DaemonService.SignVTXOForfeit:input_type -> waverpc.SignVTXOForfeitRequest
-	61,  // 93: waverpc.DaemonService.RefreshVTXOs:input_type -> waverpc.RefreshVTXOsRequest
-	67,  // 94: waverpc.DaemonService.RefreshCustomVTXOs:input_type -> waverpc.RefreshCustomVTXOsRequest
-	70,  // 95: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:input_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsRequest
-	73,  // 96: waverpc.DaemonService.SubmitForfeitParticipantSignatures:input_type -> waverpc.SubmitForfeitParticipantSignaturesRequest
-	76,  // 97: waverpc.DaemonService.LeaveVTXOs:input_type -> waverpc.LeaveVTXOsRequest
-	78,  // 98: waverpc.DaemonService.SendOnChain:input_type -> waverpc.SendOnChainRequest
-	80,  // 99: waverpc.DaemonService.Board:input_type -> waverpc.BoardRequest
-	82,  // 100: waverpc.DaemonService.JoinNextRound:input_type -> waverpc.JoinNextRoundRequest
-	84,  // 101: waverpc.DaemonService.SweepBoardingUTXOs:input_type -> waverpc.SweepBoardingUTXOsRequest
-	87,  // 102: waverpc.DaemonService.ListBoardingSweeps:input_type -> waverpc.ListBoardingSweepsRequest
-	93,  // 103: waverpc.DaemonService.ListRounds:input_type -> waverpc.ListRoundsRequest
-	94,  // 104: waverpc.DaemonService.GetRound:input_type -> waverpc.GetRoundRequest
-	97,  // 105: waverpc.DaemonService.WatchRounds:input_type -> waverpc.WatchRoundsRequest
-	100, // 106: waverpc.DaemonService.ListOORSessions:input_type -> waverpc.ListOORSessionsRequest
-	102, // 107: waverpc.DaemonService.GetOORSession:input_type -> waverpc.GetOORSessionRequest
-	104, // 108: waverpc.DaemonService.EstimateFee:input_type -> waverpc.EstimateFeeRequest
-	106, // 109: waverpc.DaemonService.GetFeeHistory:input_type -> waverpc.GetFeeHistoryRequest
-	109, // 110: waverpc.DaemonService.ListTransactions:input_type -> waverpc.ListTransactionsRequest
-	112, // 111: waverpc.DaemonService.Unroll:input_type -> waverpc.UnrollRequest
-	114, // 112: waverpc.DaemonService.GetUnrollStatus:input_type -> waverpc.GetUnrollStatusRequest
-	119, // 113: waverpc.DaemonService.ArmVHTLCRecovery:input_type -> waverpc.ArmVHTLCRecoveryRequest
-	121, // 114: waverpc.DaemonService.EscalateVHTLCRecovery:input_type -> waverpc.EscalateVHTLCRecoveryRequest
-	123, // 115: waverpc.DaemonService.CancelVHTLCRecovery:input_type -> waverpc.CancelVHTLCRecoveryRequest
-	125, // 116: waverpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> waverpc.GetVHTLCRecoveryStatusRequest
-	127, // 117: waverpc.DaemonService.ListVHTLCRecoveries:input_type -> waverpc.ListVHTLCRecoveriesRequest
-	130, // 118: waverpc.DaemonService.SignOutSwapHtlcAck:input_type -> waverpc.SignOutSwapHtlcAckRequest
-	132, // 119: waverpc.DaemonService.SignCreditAccountAuthorization:input_type -> waverpc.SignCreditAccountAuthorizationRequest
-	135, // 120: waverpc.MacaroonService.BakeMacaroon:input_type -> waverpc.BakeMacaroonRequest
-	138, // 121: waverpc.MacaroonService.ListPermissions:input_type -> waverpc.ListPermissionsRequest
-	12,  // 122: waverpc.DaemonService.GetInfo:output_type -> waverpc.GetInfoResponse
-	15,  // 123: waverpc.DaemonService.GenSeed:output_type -> waverpc.GenSeedResponse
-	17,  // 124: waverpc.DaemonService.InitWallet:output_type -> waverpc.InitWalletResponse
-	19,  // 125: waverpc.DaemonService.UnlockWallet:output_type -> waverpc.UnlockWalletResponse
-	21,  // 126: waverpc.DaemonService.GetBalance:output_type -> waverpc.GetBalanceResponse
-	26,  // 127: waverpc.DaemonService.ListVTXOs:output_type -> waverpc.ListVTXOsResponse
-	28,  // 128: waverpc.DaemonService.NewAddress:output_type -> waverpc.NewAddressResponse
-	30,  // 129: waverpc.DaemonService.NewReceiveScript:output_type -> waverpc.NewReceiveScriptResponse
-	32,  // 130: waverpc.DaemonService.ReceiveAuthKey:output_type -> waverpc.ReceiveAuthKeyResponse
-	34,  // 131: waverpc.DaemonService.SignReceiveAuthMessage:output_type -> waverpc.SignReceiveAuthMessageResponse
-	36,  // 132: waverpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> waverpc.SignReceiveAuthMessageCompactResponse
-	38,  // 133: waverpc.DaemonService.ReceiveAuthECDH:output_type -> waverpc.ReceiveAuthECDHResponse
-	40,  // 134: waverpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> waverpc.GetIndexedVTXOByPkScriptResponse
-	42,  // 135: waverpc.DaemonService.GetVTXOExpiryInfo:output_type -> waverpc.GetVTXOExpiryInfoResponse
-	44,  // 136: waverpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> waverpc.GetIndexedOORSessionByTxidResponse
-	47,  // 137: waverpc.DaemonService.SendVTXO:output_type -> waverpc.SendVTXOResponse
-	51,  // 138: waverpc.DaemonService.SendOOR:output_type -> waverpc.SendOORResponse
-	54,  // 139: waverpc.DaemonService.PrepareOOR:output_type -> waverpc.PrepareOORResponse
-	56,  // 140: waverpc.DaemonService.SignOORCustomInput:output_type -> waverpc.SignOORCustomInputResponse
-	58,  // 141: waverpc.DaemonService.SignVTXOForfeit:output_type -> waverpc.SignVTXOForfeitResponse
-	62,  // 142: waverpc.DaemonService.RefreshVTXOs:output_type -> waverpc.RefreshVTXOsResponse
-	68,  // 143: waverpc.DaemonService.RefreshCustomVTXOs:output_type -> waverpc.RefreshCustomVTXOsResponse
-	71,  // 144: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
-	74,  // 145: waverpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> waverpc.SubmitForfeitParticipantSignaturesResponse
-	77,  // 146: waverpc.DaemonService.LeaveVTXOs:output_type -> waverpc.LeaveVTXOsResponse
-	79,  // 147: waverpc.DaemonService.SendOnChain:output_type -> waverpc.SendOnChainResponse
-	81,  // 148: waverpc.DaemonService.Board:output_type -> waverpc.BoardResponse
-	83,  // 149: waverpc.DaemonService.JoinNextRound:output_type -> waverpc.JoinNextRoundResponse
-	86,  // 150: waverpc.DaemonService.SweepBoardingUTXOs:output_type -> waverpc.SweepBoardingUTXOsResponse
-	90,  // 151: waverpc.DaemonService.ListBoardingSweeps:output_type -> waverpc.ListBoardingSweepsResponse
-	96,  // 152: waverpc.DaemonService.ListRounds:output_type -> waverpc.ListRoundsResponse
-	95,  // 153: waverpc.DaemonService.GetRound:output_type -> waverpc.GetRoundResponse
-	98,  // 154: waverpc.DaemonService.WatchRounds:output_type -> waverpc.WatchRoundsResponse
-	101, // 155: waverpc.DaemonService.ListOORSessions:output_type -> waverpc.ListOORSessionsResponse
-	103, // 156: waverpc.DaemonService.GetOORSession:output_type -> waverpc.GetOORSessionResponse
-	105, // 157: waverpc.DaemonService.EstimateFee:output_type -> waverpc.EstimateFeeResponse
-	108, // 158: waverpc.DaemonService.GetFeeHistory:output_type -> waverpc.GetFeeHistoryResponse
-	111, // 159: waverpc.DaemonService.ListTransactions:output_type -> waverpc.ListTransactionsResponse
-	113, // 160: waverpc.DaemonService.Unroll:output_type -> waverpc.UnrollResponse
-	118, // 161: waverpc.DaemonService.GetUnrollStatus:output_type -> waverpc.GetUnrollStatusResponse
-	120, // 162: waverpc.DaemonService.ArmVHTLCRecovery:output_type -> waverpc.ArmVHTLCRecoveryResponse
-	122, // 163: waverpc.DaemonService.EscalateVHTLCRecovery:output_type -> waverpc.EscalateVHTLCRecoveryResponse
-	124, // 164: waverpc.DaemonService.CancelVHTLCRecovery:output_type -> waverpc.CancelVHTLCRecoveryResponse
-	126, // 165: waverpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> waverpc.GetVHTLCRecoveryStatusResponse
-	128, // 166: waverpc.DaemonService.ListVHTLCRecoveries:output_type -> waverpc.ListVHTLCRecoveriesResponse
-	131, // 167: waverpc.DaemonService.SignOutSwapHtlcAck:output_type -> waverpc.SignOutSwapHtlcAckResponse
-	133, // 168: waverpc.DaemonService.SignCreditAccountAuthorization:output_type -> waverpc.SignCreditAccountAuthorizationResponse
-	136, // 169: waverpc.MacaroonService.BakeMacaroon:output_type -> waverpc.BakeMacaroonResponse
-	139, // 170: waverpc.MacaroonService.ListPermissions:output_type -> waverpc.ListPermissionsResponse
-	122, // [122:171] is the sub-list for method output_type
-	73,  // [73:122] is the sub-list for method input_type
-	73,  // [73:73] is the sub-list for extension type_name
-	73,  // [73:73] is the sub-list for extension extendee
-	0,   // [0:73] is the sub-list for field type_name
+	1,   // 7: waverpc.ListVTXOsRequest.statuses:type_name -> waverpc.VTXOStatus
+	23,  // 8: waverpc.ListVTXOsResponse.vtxos:type_name -> waverpc.VTXO
+	1,   // 9: waverpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> waverpc.VTXOStatus
+	23,  // 10: waverpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> waverpc.VTXO
+	1,   // 11: waverpc.GetVTXOExpiryInfoRequest.status_filter:type_name -> waverpc.VTXOStatus
+	22,  // 12: waverpc.GetVTXOExpiryInfoResponse.expiry_info:type_name -> waverpc.VTXOExpiryInfo
+	23,  // 13: waverpc.GetVTXOExpiryInfoResponse.vtxo:type_name -> waverpc.VTXO
+	45,  // 14: waverpc.SendVTXORequest.recipients:type_name -> waverpc.Output
+	45,  // 15: waverpc.SendOORRequest.recipients:type_name -> waverpc.Output
+	49,  // 16: waverpc.SendOORRequest.custom_inputs:type_name -> waverpc.CustomOORInput
+	50,  // 17: waverpc.CustomOORInput.external_signatures:type_name -> waverpc.TaprootScriptSignature
+	45,  // 18: waverpc.PrepareOORRequest.recipient:type_name -> waverpc.Output
+	49,  // 19: waverpc.PrepareOORRequest.custom_inputs:type_name -> waverpc.CustomOORInput
+	53,  // 20: waverpc.PrepareOORResponse.custom_inputs:type_name -> waverpc.PreparedOORCustomInput
+	49,  // 21: waverpc.SignOORCustomInputRequest.custom_input:type_name -> waverpc.CustomOORInput
+	50,  // 22: waverpc.SignOORCustomInputResponse.signature:type_name -> waverpc.TaprootScriptSignature
+	3,   // 23: waverpc.ForfeitSigningContext.signing_route:type_name -> waverpc.ForfeitSigningRoute
+	60,  // 24: waverpc.RefreshVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
+	63,  // 25: waverpc.RefreshVTXOsResponse.fee_estimate:type_name -> waverpc.RefreshFeeEstimate
+	64,  // 26: waverpc.RefreshFeeEstimate.outpoints:type_name -> waverpc.OutpointFeeEstimate
+	59,  // 27: waverpc.CustomRefreshVTXOInput.forfeit_signing_context:type_name -> waverpc.ForfeitSigningContext
+	65,  // 28: waverpc.RefreshCustomVTXOsRequest.inputs:type_name -> waverpc.CustomRefreshVTXOInput
+	66,  // 29: waverpc.RefreshCustomVTXOsRequest.outputs:type_name -> waverpc.CustomRefreshVTXOOutput
+	3,   // 30: waverpc.PendingForfeitParticipantSignatureRequest.signing_route:type_name -> waverpc.ForfeitSigningRoute
+	69,  // 31: waverpc.ListPendingForfeitParticipantSignatureRequestsResponse.requests:type_name -> waverpc.PendingForfeitParticipantSignatureRequest
+	72,  // 32: waverpc.SubmitForfeitParticipantSignaturesRequest.signatures:type_name -> waverpc.ForfeitParticipantSignature
+	60,  // 33: waverpc.LeaveVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
+	75,  // 34: waverpc.LeaveVTXOsRequest.default_destination:type_name -> waverpc.LeaveDestination
+	140, // 35: waverpc.LeaveVTXOsRequest.destinations:type_name -> waverpc.LeaveVTXOsRequest.DestinationsEntry
+	75,  // 36: waverpc.SendOnChainRequest.destination:type_name -> waverpc.LeaveDestination
+	85,  // 37: waverpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> waverpc.BoardingSweepOutput
+	88,  // 38: waverpc.BoardingSweep.inputs:type_name -> waverpc.BoardingSweepInput
+	89,  // 39: waverpc.ListBoardingSweepsResponse.sweeps:type_name -> waverpc.BoardingSweep
+	4,   // 40: waverpc.RoundInfo.state:type_name -> waverpc.RoundState
+	91,  // 41: waverpc.RoundInfo.vtxos:type_name -> waverpc.RoundVTXOInfo
+	4,   // 42: waverpc.ListRoundsRequest.state_filter:type_name -> waverpc.RoundState
+	92,  // 43: waverpc.GetRoundResponse.round:type_name -> waverpc.RoundInfo
+	92,  // 44: waverpc.ListRoundsResponse.rounds:type_name -> waverpc.RoundInfo
+	92,  // 45: waverpc.WatchRoundsResponse.round:type_name -> waverpc.RoundInfo
+	5,   // 46: waverpc.OORSessionInfo.direction:type_name -> waverpc.OORSessionDirection
+	6,   // 47: waverpc.OORSessionInfo.status:type_name -> waverpc.OORSessionStatus
+	5,   // 48: waverpc.ListOORSessionsRequest.direction_filter:type_name -> waverpc.OORSessionDirection
+	6,   // 49: waverpc.ListOORSessionsRequest.status_filter:type_name -> waverpc.OORSessionStatus
+	99,  // 50: waverpc.ListOORSessionsResponse.sessions:type_name -> waverpc.OORSessionInfo
+	99,  // 51: waverpc.GetOORSessionResponse.session:type_name -> waverpc.OORSessionInfo
+	107, // 52: waverpc.GetFeeHistoryResponse.entries:type_name -> waverpc.FeeHistoryEntry
+	110, // 53: waverpc.ListTransactionsResponse.transactions:type_name -> waverpc.TransactionHistoryEntry
+	7,   // 54: waverpc.GetUnrollStatusResponse.status:type_name -> waverpc.UnrollJobStatus
+	115, // 55: waverpc.GetUnrollStatusResponse.progress:type_name -> waverpc.UnrollProgress
+	116, // 56: waverpc.GetUnrollStatusResponse.csv:type_name -> waverpc.UnrollCSV
+	117, // 57: waverpc.GetUnrollStatusResponse.fees:type_name -> waverpc.UnrollFees
+	8,   // 58: waverpc.ArmVHTLCRecoveryRequest.direction:type_name -> waverpc.VHTLCRecoveryDirection
+	9,   // 59: waverpc.ArmVHTLCRecoveryRequest.action:type_name -> waverpc.VHTLCRecoveryAction
+	129, // 60: waverpc.ArmVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
+	129, // 61: waverpc.EscalateVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
+	129, // 62: waverpc.CancelVHTLCRecoveryResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
+	129, // 63: waverpc.GetVHTLCRecoveryStatusResponse.status:type_name -> waverpc.VHTLCRecoveryStatus
+	129, // 64: waverpc.ListVHTLCRecoveriesResponse.statuses:type_name -> waverpc.VHTLCRecoveryStatus
+	8,   // 65: waverpc.VHTLCRecoveryStatus.direction:type_name -> waverpc.VHTLCRecoveryDirection
+	9,   // 66: waverpc.VHTLCRecoveryStatus.action:type_name -> waverpc.VHTLCRecoveryAction
+	10,  // 67: waverpc.VHTLCRecoveryStatus.state:type_name -> waverpc.VHTLCRecoveryState
+	7,   // 68: waverpc.VHTLCRecoveryStatus.unroll_status:type_name -> waverpc.UnrollJobStatus
+	134, // 69: waverpc.BakeMacaroonRequest.permissions:type_name -> waverpc.MacaroonPermission
+	134, // 70: waverpc.MacaroonPermissionList.permissions:type_name -> waverpc.MacaroonPermission
+	141, // 71: waverpc.ListPermissionsResponse.method_permissions:type_name -> waverpc.ListPermissionsResponse.MethodPermissionsEntry
+	75,  // 72: waverpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> waverpc.LeaveDestination
+	137, // 73: waverpc.ListPermissionsResponse.MethodPermissionsEntry.value:type_name -> waverpc.MacaroonPermissionList
+	11,  // 74: waverpc.DaemonService.GetInfo:input_type -> waverpc.GetInfoRequest
+	14,  // 75: waverpc.DaemonService.GenSeed:input_type -> waverpc.GenSeedRequest
+	16,  // 76: waverpc.DaemonService.InitWallet:input_type -> waverpc.InitWalletRequest
+	18,  // 77: waverpc.DaemonService.UnlockWallet:input_type -> waverpc.UnlockWalletRequest
+	20,  // 78: waverpc.DaemonService.GetBalance:input_type -> waverpc.GetBalanceRequest
+	25,  // 79: waverpc.DaemonService.ListVTXOs:input_type -> waverpc.ListVTXOsRequest
+	27,  // 80: waverpc.DaemonService.NewAddress:input_type -> waverpc.NewAddressRequest
+	29,  // 81: waverpc.DaemonService.NewReceiveScript:input_type -> waverpc.NewReceiveScriptRequest
+	31,  // 82: waverpc.DaemonService.ReceiveAuthKey:input_type -> waverpc.ReceiveAuthKeyRequest
+	33,  // 83: waverpc.DaemonService.SignReceiveAuthMessage:input_type -> waverpc.SignReceiveAuthMessageRequest
+	35,  // 84: waverpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> waverpc.SignReceiveAuthMessageCompactRequest
+	37,  // 85: waverpc.DaemonService.ReceiveAuthECDH:input_type -> waverpc.ReceiveAuthECDHRequest
+	39,  // 86: waverpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> waverpc.GetIndexedVTXOByPkScriptRequest
+	41,  // 87: waverpc.DaemonService.GetVTXOExpiryInfo:input_type -> waverpc.GetVTXOExpiryInfoRequest
+	43,  // 88: waverpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> waverpc.GetIndexedOORSessionByTxidRequest
+	46,  // 89: waverpc.DaemonService.SendVTXO:input_type -> waverpc.SendVTXORequest
+	48,  // 90: waverpc.DaemonService.SendOOR:input_type -> waverpc.SendOORRequest
+	52,  // 91: waverpc.DaemonService.PrepareOOR:input_type -> waverpc.PrepareOORRequest
+	55,  // 92: waverpc.DaemonService.SignOORCustomInput:input_type -> waverpc.SignOORCustomInputRequest
+	57,  // 93: waverpc.DaemonService.SignVTXOForfeit:input_type -> waverpc.SignVTXOForfeitRequest
+	61,  // 94: waverpc.DaemonService.RefreshVTXOs:input_type -> waverpc.RefreshVTXOsRequest
+	67,  // 95: waverpc.DaemonService.RefreshCustomVTXOs:input_type -> waverpc.RefreshCustomVTXOsRequest
+	70,  // 96: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:input_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsRequest
+	73,  // 97: waverpc.DaemonService.SubmitForfeitParticipantSignatures:input_type -> waverpc.SubmitForfeitParticipantSignaturesRequest
+	76,  // 98: waverpc.DaemonService.LeaveVTXOs:input_type -> waverpc.LeaveVTXOsRequest
+	78,  // 99: waverpc.DaemonService.SendOnChain:input_type -> waverpc.SendOnChainRequest
+	80,  // 100: waverpc.DaemonService.Board:input_type -> waverpc.BoardRequest
+	82,  // 101: waverpc.DaemonService.JoinNextRound:input_type -> waverpc.JoinNextRoundRequest
+	84,  // 102: waverpc.DaemonService.SweepBoardingUTXOs:input_type -> waverpc.SweepBoardingUTXOsRequest
+	87,  // 103: waverpc.DaemonService.ListBoardingSweeps:input_type -> waverpc.ListBoardingSweepsRequest
+	93,  // 104: waverpc.DaemonService.ListRounds:input_type -> waverpc.ListRoundsRequest
+	94,  // 105: waverpc.DaemonService.GetRound:input_type -> waverpc.GetRoundRequest
+	97,  // 106: waverpc.DaemonService.WatchRounds:input_type -> waverpc.WatchRoundsRequest
+	100, // 107: waverpc.DaemonService.ListOORSessions:input_type -> waverpc.ListOORSessionsRequest
+	102, // 108: waverpc.DaemonService.GetOORSession:input_type -> waverpc.GetOORSessionRequest
+	104, // 109: waverpc.DaemonService.EstimateFee:input_type -> waverpc.EstimateFeeRequest
+	106, // 110: waverpc.DaemonService.GetFeeHistory:input_type -> waverpc.GetFeeHistoryRequest
+	109, // 111: waverpc.DaemonService.ListTransactions:input_type -> waverpc.ListTransactionsRequest
+	112, // 112: waverpc.DaemonService.Unroll:input_type -> waverpc.UnrollRequest
+	114, // 113: waverpc.DaemonService.GetUnrollStatus:input_type -> waverpc.GetUnrollStatusRequest
+	119, // 114: waverpc.DaemonService.ArmVHTLCRecovery:input_type -> waverpc.ArmVHTLCRecoveryRequest
+	121, // 115: waverpc.DaemonService.EscalateVHTLCRecovery:input_type -> waverpc.EscalateVHTLCRecoveryRequest
+	123, // 116: waverpc.DaemonService.CancelVHTLCRecovery:input_type -> waverpc.CancelVHTLCRecoveryRequest
+	125, // 117: waverpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> waverpc.GetVHTLCRecoveryStatusRequest
+	127, // 118: waverpc.DaemonService.ListVHTLCRecoveries:input_type -> waverpc.ListVHTLCRecoveriesRequest
+	130, // 119: waverpc.DaemonService.SignOutSwapHtlcAck:input_type -> waverpc.SignOutSwapHtlcAckRequest
+	132, // 120: waverpc.DaemonService.SignCreditAccountAuthorization:input_type -> waverpc.SignCreditAccountAuthorizationRequest
+	135, // 121: waverpc.MacaroonService.BakeMacaroon:input_type -> waverpc.BakeMacaroonRequest
+	138, // 122: waverpc.MacaroonService.ListPermissions:input_type -> waverpc.ListPermissionsRequest
+	12,  // 123: waverpc.DaemonService.GetInfo:output_type -> waverpc.GetInfoResponse
+	15,  // 124: waverpc.DaemonService.GenSeed:output_type -> waverpc.GenSeedResponse
+	17,  // 125: waverpc.DaemonService.InitWallet:output_type -> waverpc.InitWalletResponse
+	19,  // 126: waverpc.DaemonService.UnlockWallet:output_type -> waverpc.UnlockWalletResponse
+	21,  // 127: waverpc.DaemonService.GetBalance:output_type -> waverpc.GetBalanceResponse
+	26,  // 128: waverpc.DaemonService.ListVTXOs:output_type -> waverpc.ListVTXOsResponse
+	28,  // 129: waverpc.DaemonService.NewAddress:output_type -> waverpc.NewAddressResponse
+	30,  // 130: waverpc.DaemonService.NewReceiveScript:output_type -> waverpc.NewReceiveScriptResponse
+	32,  // 131: waverpc.DaemonService.ReceiveAuthKey:output_type -> waverpc.ReceiveAuthKeyResponse
+	34,  // 132: waverpc.DaemonService.SignReceiveAuthMessage:output_type -> waverpc.SignReceiveAuthMessageResponse
+	36,  // 133: waverpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> waverpc.SignReceiveAuthMessageCompactResponse
+	38,  // 134: waverpc.DaemonService.ReceiveAuthECDH:output_type -> waverpc.ReceiveAuthECDHResponse
+	40,  // 135: waverpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> waverpc.GetIndexedVTXOByPkScriptResponse
+	42,  // 136: waverpc.DaemonService.GetVTXOExpiryInfo:output_type -> waverpc.GetVTXOExpiryInfoResponse
+	44,  // 137: waverpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> waverpc.GetIndexedOORSessionByTxidResponse
+	47,  // 138: waverpc.DaemonService.SendVTXO:output_type -> waverpc.SendVTXOResponse
+	51,  // 139: waverpc.DaemonService.SendOOR:output_type -> waverpc.SendOORResponse
+	54,  // 140: waverpc.DaemonService.PrepareOOR:output_type -> waverpc.PrepareOORResponse
+	56,  // 141: waverpc.DaemonService.SignOORCustomInput:output_type -> waverpc.SignOORCustomInputResponse
+	58,  // 142: waverpc.DaemonService.SignVTXOForfeit:output_type -> waverpc.SignVTXOForfeitResponse
+	62,  // 143: waverpc.DaemonService.RefreshVTXOs:output_type -> waverpc.RefreshVTXOsResponse
+	68,  // 144: waverpc.DaemonService.RefreshCustomVTXOs:output_type -> waverpc.RefreshCustomVTXOsResponse
+	71,  // 145: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
+	74,  // 146: waverpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> waverpc.SubmitForfeitParticipantSignaturesResponse
+	77,  // 147: waverpc.DaemonService.LeaveVTXOs:output_type -> waverpc.LeaveVTXOsResponse
+	79,  // 148: waverpc.DaemonService.SendOnChain:output_type -> waverpc.SendOnChainResponse
+	81,  // 149: waverpc.DaemonService.Board:output_type -> waverpc.BoardResponse
+	83,  // 150: waverpc.DaemonService.JoinNextRound:output_type -> waverpc.JoinNextRoundResponse
+	86,  // 151: waverpc.DaemonService.SweepBoardingUTXOs:output_type -> waverpc.SweepBoardingUTXOsResponse
+	90,  // 152: waverpc.DaemonService.ListBoardingSweeps:output_type -> waverpc.ListBoardingSweepsResponse
+	96,  // 153: waverpc.DaemonService.ListRounds:output_type -> waverpc.ListRoundsResponse
+	95,  // 154: waverpc.DaemonService.GetRound:output_type -> waverpc.GetRoundResponse
+	98,  // 155: waverpc.DaemonService.WatchRounds:output_type -> waverpc.WatchRoundsResponse
+	101, // 156: waverpc.DaemonService.ListOORSessions:output_type -> waverpc.ListOORSessionsResponse
+	103, // 157: waverpc.DaemonService.GetOORSession:output_type -> waverpc.GetOORSessionResponse
+	105, // 158: waverpc.DaemonService.EstimateFee:output_type -> waverpc.EstimateFeeResponse
+	108, // 159: waverpc.DaemonService.GetFeeHistory:output_type -> waverpc.GetFeeHistoryResponse
+	111, // 160: waverpc.DaemonService.ListTransactions:output_type -> waverpc.ListTransactionsResponse
+	113, // 161: waverpc.DaemonService.Unroll:output_type -> waverpc.UnrollResponse
+	118, // 162: waverpc.DaemonService.GetUnrollStatus:output_type -> waverpc.GetUnrollStatusResponse
+	120, // 163: waverpc.DaemonService.ArmVHTLCRecovery:output_type -> waverpc.ArmVHTLCRecoveryResponse
+	122, // 164: waverpc.DaemonService.EscalateVHTLCRecovery:output_type -> waverpc.EscalateVHTLCRecoveryResponse
+	124, // 165: waverpc.DaemonService.CancelVHTLCRecovery:output_type -> waverpc.CancelVHTLCRecoveryResponse
+	126, // 166: waverpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> waverpc.GetVHTLCRecoveryStatusResponse
+	128, // 167: waverpc.DaemonService.ListVHTLCRecoveries:output_type -> waverpc.ListVHTLCRecoveriesResponse
+	131, // 168: waverpc.DaemonService.SignOutSwapHtlcAck:output_type -> waverpc.SignOutSwapHtlcAckResponse
+	133, // 169: waverpc.DaemonService.SignCreditAccountAuthorization:output_type -> waverpc.SignCreditAccountAuthorizationResponse
+	136, // 170: waverpc.MacaroonService.BakeMacaroon:output_type -> waverpc.BakeMacaroonResponse
+	139, // 171: waverpc.MacaroonService.ListPermissions:output_type -> waverpc.ListPermissionsResponse
+	123, // [123:172] is the sub-list for method output_type
+	74,  // [74:123] is the sub-list for method input_type
+	74,  // [74:74] is the sub-list for extension type_name
+	74,  // [74:74] is the sub-list for extension extendee
+	0,   // [0:74] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -769,8 +769,8 @@ message VTXOSettlement {
 }
 
 message ListVTXOsRequest {
-    // status_filter restricts the response to VTXOs matching this status.
-    // If VTXO_STATUS_UNSPECIFIED (default), all statuses are returned.
+    // status_filter restricts the response to VTXOs in this status. It is
+    // equivalent to a single entry in statuses.
     VTXOStatus status_filter = 1;
 
     // min_amount_sat excludes VTXOs below this value.
@@ -782,6 +782,12 @@ message ListVTXOsRequest {
     // consumers (balance views, coin selection) that never inspect the
     // PSBTs. The default keeps the full response for compatibility.
     bool exclude_checkpoint_psbts = 3;
+
+    // statuses restricts the response to VTXOs in any of these statuses.
+    // When empty, every VTXO except VTXO_STATUS_FORFEITED and
+    // VTXO_STATUS_SPENT is returned. VTXO_STATUS_PENDING_ROUND entries are
+    // only included when listed.
+    repeated VTXOStatus statuses = 4;
 }
 
 message ListVTXOsResponse {


### PR DESCRIPTION
Supersedes #1118 and addresses #1116. Thanks @Liongrass, the tests and doc edits build on that PR.

`ListVTXOs` without a filter returns every VTXO except forfeited and spent ones, newest first. `ListVTXOsRequest` gains `repeated VTXOStatus statuses`; `status_filter` still works and is merged into that set. `VTXO_STATUS_PENDING_ROUND` projections are included only when listed. A repeated field covers multi-status filtering and avoids a second exclusive knob on the request.

`wavecli ark vtxos list --status` accepts several statuses, and `--all` expands to every status while skipping checkpoint PSBTs unless `--fields` names them. The MCP tool and schema registry match. A VTXO whose OOR package fails to load is listed without its PSBTs instead of failing the call. `protoStatusToDomain` gains the `SPENDING` case.

The store reads each requested status with the existing indexed query inside one transaction, since a parameterised IN list is not portable across SQLite and Postgres.

Callers that sum amounts from an unfiltered listing must filter on `VTXO_STATUS_LIVE` or use `GetBalance`.

Unit tests cover the default set, status lists, cross-status ordering, the spent-flag guard, the PENDING_ROUND combination and the CLI helpers.

Follow-ups: pagination for `ListVTXOs`, and clearing `forfeit_round_id` when a forfeit is released.
