### PR TITLE
waved: report balances for the configured LND account

### DIFF
--- a/systest/account_balance_test.go
+++ b/systest/account_balance_test.go
@@ -1,0 +1,94 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightninglabs/wavelength/waved"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountBalanceReporting exercises real LND account aggregation through
+// the daemon RPC and HTTP metrics. A watch-only co-tenant account is sufficient
+// to reproduce the reporting bug; this test makes no claim about spending it.
+func TestAccountBalanceReporting(t *testing.T) {
+	ParallelN(t)
+	metricsAddr := newLoopbackAddr(t)
+	fixture := newDirectedSendFixture(t, func(cfg *waved.Config) {
+		cfg.Metrics.ListenAddr = metricsAddr
+		cfg.Lnd.Account = ""
+	})
+	h := fixture.harness.Harness
+	tenant := h.StartAdditionalLND("balance-tenant")
+	accounts, err := tenant.Client.WalletKit.ListAccounts(
+		t.Context(),
+		"default", walletrpc.AddressType_TAPROOT_PUBKEY,
+	)
+	require.NoError(t, err)
+	require.Len(t, accounts, 1)
+	ctx, timeout, raw := h.LND.WalletKit.RawClientWithMacAuth(t.Context())
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	_, err = raw.ImportAccount(ctx, &walletrpc.ImportAccountRequest{
+		Name:              "co-tenant",
+		ExtendedPublicKey: accounts[0].ExtendedPublicKey,
+		AddressType:       walletrpc.AddressType_TAPROOT_PUBKEY,
+	})
+	require.NoError(t, err)
+
+	for account, amount := range map[string]btcutil.Amount{
+		"default": 100_000, "co-tenant": 250_000,
+	} {
+		addr, err := h.LND.WalletKit.NextAddr(
+			t.Context(), account,
+			walletrpc.AddressType_TAPROOT_PUBKEY, false,
+		)
+		require.NoError(t, err)
+		h.Faucet(addr.String(), amount)
+	}
+	h.GenerateAndWait(1)
+	// The old wrapper must observe both accounts; this negative control
+	// ensures a missing co-tenant credit cannot make the test pass.
+	require.Eventually(t, func() bool {
+		balance, err := h.LND.Client.WalletBalance(t.Context())
+
+		return err == nil && balance.Confirmed == 350_000
+	}, 30*time.Second, 100*time.Millisecond)
+
+	resp, err := fixture.client.GetBalance(
+		t.Context(), &waverpc.GetBalanceRequest{},
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 100_000, resp.OnchainWalletConfirmedSat)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, "http://"+metricsAddr+"/metrics",
+		nil,
+	)
+	require.NoError(t, err)
+	scrape, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, scrape.Body.Close())
+	}()
+	require.Equal(t, http.StatusOK, scrape.StatusCode)
+	body, err := io.ReadAll(scrape.Body)
+	require.NoError(t, err)
+	require.Contains(
+		t, string(body),
+		"waved_wallet_confirmed_satoshis 100000\n",
+	)
+	require.Contains(
+		t, string(body),
+		"waved_wallet_unconfirmed_satoshis 0\n",
+	)
+}

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -57,6 +57,15 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   and belong to no wallet account. Scoping that dispatcher empties both, and
   does so even with no account configured, since lnd reads an empty account
   as *every* account but `"default"` as a real filter.
+- `GetBalance.onchain_wallet_confirmed_sat` and both wallet balance metrics
+  use `Server.lndWalletBalance`, with the same normalized account as spending.
+  Its raw LND call preserves lndclient authentication and RPC timeout. Empty
+  config selects `"default"`, never LND's all-accounts balance. Local-wallet
+  balance semantics and imported-script observation remain unchanged. The
+  LND account balance excludes imported boarding-script outputs as well as
+  co-tenant funds; those outputs retain their separate boarding balance
+  fields. Existing LND wallet gauges can therefore decrease on upgrade even
+  when `lnd.account` is empty.
 - `validateLndAccount` refuses to start on a configured account that is
   missing, not taproot-scoped, or watch-only. Without it each of those fails
   later and worse — a missing account silently filters every UTXO away, a

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -57,6 +57,15 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   and belong to no wallet account. Scoping that dispatcher empties both, and
   does so even with no account configured, since lnd reads an empty account
   as *every* account but `"default"` as a real filter.
+- `GetBalance.onchain_wallet_confirmed_sat` and both wallet balance metrics
+  use `Server.lndWalletBalance`, with the same normalized account as spending.
+  Its raw LND call preserves lndclient authentication and RPC timeout. Empty
+  config selects `"default"`, never LND's all-accounts balance. Local-wallet
+  balance semantics and imported-script observation remain unchanged. The
+  LND account balance excludes imported boarding-script outputs as well as
+  co-tenant funds; those outputs retain their separate boarding balance
+  fields. Existing LND wallet gauges can therefore decrease on upgrade even
+  when `lnd.account` is empty.
 - `validateLndAccount` refuses to start on a configured account that is
   missing, not taproot-scoped, or watch-only. Without it each of those fails
   later and worse — a missing account silently filters every UTXO away, a

--- a/waved/lnd_balance.go
+++ b/waved/lnd_balance.go
@@ -1,0 +1,25 @@
+package waved
+
+import (
+	"context"
+
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/lnrpc"
+)
+
+// lndWalletBalance reports only the account this daemon spends from. Both the
+// balance RPC and metrics use this boundary so co-tenant funds stay excluded.
+// The raw client preserves lndclient's authentication and configured timeout;
+// lndclient.WalletBalance has no account selector and sums the whole node.
+func (s *Server) lndWalletBalance(ctx context.Context,
+	client lndclient.LightningClient) (*lnrpc.WalletBalanceResponse,
+	error) {
+
+	ctx, timeout, raw := client.RawClientWithMacAuth(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return raw.WalletBalance(ctx, &lnrpc.WalletBalanceRequest{
+		Account: s.lndWalletAccount(),
+	})
+}

--- a/waved/rpc_onchain_balance_test.go
+++ b/waved/rpc_onchain_balance_test.go
@@ -1,0 +1,367 @@
+package waved
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/wavelength/btcwbackend"
+	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/clock"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// accountBalanceClient models LND's empty-account aggregation and exposes the
+// authenticated raw client used by account-scoped reporting.
+type accountBalanceClient struct {
+	lndclient.LightningClient
+	raw     *accountBalanceRPC
+	timeout time.Duration
+}
+
+// RawClientWithMacAuth preserves the caller context and adds test credentials.
+func (c *accountBalanceClient) RawClientWithMacAuth(ctx context.Context) (
+	context.Context, time.Duration, lnrpc.LightningClient) {
+
+	return metadata.AppendToOutgoingContext(
+			ctx, "macaroon", "test-macaroon",
+		),
+		c.timeout, c.raw
+}
+
+// WalletBalance reproduces the pinned lndclient's node-wide request.
+func (c *accountBalanceClient) WalletBalance(ctx context.Context) (
+	*lndclient.WalletBalance, error) {
+
+	ctx, timeout, raw := c.RawClientWithMacAuth(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	resp, err := raw.WalletBalance(ctx, &lnrpc.WalletBalanceRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &lndclient.WalletBalance{
+		Confirmed:   btcutil.Amount(resp.ConfirmedBalance),
+		Unconfirmed: btcutil.Amount(resp.UnconfirmedBalance),
+	}, nil
+}
+
+// accountBalanceRPC returns per-account funds, or their sum for an empty
+// filter.
+type accountBalanceRPC struct {
+	lnrpc.LightningClient
+	t        *testing.T
+	balances map[string]*lnrpc.WalletBalanceResponse
+	err      error
+	wait     bool
+	contexts []context.Context
+}
+
+// WalletBalance checks authentication and deadlines at the transport boundary.
+func (c *accountBalanceRPC) WalletBalance(ctx context.Context,
+	req *lnrpc.WalletBalanceRequest, _ ...grpc.CallOption) (
+	*lnrpc.WalletBalanceResponse, error) {
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	require.True(c.t, ok)
+	require.Equal(c.t, []string{"test-macaroon"}, md.Get("macaroon"))
+	_, ok = ctx.Deadline()
+	require.True(c.t, ok, "raw RPC must have a deadline")
+	c.contexts = append(c.contexts, ctx)
+	if c.wait {
+		<-ctx.Done()
+
+		return nil, ctx.Err()
+	}
+	if c.err != nil {
+		return nil, c.err
+	}
+	result := &lnrpc.WalletBalanceResponse{}
+	for account, balance := range c.balances {
+		if req.Account == "" || req.Account == account {
+			result.ConfirmedBalance += balance.ConfirmedBalance
+			result.UnconfirmedBalance += balance.UnconfirmedBalance
+		}
+	}
+	if req.Account != "" && c.balances[req.Account] == nil {
+		return nil, status.Error(codes.NotFound, "account not found")
+	}
+
+	return result, nil
+}
+
+// newBalanceRPCServer wires the real balance handler to an empty boarding
+// store.
+func newBalanceRPCServer(t *testing.T) *RPCServer {
+	t.Helper()
+	ready := make(chan struct{})
+	close(ready)
+
+	return NewRPCServer(&Server{
+		cfg:         &Config{},
+		walletReady: ready,
+		db:          db.NewTestSqliteDB(t),
+		chainParams: &chaincfg.RegressionNetParams,
+		clk:         clock.NewDefaultClock(),
+	})
+}
+
+// TestLNDAccountBalanceReporting proves both reporting surfaces exclude funds
+// in other accounts, including when an empty config selects the default
+// account.
+func TestLNDAccountBalanceReporting(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		config                 *LndConfig
+		confirmed, unconfirmed int64
+	}{
+		{
+			name:        "nil config",
+			confirmed:   100_000,
+			unconfirmed: 1_000,
+		},
+		{
+			name:        "empty config",
+			config:      &LndConfig{},
+			confirmed:   100_000,
+			unconfirmed: 1_000,
+		},
+		{
+			name: "explicit default",
+			config: &LndConfig{
+				Account: "default",
+			},
+			confirmed:   100_000,
+			unconfirmed: 1_000,
+		},
+		{
+			name: "configured account",
+			config: &LndConfig{
+				Account: "tenant",
+			},
+			confirmed:   250_000,
+			unconfirmed: 2_000,
+		},
+		{
+			name: "empty account",
+			config: &LndConfig{
+				Account: "empty",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			balances := map[string]*lnrpc.WalletBalanceResponse{
+				"default": {
+					ConfirmedBalance:   100_000,
+					UnconfirmedBalance: 1_000,
+				},
+				"tenant": {
+					ConfirmedBalance:   250_000,
+					UnconfirmedBalance: 2_000,
+				},
+				"empty": {},
+			}
+			raw := &accountBalanceRPC{t: t, balances: balances}
+			client := &accountBalanceClient{
+				raw:     raw,
+				timeout: time.Second,
+			}
+			rpc := newBalanceRPCServer(t)
+			rpc.server.cfg.Lnd = tc.config
+			rpc.server.lnd = fn.Some(
+				&lndclient.GrpcLndServices{
+					LndServices: lndclient.LndServices{
+						Client: client,
+						WalletKit: &balanceWalletKit{
+							t: t,
+						},
+					},
+				},
+			)
+			// The unscoped negative control must include both
+			// funded accounts.
+			node, err := client.WalletBalance(t.Context())
+			require.NoError(t, err)
+			require.EqualValues(t, 350_000, node.Confirmed)
+			resp, err := rpc.GetBalance(
+				t.Context(), &waverpc.GetBalanceRequest{},
+			)
+			require.NoError(t, err)
+			require.Equal(
+				t, tc.confirmed, resp.OnchainWalletConfirmedSat,
+			)
+			confirmed, unconfirmed, err := rpc.metricsWalletBalance(
+				t.Context(),
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.confirmed, confirmed)
+			require.Equal(t, tc.unconfirmed, unconfirmed)
+			for _, ctx := range raw.contexts {
+				require.ErrorIs(t, ctx.Err(), context.Canceled)
+			}
+		})
+	}
+}
+
+// TestLNDAccountBalanceErrors proves failed or canceled reads cannot publish
+// a successful zero balance through either RPC or metrics.
+func TestLNDAccountBalanceErrors(t *testing.T) {
+	boom := errors.New("balance unavailable")
+	for _, tc := range []struct {
+		name         string
+		err          error
+		wait, cancel bool
+		timeout      time.Duration
+	}{
+		{
+			name:    "RPC error",
+			err:     boom,
+			timeout: time.Second,
+		},
+		{
+			name:    "missing account",
+			timeout: time.Second,
+		},
+		{
+			name:    "RPC timeout",
+			wait:    true,
+			timeout: time.Millisecond,
+		},
+		{
+			name:    "caller canceled",
+			wait:    true,
+			cancel:  true,
+			timeout: time.Hour,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := &accountBalanceRPC{
+				t:    t,
+				err:  tc.err,
+				wait: tc.wait,
+			}
+			rpc := newBalanceRPCServer(t)
+			rpc.server.cfg.Lnd = &LndConfig{Account: "missing"}
+			rpc.server.lnd = fn.Some(
+				&lndclient.GrpcLndServices{
+					LndServices: lndclient.LndServices{
+						Client: &accountBalanceClient{
+							raw:     raw,
+							timeout: tc.timeout,
+						},
+						WalletKit: &balanceWalletKit{
+							t: t,
+						},
+					},
+				},
+			)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			if tc.cancel {
+				cancel()
+			}
+			// Exercise the exact fetcher used by GetBalance without
+			// letting a canceled context stop first at its earlier
+			// database queries.
+			balance, err := sumOnchainWalletConfirmed(
+				ctx, rpc.walletBalanceFetchers(),
+			)
+			require.Error(t, err)
+			require.Zero(t, balance)
+			confirmed, unconfirmed, err := rpc.metricsWalletBalance(
+				ctx,
+			)
+			require.Error(t, err)
+			require.Zero(t, confirmed)
+			require.Zero(t, unconfirmed)
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			}
+			if tc.wait {
+				want := context.DeadlineExceeded
+				if tc.cancel {
+					want = context.Canceled
+				}
+				require.ErrorIs(t, err, want)
+			}
+			if !tc.cancel {
+				resp, err := rpc.GetBalance(
+					ctx, &waverpc.GetBalanceRequest{},
+				)
+				require.Equal(
+					t, codes.Internal, status.Code(err),
+				)
+				require.Nil(t, resp)
+			}
+		})
+	}
+}
+
+// TestLocalWalletBalanceReporting preserves RPC/metrics parity for both local
+// backends using their shared real btcwallet balance implementation.
+func TestLocalWalletBalanceReporting(t *testing.T) {
+	w := newFundedLwWallet(t)
+	addr, err := w.NewAddress(t.Context())
+	require.NoError(t, err)
+	script, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	fundConfirmedUTXO(t, w, script)
+	for _, backend := range []string{"lwwallet", "btcwallet"} {
+		t.Run(backend, func(t *testing.T) {
+			rpc := newBalanceRPCServer(t)
+			// An LND setting must have no effect on either local
+			// backend.
+			rpc.server.cfg.Lnd = &LndConfig{Account: "unrelated"}
+			if backend == "lwwallet" {
+				rpc.server.lwWallet = fn.Some(w)
+			} else {
+				rpc.server.btcwWallet = fn.Some(
+					&btcwbackend.Wallet{
+						Wallet: w.Wallet,
+					},
+				)
+			}
+			balance, err := sumOnchainWalletConfirmed(
+				t.Context(), rpc.walletBalanceFetchers(),
+			)
+			require.NoError(t, err)
+			require.EqualValues(t, 1_000_000, balance)
+			confirmed, unconfirmed, err := rpc.metricsWalletBalance(
+				t.Context(),
+			)
+			require.NoError(t, err)
+			require.EqualValues(t, balance, confirmed)
+			require.Zero(t, unconfirmed)
+		})
+	}
+}
+
+// balanceWalletKit keeps boarding observation unscoped while balance reporting
+// uses an explicit account filter.
+type balanceWalletKit struct {
+	lndclient.WalletKitClient
+	t *testing.T
+}
+
+// ListUnspent asserts observation still spans imported boarding scripts.
+func (w *balanceWalletKit) ListUnspent(_ context.Context, _, _ int32,
+	opts ...lndclient.ListUnspentOption) ([]*lnwallet.Utxo, error) {
+
+	require.Empty(w.t, opts)
+
+	return nil, nil
+}

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -1063,13 +1063,13 @@ func (r *RPCServer) walletBalanceFetchers() []onchainWalletConfirmedFetcher {
 		fetchers = append(fetchers, func(ctx context.Context) (
 			btcutil.Amount, error) {
 
-			wb, err := lndSvc.Client.WalletBalance(ctx)
+			wb, err := r.server.lndWalletBalance(ctx, lndSvc.Client)
 			if err != nil {
 				return 0, fmt.Errorf("lnd wallet balance: %w",
 					err)
 			}
 
-			return wb.Confirmed, nil
+			return btcutil.Amount(wb.ConfirmedBalance), nil
 		})
 	})
 
@@ -1146,14 +1146,14 @@ func (r *RPCServer) metricsWalletBalance(ctx context.Context) (int64, int64,
 	)
 	r.server.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
 		found = true
-		wb, balErr := lndSvc.Client.WalletBalance(ctx)
+		wb, balErr := r.server.lndWalletBalance(ctx, lndSvc.Client)
 		if balErr != nil {
 			qErr = fmt.Errorf("lnd wallet balance: %w", balErr)
 
 			return
 		}
-		confirmed = int64(wb.Confirmed)
-		unconfirmed = int64(wb.Unconfirmed)
+		confirmed = wb.ConfirmedBalance
+		unconfirmed = wb.UnconfirmedBalance
 	})
 	r.server.lwWallet.WhenSome(func(w *lwwallet.Wallet) {
 		found = true


### PR DESCRIPTION
## The problem

A daemon configured with `lnd.account` spends only that account's coins. Its on-chain balance RPC and wallet metrics still used LND's node-wide balance, so a shared node could report money that the daemon could not use to fund an exit.

For example, with 100,000 sat in `default` and 250,000 sat in another account, a default-account daemon reported 350,000 sat. An empty configured account also reported the whole node's balance.

## The fix

Route `GetBalance.onchain_wallet_confirmed_sat` and the confirmed/unconfirmed wallet gauges through one account-scoped LND balance helper. It uses the same account normalization as spending: an empty `lnd.account` selects `default`.

The pinned `lndclient.WalletBalance` has no account selector. The helper uses `RawClientWithMacAuth`, applies its configured RPC timeout, and sends `WalletBalanceRequest.Account`. RPC failures still fail the balance request and cause metrics to omit the wallet gauges.

The invariant is that another account's coins never enter this daemon's reported backing-wallet balance. Local `lwwallet`/`btcwallet` behavior and the deliberately unfiltered observation of imported boarding scripts stay unchanged. The narrower LND figures also exclude imported boarding-script outputs, which continue to appear in the separate boarding-balance fields. Existing wallet gauges can therefore decrease on upgrade even with empty account configuration. `total_confirmed_sat` keeps its existing boarding-plus-VTXO calculation. No protocol, schema, or dependency change is required.

## Tests

- Reproduced the failure before the fix: default, custom, and empty accounts all returned 350,000 sat in the regression fixture.
- Unit coverage checks two funded accounts, omitted/empty/explicit-default config, configured and empty accounts, both metrics values, missing accounts, RPC errors, cancellation, deadlines, authentication, and context cleanup.
- Backend-parity coverage exercises both local backends' shared real btcwallet balance implementation.
- A real Bitcoin/LND system test funds two accounts and checks the daemon RPC plus HTTP metrics. Its unscoped negative control sees 350,000 sat; reporting sees only the default account's 100,000 sat. The co-tenant fixture is watch-only and tests reporting, not custom-account spending.
- Account-reporting and existing boarding-observation system tests pass with both SQLite and PostgreSQL.

Validation: broad unit suite (including `baselib`), focused and trace-logging tests, focused race tests, full local lint, formatting, Go documentation audit, module tidiness, module verification, and signed commit/message checks. Required CI results are tracked on this PR.

Fixes #1141.
