### PR TITLE
build: bump version to v0.1.2-rc5

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -19,7 +19,7 @@ const (
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = "rc4"
+	AppPreRelease = "rc5"
 )
 
 var (


### PR DESCRIPTION
## Summary

Bump `build/version.go` from `v0.1.2-rc4` to `v0.1.2-rc5` after the release sync in #1301. This is a one-line version change based on release tip `c146e008`.

No workflow changes, tags, or release publication are included.

## Validation

- `make fmt-changed base=origin/v0.1.x-branch`: passed.
- `make lint-changed-local base=origin/v0.1.x-branch`: passed.
- `go test ./build` and `make unit pkg=build log="stdlog trace" timeout=5m`: passed.
- `make build`: passed; both `waved --version` and `wavecli --version` report `0.1.2-rc5`.
- `make tidy-module-check`: passed on the committed, clean tree.
- Commit-message lint against main and the release branch, plus `git diff --check`: passed.

Full system tests and local agent-review CI were not run for this version-only change. Remote CI remains pending.
