### PR TITLE
build: bump version to v0.1.2

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -19,7 +19,7 @@ const (
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = "rc5"
+	AppPreRelease = ""
 )
 
 var (


### PR DESCRIPTION
## Summary

Remove the `rc5` prerelease suffix in `build/version.go` to prepare stable `v0.1.2`. This is a one-line change based on release tip `945c7662`; the major, minor, and patch versions remain unchanged.

No backports or workflow changes are included. Existing release workflows distinguish stable tags from release candidates and create a draft release.

## Validation

- `make fmt-changed base=origin/v0.1.x-branch`: passed.
- `make lint-changed-local base=origin/v0.1.x-branch`: passed, no issues.
- `go test ./build` and `make unit pkg=build log="stdlog trace" timeout=5m`: passed.
- `make build`: passed; both binaries report `0.1.2`.
- `make tidy-module-check` on the committed tree: passed.
- Commit-message lint against main and the release branch, plus `git diff --check`: passed.

Full system tests and local agent-review CI were not run for this version-only change. Remote CI is pending.

## After merge

Tag the approved merged release commit as `v0.1.2`, build locally with `make docker-release tag=v0.1.2`, verify and sign the manifest, wait for release CI, then upload the signature only after the CI manifest matches the local manifest byte-for-byte. The release remains a draft for maintainer publication.
