### PR TITLE
docs: nightly doc-gardening sweep 2026-09-09

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,6 +26,7 @@ package may import from a higher layer.
 | [`lib/tx/oor`](lib/tx/oor/) | OOR submit/finalize package builders and validators |
 | [`lib/tx/psbtutil`](lib/tx/psbtutil/) | PSBT encoding, decoding, and signature attachment helpers |
 | [`lib/recovery`](lib/recovery/) | Immutable recovery proof graph, session state machine, TLV codec for unilateral exit |
+| [`tapassets`](tapassets/) | Adapts tap-sdk custom-anchor transitions to Ark trees: caller-funded asset batch anchors and asset-aware VTXO tree materialization, journaled for restart-safe replay |
 | [`unrollplan`](unrollplan/) | Pure dependency-resolution planner driving unilateral-exit broadcast/sweep ordering |
 | [`vhtlcrecovery`](vhtlcrecovery/) | Durable control-plane types for vHTLC on-chain recovery jobs (action, state, script parameters, swap linkage) |
 | [`credit`](credit/) | Client-side credit subsystem: supervisor/per-operation-actor pair driving fault-tolerant sub-floor pay, credit-receive, and redeem flows against the authoritative server ledger |

--- a/arkrpc/AGENTS.md
+++ b/arkrpc/AGENTS.md
@@ -48,3 +48,7 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   These mirror `roundpb.TreeFromProto`; keep the two decoders in step.
 - Child iteration during flattening is sorted by output index for
   deterministic serialization.
+- `GetInfoResponse.vtxo_confirmations` is the depth clients must wait before
+  spending VTXOs a round created, and is deliberately separate from
+  `min_confirmations`, which protects the on-chain boarding inputs a new round
+  consumes. Conflating the two either strands fresh VTXOs or admits them early.

--- a/arkrpc/CLAUDE.md
+++ b/arkrpc/CLAUDE.md
@@ -48,3 +48,7 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   These mirror `roundpb.TreeFromProto`; keep the two decoders in step.
 - Child iteration during flattening is sorted by output index for
   deterministic serialization.
+- `GetInfoResponse.vtxo_confirmations` is the depth clients must wait before
+  spending VTXOs a round created, and is deliberately separate from
+  `min_confirmations`, which protects the on-chain boarding inputs a new round
+  consumes. Conflating the two either strands fresh VTXOs or admits them early.

--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -187,6 +187,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
 - `recovery escalate` refuses to run on non-interactive stdin unless
   `--yes` is passed — it never blocks on a y/N prompt an agent can't
   answer.
+- `ark vtxos list --status` is a repeatable string slice, not a single
+  value, and is mutually exclusive with `--all`. Bare `list` shows the
+  daemon's inventory default (every VTXO except forfeited and spent,
+  newest first); `--all` expands to the full status set explicitly. The
+  command also sets `exclude_checkpoint_psbts` unless the caller names
+  `oor_final_checkpoint_psbts` in `--fields`, so the common listing path
+  does not drag the OOR checkpoint PSBT blobs through the CLI.
 - `ark vtxos refresh` is gated on fee consent: a real refresh fetches
   the dry-run estimate and prompts with it on a TTY, and refuses on
   non-interactive stdin without `--yes` (same posture as `leave --all`

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -187,6 +187,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
 - `recovery escalate` refuses to run on non-interactive stdin unless
   `--yes` is passed — it never blocks on a y/N prompt an agent can't
   answer.
+- `ark vtxos list --status` is a repeatable string slice, not a single
+  value, and is mutually exclusive with `--all`. Bare `list` shows the
+  daemon's inventory default (every VTXO except forfeited and spent,
+  newest first); `--all` expands to the full status set explicitly. The
+  command also sets `exclude_checkpoint_psbts` unless the caller names
+  `oor_final_checkpoint_psbts` in `--fields`, so the common listing path
+  does not drag the OOR checkpoint PSBT blobs through the CLI.
 - `ark vtxos refresh` is gated on fee consent: a real refresh fetches
   the dry-run estimate and prompts with it on a TTY, and refuses on
   non-interactive stdin without `--yes` (same posture as `leave --all`

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ into specific topics below.
 | [mailbox_durable_actor_layer.md](mailbox_durable_actor_layer.md) | The durable mailbox and durable actor: leases, dedup, transactional outbox, DurableAsk, and the classic vs. Read/Commit (`TxBehavior`/`Exec[S]`) execution paths |
 | [mailbox_transport_serverconn_clientconn.md](mailbox_transport_serverconn_clientconn.md) | The RPC-over-mailbox transport relating this client's `serverconn` to the operator's `clientconn`: envelope, edge API, shared `mailbox/conn` primitives, ack watermark, identity/auth/liveness, and the wire contract |
 | [RPC_MAILBOX_CONTRACT.md](RPC_MAILBOX_CONTRACT.md) | Envelope semantics, at-least-once delivery, ack watermarks |
+| [mailbox_ingress_safety.md](mailbox_ingress_safety.md) | Commit-before-ack on durable event routes: `delivery-v1:` occurrence IDs and replay retention, ingress receipts, quarantine of rejected envelopes for recovery, and cursor validation before dispatch |
 | [credit_durable_actor_design.md](credit_durable_actor_design.md) | Credit subsystem durable-actor design: supervisor + per-operation actors driving fault-tolerant sub-floor pay, credit-receive, and redeem flows against the authoritative server ledger |
 | [wavewalletdk_mobile.md](wavewalletdk_mobile.md) | gomobile-safe `sdk/wavewalletdk/mobile` facade: drives an embedded in-process `waved` wallet from Android/iOS over the private bufconn transport (bytes-out API, no daemon binary) |
 

--- a/lib/actormsg/AGENTS.md
+++ b/lib/actormsg/AGENTS.md
@@ -25,7 +25,7 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
   (`true` for directed sends) or parks in `PendingRoundAssembly` for
   batching (`false` for refresh/leave flows).
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
-- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
+- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript, `ReserveEpoch`).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.
 
 ## Relationships
@@ -38,6 +38,15 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - All cross-boundary actor messages must implement the appropriate marker interface (`RoundReceivable`, `VTXOManagerMsg`, etc.) for type-safe actor routing.
 - Service key names are constants (`RoundActorServiceKeyName`, `VTXOManagerServiceKeyName`) shared across the codebase for consistent actor discovery.
 - `SelectedVTXO` intentionally duplicates minimal VTXO info to avoid `wallet` importing `vtxo.Descriptor`.
+- **Spend releases are epoch-fenced.** The manager stamps a monotonic
+  `ReserveEpoch` on each spend reservation and echoes it in `SelectedVTXO`. The
+  owning session carries that epoch into its durable state and names it in
+  `ReleaseSpendRequest.ReserveEpochs`, so `vtxo.Manager.handleReleaseSpend`
+  refuses a release whose epoch no longer matches. Without the fence, a
+  redelivered release from a rolled-back session returns a coin that a newer
+  session has already re-reserved and is actively spending. An absent entry (or
+  a nil map) releases unconditionally, which is what callers holding no epoch
+  — a manual unlock, a forfeit-input reservation — need.
 
 ## Deep Docs
 

--- a/lib/actormsg/CLAUDE.md
+++ b/lib/actormsg/CLAUDE.md
@@ -25,7 +25,7 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
   (`true` for directed sends) or parks in `PendingRoundAssembly` for
   batching (`false` for refresh/leave flows).
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
-- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
+- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript, `ReserveEpoch`).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.
 
 ## Relationships
@@ -38,6 +38,15 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - All cross-boundary actor messages must implement the appropriate marker interface (`RoundReceivable`, `VTXOManagerMsg`, etc.) for type-safe actor routing.
 - Service key names are constants (`RoundActorServiceKeyName`, `VTXOManagerServiceKeyName`) shared across the codebase for consistent actor discovery.
 - `SelectedVTXO` intentionally duplicates minimal VTXO info to avoid `wallet` importing `vtxo.Descriptor`.
+- **Spend releases are epoch-fenced.** The manager stamps a monotonic
+  `ReserveEpoch` on each spend reservation and echoes it in `SelectedVTXO`. The
+  owning session carries that epoch into its durable state and names it in
+  `ReleaseSpendRequest.ReserveEpochs`, so `vtxo.Manager.handleReleaseSpend`
+  refuses a release whose epoch no longer matches. Without the fence, a
+  redelivered release from a rolled-back session returns a coin that a newer
+  session has already re-reserved and is actively spending. An absent entry (or
+  a nil map) releases unconditionally, which is what callers holding no epoch
+  — a manual unlock, a forfeit-input reservation — need.
 
 ## Deep Docs
 

--- a/lib/tree/AGENTS.md
+++ b/lib/tree/AGENTS.md
@@ -10,7 +10,9 @@ descriptors through branch nodes to the batch output.
 
 - `Tree` — Complete VTXO or connector tree: root outpoint, root output, node hierarchy, and traversal helpers. `Verify` checks structure plus value flow; `ValidateValueConservation` exposes the funding check separately for callers that have already bound `BatchOutput` to an authoritative prevout. Built via `BuildVTXOTree` or `BuildConnectorTree`.
 - `Node` — Single tree node representing a transaction in the tree (branch or leaf).
-- `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay.
+- `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay, and `AssetAmount` (zero for Bitcoin-only leaves).
+- `AssetTreeContext` — Per-tree asset state populated by builders before the tree is shared: asset ref, per-node asset amounts, per-input signing tweaks, per-leaf asset commitment roots, and the sealed transfer package for each node input. `Validate(root)` checks the context against the materialized tree. `Tree.AssetContext` is nil for Bitcoin-only trees.
+- `BatchOutputSpec` — A batch output plus its taproot tree (`Output`, untweaked `InternalKey`, operator `SweepLeaf`), built by `BuildBatchOutputSpec`. `TapTreeBytes` exposes the encoded tree for callers that must compose an asset commitment into the same output.
 - `VTXODescriptor` — Interface for VTXO metadata needed by tree construction (amount, cosigners, owner key).
 - `ConnectorDescriptor` — Describes a connector output for forfeit transaction construction.
 - `Structure` — Intermediate tree layout built by `BuildStructure` before materialization.
@@ -23,7 +25,7 @@ descriptors through branch nodes to the batch output.
 ## Relationships
 
 - **Depends on**: `lib/arkscript` (taproot script construction, policy templates, `SpendInfo`).
-- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization).
+- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization, including the asset context), `tapassets` (asset tree structure and materialization), `rpc/roundpb` (`TreeFromProto`/`TreeToProto`).
 
 ## Invariants
 
@@ -42,6 +44,12 @@ descriptors through branch nodes to the batch output.
   all outputs and recurses only into retained children. The traversal rejects
   cycles and nodes shared by multiple parents. `Node.Verify` checks only
   parent-child outpoint topology and is not a trust-boundary validator.
+- Asset trees carry a per-node `SigningTweak` in `AssetTreeContext` instead of
+  deriving the branch tweak from `SweepTapscriptRoot` alone: the tweak must also
+  commit to the node's Taproot Asset commitment root. Bitcoin-only trees leave
+  the context nil and keep using `SweepTapscriptRoot`. A tree that has an
+  `AssetContext` must pass `AssetContext.Validate(Root)` — asset amounts must
+  flow through the node hierarchy the same way carrier values do.
 - **Cache-aliasing invariant**: a `*Tree` is effectively immutable once published from
   a builder or resolver. Multiple downstream consumers may share the same `*Tree`
   pointer through caches and ancestry-fragment slices. Silently mutating a shared

--- a/lib/tree/CLAUDE.md
+++ b/lib/tree/CLAUDE.md
@@ -10,7 +10,9 @@ descriptors through branch nodes to the batch output.
 
 - `Tree` — Complete VTXO or connector tree: root outpoint, root output, node hierarchy, and traversal helpers. `Verify` checks structure plus value flow; `ValidateValueConservation` exposes the funding check separately for callers that have already bound `BatchOutput` to an authoritative prevout. Built via `BuildVTXOTree` or `BuildConnectorTree`.
 - `Node` — Single tree node representing a transaction in the tree (branch or leaf).
-- `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay.
+- `LeafDescriptor` — Describes a single VTXO leaf: amount, owner pubkeys, cosigner keys, CSV delay, and `AssetAmount` (zero for Bitcoin-only leaves).
+- `AssetTreeContext` — Per-tree asset state populated by builders before the tree is shared: asset ref, per-node asset amounts, per-input signing tweaks, per-leaf asset commitment roots, and the sealed transfer package for each node input. `Validate(root)` checks the context against the materialized tree. `Tree.AssetContext` is nil for Bitcoin-only trees.
+- `BatchOutputSpec` — A batch output plus its taproot tree (`Output`, untweaked `InternalKey`, operator `SweepLeaf`), built by `BuildBatchOutputSpec`. `TapTreeBytes` exposes the encoded tree for callers that must compose an asset commitment into the same output.
 - `VTXODescriptor` — Interface for VTXO metadata needed by tree construction (amount, cosigners, owner key).
 - `ConnectorDescriptor` — Describes a connector output for forfeit transaction construction.
 - `Structure` — Intermediate tree layout built by `BuildStructure` before materialization.
@@ -23,7 +25,7 @@ descriptors through branch nodes to the batch output.
 ## Relationships
 
 - **Depends on**: `lib/arkscript` (taproot script construction, policy templates, `SpendInfo`).
-- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization).
+- **Depended on by**: `round` (tree construction/validation), `oor` (tree references), `db` (tree serialization, including the asset context), `tapassets` (asset tree structure and materialization), `rpc/roundpb` (`TreeFromProto`/`TreeToProto`).
 
 ## Invariants
 
@@ -42,6 +44,12 @@ descriptors through branch nodes to the batch output.
   all outputs and recurses only into retained children. The traversal rejects
   cycles and nodes shared by multiple parents. `Node.Verify` checks only
   parent-child outpoint topology and is not a trust-boundary validator.
+- Asset trees carry a per-node `SigningTweak` in `AssetTreeContext` instead of
+  deriving the branch tweak from `SweepTapscriptRoot` alone: the tweak must also
+  commit to the node's Taproot Asset commitment root. Bitcoin-only trees leave
+  the context nil and keep using `SweepTapscriptRoot`. A tree that has an
+  `AssetContext` must pass `AssetContext.Validate(Root)` — asset amounts must
+  flow through the node hierarchy the same way carrier values do.
 - **Cache-aliasing invariant**: a `*Tree` is effectively immutable once published from
   a builder or resolver. Multiple downstream consumers may share the same `*Tree`
   pointer through caches and ancestry-fragment slices. Silently mutating a shared

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -15,7 +15,9 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `VTXORequest` — Describes a new VTXO to create in a round (amount, policy
   template, owner key, signing key). `IsChange bool` (TLV record 4) marks the
   output that absorbs the server-computed fee residual under the #270
-  seal-time handshake; serialized into `JoinRoundAuth`.
+  seal-time handshake; serialized into `JoinRoundAuth`. `AssetRef string` /
+  `AssetAmount uint64` request a Taproot Asset VTXO instead of a Bitcoin one;
+  `ValidateAssetFields` enforces the pairing rules (see Invariants).
 - `ForfeitRequest` — Describes a VTXO being forfeited: `VTXOOutpoint`,
   local-only `Amount`, plus optional `AuthSpend *arkscript.SpendPath`
   (proof-of-control path for custom-script join-auth construction) and
@@ -36,6 +38,8 @@ server during round participation. These types are used across `round`, `vtxo`,
   cap on the cumulative on-chain vbytes a recipient must publish to claim a
   VTXO produced by an OOR submit unilaterally. Zero means no cap enforced
   server-side (clients fall back to a conservative local default).
+  `VTXOConfirmations uint32` is the depth at which VTXOs created by a round
+  become spendable off-chain, read through `VTXOTargetConfirmations()`.
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; multi-input OOR VTXOs carry one entry per distinct (commitment tx, tree path) pair — entries may share a commitment txid when inputs sat at different leaves of one commitment tree.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
@@ -63,6 +67,18 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
 - `VTXOSigningKeyFamily` (45) is the HD key family used for per-round VTXO MuSig2 signing keys.
 - `JoinRoundAuthMessage` produces a deterministic, versioned TLV byte encoding that the client signs (and the server verifies) via BIP-322.
+- `VTXORequest.AssetRef` and `AssetAmount` are all-or-nothing: both empty is a
+  plain Bitcoin request, both set is an asset request, and either one alone is
+  an error. An asset request additionally requires `FixedAmount` (asset outputs
+  are never eligible for the implicit-change fee residual) and forbids
+  `IsChange`. Both fields are serialized into `JoinRoundAuth`, so the operator
+  cannot substitute a different asset or amount than the client signed for.
+- `OperatorTerms.VTXOTargetConfirmations()` is the only correct way to read the
+  round-VTXO activation depth. A zero `VTXOConfirmations` means the operator
+  does not advertise the split field, and the accessor falls back to
+  `MinConfirmations` to preserve the legacy policy that reused the
+  boarding-input minimum for commitment outputs. Reading the raw field treats
+  legacy operators as "zero confirmations required".
 
 ## Deep Docs
 

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -15,7 +15,9 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `VTXORequest` — Describes a new VTXO to create in a round (amount, policy
   template, owner key, signing key). `IsChange bool` (TLV record 4) marks the
   output that absorbs the server-computed fee residual under the #270
-  seal-time handshake; serialized into `JoinRoundAuth`.
+  seal-time handshake; serialized into `JoinRoundAuth`. `AssetRef string` /
+  `AssetAmount uint64` request a Taproot Asset VTXO instead of a Bitcoin one;
+  `ValidateAssetFields` enforces the pairing rules (see Invariants).
 - `ForfeitRequest` — Describes a VTXO being forfeited: `VTXOOutpoint`,
   local-only `Amount`, plus optional `AuthSpend *arkscript.SpendPath`
   (proof-of-control path for custom-script join-auth construction) and
@@ -36,6 +38,8 @@ server during round participation. These types are used across `round`, `vtxo`,
   cap on the cumulative on-chain vbytes a recipient must publish to claim a
   VTXO produced by an OOR submit unilaterally. Zero means no cap enforced
   server-side (clients fall back to a conservative local default).
+  `VTXOConfirmations uint32` is the depth at which VTXOs created by a round
+  become spendable off-chain, read through `VTXOTargetConfirmations()`.
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; multi-input OOR VTXOs carry one entry per distinct (commitment tx, tree path) pair — entries may share a commitment txid when inputs sat at different leaves of one commitment tree.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
@@ -63,6 +67,18 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
 - `VTXOSigningKeyFamily` (45) is the HD key family used for per-round VTXO MuSig2 signing keys.
 - `JoinRoundAuthMessage` produces a deterministic, versioned TLV byte encoding that the client signs (and the server verifies) via BIP-322.
+- `VTXORequest.AssetRef` and `AssetAmount` are all-or-nothing: both empty is a
+  plain Bitcoin request, both set is an asset request, and either one alone is
+  an error. An asset request additionally requires `FixedAmount` (asset outputs
+  are never eligible for the implicit-change fee residual) and forbids
+  `IsChange`. Both fields are serialized into `JoinRoundAuth`, so the operator
+  cannot substitute a different asset or amount than the client signed for.
+- `OperatorTerms.VTXOTargetConfirmations()` is the only correct way to read the
+  round-VTXO activation depth. A zero `VTXOConfirmations` means the operator
+  does not advertise the split field, and the accessor falls back to
+  `MinConfirmations` to preserve the legacy policy that reused the
+  boarding-input minimum for commitment outputs. Reading the raw field treats
+  legacy operators as "zero confirmations required".
 
 ## Deep Docs
 

--- a/rpc/roundpb/AGENTS.md
+++ b/rpc/roundpb/AGENTS.md
@@ -24,11 +24,19 @@ All `*.pb.go` files are generated — never edit directly; regenerate with
   `MethodSubmitVTXOForfeitSigs` (VTXO forfeit sigs).
 - `TreeFromProto` / `TreeToProto` — Convert between `*VTXOTree` proto and
   `lib/tree.Tree`; `TreeFromProto` takes `WithMaxTreeNodes` to bound the
-  deserialized node count (`DefaultMaxTreeNodes` = 50,000).
+  deserialized node count (`DefaultMaxTreeNodes` = 50,000). Both carry the
+  asset-tree fields: `VTXOTree.asset_ref` plus per-node `signing_tweak`,
+  `asset_amount`, and `asset_commitment_root`, which round-trip through
+  `lib/tree.AssetTreeContext`.
 - `OutpointFromProto`/`ToProto`, `TxOutFromProto`/`ToProto`,
   `PSBTFromBytes`/`ToBytes`, `MsgTxFromBytes`/`ToBytes`,
   `SchnorrSigFromBytes`/`ToBytes` — wire/proto ⇄ Go conversions for the
   round protocol's payload types.
+- Asset-round proto surface: `VTXORequest.asset_ref` / `asset_amount` name the
+  Taproot Asset a client is requesting (mirroring `lib/types.VTXORequest`), and
+  `ClientBatchInfo.asset_leaf_packages` returns the sealed transfer package for
+  each asset VTXO created for that client, keyed by VTXO outpoint. All are
+  empty/absent for Bitcoin-only rounds.
 - `FlowVersion` / `FlowVersionV1` / `ValidateFlowVersion` — the per-round
   choreography version stamped by the operator and validated by the
   client; fails closed on any version this build does not understand.

--- a/rpc/roundpb/CLAUDE.md
+++ b/rpc/roundpb/CLAUDE.md
@@ -24,11 +24,19 @@ All `*.pb.go` files are generated — never edit directly; regenerate with
   `MethodSubmitVTXOForfeitSigs` (VTXO forfeit sigs).
 - `TreeFromProto` / `TreeToProto` — Convert between `*VTXOTree` proto and
   `lib/tree.Tree`; `TreeFromProto` takes `WithMaxTreeNodes` to bound the
-  deserialized node count (`DefaultMaxTreeNodes` = 50,000).
+  deserialized node count (`DefaultMaxTreeNodes` = 50,000). Both carry the
+  asset-tree fields: `VTXOTree.asset_ref` plus per-node `signing_tweak`,
+  `asset_amount`, and `asset_commitment_root`, which round-trip through
+  `lib/tree.AssetTreeContext`.
 - `OutpointFromProto`/`ToProto`, `TxOutFromProto`/`ToProto`,
   `PSBTFromBytes`/`ToBytes`, `MsgTxFromBytes`/`ToBytes`,
   `SchnorrSigFromBytes`/`ToBytes` — wire/proto ⇄ Go conversions for the
   round protocol's payload types.
+- Asset-round proto surface: `VTXORequest.asset_ref` / `asset_amount` name the
+  Taproot Asset a client is requesting (mirroring `lib/types.VTXORequest`), and
+  `ClientBatchInfo.asset_leaf_packages` returns the sealed transfer package for
+  each asset VTXO created for that client, keyed by VTXO outpoint. All are
+  empty/absent for Bitcoin-only rounds.
 - `FlowVersion` / `FlowVersionV1` / `ValidateFlowVersion` — the per-round
   choreography version stamped by the operator and validated by the
   client; fails closed on any version this build does not understand.

--- a/sdk/ark/AGENTS.md
+++ b/sdk/ark/AGENTS.md
@@ -76,8 +76,14 @@ transport, without duplicating Ark runtime behavior.
   server; it does not own the caller's `DaemonServer` runtime. `Close()`
   tears down only the private transport.
 - `ServerInfo` is a bootstrap-time operator-terms snapshot, including the
-  advisory `FreeRefreshWindowBlocks`; refresh after reconnect is not wired
-  through yet.
+  advisory `FreeRefreshWindowBlocks` and `VTXOConfirmations` (the depth at
+  which round-created VTXOs become spendable, distinct from
+  `MinConfirmations`, which covers boarding inputs); refresh after reconnect
+  is not wired through yet.
+- `ListVTXOs(ctx, nil)` is not "no filter". A nil request lists the daemon's
+  inventory set — every VTXO except forfeited and spent, newest first — of
+  which only live entries are spendable. Callers computing a spendable
+  balance must filter, not assume.
 - Pre-1.0, some methods intentionally return `waverpc` protobuf types
   directly. Those passthrough APIs are not yet treated as stable SDK-owned
   models.

--- a/sdk/ark/CLAUDE.md
+++ b/sdk/ark/CLAUDE.md
@@ -76,8 +76,14 @@ transport, without duplicating Ark runtime behavior.
   server; it does not own the caller's `DaemonServer` runtime. `Close()`
   tears down only the private transport.
 - `ServerInfo` is a bootstrap-time operator-terms snapshot, including the
-  advisory `FreeRefreshWindowBlocks`; refresh after reconnect is not wired
-  through yet.
+  advisory `FreeRefreshWindowBlocks` and `VTXOConfirmations` (the depth at
+  which round-created VTXOs become spendable, distinct from
+  `MinConfirmations`, which covers boarding inputs); refresh after reconnect
+  is not wired through yet.
+- `ListVTXOs(ctx, nil)` is not "no filter". A nil request lists the daemon's
+  inventory set — every VTXO except forfeited and spent, newest first — of
+  which only live entries are spendable. Callers computing a spendable
+  balance must filter, not assume.
 - Pre-1.0, some methods intentionally return `waverpc` protobuf types
   directly. Those passthrough APIs are not yet treated as stable SDK-owned
   models.

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -169,6 +169,30 @@ default builds avoid the swap executor's dependency graph.
   calls `listLiveVTXOsForLeave` for sweep-all enumeration.
 - `SendResponse.actual_amount_sat` carries the true outflow for sweep-all
   sends and SHOULD be echoed back before the send is treated as confirmed.
+- **The onchain send preview quotes every selected VTXO, not the destination
+  amount.** `quoteOnchainInputs` calls `EstimateFee` once per distinct
+  (amount, remaining-blocks) pair across the selected inputs and sums the
+  results, because each forfeit pays its own fixed operator components.
+  Quoting the destination amount once undercounts those charges and prices the
+  wrong principal when a bounded send returns change. Remaining lifetime comes
+  from `batch_expiry` minus the `GetInfo` block height, clamped to at least one
+  block. Quotes assume batch size one; the binding fee is set from actual round
+  occupancy when the round seals.
+- **A partial remote sum must never be reported as COMPLETE.** Any missing
+  timing context (zero block height, absent `batch_expiry`), unreachable
+  operator, or overflowing total discards the *entire* remote estimate and
+  falls back to `localOnchainFeeFloor` as `LOCAL_ONLY`. The one case that does
+  not fall back is an operator quote returning `below_dust_warning`: that is an
+  input the operator has already priced as uneconomic, so the preview is
+  rejected with `FailedPrecondition` rather than being papered over with a
+  cheaper-looking local floor.
+- `fetchOnchainTerms` carries the chain height alongside the operator policy
+  from one `GetInfo` call; a nil `ServerInfo` yields zero policy values (via the
+  nil-safe generated getters) rather than aborting, so the preview still
+  renders.
+- `stampLateTransition` records observation time on activity transitions that
+  arrive after the stored row's `UpdatedAtUnix`, so a late projection is
+  distinguishable from an in-order one.
 - **Cooperative-leave EXIT fee**: at completion
   (`applyCooperativeLeaveForfeited`), the forfeited source VTXO's
   settlement carries the forfeit round's operator fee (from the daemon

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -169,6 +169,30 @@ default builds avoid the swap executor's dependency graph.
   calls `listLiveVTXOsForLeave` for sweep-all enumeration.
 - `SendResponse.actual_amount_sat` carries the true outflow for sweep-all
   sends and SHOULD be echoed back before the send is treated as confirmed.
+- **The onchain send preview quotes every selected VTXO, not the destination
+  amount.** `quoteOnchainInputs` calls `EstimateFee` once per distinct
+  (amount, remaining-blocks) pair across the selected inputs and sums the
+  results, because each forfeit pays its own fixed operator components.
+  Quoting the destination amount once undercounts those charges and prices the
+  wrong principal when a bounded send returns change. Remaining lifetime comes
+  from `batch_expiry` minus the `GetInfo` block height, clamped to at least one
+  block. Quotes assume batch size one; the binding fee is set from actual round
+  occupancy when the round seals.
+- **A partial remote sum must never be reported as COMPLETE.** Any missing
+  timing context (zero block height, absent `batch_expiry`), unreachable
+  operator, or overflowing total discards the *entire* remote estimate and
+  falls back to `localOnchainFeeFloor` as `LOCAL_ONLY`. The one case that does
+  not fall back is an operator quote returning `below_dust_warning`: that is an
+  input the operator has already priced as uneconomic, so the preview is
+  rejected with `FailedPrecondition` rather than being papered over with a
+  cheaper-looking local floor.
+- `fetchOnchainTerms` carries the chain height alongside the operator policy
+  from one `GetInfo` call; a nil `ServerInfo` yields zero policy values (via the
+  nil-safe generated getters) rather than aborting, so the preview still
+  renders.
+- `stampLateTransition` records observation time on activity transitions that
+  arrive after the stored row's `UpdatedAtUnix`, so a late projection is
+  distinguishable from an in-order one.
 - **Cooperative-leave EXIT fee**: at completion
   (`applyCooperativeLeaveForfeited`), the forfeited source VTXO's
   settlement carries the forfeit round's operator fee (from the daemon

--- a/tapassets/AGENTS.md
+++ b/tapassets/AGENTS.md
@@ -1,0 +1,96 @@
+# tapassets
+
+## Purpose
+
+Adapts tap-sdk custom-anchor transitions to Ark trees. Given confirmed Taproot
+Asset inputs, this package derives a caller-funded *batch anchor output* that
+carries the assets, then materializes a full asset-aware VTXO tree beneath that
+output — each node transaction being a tap-sdk custom-anchor transition whose
+Bitcoin template is an Ark tree node.
+
+The package is a pure library over `lib/tree` plus the external `tap-sdk`
+wallet; it is not yet wired into the daemon and has no in-repo importers.
+
+## Key Types
+
+- `BatchAnchorCommitter` — Creates caller-funded asset batch outputs. Built by
+  `NewBatchAnchorCommitter`; drives the three-step
+  `DeriveScript` → `Commit` → `Publish` flow.
+- `BatchAnchorRequest` — Moves confirmed assets into one caller-funded output:
+  asset ref, amount, funding `Sources`, MuSig2 `Cosigners`, operator
+  `SweepLeaf`, `Digest`, and the anchor transaction's `OutputIndex` /
+  `OutputValueSat`.
+- `BatchAnchorScript` — The derived batch output: composed `PkScript`, untweaked
+  cosigner `InternalKey`, `SigningTweak` (commits to sweep leaf plus asset
+  root), `AssetRoot`, and an optional `ChangePkScript`.
+- `BatchAnchorCommit` — The sealed transition: `PackageBytes`, `AnchorPSBT`, the
+  echoed `Script`, and the `RootSource` handed to tree materialization.
+- `BatchAnchorSource` / `BatchAnchorChange` — One confirmed asset input, and the
+  surplus returned to the operator's tapd wallet on its own anchor output
+  (derived via `DeriveBatchAnchorChange`).
+- `BuildAssetTree(ctx, TreeMaterializerConfig, AssetTreeRequest) (*tree.Tree, error)`
+  — Builds and materializes an asset VTXO tree below a batch output.
+- `AssetTreeRequest` — Leaves, operator key, radix, batch outpoint/output, and
+  the tree's total `AssetAmount`.
+- `TreeMaterializerConfig` — tap-sdk `Wallet`, journal `Store`, `AssetRef`,
+  operator `SweepLeaf`, a `LeafAnchor` callback, the `Root` asset source, and
+  the `Digest` that scopes deterministic asset script keys.
+- `TreeRootAssetSource` / `TreeRootAssetInput` — The asset states the root node
+  spends, plus the batch output's `SigningTweak` and `BatchPkScript`.
+- `TreeLeafAnchor` — Taproot data for a leaf VTXO output (uncomposed pkScript,
+  internal key, canonical tap leaves). `StandardVTXOLeafAnchor` produces one
+  from an `arkscript` standard VTXO template.
+- `Store` — Two-method (`Load`/`Store`) durable journal for sealed transition
+  packages; `ErrStoreNotFound` reports an absent key.
+- `ErrReconciliationRequired` — Publication outcome is unknown and must be
+  reconciled before any retry.
+
+## Relationships
+
+- **Depends on**: `lib/tree` (structure building, materialization, cosigner and
+  internal-key math, `AssetTreeContext`), `lib/arkscript` (leaf policy
+  compilation for `StandardVTXOLeafAnchor`), `lib/tx/psbtutil` (anchor PSBT
+  handling), and the external `github.com/lightninglabs/tap-sdk` wallet.
+- **Depended on by**: nothing yet — the batch-anchor and asset-tree flows are
+  built and tested standalone ahead of the daemon wiring.
+- **Sends** / **Receives**: none. This package holds no actor; it is called
+  synchronously by whichever component eventually owns asset rounds.
+
+## Invariants
+
+- **Value conservation is checked twice.** Leaf carrier values must sum exactly
+  to the batch output's Bitcoin value (tree transactions are zero fee for v3
+  ephemeral-anchor relay), and leaf asset amounts must sum exactly to both
+  `AssetTreeRequest.AssetAmount` and the total carried by
+  `TreeRootAssetSource.Inputs`. All three sums are overflow-checked.
+- Every leaf must carry a non-zero asset amount and a unique cosigner key; a
+  repeated cosigner is rejected before materialization.
+- `AssetTreeRequest.BatchOutput.PkScript` must equal
+  `TreeMaterializerConfig.Root.BatchPkScript` — the tree is refused if the
+  output being spent is not the one the asset source describes.
+- **Commits are journaled before they are trusted.** `commitDurably` keys each
+  custom-anchor commit by a domain-separated SHA-256 digest of the request. A
+  replay with a matching digest returns the journaled sealed package instead of
+  re-committing; a *different* request under the same key is an error, not an
+  overwrite. The journal write runs under `context.WithoutCancel` with its own
+  timeout so a cancelled caller cannot lose a commit that already happened.
+- `Publish` failures that carry a tap-sdk `CustomAnchorPublishAttemptError` with
+  `OutcomeUnknown` are joined with `ErrReconciliationRequired`. Callers must
+  reconcile the on-chain outcome before retrying — a blind retry can
+  double-spend the asset inputs.
+- Anchor broadcast is always external: `sdkDriver.Commit` sets
+  `SkipAnchorTxBroadcast` and `ExternalBroadcast`, so tapd seals the transfer
+  but never puts the anchor transaction on the wire. The caller funds, signs,
+  and broadcasts it.
+- Batch-anchor output indexes must be final before deriving a request with
+  change; `DeriveScript` balances the template first.
+- The materialized tree is run through `tree.Tree.Verify` before it is returned,
+  so an inconsistent materialization fails closed rather than escaping.
+
+## Deep Docs
+
+- [lib/tree/CLAUDE.md](../lib/tree/CLAUDE.md) — Tree structure, materialization,
+  and the `AssetTreeContext` this package populates.
+- [lib/arkscript/CLAUDE.md](../lib/arkscript/CLAUDE.md) — Policy templates
+  behind `StandardVTXOLeafAnchor`.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/tapassets/CLAUDE.md
+++ b/tapassets/CLAUDE.md
@@ -1,0 +1,96 @@
+# tapassets
+
+## Purpose
+
+Adapts tap-sdk custom-anchor transitions to Ark trees. Given confirmed Taproot
+Asset inputs, this package derives a caller-funded *batch anchor output* that
+carries the assets, then materializes a full asset-aware VTXO tree beneath that
+output — each node transaction being a tap-sdk custom-anchor transition whose
+Bitcoin template is an Ark tree node.
+
+The package is a pure library over `lib/tree` plus the external `tap-sdk`
+wallet; it is not yet wired into the daemon and has no in-repo importers.
+
+## Key Types
+
+- `BatchAnchorCommitter` — Creates caller-funded asset batch outputs. Built by
+  `NewBatchAnchorCommitter`; drives the three-step
+  `DeriveScript` → `Commit` → `Publish` flow.
+- `BatchAnchorRequest` — Moves confirmed assets into one caller-funded output:
+  asset ref, amount, funding `Sources`, MuSig2 `Cosigners`, operator
+  `SweepLeaf`, `Digest`, and the anchor transaction's `OutputIndex` /
+  `OutputValueSat`.
+- `BatchAnchorScript` — The derived batch output: composed `PkScript`, untweaked
+  cosigner `InternalKey`, `SigningTweak` (commits to sweep leaf plus asset
+  root), `AssetRoot`, and an optional `ChangePkScript`.
+- `BatchAnchorCommit` — The sealed transition: `PackageBytes`, `AnchorPSBT`, the
+  echoed `Script`, and the `RootSource` handed to tree materialization.
+- `BatchAnchorSource` / `BatchAnchorChange` — One confirmed asset input, and the
+  surplus returned to the operator's tapd wallet on its own anchor output
+  (derived via `DeriveBatchAnchorChange`).
+- `BuildAssetTree(ctx, TreeMaterializerConfig, AssetTreeRequest) (*tree.Tree, error)`
+  — Builds and materializes an asset VTXO tree below a batch output.
+- `AssetTreeRequest` — Leaves, operator key, radix, batch outpoint/output, and
+  the tree's total `AssetAmount`.
+- `TreeMaterializerConfig` — tap-sdk `Wallet`, journal `Store`, `AssetRef`,
+  operator `SweepLeaf`, a `LeafAnchor` callback, the `Root` asset source, and
+  the `Digest` that scopes deterministic asset script keys.
+- `TreeRootAssetSource` / `TreeRootAssetInput` — The asset states the root node
+  spends, plus the batch output's `SigningTweak` and `BatchPkScript`.
+- `TreeLeafAnchor` — Taproot data for a leaf VTXO output (uncomposed pkScript,
+  internal key, canonical tap leaves). `StandardVTXOLeafAnchor` produces one
+  from an `arkscript` standard VTXO template.
+- `Store` — Two-method (`Load`/`Store`) durable journal for sealed transition
+  packages; `ErrStoreNotFound` reports an absent key.
+- `ErrReconciliationRequired` — Publication outcome is unknown and must be
+  reconciled before any retry.
+
+## Relationships
+
+- **Depends on**: `lib/tree` (structure building, materialization, cosigner and
+  internal-key math, `AssetTreeContext`), `lib/arkscript` (leaf policy
+  compilation for `StandardVTXOLeafAnchor`), `lib/tx/psbtutil` (anchor PSBT
+  handling), and the external `github.com/lightninglabs/tap-sdk` wallet.
+- **Depended on by**: nothing yet — the batch-anchor and asset-tree flows are
+  built and tested standalone ahead of the daemon wiring.
+- **Sends** / **Receives**: none. This package holds no actor; it is called
+  synchronously by whichever component eventually owns asset rounds.
+
+## Invariants
+
+- **Value conservation is checked twice.** Leaf carrier values must sum exactly
+  to the batch output's Bitcoin value (tree transactions are zero fee for v3
+  ephemeral-anchor relay), and leaf asset amounts must sum exactly to both
+  `AssetTreeRequest.AssetAmount` and the total carried by
+  `TreeRootAssetSource.Inputs`. All three sums are overflow-checked.
+- Every leaf must carry a non-zero asset amount and a unique cosigner key; a
+  repeated cosigner is rejected before materialization.
+- `AssetTreeRequest.BatchOutput.PkScript` must equal
+  `TreeMaterializerConfig.Root.BatchPkScript` — the tree is refused if the
+  output being spent is not the one the asset source describes.
+- **Commits are journaled before they are trusted.** `commitDurably` keys each
+  custom-anchor commit by a domain-separated SHA-256 digest of the request. A
+  replay with a matching digest returns the journaled sealed package instead of
+  re-committing; a *different* request under the same key is an error, not an
+  overwrite. The journal write runs under `context.WithoutCancel` with its own
+  timeout so a cancelled caller cannot lose a commit that already happened.
+- `Publish` failures that carry a tap-sdk `CustomAnchorPublishAttemptError` with
+  `OutcomeUnknown` are joined with `ErrReconciliationRequired`. Callers must
+  reconcile the on-chain outcome before retrying — a blind retry can
+  double-spend the asset inputs.
+- Anchor broadcast is always external: `sdkDriver.Commit` sets
+  `SkipAnchorTxBroadcast` and `ExternalBroadcast`, so tapd seals the transfer
+  but never puts the anchor transaction on the wire. The caller funds, signs,
+  and broadcasts it.
+- Batch-anchor output indexes must be final before deriving a request with
+  change; `DeriveScript` balances the template first.
+- The materialized tree is run through `tree.Tree.Verify` before it is returned,
+  so an inconsistent materialization fails closed rather than escaping.
+
+## Deep Docs
+
+- [lib/tree/CLAUDE.md](../lib/tree/CLAUDE.md) — Tree structure, materialization,
+  and the `AssetTreeContext` this package populates.
+- [lib/arkscript/CLAUDE.md](../lib/arkscript/CLAUDE.md) — Policy templates
+  behind `StandardVTXOLeafAnchor`.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -105,6 +105,16 @@ refresh, leave, OOR spend, and directed send flows.
 - `handleSendVTXOs` uses a `defer`-based release rather than a `releaseAndFail` helper: any error path (including dry-run) falls through to the deferred release, and the `committed` flag is set only after the round actor accepts the intent. Context is preserved via `context.WithoutCancel` so cleanup is not dropped when the caller disconnects.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
 - `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
+- **Refresh intents leave `SigningKey` empty on purpose.** `handleRefreshVTXOs`
+  used to reuse the source VTXO's `ClientKey` as the MuSig2 signing key; round
+  registration now derives a fresh locator-backed key instead. Reusing the old
+  owner descriptor breaks for legacy VTXOs that retain the pubkey but not its
+  LND key locator, leaving nothing able to sign the tree. Do not repopulate the
+  field.
+- `SelectedVTXO.ReserveEpoch` is copied straight through from the VTXO
+  manager's `actormsg.SelectedVTXO` in `handleSelectAndLockVTXOs`, so the OOR
+  transfer that spends the coin can name the reservation on release. Dropping it
+  silently downgrades the release to unconditional.
 - The wallet tracks, in memory, boarding outpoints already handed to the round
   actor via `TriggerBoardMsg` that have not yet left the confirmed set, and
   excludes them from later triggers. This keeps a second per-block trigger

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -105,6 +105,16 @@ refresh, leave, OOR spend, and directed send flows.
 - `handleSendVTXOs` uses a `defer`-based release rather than a `releaseAndFail` helper: any error path (including dry-run) falls through to the deferred release, and the `committed` flag is set only after the round actor accepts the intent. Context is preserved via `context.WithoutCancel` so cleanup is not dropped when the caller disconnects.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
 - `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
+- **Refresh intents leave `SigningKey` empty on purpose.** `handleRefreshVTXOs`
+  used to reuse the source VTXO's `ClientKey` as the MuSig2 signing key; round
+  registration now derives a fresh locator-backed key instead. Reusing the old
+  owner descriptor breaks for legacy VTXOs that retain the pubkey but not its
+  LND key locator, leaving nothing able to sign the tree. Do not repopulate the
+  field.
+- `SelectedVTXO.ReserveEpoch` is copied straight through from the VTXO
+  manager's `actormsg.SelectedVTXO` in `handleSelectAndLockVTXOs`, so the OOR
+  transfer that spends the coin can name the reservation on release. Dropping it
+  silently downgrades the release to unconditional.
 - The wallet tracks, in memory, boarding outpoints already handed to the round
   actor via `TriggerBoardMsg` that have not yet left the confirmed set, and
   excludes them from later triggers. This keeps a second per-block trigger

--- a/waverpc/AGENTS.md
+++ b/waverpc/AGENTS.md
@@ -45,6 +45,20 @@ helper file (`errors.go`) for structured wallet-lifecycle errors.
 - `errors.go` is hand-written and not regenerated; callers must match wallet
   lifecycle errors via `IsWalletNotReadyError`/`WalletNotReadyState`, never by
   parsing the error message string.
+- `ListVTXOsRequest` has two status selectors and they are not
+  interchangeable at the default. `status_filter` (singular, legacy) is
+  equivalent to one entry in the repeated `statuses` field. When **both** are
+  unset the response is the *inventory* set — every VTXO except
+  `VTXO_STATUS_FORFEITED` and `VTXO_STATUS_SPENT` — not "all statuses" as the
+  older comment claimed. `VTXO_STATUS_PENDING_ROUND` entries are returned only
+  when explicitly listed. Callers that want a spendable-balance view must
+  filter to live entries themselves; the default deliberately includes
+  non-spendable inventory so a VTXO never silently vanishes from a listing.
+- `ServerInfo.vtxo_confirmations` is the depth at which new round VTXOs become
+  spendable off-chain, and is **independent of** `min_confirmations`, which
+  governs the on-chain boarding inputs a new round consumes. Zero means the
+  operator does not advertise the split field; consumers fall back to
+  `min_confirmations` (see `lib/types.OperatorTerms.VTXOTargetConfirmations`).
 - `NewReceiveScriptRequest.idempotency_key` is an API-level contract, not just
   an implementation detail: the key namespace is **global to one daemon**, so
   callers sharing a daemon must prefix keys with an application or tenant

--- a/waverpc/CLAUDE.md
+++ b/waverpc/CLAUDE.md
@@ -45,6 +45,20 @@ helper file (`errors.go`) for structured wallet-lifecycle errors.
 - `errors.go` is hand-written and not regenerated; callers must match wallet
   lifecycle errors via `IsWalletNotReadyError`/`WalletNotReadyState`, never by
   parsing the error message string.
+- `ListVTXOsRequest` has two status selectors and they are not
+  interchangeable at the default. `status_filter` (singular, legacy) is
+  equivalent to one entry in the repeated `statuses` field. When **both** are
+  unset the response is the *inventory* set — every VTXO except
+  `VTXO_STATUS_FORFEITED` and `VTXO_STATUS_SPENT` — not "all statuses" as the
+  older comment claimed. `VTXO_STATUS_PENDING_ROUND` entries are returned only
+  when explicitly listed. Callers that want a spendable-balance view must
+  filter to live entries themselves; the default deliberately includes
+  non-spendable inventory so a VTXO never silently vanishes from a listing.
+- `ServerInfo.vtxo_confirmations` is the depth at which new round VTXOs become
+  spendable off-chain, and is **independent of** `min_confirmations`, which
+  governs the on-chain boarding inputs a new round consumes. Zero means the
+  operator does not advertise the split field; consumers fall back to
+  `min_confirmations` (see `lib/types.OperatorTerms.VTXOTargetConfirmations`).
 - `NewReceiveScriptRequest.idempotency_key` is an API-level contract, not just
   an implementation detail: the key namespace is **global to one daemon**, so
   callers sharing a daemon must prefix keys with an application or tenant


### PR DESCRIPTION
Automated nightly doc-gardening sweep: refreshes the per-package documentation graph and knowledge base for changes merged since the last sweep (baseline `9e03582`, 2026-09-02).

Workflow run: https://github.com/lightninglabs/wavelength/actions

## What changed

- **New package**: `tapassets/CLAUDE.md` + `AGENTS.md` — tap-sdk custom-anchor
  batch anchors and asset-aware VTXO tree materialization. Added to
  `ARCHITECTURE.md` Layer 1.
- **Asset-round surface**: `lib/tree` (`AssetTreeContext`, `BatchOutputSpec`,
  per-node signing tweaks), `lib/types` (asset `VTXORequest` fields and their
  all-or-nothing validation rules), `rpc/roundpb` (asset proto fields).
- **VTXO activation depth**: `waverpc`, `arkrpc`, `sdk/ark`, `lib/types` —
  `vtxo_confirmations` is distinct from `min_confirmations`, with the legacy
  fallback documented.
- **ListVTXOs default**: `waverpc`, `sdk/ark`, `cmd/wavecli/waveclicommands` —
  the no-filter default is the inventory set, not "all statuses".
- **Reservation epoch fence**: `lib/actormsg`, `wallet`.
- **Onchain fee quoting**: `swapwallet` — per-input operator quotes and the
  all-or-nothing fallback rule.
- **`docs/index.md`**: added the previously unindexed
  `mailbox_ingress_safety.md` (this was failing `make doc-check`'s index rule).

## Review notes

Please review the updated `CLAUDE.md`/`AGENTS.md` and `ARCHITECTURE.md` diffs —
in particular the new `tapassets` invariants (journaled commits, the
`ErrReconciliationRequired` contract, and the double value-conservation check),
which were derived from reading the package sources rather than from an
existing design doc.

`make doc-check` passes. Docs-only change; no Go source was touched.
