### PR TITLE
txconfirm: retry transient final exit sweep broadcasts

### DIFF
--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -96,10 +96,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
 
 ## Invariants
 
-- **Never give up on a no-mempool tx**: a tx whose broadcast reached no
-  mempool stays in `Broadcasting` and is re-attempted every
+- **Retry by contract**: an anchor parent or a request opting into
+  `RetryUntilAccepted` stays in `Broadcasting` when acceptance is unproven
+  and is re-attempted every
   `FeeBumpIntervalBlocks`, never transitioning to terminal `Failed`. This
-  covers `ErrCPFPFeeInputUnavailable` and transient package-relay
+  preserves terminal failure for ordinary anchorless requests and covers
+  `ErrCPFPFeeInputUnavailable` and transient package-relay
   rejections (min-relay-fee on the zero-fee anchor parent, mempool-full,
   fee input spent mid-submit) — the conditions CPFP retry exists to
   overcome. Only a structurally permanent error
@@ -110,7 +112,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   CSV-timeout path, so the actor escalates to operators rather than
   silently aborting.
 - **Strict dedup check**: two `EnsureConfirmedReq` for the same txid
-  must agree on `TargetConfs` and `ConfirmationPkScript`; mismatches
+  must agree on `TargetConfs`, `ConfirmationPkScript`, and
+  `RetryUntilAccepted`; mismatches
   return `ErrEnsureParamsMismatch` rather than silently reusing the
   existing watch.
 - **Setup errors stay retryable.** Block-subscription and confirmation-watch

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -96,10 +96,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
 
 ## Invariants
 
-- **Never give up on a no-mempool tx**: a tx whose broadcast reached no
-  mempool stays in `Broadcasting` and is re-attempted every
+- **Retry by contract**: an anchor parent or a request opting into
+  `RetryUntilAccepted` stays in `Broadcasting` when acceptance is unproven
+  and is re-attempted every
   `FeeBumpIntervalBlocks`, never transitioning to terminal `Failed`. This
-  covers `ErrCPFPFeeInputUnavailable` and transient package-relay
+  preserves terminal failure for ordinary anchorless requests and covers
+  `ErrCPFPFeeInputUnavailable` and transient package-relay
   rejections (min-relay-fee on the zero-fee anchor parent, mempool-full,
   fee input spent mid-submit) — the conditions CPFP retry exists to
   overcome. Only a structurally permanent error
@@ -110,7 +112,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   CSV-timeout path, so the actor escalates to operators rather than
   silently aborting.
 - **Strict dedup check**: two `EnsureConfirmedReq` for the same txid
-  must agree on `TargetConfs` and `ConfirmationPkScript`; mismatches
+  must agree on `TargetConfs`, `ConfirmationPkScript`, and
+  `RetryUntilAccepted`; mismatches
   return `ErrEnsureParamsMismatch` rather than silently reusing the
   existing watch.
 - **Setup errors stay retryable.** Block-subscription and confirmation-watch

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -753,8 +753,9 @@ func (a *TxBroadcasterActor) discardIncompleteTrackedTx(ctx context.Context,
 //     never be accepted as submitted, so retrying is pointless. Fail it
 //     terminally and notify subscribers.
 //
-//   - any other error on an anchor (CPFP) parent: the tx reached no mempool but
-//     the failure is plausibly transient — a missing confirmed fee input
+//   - any other error on an opted-in tx or anchor (CPFP) parent: acceptance
+//     is unproven and retrying the same transaction is safe. For example,
+//     a transient backend failure, a missing confirmed fee input
 //     (ErrCPFPFeeInputUnavailable), a min-relay-fee rejection of the zero-fee
 //     anchor parent, a mempool-full condition, or a fee input spent out from
 //     under us. These are exactly the conditions CPFP retry exists to overcome,
@@ -764,7 +765,7 @@ func (a *TxBroadcasterActor) discardIncompleteTrackedTx(ctx context.Context,
 //     gives up on such a tx: a fraud-response checkpoint must land before the
 //     counterparty's CSV-timeout path can win.
 //
-//   - any other error on a non-anchor parent: a plain direct broadcast with no
+//   - any other error on a non-opted-in anchorless tx: direct broadcast with no
 //     CPFP retry machinery. There is nothing to fee-bump and no fund-risk
 //     retry contract, so fail it terminally as before.
 //
@@ -809,9 +810,11 @@ func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
 
 		return TxStateFailed, err
 
-	case findAnchorOutput(entry.data.Tx) >= 0:
-		// An anchor (CPFP) parent reached no mempool. The failure is
-		// plausibly transient and this is the fund-risk path, so stay
+	case entry.data.RetryUntilAccepted ||
+		findAnchorOutput(entry.data.Tx) >= 0:
+
+		// The caller or anchor contract requires continued submission.
+		// Acceptance is unproven, so keep the same signed transaction
 		// in Broadcasting, re-attempt next interval, and escalate
 		// rather than give up.
 		err := a.recordBroadcastFailure(ctx, entry, err)
@@ -830,7 +833,7 @@ func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
 }
 
 // isPermanentBroadcastError reports whether a broadcast error is structural and
-// can never succeed on retry, so an anchor-bearing tracked tx should fail
+// can never succeed on retry, so even a retry-enabled tracked tx must fail
 // terminally rather than spin in the Broadcasting retry loop. Transient
 // conditions on an anchor parent are kept retryable, because on a fund-risk
 // path (e.g. a fraud-response checkpoint) it is safer to keep trying and alert

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -71,7 +71,7 @@ var (
 
 // ErrEnsureParamsMismatch is returned by EnsureConfirmedReq when a second
 // caller asks to confirm a txid that is already being tracked, but with
-// different confirmation parameters (TargetConfs or ConfirmationPkScript)
+// different confirmation parameters or initial-broadcast retry policy
 // than the in-flight tracker. Silently reusing the existing entry would
 // cause one subscriber to receive a notification that does not match the
 // criteria it asked for, so the second request is rejected outright and
@@ -1641,10 +1641,11 @@ func (a *TxBroadcasterActor) newTrackedTx(ctx context.Context,
 		ConfirmationPkScript: append(
 			[]byte(nil), confirmationPkScript...,
 		),
-		Label:       req.Label,
-		HeightHint:  heightHint,
-		TargetConfs: targetConfs,
-		ParentFee:   req.ParentFee,
+		Label:              req.Label,
+		HeightHint:         heightHint,
+		TargetConfs:        targetConfs,
+		ParentFee:          req.ParentFee,
+		RetryUntilAccepted: req.RetryUntilAccepted,
 	}
 	fsm := newTrackedTxStateMachine(fsmLog, data)
 
@@ -1694,9 +1695,14 @@ func normalizeTargetConfs(req *EnsureConfirmedReq) uint32 {
 // validateEnsureMatch checks that an incoming EnsureConfirmedReq is
 // compatible with the already-tracked entry for the same txid. Two
 // callers that share a txid must also agree on TargetConfs and
-// ConfirmationPkScript, otherwise the confirmation notification one of
+// ConfirmationPkScript and RetryUntilAccepted, otherwise the lifecycle one of
 // them receives would not match the criteria it asked for.
 func validateEnsureMatch(req *EnsureConfirmedReq, existing *trackedTx) error {
+	if req.RetryUntilAccepted != existing.data.RetryUntilAccepted {
+		return fmt.Errorf("%w: txid=%s retry policy mismatch",
+			ErrEnsureParamsMismatch, existing.data.Txid)
+	}
+
 	reqConfs := normalizeTargetConfs(req)
 	if reqConfs != existing.data.TargetConfs {
 		return fmt.Errorf("%w: txid=%s existing=%d incoming=%d",

--- a/txconfirm/doc.go
+++ b/txconfirm/doc.go
@@ -50,7 +50,8 @@
 // tracked entry only while a terminal notification still needs retry
 // delivery.
 //
-// A broadcast that reaches no mempool at all does NOT advance to
+// For anchor parents and requests with RetryUntilAccepted, an initial
+// broadcast whose acceptance is unproven does NOT advance to
 // AwaitingConfirmation. It stays in Broadcasting and self-loops there,
 // re-attempting every fee-bump interval, and is never failed
 // automatically — only a structurally permanent error (a non-TRUC
@@ -60,7 +61,9 @@
 // Config.BroadcastFailureAlertThreshold consecutive failures the actor
 // emits a rate-limited operator escalation, because a fund-risk tx (e.g.
 // a fraud-response checkpoint) must eventually land rather than be
-// silently abandoned.
+// silently abandoned. Ordinary anchorless requests retain terminal failure
+// by default. Deduplicated requests must agree on RetryUntilAccepted. The
+// tracker is in memory; callers must reassert the policy after restart.
 //
 // # CPFP correctness
 //

--- a/txconfirm/fsm_types.go
+++ b/txconfirm/fsm_types.go
@@ -27,11 +27,13 @@ type trackedTxState interface {
 		trackedTxEvent, trackedTxOutboxEvent, *trackedTxEnvironment,
 	]
 
+	// trackedTxStateSealed limits implementations to this package.
 	trackedTxStateSealed()
 }
 
 // trackedTxEvent is the sealed event surface accepted by the tracked-tx FSM.
 type trackedTxEvent interface {
+	// trackedTxEventSealed limits implementations to this package.
 	trackedTxEventSealed()
 }
 
@@ -41,6 +43,7 @@ type trackedTxEvent interface {
 // events. The sealed interface still exists so the package follows the same
 // protofsm shape as the rest of the codebase.
 type trackedTxOutboxEvent interface {
+	// trackedTxOutboxEventSealed limits implementations to this package.
 	trackedTxOutboxEventSealed()
 }
 
@@ -71,6 +74,9 @@ type trackedTxData struct {
 
 	// TargetConfs is the required confirmation count.
 	TargetConfs uint32
+
+	// RetryUntilAccepted is the caller's initial-broadcast retry contract.
+	RetryUntilAccepted bool
 
 	// ParentFee is the absolute miner fee, in satoshis, that the tracked
 	// transaction already pays on its own. It is used only for a funded-

--- a/txconfirm/messages.go
+++ b/txconfirm/messages.go
@@ -135,6 +135,16 @@ type EnsureConfirmedReq struct {
 	// TargetConfs is the required confirmation count. Zero defaults to one.
 	TargetConfs uint32
 
+	// RetryUntilAccepted keeps transient initial broadcast failures in
+	// Broadcasting and retries the same signed transaction at the
+	// configured block interval, with operator escalation after repeated
+	// failures. Permanent structural errors still fail. False preserves the
+	// default: anchor parents retry, ordinary anchorless transactions fail
+	// terminally. Callers must restore this policy when reissuing after
+	// restart; txconfirm tracking is in memory. Requests for the same txid
+	// must agree.
+	RetryUntilAccepted bool
+
 	// ParentFee is the absolute miner fee, in satoshis, that Tx already
 	// pays. It is used only for a funded-anchor parent so a later CPFP fee
 	// bump subtracts the parent's own fee and lands the combined fee on the

--- a/txconfirm/retry_policy_test.go
+++ b/txconfirm/retry_policy_test.go
@@ -1,9 +1,14 @@
 package txconfirm
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,4 +60,131 @@ func TestEnsureRetryPolicyDedup(t *testing.T) {
 			mustHaveNoNotification(t, other)
 		})
 	}
+}
+
+// TestAnchorlessRetryUntilAccepted proves that repeated transient failures keep
+// the original signed transaction watched, use block pacing, and escalate
+// before recovery. Backend acceptance with a lost response is safe to retry
+// unchanged.
+func TestAnchorlessRetryUntilAccepted(t *testing.T) {
+	for _, recoveryErr := range []error{nil, fmt.Errorf(
+		"txn-already-in-mempool")} {
+		t.Run(fmt.Sprint(recoveryErr), func(t *testing.T) {
+			var logs bytes.Buffer
+			logger := btclog.NewSLogger(
+				btclog.NewDefaultHandler(&logs),
+			)
+			logger.SetLevel(btclog.LevelTrace)
+			chain := newFakeChainSourceRef(100)
+			chain.broadcastErr = fmt.Errorf("backend temporarily " +
+				"unavailable")
+			ref, _ := newTestActor(t, Config{
+				ChainSource: chain, FeeBumpIntervalBlocks: 2,
+				BroadcastFailureAlertThreshold: 3,
+				Log: fn.Some[btclog.Logger](
+					logger,
+				),
+			})
+			tx := makeTestTx(false)
+			tx.TxIn[0].Witness = wire.TxWitness{[]byte{1, 2, 3}}
+			original := tx.Copy()
+			sub := actor.NewChannelTellOnlyRef[Notification](
+				"retry", 4,
+			)
+			req := &EnsureConfirmedReq{
+				Tx:                 tx,
+				Subscriber:         sub,
+				RetryUntilAccepted: true,
+			}
+			require.Equal(
+				t, TxStateBroadcasting,
+				mustEnsure(t, ref.Ref(), req).State,
+			)
+			// The caller cannot mutate the actor's retained
+			// transaction after admission.
+			tx.TxIn[0].Witness[0][0] = 9
+			req.Tx = original
+			for _, step := range []struct {
+				height int32
+				calls  int
+			}{
+				{
+					101,
+					1,
+				}, {
+					102,
+					2,
+				}, {
+					102,
+					2,
+				}, {
+					103,
+					2,
+				}, {
+					104,
+					3,
+				}, {
+					105,
+					3,
+				},
+			} {
+				chain.emitBlock(t, step.height)
+				require.Equal(
+					t, TxStateBroadcasting,
+					mustEnsure(t, ref.Ref(), req).State,
+				)
+				require.Equal(
+					t, step.calls,
+					chain.broadcastCallCount(),
+				)
+			}
+			mustHaveNoNotification(t, sub)
+			require.Contains(
+				t, logs.String(),
+				"operator intervention",
+			)
+			chain.mu.Lock()
+			chain.broadcastErr = recoveryErr
+			chain.mu.Unlock()
+			chain.emitBlock(t, 106)
+			require.Equal(
+				t, TxStateAwaitingConfirmation,
+				mustEnsure(t, ref.Ref(), req).State,
+			)
+			require.Equal(t, 4, chain.broadcastCallCount())
+			chain.mu.Lock()
+			for _, call := range chain.broadcastCalls {
+				require.Equal(t, original, call.Tx)
+				require.Equal(
+					t, original.TxHash(), call.Tx.TxHash(),
+				)
+			}
+			chain.mu.Unlock()
+			require.Equal(t, 0, chain.packageCallCount())
+			chain.emitConfirmation(t, original.TxHash(), 107)
+			notification := mustAwaitNotification(t, sub)
+			confirmed, ok := notification.(*TxConfirmed)
+			require.True(t, ok)
+			require.Equal(t, original.TxHash(), confirmed.Txid)
+		})
+	}
+}
+
+// TestRetryPolicyCannotOverrideStructuralRejection keeps the broadcaster's
+// non-TRUC ephemeral-anchor gate terminal even when a caller opts into retry.
+func TestRetryPolicyCannotOverrideStructuralRejection(t *testing.T) {
+	chain := newFakeChainSourceRef(100)
+	ref, _ := newTestActor(t, Config{ChainSource: chain})
+	tx := makeTestTx(true)
+	tx.Version = 2
+	sub := actor.NewChannelTellOnlyRef[Notification]("invalid", 4)
+	req := &EnsureConfirmedReq{
+		Tx:                 tx,
+		Subscriber:         sub,
+		RetryUntilAccepted: true,
+	}
+	require.Equal(t, TxStateFailed, mustEnsure(t, ref.Ref(), req).State)
+	require.IsType(t, &TxFailed{}, mustAwaitNotification(t, sub))
+	require.Zero(t, chain.broadcastCallCount())
+	require.Zero(t, chain.packageCallCount())
 }

--- a/txconfirm/retry_policy_test.go
+++ b/txconfirm/retry_policy_test.go
@@ -1,0 +1,58 @@
+package txconfirm
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureRetryPolicyDedup rejects policy changes in either direction without
+// attaching the rejected subscriber or disturbing the original confirmation.
+func TestEnsureRetryPolicyDedup(t *testing.T) {
+	for _, retry := range []bool{false, true} {
+		name := map[bool]string{false: "terminal", true: "retry"}[retry]
+		t.Run(name, func(t *testing.T) {
+			chain := newFakeChainSourceRef(100)
+			ref, _ := newTestActor(
+				t, Config{
+					ChainSource: chain,
+				},
+			)
+			tx := makeTestTx(false)
+			first := actor.NewChannelTellOnlyRef[Notification](
+				"first", 4,
+			)
+			other := actor.NewChannelTellOnlyRef[Notification](
+				"other", 4,
+			)
+			req := &EnsureConfirmedReq{
+				Tx:                 tx,
+				Subscriber:         first,
+				RetryUntilAccepted: retry,
+			}
+			require.True(
+				t, mustEnsure(t, ref.Ref(), req).Created,
+			)
+			require.False(
+				t, mustEnsure(t, ref.Ref(), req).Created,
+			)
+			conflict := &EnsureConfirmedReq{
+				Tx:                 tx,
+				Subscriber:         other,
+				RetryUntilAccepted: !retry,
+			}
+			_, err := ref.Ref().Ask(t.Context(), conflict).
+				Await(t.Context()).Unpack()
+			require.ErrorIs(t, err, ErrEnsureParamsMismatch)
+			require.Equal(t, 1, chain.broadcastCallCount())
+			require.Equal(t, 1, chain.registerConfCount())
+			chain.emitConfirmation(t, tx.TxHash(), 101)
+			require.IsType(
+				t, &TxConfirmed{},
+				mustAwaitNotification(t, first),
+			)
+			mustHaveNoNotification(t, other)
+		})
+	}
+}

--- a/unroll/README.md
+++ b/unroll/README.md
@@ -160,6 +160,20 @@ sequenceDiagram
     Behavior->>FSM: SweepBroadcastedEvent
 ```
 
+The final sweep sets `RetryUntilAccepted` on both first submission and
+restart reissue. A transient backend error keeps txconfirm in `Broadcasting`
+and retries the same signed transaction at its existing block interval,
+with operator escalation after repeated failures. Unroll keeps waiting for
+confirmation without consuming its three-attempt build/terminal-failure
+budget. The existing `ErrNonTRUCParent` gate still reports `TxFailed` for
+non-v3 ephemeral-anchor parents. Other backend rejections keep retrying;
+this change adds no backend rejection classification.
+
+Txconfirm tracking is in memory. The retry flag is reconstructed by the
+sweep caller, so existing checkpoints need no migration. Boarding sweeps
+already carry a funded anchor and retain their existing retry behavior;
+ordinary anchorless wallet transactions retain their terminal default.
+
 ### 2. Fail-closed admission
 
 `UnrollRegistryActor.handleEnsure` calls `Store.UpsertRecord` synchronously

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -762,6 +762,7 @@ func (b *behavior) startSweep(ctx context.Context,
 
 	_, err = b.cfg.TxConfirmRef.Ask(ctx, &txconfirm.EnsureConfirmedReq{
 		Tx:                   b.sweepTx,
+		RetryUntilAccepted:   true,
 		ConfirmationPkScript: sweepPkScript,
 		Label:                sweepLabel,
 		Subscriber:           b.notificationRef(),
@@ -2408,6 +2409,7 @@ func (b *behavior) routeOutbox(ctx context.Context, ax actor.Exec[unrollTx],
 			_, err = b.cfg.TxConfirmRef.Ask(
 				ctx, &txconfirm.EnsureConfirmedReq{
 					Tx:                   b.sweepTx,
+					RetryUntilAccepted:   true,
 					ConfirmationPkScript: sweepPkScript,
 					Label: "unroll-sweep-" +
 						b.cfg.TargetOutpoint.String(),

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -3743,6 +3743,8 @@ func TestResumeReissuesSweepConfirmation(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return txconfirmRef.requestCountForTxid(sweepTxid) == 1
 	}, testTimeout, 10*time.Millisecond)
+	require.True(t, txconfirmRef.lastRequest(t).RetryUntilAccepted)
+	requireSameSweep(t, sweepTx, txconfirmRef.lastRequest(t).Tx)
 }
 
 // TestResumeRetriesDeferredSweepBuild verifies a checkpoint that has reached
@@ -4109,6 +4111,16 @@ func TestSweepBroadcastRetryReusesCachedTxWithoutFeeEstimate(t *testing.T) {
 	)
 	require.Equal(t, 1, chainSource.feeRequestCount())
 	require.Equal(t, int64(1), wallet.pkScriptRequestCount())
+
+	require.True(t, txconfirmRef.lastRequest(t).RetryUntilAccepted)
+	for _, txid := range []chainhash.Hash{
+		proof.RootTxids()[0], proof.TargetOutpoint().Hash,
+	} {
+		require.False(
+			t,
+			txconfirmRef.requestByTxid(t, txid).RetryUntilAccepted,
+		)
+	}
 
 	chainSource.setFeeEstimate(0, fmt.Errorf("estimator unavailable"))
 	txconfirmRef.emitFailed(t, 2, sweepTxid, "broadcast rejected")

--- a/unroll/sweep_retry_restart_test.go
+++ b/unroll/sweep_retry_restart_test.go
@@ -1,0 +1,229 @@
+package unroll
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/chainsource"
+	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/db/actordelivery"
+	"github.com/lightninglabs/wavelength/txconfirm"
+	"github.com/lightninglabs/wavelength/unrollplan"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// retrySweepChain injects an ambiguous submission failure at the chain boundary
+// while retaining real unroll and txconfirm actors on either side of restart.
+type retrySweepChain struct {
+	*fakeChainSourceRef
+	retryMu  sync.Mutex
+	failure  error
+	attempts chan *wire.MsgTx
+	blocks   map[string]actor.TellOnlyRef[chainsource.BlockEpoch]
+}
+
+// Ask captures exact broadcast bytes and keeps block subscriptions by owner.
+func (c *retrySweepChain) Ask(ctx context.Context,
+	msg chainsource.ChainSourceMsg,
+) actor.Future[chainsource.ChainSourceResp] {
+
+	c.retryMu.Lock()
+	defer c.retryMu.Unlock()
+	if req, ok := msg.(*chainsource.SubscribeBlocksRequest); ok {
+		c.blocks[req.CallerID] = req.NotifyActor.UnwrapOr(nil)
+	}
+	if req, ok := msg.(*chainsource.BroadcastTxRequest); ok {
+		c.attempts <- req.Tx.Copy()
+		promise := actor.NewPromise[chainsource.ChainSourceResp]()
+		if c.failure != nil {
+			promise.Complete(
+				fn.Err[chainsource.ChainSourceResp](c.failure),
+			)
+		} else {
+			promise.Complete(
+				fn.Ok[chainsource.ChainSourceResp](
+					&chainsource.BroadcastTxResponse{},
+				),
+			)
+		}
+
+		return promise.Future()
+	}
+
+	return c.fakeChainSourceRef.Ask(ctx, msg)
+}
+
+// advance delivers a new block after changing the injected broadcast outcome.
+func (c *retrySweepChain) advance(t *testing.T, height int32, failure error) {
+	t.Helper()
+	c.retryMu.Lock()
+	c.failure = failure
+	refs := make(
+		[]actor.TellOnlyRef[chainsource.BlockEpoch], 0, len(c.blocks),
+	)
+	for _, ref := range c.blocks {
+		refs = append(refs, ref)
+	}
+	c.retryMu.Unlock()
+	for _, ref := range refs {
+		require.NoError(
+			t,
+			ref.Tell(
+				t.Context(), chainsource.BlockEpoch{
+					Height: height,
+				},
+			),
+		)
+	}
+}
+
+// nextAttempt waits for a real broadcaster submission rather than polling time.
+func (c *retrySweepChain) nextAttempt(t *testing.T) *wire.MsgTx {
+	t.Helper()
+	select {
+	case tx := <-c.attempts:
+		return tx
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("sweep was not submitted")
+
+		return nil
+	}
+}
+
+// TestSweepTransientFailureRestartRecovery proves the final anchorless sweep
+// survives a transient submission error and full actor restart. Its serialized
+// SQLite checkpoint restores the same signed transaction, retry contract, and
+// unconsumed unroll budget; confirmation then completes the exit.
+func TestSweepTransientFailureRestartRecovery(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	sqlDB := db.NewTestDB(t)
+	delivery, err := actordelivery.NewTxAwareDeliveryStoreFromDB(
+		sqlDB.DB, sqlDB.Backend(), clock.NewDefaultClock(),
+		btclog.Disabled,
+	)
+	require.NoError(t, err)
+	const actorID = "retry-sweep-restart"
+	raw, err := encodeCheckpoint(&actorCheckpoint{
+		Version: checkpointVersion, Height: 110, Started: true,
+		Trigger: TriggerRestart,
+		State: unrollplan.State{
+			ConfirmedTxids: []chainhash.Hash{
+				proof.RootTxids()[0],
+				proof.TargetOutpoint().Hash,
+			},
+			TargetConfirmHeight: fn.Some[int32](108),
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		delivery.SaveCheckpoint(
+			t.Context(), actor.CheckpointParams{
+				ActorID:   actorID,
+				StateType: checkpointStateType,
+				StateData: raw,
+				Version:   checkpointVersion,
+			},
+		),
+	)
+	chain := &retrySweepChain{
+		fakeChainSourceRef: &fakeChainSourceRef{
+			bestHeight: 110,
+		},
+		failure: fmt.Errorf("backend unavailable after " +
+			"submission"),
+		attempts: make(chan *wire.MsgTx, 16),
+		blocks: make(
+			map[string]actor.TellOnlyRef[chainsource.BlockEpoch],
+		),
+	}
+	wallet := &fakeSweepWallet{}
+	var original *wire.MsgTx
+	for generation := 0; generation < 2; generation++ {
+		txBehavior := txconfirm.NewTxBroadcasterActor(txconfirm.Config{
+			ChainSource: chain, FeeBumpIntervalBlocks: 2,
+		})
+		txActor := actor.NewActor(actor.ActorConfig[
+			txconfirm.Msg,
+			txconfirm.Resp,
+		]{
+			ID:          "retry-txconfirm",
+			Behavior:    txBehavior,
+			MailboxSize: 64,
+		})
+		txBehavior.SetSelfRef(txActor.TellRef())
+		txActor.Start()
+		t.Cleanup(txActor.Stop)
+		exit, err := NewVTXOUnrollActor(
+			Config{
+				ActorID:        actorID,
+				TargetOutpoint: proof.TargetOutpoint(),
+				DeliveryStore:  delivery,
+				ProofAssembler: &mockProofAssembler{
+					proof: proof,
+				},
+				VTXOStore:    &mockVTXOStore{desc: desc},
+				TxConfirmRef: txActor.Ref(),
+				ChainSource:  chain,
+				Wallet:       wallet,
+			},
+		)
+		require.NoError(t, err)
+		t.Cleanup(exit.Stop)
+		mustAsk(t, exit.Ref(), &ResumeUnrollRequest{Height: 110})
+		attempt := chain.nextAttempt(t)
+		if original == nil {
+			original = attempt
+		} else {
+			requireSameSweep(t, original, attempt)
+		}
+		response := mustAsk(t, exit.Ref(), &GetStateRequest{})
+		state, ok := response.(*GetStateResp)
+		require.True(t, ok)
+		require.Equal(t, PhaseSweepConfirmation, state.Phase)
+		checkpoint, err := delivery.LoadCheckpoint(t.Context(), actorID)
+		require.NoError(t, err)
+		saved, err := decodeCheckpoint(checkpoint.StateData)
+		require.NoError(t, err)
+		require.Zero(t, saved.SweepAttempts)
+		requireSameSweep(t, original, saved.SweepTx)
+		require.Equal(t, int64(1), wallet.pkScriptRequestCount())
+		if generation == 1 {
+			chain.advance(t, 112, nil)
+			requireSameSweep(t, original, chain.nextAttempt(t))
+			chain.emitConfirmed(t, original.TxHash(), 113)
+			require.Eventually(t, func() bool {
+				state, ok := mustAsk(
+					t, exit.Ref(), &GetStateRequest{},
+				).(*GetStateResp)
+
+				return ok && state.Phase == PhaseCompleted
+			}, 5*time.Second, 10*time.Millisecond)
+		}
+		exit.Stop()
+		txActor.Stop()
+	}
+}
+
+// requireSameSweep compares wire bytes, including witnesses, across checkpoint
+// decoding, where empty script slices may differ from nil slices in memory.
+func requireSameSweep(t *testing.T, want, got *wire.MsgTx) {
+	t.Helper()
+	var wantBytes, gotBytes bytes.Buffer
+	require.NoError(t, want.Serialize(&wantBytes))
+	require.NoError(t, got.Serialize(&gotBytes))
+	require.Equal(t, wantBytes.Bytes(), gotBytes.Bytes())
+	require.Equal(t, want.TxHash(), got.TxHash())
+}


### PR DESCRIPTION
## The problem

A unilateral exit ends by sweeping the recovered output to the wallet. The wallet signs and persists this transaction before asking txconfirm to broadcast it.

A temporary backend outage on that first submission currently produces terminal `TxFailed`. The final sweep has no anchor output, and txconfirm infers its retry behavior from that shape. Unroll resubmits the saved sweep three times, then marks the exit failed even though the backend may recover later.

## The fix

Add `RetryUntilAccepted` to `EnsureConfirmedReq`. The final unroll sweep sets it both on first submission and when restoring its confirmation tracking after restart.

An opted-in transient error keeps the transaction in `Broadcasting`. Txconfirm retries at the existing block interval and retains its operator warning after repeated failures. Successful submission, or an existing already-known response, advances it to `AwaitingConfirmation`.

```mermaid
flowchart LR
    A[Persist signed sweep] --> B[Broadcasting]
    B -->|Transient error: wait existing interval| B
    B -->|Accepted or already known| C[Awaiting confirmation]
    B -->|Structural rejection| D[Failed]
    C -->|Confirmed| E[Exit completed]
```

## Safety rule

Every retry submits the same signed transaction and transaction ID. Two requests for the same transaction ID must agree on retry policy; a conflict is rejected before the new subscriber attaches.

## What does not change

- Ordinary anchorless transactions retain terminal behavior by default.
- Anchor parents retain their existing retry behavior. Boarding sweeps already contain a funded anchor and need no caller change.
- The existing permanent-error classifier still rejects structurally invalid non-v3 ephemeral-anchor parents.
- This does not reprice anchorless sweeps or add a replacement transaction.

## Tests

- Both directions of conflicting-policy deduplication, matching-policy reuse, and delivery only to accepted subscribers.
- Transient anchorless failure, retained `Broadcasting` state, interval pacing, repeated-failure escalation, and later confirmation with unchanged signed bytes and transaction ID.
- Recovery after an ambiguous submission followed by an already-known response.
- Ordinary anchorless terminal failure and structural rejection despite retry opt-in.
- Unroll first-submit and restart caller wiring, plus both actors restarting against a SQLite checkpoint and completing the saved sweep without consuming the caller's failure budget.

Validation completed locally: root-module `go test ./...`; full `-race` suites for `txconfirm`, `unroll`, and `wallet`; SQLite and PostgreSQL `make systest`; changed-code lint; Go declaration documentation audit; formatting; module tidiness; and commit-message lint. GitHub CI is green on final head `2dbd4f79`: 19 checks passed and 3 were intentionally skipped. Gateway re-review of the final head returned **READY WITH FOLLOW-UPS**, no blockers, and no unresolved review threads. All three commits are GitHub Verified.

`make ast-lint` completed with advisory style warnings. The extra `make doc-check` fails on a pre-existing missing `docs/mailbox_ingress_safety.md` entry in `docs/index.md`; neither file is changed here.

Repeated-failure visibility through the exit status API is tracked separately in #1315. Operator escalation in logs remains in this fix.

## Compatibility and rollout

No database migration, wire change, or other repository change is required. Txconfirm's request and tracker are in memory. Unroll reconstructs the flag from the operation type when restoring its existing persisted sweep. Existing in-flight exits benefit after upgrade; previously terminal failed jobs are not automatically reopened. Downgrading restores the old retry behavior.

Fixes #1185.
