### PR TITLE
unroll: reprice and readmit fee-rejected exit sweeps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/btcsuite/btcd/v2transport v1.0.1 // indirect
 	github.com/btcsuite/btclog v1.0.0 // indirect
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.4.0 // indirect
-	github.com/btcsuite/btcwallet/wallet/txrules v1.3.0 // indirect
+	github.com/btcsuite/btcwallet/wallet/txrules v1.3.0
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.3.0 // indirect
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 // indirect

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -40,7 +40,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   coordination.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — public Ask API:
   register interest in a txid with `TargetConfs`, `ConfirmationPkScript`,
-  and a subscriber. An Ask error means the subscriber was not retained:
+  `RetryUntilAccepted`, and a subscriber. An Ask error means the subscriber was not retained:
   no later notification arrives and the caller must re-send
   `EnsureConfirmedReq` to attach.
 - `CancelInterestReq` / `CancelInterestResp` — drop a subscriber; the
@@ -51,7 +51,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   holding an unapplied terminal transition answers `Bumped: false` instead
   of broadcasting again.
 - `TxConfirmed` / `TxFailed` — terminal `Notification` types delivered
-  to each subscriber.
+  to each subscriber. `TxFailed.Class` carries a `BroadcastFailureClass`:
+  unknown, explicit fee rejection, or permanent invalidity. The conservative
+  `ClassifyBroadcastFailure` helper recognizes RPC/HTTP reason strings;
+  known/accepted outcomes must be handled first.
 - `NewServiceKey` / `LookupRef` — actor-system service-key helpers
   (`ServiceKeyName = "txconfirm"`) so callers resolve the shared actor
   ref via the receptionist instead of holding a direct reference.
@@ -96,21 +99,19 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
 
 ## Invariants
 
-- **Retry by contract**: an anchor parent or a request opting into
-  `RetryUntilAccepted` stays in `Broadcasting` when acceptance is unproven
-  and is re-attempted every
-  `FeeBumpIntervalBlocks`, never transitioning to terminal `Failed`. This
-  preserves terminal failure for ordinary anchorless requests and covers
-  `ErrCPFPFeeInputUnavailable` and transient package-relay
-  rejections (min-relay-fee on the zero-fee anchor parent, mempool-full,
-  fee input spent mid-submit) — the conditions CPFP retry exists to
-  overcome. Only a structurally permanent error
-  (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`) fails
-  terminally; `ErrParentAlreadyBroadcast` advances to
-  `AwaitingConfirmation` (a live parent exists on another path). Rationale:
-  a fraud-response checkpoint must land before the counterparty's
-  CSV-timeout path, so the actor escalates to operators rather than
-  silently aborting.
+- **Direct rejection classification.** Explicit fee or structural rejection
+  of an anchorless candidate produces `TxFailed` even with
+  `RetryUntilAccepted`. The signing owner can reprice a fee-rejected candidate;
+  unchanged-byte retry cannot repair it. `TxFailed.Class` is recomputed from
+  the stable stored reason on notification redelivery. Known/accepted outcomes
+  are handled before classification.
+- **Retry by contract.** Other errors on an anchor parent or a request with
+  `RetryUntilAccepted` keep it in `Broadcasting` and retry at
+  `FeeBumpIntervalBlocks`, with operator escalation after repeated failure.
+  Anchor package fee rejection keeps its CPFP recovery path. A structural
+  `ErrNonTRUCParent` still fails; `ErrParentAlreadyBroadcast` advances to
+  `AwaitingConfirmation`. Ordinary anchorless requests retain terminal failure
+  by default.
 - **Strict dedup check**: two `EnsureConfirmedReq` for the same txid
   must agree on `TargetConfs`, `ConfirmationPkScript`, and
   `RetryUntilAccepted`; mismatches

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -40,7 +40,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   coordination.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — public Ask API:
   register interest in a txid with `TargetConfs`, `ConfirmationPkScript`,
-  and a subscriber. An Ask error means the subscriber was not retained:
+  `RetryUntilAccepted`, and a subscriber. An Ask error means the subscriber was not retained:
   no later notification arrives and the caller must re-send
   `EnsureConfirmedReq` to attach.
 - `CancelInterestReq` / `CancelInterestResp` — drop a subscriber; the
@@ -51,7 +51,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   holding an unapplied terminal transition answers `Bumped: false` instead
   of broadcasting again.
 - `TxConfirmed` / `TxFailed` — terminal `Notification` types delivered
-  to each subscriber.
+  to each subscriber. `TxFailed.Class` carries a `BroadcastFailureClass`:
+  unknown, explicit fee rejection, or permanent invalidity. The conservative
+  `ClassifyBroadcastFailure` helper recognizes RPC/HTTP reason strings;
+  known/accepted outcomes must be handled first.
 - `NewServiceKey` / `LookupRef` — actor-system service-key helpers
   (`ServiceKeyName = "txconfirm"`) so callers resolve the shared actor
   ref via the receptionist instead of holding a direct reference.
@@ -96,21 +99,19 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
 
 ## Invariants
 
-- **Retry by contract**: an anchor parent or a request opting into
-  `RetryUntilAccepted` stays in `Broadcasting` when acceptance is unproven
-  and is re-attempted every
-  `FeeBumpIntervalBlocks`, never transitioning to terminal `Failed`. This
-  preserves terminal failure for ordinary anchorless requests and covers
-  `ErrCPFPFeeInputUnavailable` and transient package-relay
-  rejections (min-relay-fee on the zero-fee anchor parent, mempool-full,
-  fee input spent mid-submit) — the conditions CPFP retry exists to
-  overcome. Only a structurally permanent error
-  (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`) fails
-  terminally; `ErrParentAlreadyBroadcast` advances to
-  `AwaitingConfirmation` (a live parent exists on another path). Rationale:
-  a fraud-response checkpoint must land before the counterparty's
-  CSV-timeout path, so the actor escalates to operators rather than
-  silently aborting.
+- **Direct rejection classification.** Explicit fee or structural rejection
+  of an anchorless candidate produces `TxFailed` even with
+  `RetryUntilAccepted`. The signing owner can reprice a fee-rejected candidate;
+  unchanged-byte retry cannot repair it. `TxFailed.Class` is recomputed from
+  the stable stored reason on notification redelivery. Known/accepted outcomes
+  are handled before classification.
+- **Retry by contract.** Other errors on an anchor parent or a request with
+  `RetryUntilAccepted` keep it in `Broadcasting` and retry at
+  `FeeBumpIntervalBlocks`, with operator escalation after repeated failure.
+  Anchor package fee rejection keeps its CPFP recovery path. A structural
+  `ErrNonTRUCParent` still fails; `ErrParentAlreadyBroadcast` advances to
+  `AwaitingConfirmation`. Ordinary anchorless requests retain terminal failure
+  by default.
 - **Strict dedup check**: two `EnsureConfirmedReq` for the same txid
   must agree on `TargetConfs`, `ConfirmationPkScript`, and
   `RetryUntilAccepted`; mismatches

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -753,6 +753,10 @@ func (a *TxBroadcasterActor) discardIncompleteTrackedTx(ctx context.Context,
 //     never be accepted as submitted, so retrying is pointless. Fail it
 //     terminally and notify subscribers.
 //
+//   - explicit fee or structural rejection on an anchorless candidate: fail
+//     this candidate with its class so the signing owner can act. A fee change
+//     requires a new transaction, even when RetryUntilAccepted was requested.
+//
 //   - any other error on an opted-in tx or anchor (CPFP) parent: acceptance
 //     is unproven and retrying the same transaction is safe. For example,
 //     a transient backend failure, a missing confirmed fee input
@@ -776,6 +780,8 @@ func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
 	entry *trackedTx, err error) (TxState, error) {
 
 	a.maybeEnsureFeeInputSupply(ctx, err)
+	directRejection := findAnchorOutput(entry.data.Tx) < 0 &&
+		ClassifyBroadcastFailure(err) != BroadcastFailureUnknown
 
 	switch {
 	case err == nil:
@@ -801,9 +807,12 @@ func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
 
 		return TxStateAwaitingConfirmation, err
 
-	case isPermanentBroadcastError(err):
-		// The tx is structurally unacceptable (e.g. a non-TRUC parent);
-		// no amount of retrying will land it, so fail terminally.
+	case isPermanentBroadcastError(err) || directRejection:
+		// Structural errors cannot succeed unchanged. An explicit
+		// direct fee rejection also needs the signing owner to change
+		// the candidate, before any opt-in retry contract can resubmit
+		// the same bytes. Anchor packages keep their existing CPFP
+		// recovery path.
 		err := a.failTrackedTx(
 			ctx, entry, fmt.Sprintf("broadcast: %v", err),
 		)

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -2633,6 +2633,9 @@ func (a *TxBroadcasterActor) notifyOneFailed(ctx context.Context,
 			return subscriber.Tell(notifyCtx, &TxFailed{
 				Txid:   txid,
 				Reason: reason,
+				Class: ClassifyBroadcastFailure(
+					errors.New(reason),
+				),
 			})
 		},
 	)

--- a/txconfirm/doc.go
+++ b/txconfirm/doc.go
@@ -50,20 +50,23 @@
 // tracked entry only while a terminal notification still needs retry
 // delivery.
 //
-// For anchor parents and requests with RetryUntilAccepted, an initial
-// broadcast whose acceptance is unproven does NOT advance to
+// Explicit direct fee or structural rejection returns a classified TxFailed
+// before RetryUntilAccepted is considered: the signing owner must change a
+// fee-rejected candidate. Anchor package fee rejection keeps its CPFP path.
+//
+// For other errors on anchor parents and requests with RetryUntilAccepted, an
+// initial broadcast whose acceptance is unproven does NOT advance to
 // AwaitingConfirmation. It stays in Broadcasting and self-loops there,
-// re-attempting every fee-bump interval, and is never failed
-// automatically — only a structurally permanent error (a non-TRUC
-// parent) is terminal. Transient conditions such as a missing confirmed
-// fee input, a min-relay-fee rejection of the zero-fee anchor parent, or
-// a mempool-full backend keep retrying. After
-// Config.BroadcastFailureAlertThreshold consecutive failures the actor
-// emits a rate-limited operator escalation, because a fund-risk tx (e.g.
-// a fraud-response checkpoint) must eventually land rather than be
-// silently abandoned. Ordinary anchorless requests retain terminal failure
-// by default. Deduplicated requests must agree on RetryUntilAccepted. The
-// tracker is in memory; callers must reassert the policy after restart.
+// re-attempting every fee-bump interval, and is never failed automatically —
+// only a structurally permanent error (a non-TRUC parent) is terminal.
+// Transient conditions such as a missing confirmed fee input, a min-relay-fee
+// rejection of the zero-fee anchor parent, or a mempool-full backend keep
+// retrying. After Config.BroadcastFailureAlertThreshold consecutive failures
+// the actor emits a rate-limited operator escalation, because a fund-risk tx
+// (e.g. a fraud-response checkpoint) must eventually land rather than be
+// silently abandoned. Ordinary anchorless requests retain terminal failure by
+// default. Deduplicated requests must agree on RetryUntilAccepted. The tracker
+// is in memory; callers must reassert the policy after restart.
 //
 // # CPFP correctness
 //

--- a/txconfirm/messages.go
+++ b/txconfirm/messages.go
@@ -413,6 +413,9 @@ type TxFailed struct {
 
 	// Reason is a stable human-readable failure reason.
 	Reason string
+
+	// Class preserves the rejection disposition independently of the text.
+	Class BroadcastFailureClass
 }
 
 // MessageType returns the stable message type identifier.

--- a/txconfirm/rejection.go
+++ b/txconfirm/rejection.go
@@ -1,0 +1,63 @@
+package txconfirm
+
+import (
+	"errors"
+	"strings"
+)
+
+// BroadcastFailureClass describes what a failed submission proves. It does
+// not prove that a previous submission of the same transaction was absent.
+type BroadcastFailureClass uint8
+
+const (
+	// BroadcastFailureUnknown includes transport errors and unclassified
+	// rejections. A caller must preserve the submitted transaction.
+	BroadcastFailureUnknown BroadcastFailureClass = iota
+
+	// BroadcastFailureFee identifies an explicit insufficient-fee policy
+	// rejection. A transaction owner may construct a higher-fee
+	// replacement, retaining evidence of every candidate that could still
+	// confirm.
+	BroadcastFailureFee
+
+	// BroadcastFailurePermanent identifies invalid transaction structure or
+	// script execution. Changing the fee cannot repair it.
+	BroadcastFailurePermanent
+)
+
+// ClassifyBroadcastFailure recognizes explicit backend rejection reasons.
+// Unknown errors stay ambiguous. The string forms are required for RPC and
+// HTTP backends that do not preserve Go error types, and for legacy durable
+// failure records. Already-known outcomes must be handled before this helper.
+func ClassifyBroadcastFailure(err error) BroadcastFailureClass {
+	if err == nil {
+		return BroadcastFailureUnknown
+	}
+	if errors.Is(err, ErrNonTRUCParent) {
+		return BroadcastFailurePermanent
+	}
+	reason := strings.ToLower(err.Error())
+	for _, structural := range []string{
+		strings.ToLower(ErrNonTRUCParent.Error()),
+		"mandatory-script-verify-flag-failed",
+		"non-mandatory-script-verify-flag",
+		"bad-txns-vout-negative",
+		"bad-txns-inputs-duplicate",
+		"bad-txns-txouttotal-toolarge",
+	} {
+		if strings.Contains(reason, structural) {
+			return BroadcastFailurePermanent
+		}
+	}
+	for _, fee := range []string{
+		"min relay fee not met",
+		"mempool min fee not met",
+		"insufficient fee",
+	} {
+		if strings.Contains(reason, fee) {
+			return BroadcastFailureFee
+		}
+	}
+
+	return BroadcastFailureUnknown
+}

--- a/txconfirm/rejection_test.go
+++ b/txconfirm/rejection_test.go
@@ -73,21 +73,36 @@ func TestDirectBroadcastFailureCarriesClass(t *testing.T) {
 	for _, tc := range []struct {
 		reason string
 		class  BroadcastFailureClass
+		retry  bool
 	}{
 		{
 			"min relay fee not met",
+			BroadcastFailureFee, false,
+		},
+		{
+			"mandatory-script-verify-flag-failed",
+			BroadcastFailurePermanent, false,
+		},
+		{
+			"connection reset by peer",
+			BroadcastFailureUnknown, false,
+		},
+		{
+			"min relay fee not met",
 			BroadcastFailureFee,
+			true,
 		},
 		{
 			"mandatory-script-verify-flag-failed",
 			BroadcastFailurePermanent,
-		},
-		{
-			"connection reset by peer",
-			BroadcastFailureUnknown,
+			true,
 		},
 	} {
-		t.Run(tc.reason, func(t *testing.T) {
+		name := tc.reason
+		if tc.retry {
+			name += "/retry"
+		}
+		t.Run(name, func(t *testing.T) {
 			chain := newFakeChainSourceRef(100)
 			chain.broadcastErr = errors.New(tc.reason)
 			ref, _ := newTestActor(t, Config{
@@ -99,6 +114,7 @@ func TestDirectBroadcastFailureCarriesClass(t *testing.T) {
 			)
 			resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
 				Tx: makeTestTx(false), Subscriber: sub,
+				RetryUntilAccepted: tc.retry,
 			})
 			require.Equal(t, TxStateFailed, resp.State)
 			failed, ok := mustAwaitNotification(t, sub).(*TxFailed)

--- a/txconfirm/rejection_test.go
+++ b/txconfirm/rejection_test.go
@@ -1,0 +1,111 @@
+package txconfirm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBroadcastFailureClassification keeps transport ambiguity and structural
+// invalidity outside the class that authorizes a fee replacement.
+func TestBroadcastFailureClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want BroadcastFailureClass
+	}{
+		{
+			"minimum relay",
+			errors.New("broadcast: min relay fee not met"),
+			BroadcastFailureFee,
+		},
+		{
+			"mempool floor",
+			errors.New("RPC: mempool min fee not met"),
+			BroadcastFailureFee,
+		},
+		{"replacement fee", errors.New("insufficient fee, rejecting " +
+			"replacement"), BroadcastFailureFee},
+		{
+			"script",
+			errors.New("mandatory-script-verify-flag-failed"),
+			BroadcastFailurePermanent,
+		},
+		{
+			"structure",
+			errors.New("bad-txns-vout-negative"),
+			BroadcastFailurePermanent,
+		},
+		{"version", fmt.Errorf(
+			"broadcast: %w",
+			ErrNonTRUCParent), BroadcastFailurePermanent},
+		{
+			"timeout",
+			context.DeadlineExceeded,
+			BroadcastFailureUnknown,
+		},
+		{
+			"unclassified",
+			errors.New("mempool reject"),
+			BroadcastFailureUnknown,
+		},
+		{
+			"none",
+			nil,
+			BroadcastFailureUnknown,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(
+				t, tc.want, ClassifyBroadcastFailure(tc.err),
+			)
+		})
+	}
+}
+
+// TestDirectBroadcastFailureCarriesClass exercises the actual anchorless
+// submission and terminal notification path, including the invalid control.
+func TestDirectBroadcastFailureCarriesClass(t *testing.T) {
+	for _, tc := range []struct {
+		reason string
+		class  BroadcastFailureClass
+	}{
+		{
+			"min relay fee not met",
+			BroadcastFailureFee,
+		},
+		{
+			"mandatory-script-verify-flag-failed",
+			BroadcastFailurePermanent,
+		},
+		{
+			"connection reset by peer",
+			BroadcastFailureUnknown,
+		},
+	} {
+		t.Run(tc.reason, func(t *testing.T) {
+			chain := newFakeChainSourceRef(100)
+			chain.broadcastErr = errors.New(tc.reason)
+			ref, _ := newTestActor(t, Config{
+				ChainSource: chain,
+				Wallet:      &fakeWallet{},
+			})
+			sub := actor.NewChannelTellOnlyRef[Notification](
+				"fee-sub", 4,
+			)
+			resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+				Tx: makeTestTx(false), Subscriber: sub,
+			})
+			require.Equal(t, TxStateFailed, resp.State)
+			failed, ok := mustAwaitNotification(t, sub).(*TxFailed)
+			require.True(t, ok)
+			require.Equal(t, tc.class, failed.Class)
+			require.Contains(t, failed.Reason, tc.reason)
+			require.Equal(t, 1, chain.broadcastCallCount())
+		})
+	}
+}

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -36,8 +36,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   zero falls back to the default), `RegistryRef`.
 - `behavior` — actor behavior implementing `actor.TxBehavior[Msg, Resp,
   unrollTx]`. Holds `b.sweepTx` (restored from checkpoint on boot) so
-  retries and replays converge on a single sweep txid / pkScript under
-  `txconfirm`'s txid-keyed dedup. The `dispatch` method runs the full
+  retries and replays reuse the staged candidate under
+  `txconfirm`'s txid-keyed dedup. Explicit fee rejection permits a signed
+  replacement to the same destination; prior candidates remain checkpointed.
+  The `dispatch` method runs the full
   FSM pipeline including Stage writes; `Receive` owns the single
   lease-fenced Commit. It also tracks whether a restored checkpoint still
   needs its first reissue after re-admission.
@@ -54,7 +56,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   `PhaseMaterializing`, `PhaseCSVPending`, `PhaseSweepBroadcast`,
   `PhaseSweepConfirmation`, `PhaseCompleted`, `PhaseFailed`.
 - `JobState` — durable FSM state (height, trigger, planner state,
-  `FailReason`, `SweepAttempts`).
+  `FailReason`, `SweepAttempts`, `RejectedSweep`, `RepriceAfter`, `RetrySame`).
+  Rejected identity and height pace fee retries; `RetrySame` preserves a
+  candidate while waiting for spend evidence after replacement failure.
 
 ### Registry
 
@@ -105,7 +109,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   `validateExitPolicyIdentity` checks consistency at admit time. Dedup
   runs against `r.active`, `r.pending`, AND `Store.GetRecord` so a
   repeat after termination returns `Created=false` with the historical
-  `ActorID`, never clobbering the sweep txid / failure reason. The one
+  `ActorID`, never clobbering the sweep txid / failure reason. One
   exception is a **recoverable** terminal failure
   (`RecoverableFailure`): the prior exit failed cleanly with no on-chain
   footprint and the VTXO was rolled back to live (wavelength#602), so
@@ -113,7 +117,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   overwriting the stale record) instead of deduping — otherwise a
   recovered VTXO could never be unrolled again. Any existing unroll job
   for the same target must carry the same `(ExitPolicyKind,
-  ExitPolicyRef)`; mismatches fail closed.
+  ExitPolicyRef)`; mismatches fail closed. A legacy terminal fee rejection
+  is also resumable after validating the saved candidate and policy. Its
+  registry row becomes non-terminal before the same actor ID is restored.
 - `ExitSpendPolicyResolver` — interface for looking up the final spend
   policy by `(ExitPolicyKind, ExitPolicyRef)`. Implemented by
   `vhtlcrecovery/unrollpolicy.ExitSpendPolicyResolver`.
@@ -222,7 +228,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   counterparty spend racing our forfeit).
 - **Sends**:
   - → `txconfirm` (Ask): `EnsureConfirmedReq` per proof node and for
-    the final sweep; txid dedup makes retries idempotent.
+    the final sweep; txid dedup makes retries idempotent. Final sweeps set
+    `RetryUntilAccepted` on first submit and reissue. Transient failures retry
+    unchanged bytes; explicit direct fee rejection returns to the signing owner.
   - → `chainsource` (Ask): `RegisterSpendRequest` on the target
     outpoint to catch external spends, `BestHeightRequest`,
     `FeeEstimateRequest`.
@@ -264,16 +272,25 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 
 ## Invariants
 
-- **Persist-before-broadcast.** `startSweep` calls
-  `persistCheckpoint` (writing `b.sweepTx` into the TLV checkpoint)
-  BEFORE `txconfirm.Ask`. Any handler retry or restart restores the
-  same sweep tx, and `txconfirm`'s txid-keyed dedup makes the
-  resubmit a benign no-op — never a second sweep with a freshly
-  derived wallet pkScript racing the first on-chain.
-- **Sweep tx reuse.** `startSweep` skips `buildSweepTx` when
-  `b.sweepTx` is already set; every retry converges on the same
-  sweep txid/pkScript and avoids burning BIP32 addresses on fee-spike
-  retries.
+- **Persist-before-broadcast.** `startSweep` stages the signed candidate and
+  prior candidate history before cleanup or `txconfirm.Ask`. A restart or
+  route retry reuses that staged transaction and wallet destination.
+- **Reprice only explicit fee rejection.** `TxFailedMsg.Class` distinguishes
+  fee rejection from permanent invalidity and unknown errors. Fee rejection
+  records the rejected txid and height without consuming `SweepAttempts`.
+  A later block and a higher usable estimate permit a new signed candidate
+  with the same input, destination, sequence and locktime. The absolute fee
+  and feerate must increase within the existing cap; dust, unavailable or
+  uneconomic estimates leave the obligation pending. Replacement estimates
+  never use the emergency fallback.
+- **Either candidate may confirm.** Cancel the old txconfirm interest before
+  submitting a replacement, and attempt wallet removal as best-effort
+  housekeeping. Removal errors are logged and do not block submission.
+  Retain the old candidate's signed bytes. Confirmed spend evidence selects
+  the winning candidate for completion and fee accounting. A replacement's
+  failure, even permanent invalidity, cannot prove an earlier candidate
+  will never confirm. Keep the obligation pending while that evidence
+  arrives. Initial permanent and unknown failures retain bounded retries.
 - **Estimate before construction.** A fee-estimator error leaves the actor in
   `AwaitingSweepBroadcast` without deriving an address or consuming a sweep
   attempt. The next height retries estimation. An explicitly configured local
@@ -298,7 +315,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   A **recoverable** terminal failure is the deliberate exception: the
   VTXO was rolled back to live (wavelength#602), so `handleEnsure`
   falls through both the `r.pending` and `Store.GetRecord` arms to
-  re-admit a fresh exit rather than strand the recovered coin.
+  re-admit a fresh exit rather than strand the recovered coin. Legacy
+  terminal fee failures resume the same obligation after checkpoint and
+  policy validation. Readmission waits for the old child to stop and its
+  terminal persistence to finish, then persists a non-terminal row before
+  spawning. The daemon's existing scan of VTXOs in unilateral exit supplies
+  the boot-time Ensure request, including for historical terminal rows.
 - **Fail-closed on restore gaps.** `handleEnsure` validates restorable
   non-terminal records via `validateRestorableRecords` before re-admitting
   them; a record with an unrecognized `ExitPolicyKind` or missing ref fails
@@ -320,7 +342,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   The checkpoint codec in `snapshot.go` is also TLV.
 - **Checkpoint persists the sweep tx** via `wire.MsgTx.Serialize`
   under `checkpointSweepTxRecordType` so restore produces the exact
-  same `b.sweepTx` as the pre-broadcast commit.
+  same `b.sweepTx` as the pre-broadcast commit. Version 2 also persists
+  rejected-candidate identity, retry height and prior signed candidates.
+  Version 1 remains readable; older binaries refuse version 2, so downgrade
+  requires an explicit recovery plan for these jobs.
 - **Phase ↔ DB status mapping is lossless.** `PhaseSweepBroadcast`
   maps to `UnilateralExitJobStatusSweepBroadcasting` (=6) and
   `PhaseSweepConfirmation` to `UnilateralExitJobStatusSweeping` (=3)

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -36,8 +36,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   zero falls back to the default), `RegistryRef`.
 - `behavior` — actor behavior implementing `actor.TxBehavior[Msg, Resp,
   unrollTx]`. Holds `b.sweepTx` (restored from checkpoint on boot) so
-  retries and replays converge on a single sweep txid / pkScript under
-  `txconfirm`'s txid-keyed dedup. The `dispatch` method runs the full
+  retries and replays reuse the staged candidate under
+  `txconfirm`'s txid-keyed dedup. Explicit fee rejection permits a signed
+  replacement to the same destination; prior candidates remain checkpointed.
+  The `dispatch` method runs the full
   FSM pipeline including Stage writes; `Receive` owns the single
   lease-fenced Commit. It also tracks whether a restored checkpoint still
   needs its first reissue after re-admission.
@@ -54,7 +56,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   `PhaseMaterializing`, `PhaseCSVPending`, `PhaseSweepBroadcast`,
   `PhaseSweepConfirmation`, `PhaseCompleted`, `PhaseFailed`.
 - `JobState` — durable FSM state (height, trigger, planner state,
-  `FailReason`, `SweepAttempts`).
+  `FailReason`, `SweepAttempts`, `RejectedSweep`, `RepriceAfter`, `RetrySame`).
+  Rejected identity and height pace fee retries; `RetrySame` preserves a
+  candidate while waiting for spend evidence after replacement failure.
 
 ### Registry
 
@@ -105,7 +109,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   `validateExitPolicyIdentity` checks consistency at admit time. Dedup
   runs against `r.active`, `r.pending`, AND `Store.GetRecord` so a
   repeat after termination returns `Created=false` with the historical
-  `ActorID`, never clobbering the sweep txid / failure reason. The one
+  `ActorID`, never clobbering the sweep txid / failure reason. One
   exception is a **recoverable** terminal failure
   (`RecoverableFailure`): the prior exit failed cleanly with no on-chain
   footprint and the VTXO was rolled back to live (wavelength#602), so
@@ -113,7 +117,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   overwriting the stale record) instead of deduping — otherwise a
   recovered VTXO could never be unrolled again. Any existing unroll job
   for the same target must carry the same `(ExitPolicyKind,
-  ExitPolicyRef)`; mismatches fail closed.
+  ExitPolicyRef)`; mismatches fail closed. A legacy terminal fee rejection
+  is also resumable after validating the saved candidate and policy. Its
+  registry row becomes non-terminal before the same actor ID is restored.
 - `ExitSpendPolicyResolver` — interface for looking up the final spend
   policy by `(ExitPolicyKind, ExitPolicyRef)`. Implemented by
   `vhtlcrecovery/unrollpolicy.ExitSpendPolicyResolver`.
@@ -222,7 +228,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   counterparty spend racing our forfeit).
 - **Sends**:
   - → `txconfirm` (Ask): `EnsureConfirmedReq` per proof node and for
-    the final sweep; txid dedup makes retries idempotent.
+    the final sweep; txid dedup makes retries idempotent. Final sweeps set
+    `RetryUntilAccepted` on first submit and reissue. Transient failures retry
+    unchanged bytes; explicit direct fee rejection returns to the signing owner.
   - → `chainsource` (Ask): `RegisterSpendRequest` on the target
     outpoint to catch external spends, `BestHeightRequest`,
     `FeeEstimateRequest`.
@@ -264,16 +272,25 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
 
 ## Invariants
 
-- **Persist-before-broadcast.** `startSweep` calls
-  `persistCheckpoint` (writing `b.sweepTx` into the TLV checkpoint)
-  BEFORE `txconfirm.Ask`. Any handler retry or restart restores the
-  same sweep tx, and `txconfirm`'s txid-keyed dedup makes the
-  resubmit a benign no-op — never a second sweep with a freshly
-  derived wallet pkScript racing the first on-chain.
-- **Sweep tx reuse.** `startSweep` skips `buildSweepTx` when
-  `b.sweepTx` is already set; every retry converges on the same
-  sweep txid/pkScript and avoids burning BIP32 addresses on fee-spike
-  retries.
+- **Persist-before-broadcast.** `startSweep` stages the signed candidate and
+  prior candidate history before cleanup or `txconfirm.Ask`. A restart or
+  route retry reuses that staged transaction and wallet destination.
+- **Reprice only explicit fee rejection.** `TxFailedMsg.Class` distinguishes
+  fee rejection from permanent invalidity and unknown errors. Fee rejection
+  records the rejected txid and height without consuming `SweepAttempts`.
+  A later block and a higher usable estimate permit a new signed candidate
+  with the same input, destination, sequence and locktime. The absolute fee
+  and feerate must increase within the existing cap; dust, unavailable or
+  uneconomic estimates leave the obligation pending. Replacement estimates
+  never use the emergency fallback.
+- **Either candidate may confirm.** Cancel the old txconfirm interest before
+  submitting a replacement, and attempt wallet removal as best-effort
+  housekeeping. Removal errors are logged and do not block submission.
+  Retain the old candidate's signed bytes. Confirmed spend evidence selects
+  the winning candidate for completion and fee accounting. A replacement's
+  failure, even permanent invalidity, cannot prove an earlier candidate
+  will never confirm. Keep the obligation pending while that evidence
+  arrives. Initial permanent and unknown failures retain bounded retries.
 - **Estimate before construction.** A fee-estimator error leaves the actor in
   `AwaitingSweepBroadcast` without deriving an address or consuming a sweep
   attempt. The next height retries estimation. An explicitly configured local
@@ -298,7 +315,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   A **recoverable** terminal failure is the deliberate exception: the
   VTXO was rolled back to live (wavelength#602), so `handleEnsure`
   falls through both the `r.pending` and `Store.GetRecord` arms to
-  re-admit a fresh exit rather than strand the recovered coin.
+  re-admit a fresh exit rather than strand the recovered coin. Legacy
+  terminal fee failures resume the same obligation after checkpoint and
+  policy validation. Readmission waits for the old child to stop and its
+  terminal persistence to finish, then persists a non-terminal row before
+  spawning. The daemon's existing scan of VTXOs in unilateral exit supplies
+  the boot-time Ensure request, including for historical terminal rows.
 - **Fail-closed on restore gaps.** `handleEnsure` validates restorable
   non-terminal records via `validateRestorableRecords` before re-admitting
   them; a record with an unrecognized `ExitPolicyKind` or missing ref fails
@@ -320,7 +342,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/unroll.<
   The checkpoint codec in `snapshot.go` is also TLV.
 - **Checkpoint persists the sweep tx** via `wire.MsgTx.Serialize`
   under `checkpointSweepTxRecordType` so restore produces the exact
-  same `b.sweepTx` as the pre-broadcast commit.
+  same `b.sweepTx` as the pre-broadcast commit. Version 2 also persists
+  rejected-candidate identity, retry height and prior signed candidates.
+  Version 1 remains readable; older binaries refuse version 2, so downgrade
+  requires an explicit recovery plan for these jobs.
 - **Phase ↔ DB status mapping is lossless.** `PhaseSweepBroadcast`
   maps to `UnilateralExitJobStatusSweepBroadcasting` (=6) and
   `PhaseSweepConfirmation` to `UnilateralExitJobStatusSweeping` (=3)

--- a/unroll/README.md
+++ b/unroll/README.md
@@ -97,7 +97,7 @@ stateDiagram-v2
     AwaitingSweepBroadcast --> Failed: SweepBuildFailed<br/>(budget exhausted)
 
     AwaitingSweepConfirmation --> Completed: TxConfirmed on sweep
-    AwaitingSweepConfirmation --> AwaitingSweepBroadcast: TxFailed on sweep<br/>(retry budget remaining)
+    AwaitingSweepConfirmation --> AwaitingSweepBroadcast: TxFailed on sweep<br/>(fee rejection or retry budget remaining)
     AwaitingSweepConfirmation --> Failed: TxFailed on sweep<br/>(budget exhausted)
 
     AwaitingMaterialization --> Failed: TxFailed on proof node
@@ -123,19 +123,33 @@ Notes:
 
 ## Durability invariants
 
-Two ordering rules are load-bearing.
+Two ordering rules preserve the exit obligation.
 
 ### 1. Persist before broadcast
 
-`startSweep` writes the sweep tx to the checkpoint BEFORE asking txconfirm
-to broadcast it. On any retry (same actor lifetime or post-restart) the
-same sweep tx is restored, so:
+`startSweep` stages the signed candidate before asking txconfirm to broadcast
+it. A route retry or restart reuses those exact bytes and the same wallet
+address. An explicit relay-fee rejection leaves the exit pending. A later
+block with a higher usable estimate permits a replacement with the same input,
+destination, sequence and locktime. Both absolute fee and feerate must increase
+within the existing cap. Unavailable or uneconomic estimates leave it pending.
 
-- txconfirm's txid-keyed dedup absorbs the re-submit.
-- We never burn a new BIP32 wallet address on a retry, which would
-  otherwise race the original sweep on chain.
-- A crash between build and broadcast cannot cause a third sweep to
-  emerge from the ashes.
+The replacement and prior signed candidates are checkpointed before cancelling
+old broadcaster interest and attempting wallet removal. Broadcaster cancellation
+errors retry the same staged replacement. Wallet removal is best-effort: errors
+are logged and do not block submission or prove the old candidate is absent.
+Either candidate can still confirm; the target spend watch recognizes both and
+completion accounts for the actual winner. Even permanent rejection of a
+replacement cannot prove the prior candidate will never confirm, so the exit
+stays pending. Initial unknown errors and permanent invalidity retain bounded
+retries.
+
+Checkpoint version 2 preserves this candidate history. Version 1 remains
+readable; old binaries refuse version 2. A legacy terminal relay-fee failure
+can be re-admitted through `EnsureUnrollRequest` after its checkpoint, target
+and policy are validated. The same registry row and actor ID resume. The old
+owner must finish draining and persisting before readmission. The daemon's
+existing scan of VTXOs in unilateral exit supplies these requests on restart.
 
 Sweep construction starts only after chainsource returns a usable fee
 estimate. A temporary estimator failure leaves the actor in
@@ -165,12 +179,13 @@ restart reissue. A transient backend error keeps txconfirm in `Broadcasting`
 and retries the same signed transaction at its existing block interval,
 with operator escalation after repeated failures. Unroll keeps waiting for
 confirmation without consuming its three-attempt build/terminal-failure
-budget. The existing `ErrNonTRUCParent` gate still reports `TxFailed` for
-non-v3 ephemeral-anchor parents. Other backend rejections keep retrying;
-this change adds no backend rejection classification.
+budget. Explicit direct fee or structural rejection takes precedence over
+that retry flag and returns a classified `TxFailed` to the signing owner.
+The `ErrNonTRUCParent` gate still rejects non-v3 ephemeral-anchor parents.
 
 Txconfirm tracking is in memory. The retry flag is reconstructed by the
-sweep caller, so existing checkpoints need no migration. Boarding sweeps
+sweep caller; it needs no separate persisted field. Candidate replacement
+history uses the version-2 checkpoint described above. Boarding sweeps
 already carry a funded anchor and retain their existing retry behavior;
 ordinary anchorless wallet transactions retain their terminal default.
 

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -1580,6 +1580,7 @@ func (b *behavior) restoreCheckpoint(ctx context.Context) error {
 			decoded.Version)
 	}
 
+	reviveRejectedSweep(decoded)
 	b.pending = decoded
 	b.sweepTx = copyTx(decoded.SweepTx)
 	b.replacedSweeps = copySweepCandidates(decoded.ReplacedSweeps)

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -176,6 +176,9 @@ type behavior struct {
 
 	sweepTx *wire.MsgTx
 
+	// replacedSweeps retains signed candidates that can still confirm.
+	replacedSweeps []*wire.MsgTx
+
 	// restoredCheckpointPending keeps the first admission message on a
 	// newly constructed actor responsible for reissuing restored work, even
 	// if an older durable notification reaches the actor first.
@@ -390,17 +393,23 @@ func (b *behavior) dispatch(ctx context.Context, ax actor.Exec[unrollTx],
 		})
 
 	case *TxConfirmedMsg:
-		return b.handleEvent(ctx, ax, &TxConfirmedEvent{
-			Txid:   m.Txid,
-			Height: m.Height,
-		})
+		return b.confirmSweepCandidate(ctx, ax, m.Txid, m.Height)
 
 	case *TxFailedMsg:
+		// A replaced candidate may have a terminal notification queued
+		// before its interest was cancelled. It cannot fail the new
+		// one.
+		if b.sweepTx != nil && m.Txid != b.sweepTx.TxHash() &&
+			b.sweepCandidate(m.Txid) != nil {
+			return fn.Ok[Resp](&AckResp{})
+		}
 		b.recordFailedBroadcast(m.Txid)
 
 		return b.handleEvent(ctx, ax, &TxFailedEvent{
-			Txid:   m.Txid,
-			Reason: b.failureReasonForTx(m.Txid, m.Reason),
+			Txid:      m.Txid,
+			Reason:    b.failureReasonForTx(m.Txid, m.Reason),
+			Class:     m.Class,
+			RetrySame: len(b.replacedSweeps) > 0,
 		})
 
 	case *SpendObservedMsg:
@@ -533,39 +542,15 @@ func (b *behavior) driveEvent(ctx context.Context, ax actor.Exec[unrollTx],
 	return nil
 }
 
-// startSweep constructs the final timeout-path sweep, persists it, and
-// hands it to txconfirm for broadcast-and-wait-for-confirmation.
+// startSweep stages the signed final spend before asking txconfirm to submit
+// it. Ordinary retries reuse the same bytes. An explicit fee rejection permits
+// a higher-fee candidate for the same input and wallet destination; the old
+// candidate remains in the checkpoint so either transaction can fulfill the
+// obligation. A staged replacement is reused after restart or a failed route.
 //
-// Ordering here is load-bearing. The guiding rule is: never cross the
-// actor-boundary with a fresh sweep that the checkpoint has not yet
-// seen. Three consequences of breaking that rule make the order
-// non-obvious:
-//
-//  1. The sweep destination comes from a new BIP32 wallet address. A
-//     second, freshly-derived sweep after a retry burns a new address
-//     and races the first on chain. If both land we leak data about the
-//     wallet's key derivation.
-//
-//  2. txconfirm dedups by txid. If the re-submitted sweep has a
-//     different txid (even one output byte differs: new pkScript, new
-//     fee) the dedup misses and we double-broadcast.
-//
-//  3. A crash between "sign new sweep" and "broadcast new sweep" that
-//     happens AFTER the on-chain broadcast of an earlier attempt means
-//     restart has no trail of the broadcast sweep at all — it would
-//     build a third sweep.
-//
-// The fix is to reuse b.sweepTx (possibly restored from the checkpoint
-// via restoreCheckpoint) when it is already set, and to persist the
-// checkpoint BEFORE asking txconfirm to broadcast. On restart the same
-// transaction materializes from the checkpoint, txconfirm sees the same
-// txid it has been tracking, and the Ask resolves as a benign no-op.
-//
-// A temporarily unavailable fee estimate defers construction until the next
-// height without consuming the retry budget. Other build failures (signing,
-// malformed descriptor, or an invalid estimate) drive a SweepBuildFailedEvent
-// through the FSM so the retry budget is accounted for and the job reaches
-// terminal Failed after maxSweepAttempts.
+// Fee-estimator outages defer construction. Repricing waits for a later block
+// and a usable estimate without consuming the terminal sweep-attempt budget.
+// Other initial build failures retain the existing bounded retry behavior.
 func (b *behavior) startSweep(ctx context.Context,
 	ax actor.Exec[unrollTx]) error {
 
@@ -589,6 +574,31 @@ func (b *behavior) startSweep(ctx context.Context,
 	if b.sweepTx == nil {
 		if err := b.adoptStagedSweep(ctx, ax); err != nil {
 			return err
+		}
+	}
+
+	// An explicit rejection keeps the obligation active. Rebuild only if
+	// the stored candidate is still the rejected one; a different cached
+	// candidate was already prepared before a crash or route retry.
+	state, err := b.currentState()
+	if err != nil {
+		return err
+	}
+	rejected := stateJob(state).RejectedSweep
+	if rejected.IsSome() && !stateJob(state).RetrySame &&
+		b.sweepTx != nil &&
+		b.sweepTx.TxHash() == rejected.UnsafeFromSome() {
+
+		improved, err := b.repriceSweep(ctx)
+		if err != nil {
+			b.log.InfoS(ctx, "Deferring rejected sweep replacement",
+				slog.String("err", err.Error()),
+			)
+
+			return nil
+		}
+		if !improved {
+			return nil
 		}
 	}
 
@@ -742,6 +752,16 @@ func (b *behavior) startSweep(ctx context.Context,
 	// the EnsureConfirmedReq Ask below runs with no writer held.
 	if err := b.persistCheckpoint(ctx, ax); err != nil {
 		return err
+	}
+
+	if rejected.IsSome() &&
+		b.sweepTx.TxHash() != rejected.UnsafeFromSome() {
+
+		if err := b.stopRejectedSweep(
+			ctx, rejected.UnsafeFromSome(),
+		); err != nil {
+			return err
+		}
 	}
 
 	sweepPkScript, err := safeTxOutPkScript(b.sweepTx, 0)
@@ -1554,13 +1574,15 @@ func (b *behavior) restoreCheckpoint(ctx context.Context) error {
 		return err
 	}
 
-	if decoded.Version != checkpointVersion {
+	if decoded.Version != checkpointVersion &&
+		decoded.Version != 1 {
 		return fmt.Errorf("unknown checkpoint version %d",
 			decoded.Version)
 	}
 
 	b.pending = decoded
 	b.sweepTx = copyTx(decoded.SweepTx)
+	b.replacedSweeps = copySweepCandidates(decoded.ReplacedSweeps)
 	b.restoredCheckpointPending = decoded.Started
 
 	return nil
@@ -2021,9 +2043,9 @@ func (b *behavior) sourceSpendCallerID(outpoint wire.OutPoint) string {
 //  2. The spender is a known node in our recovery proof. That means an
 //     ancestor just confirmed; this is normal materialization traffic.
 //
-//  3. The spender is our own final sweep (matched by the sweep txid
-//     recorded in planner state). Again benign — our sweep confirming is
-//     the goal — so just propagate the height.
+//  3. The spender is a retained signed sweep candidate. Select its exact
+//     transaction for fee accounting and complete the exit, including when
+//     an earlier candidate wins the replacement race.
 //
 //  4. Anything else: the watched output was spent by someone else. This can
 //     happen if the operator cooperatively claims it, if a fraud party
@@ -2061,22 +2083,13 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 		}
 	}
 
-	// Case 3: the spender is our own sweep. Same benign outcome — we
-	// are watching our own success from a different vantage point.
-	// Compare against the sweep txid recorded in planner state
-	// (SweepBroadcastedEvent populates that) rather than b.sweepTx,
-	// so we catch the late-arriving spend notification even if the
-	// behavior has already cleared its in-memory cache.
-	state, err := b.currentState()
-	if err == nil {
-		job := stateJob(state)
-		if job.PlannerState.Sweep.Txid.IsSome() &&
-			job.PlannerState.Sweep.Txid.UnsafeFromSome() ==
-				msg.SpendingTxid {
-			return b.handleEvent(ctx, ax, &HeightUpdatedEvent{
-				Height: msg.SpendingHeight,
-			})
-		}
+	// Any retained candidate can win the replacement race. The spend
+	// notification is confirmed-chain evidence, so select its exact bytes
+	// for terminal accounting before completing the obligation.
+	if b.sweepCandidate(msg.SpendingTxid) != nil {
+		return b.confirmSweepCandidate(
+			ctx, ax, msg.SpendingTxid, msg.SpendingHeight,
+		)
 	}
 
 	// Case 4: neither of the above. Someone else spent the watched output.
@@ -2181,6 +2194,7 @@ func (b *behavior) checkpointWrite() (*actorCheckpoint,
 	}
 
 	checkpoint := checkpointFromState(state, b.sweepTx)
+	checkpoint.ReplacedSweeps = copySweepCandidates(b.replacedSweeps)
 	raw, err := encodeCheckpoint(checkpoint)
 	if err != nil {
 		return nil, nil, err
@@ -2270,13 +2284,17 @@ func (b *behavior) adoptStagedSweep(ctx context.Context,
 			return err
 		}
 
-		if decoded.Version != checkpointVersion {
+		if decoded.Version != checkpointVersion &&
+			decoded.Version != 1 {
 			return fmt.Errorf("unknown checkpoint version %d",
 				decoded.Version)
 		}
 
 		if decoded.SweepTx != nil {
 			b.sweepTx = copyTx(decoded.SweepTx)
+			b.replacedSweeps = copySweepCandidates(
+				decoded.ReplacedSweeps,
+			)
 		}
 
 		return nil

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -1520,6 +1520,7 @@ func mapTxconfirmNotification(msg txconfirm.Notification) (Msg, bool) {
 		return &TxFailedMsg{
 			Txid:   m.Txid,
 			Reason: m.Reason,
+			Class:  m.Class,
 		}, true
 
 	default:

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -181,6 +181,16 @@ func (f *fakeTxConfirmRef) Ask(_ context.Context,
 
 	promise := actor.NewPromise[txconfirm.Resp]()
 
+	if _, ok := msg.(*txconfirm.CancelInterestReq); ok {
+		promise.Complete(
+			fn.Ok[txconfirm.Resp](
+				&txconfirm.CancelInterestResp{},
+			),
+		)
+
+		return promise.Future()
+	}
+
 	req, ok := msg.(*txconfirm.EnsureConfirmedReq)
 	if !ok {
 		promise.Complete(

--- a/unroll/fsm_logic.go
+++ b/unroll/fsm_logic.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/lightninglabs/wavelength/lib/recovery"
+	"github.com/lightninglabs/wavelength/txconfirm"
 	"github.com/lightninglabs/wavelength/unrollplan"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
@@ -92,6 +93,9 @@ func processEventWithJob(ctx context.Context, job *JobState, event Event,
 		applyFailedEvent(nextJob, e)
 
 	case *SweepBroadcastedEvent:
+		nextJob.RejectedSweep = fn.None[chainhash.Hash]()
+		nextJob.RepriceAfter = 0
+		nextJob.RetrySame = false
 		nextJob.PlannerState.Sweep.Status =
 			unrollplan.SweepStatusBroadcasted
 		nextJob.PlannerState.Sweep.Txid = fn.Some(e.Txid)
@@ -275,7 +279,9 @@ func deriveStateTransition(ctx context.Context, job *JobState, env *Environment,
 		// Target confirmed + CSV matured = it is time to build
 		// and broadcast the sweep. The RequestSweepBuild outbox
 		// event is what triggers startSweep in the actor behavior.
-		outbox = append(outbox, &RequestSweepBuild{})
+		if job.RejectedSweep.IsNone() || job.Height > job.RepriceAfter {
+			outbox = append(outbox, &RequestSweepBuild{})
+		}
 
 		return transitionWithOutbox(
 			&AwaitingSweepBroadcast{
@@ -403,28 +409,43 @@ func applyConfirmedEvent(job *JobState, event *TxConfirmedEvent,
 	}
 }
 
-// applyFailedEvent records a single txconfirm failure. Proof-node
-// failures and sweep failures have different semantics:
-//
-//   - A proof-graph transaction failing is terminal. There is no way
-//     for the client to rebuild or replace an operator-signed proof
-//     node, so the only option is to surface the reason and stop.
-//
-//   - A sweep failing is often recoverable (fee too low, mempool
-//     contention, fee-spike eviction). applySweepBuildFailed bumps a
-//     retry counter and, if the budget is not exhausted, clears the
-//     planner's sweep state so deriveStateTransition will emit a fresh
-//     RequestSweepBuild. The actor's cached sweepTx also gets cleared
-//     on the next attempt because the FSM state carries
-//     SweepStatusPending again.
+// applyFailedEvent distinguishes immutable proof failure from sweep failure.
+// A fee-rejected sweep remains a live obligation and retries on a later block.
+// Its separate rejected identity makes repeated failure delivery idempotent.
+// Initial non-fee failures retain bounded retries. Once a replacement exists,
+// its failure cannot prove an earlier candidate will never confirm, so the
+// obligation stays pending. Immutable proof failures remain terminal.
 func applyFailedEvent(job *JobState, event *TxFailedEvent) {
 	if job == nil || event == nil {
+		return
+	}
+
+	// The rejected candidate is already scheduled for recovery. Replaying
+	// its failure cannot consume an attempt or move the retry deadline.
+	if job.RejectedSweep.IsSome() &&
+		job.RejectedSweep.UnsafeFromSome() == event.Txid {
 		return
 	}
 
 	// Detect sweep-tx failure by matching against the recorded sweep txid.
 	if job.PlannerState.Sweep.Txid.IsSome() &&
 		job.PlannerState.Sweep.Txid.UnsafeFromSome() == event.Txid {
+
+		if event.Class == txconfirm.BroadcastFailureFee ||
+			event.RetrySame {
+
+			if job.RejectedSweep.IsNone() {
+				job.RejectedSweep = fn.Some(event.Txid)
+				job.RepriceAfter = job.Height
+				job.RetrySame = event.Class !=
+					txconfirm.BroadcastFailureFee
+			}
+			job.PlannerState.Sweep.Status =
+				unrollplan.SweepStatusPending
+			job.PlannerState.Sweep.Txid = fn.None[chainhash.Hash]()
+
+			return
+		}
 
 		applySweepBuildFailed(job, event.Reason)
 

--- a/unroll/fsm_types.go
+++ b/unroll/fsm_types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/protofsm"
 	"github.com/lightninglabs/wavelength/lib/recovery"
+	"github.com/lightninglabs/wavelength/txconfirm"
 	"github.com/lightninglabs/wavelength/unrollplan"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
@@ -112,6 +113,17 @@ type JobState struct {
 	// SweepAttempts counts sweep build or broadcast failures so the actor
 	// can retry up to maxSweepAttempts before giving up.
 	SweepAttempts int
+
+	// RejectedSweep identifies the candidate awaiting fee replacement.
+	// Retaining its identity makes repeated failure delivery idempotent.
+	RejectedSweep fn.Option[chainhash.Hash]
+
+	// RepriceAfter defers fee recovery until a later observed block.
+	RepriceAfter int32
+
+	// RetrySame preserves ambiguous candidates while awaiting spend
+	// evidence.
+	RetrySame bool
 }
 
 // Copy returns a deep copy of the job state.
@@ -131,6 +143,9 @@ func (j *JobState) Copy() *JobState {
 		FailReason:          j.FailReason,
 		Conflicted:          j.Conflicted,
 		SweepAttempts:       j.SweepAttempts,
+		RejectedSweep:       j.RejectedSweep,
+		RepriceAfter:        j.RepriceAfter,
+		RetrySame:           j.RetrySame,
 	}
 
 	return copyState
@@ -149,6 +164,7 @@ type DeferredCheckpoint struct {
 
 // Event is the sealed input event surface accepted by the unroll FSM.
 type Event interface {
+	// eventSealed restricts events to this state machine.
 	eventSealed()
 }
 
@@ -208,6 +224,13 @@ type TxFailedEvent struct {
 
 	// Reason is the stable human-readable failure reason.
 	Reason string
+
+	// Class distinguishes explicit fee rejection from unknown failure.
+	Class txconfirm.BroadcastFailureClass
+
+	// RetrySame keeps earlier candidates observable after replacement
+	// races.
+	RetrySame bool
 }
 
 // eventSealed marks TxFailedEvent as an FSM event.
@@ -251,6 +274,7 @@ func (e *SweepBuildFailedEvent) eventSealed() {}
 
 // OutboxEvent is the sealed outbox side-effect surface emitted by the FSM.
 type OutboxEvent interface {
+	// outboxEventSealed restricts side effects to the unroll actor.
 	outboxEventSealed()
 }
 
@@ -302,6 +326,7 @@ func (o *ReissueSweepConfirmation) outboxEventSealed() {}
 type State interface {
 	protofsm.State[Event, OutboxEvent, *Environment]
 
+	// stateSealed restricts states to this lifecycle.
 	stateSealed()
 }
 

--- a/unroll/legacy_reprice.go
+++ b/unroll/legacy_reprice.go
@@ -1,0 +1,131 @@
+package unroll
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/txconfirm"
+	"github.com/lightninglabs/wavelength/unrollplan"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// feeRejectedSweepReason recognizes the old terminal error format only when
+// it names this exact sweep. Proof failures and unrelated policy errors cannot
+// authorize migration into a live sweep obligation.
+func feeRejectedSweepReason(txid chainhash.Hash, reason string) bool {
+	prefix := "sweep tx " + txid.String() + " failed:"
+
+	return strings.HasPrefix(reason, prefix) &&
+		txconfirm.ClassifyBroadcastFailure(errors.New(reason)) ==
+			txconfirm.BroadcastFailureFee
+}
+
+// feeRejectedRecord selects terminal rows eligible for checkpoint validation.
+// This predicate alone never authorizes spawning or changing a durable row.
+func feeRejectedRecord(record RegistryRecord) bool {
+	return record.Phase == PhaseFailed && !record.ConflictedFailure &&
+		record.SweepTxid != nil &&
+		feeRejectedSweepReason(*record.SweepTxid, record.FailReason)
+}
+
+// reviveRejectedSweep restores legacy fee failures as the same obligation.
+// The next normal Stage persists this state before cleanup or broadcast. A
+// crash before that Stage repeats the deterministic conversion from version 1.
+func reviveRejectedSweep(checkpoint *actorCheckpoint) bool {
+	if checkpoint == nil || checkpoint.SweepTx == nil ||
+		checkpoint.Conflicted ||
+		!feeRejectedSweepReason(
+			checkpoint.SweepTx.TxHash(), checkpoint.Fail,
+		) {
+		return false
+	}
+	txid := checkpoint.SweepTx.TxHash()
+	checkpoint.Fail = ""
+	checkpoint.SweepAttempts = 0
+	checkpoint.State.Sweep.Status = unrollplan.SweepStatusPending
+	checkpoint.State.Sweep.Txid = fn.None[chainhash.Hash]()
+	checkpoint.RejectedSweep = fn.Some(txid)
+	checkpoint.RepriceAfter = checkpoint.Height
+	checkpoint.RetrySame = false
+
+	return true
+}
+
+// prepareFeeReadmission validates the durable candidate and policy before
+// making a legacy terminal row discoverable by normal restart recovery. The
+// row is persisted before spawning, so a crash cannot lose the obligation.
+func (r *registryBehavior) prepareFeeReadmission(ctx context.Context,
+	record *RegistryRecord, req *EnsureUnrollRequest) error {
+
+	if record.ActorID != actorIDForTarget(req.Outpoint) ||
+		exitPolicyKind(record.ExitPolicyKind) != exitPolicyKind(
+			req.ExitPolicyKind,
+		) ||
+		record.ExitPolicyRef != req.ExitPolicyRef {
+		return fmt.Errorf("rejected sweep obligation identity mismatch")
+	}
+	if err := r.validateRestorableRecords(
+		[]RegistryRecord{*record},
+	); err != nil {
+		return err
+	}
+	stored, err := r.cfg.DeliveryStore.LoadCheckpoint(ctx, record.ActorID)
+	if err != nil {
+		return err
+	}
+	if stored == nil {
+		return fmt.Errorf("rejected sweep checkpoint missing")
+	}
+	checkpoint, err := decodeCheckpoint(stored.StateData)
+	if err != nil {
+		return err
+	}
+	candidate := checkpoint.SweepTx
+	if candidate == nil || len(candidate.TxIn) != 1 ||
+		len(candidate.TxOut) != 1 ||
+		candidate.TxIn[0].PreviousOutPoint != req.Outpoint ||
+		candidate.TxHash() != *record.SweepTxid ||
+		exitPolicyKind(checkpoint.ExitPolicyKind) != exitPolicyKind(
+			record.ExitPolicyKind,
+		) ||
+		checkpoint.ExitPolicyRef != record.ExitPolicyRef ||
+		!reviveRejectedSweep(checkpoint) {
+		return fmt.Errorf("rejected sweep checkpoint does not match " +
+			"terminal record")
+	}
+	next := cloneRegistryRecord(*record)
+	next.Phase = PhaseSweepBroadcast
+	next.FailReason = ""
+	next.RecoverableFailure = false
+	if err := r.cfg.Store.UpsertRecord(ctx, next); err != nil {
+		return fmt.Errorf("persist rejected sweep readmission: %w", err)
+	}
+	*record = next
+
+	return nil
+}
+
+// feeReadmissionReady fences readmission behind the old mailbox owner and its
+// asynchronous terminal write. The caller can retry after either completes.
+func (r *registryBehavior) feeReadmissionReady(target wire.OutPoint) error {
+	if drained, ok := r.feeFailureDrains[target]; ok {
+		select {
+		case <-drained:
+			delete(r.feeFailureDrains, target)
+
+		default:
+			return fmt.Errorf("prior sweep owner draining; retry " +
+				"admission")
+		}
+	}
+	if record, ok := r.pending[target]; ok && feeRejectedRecord(record) {
+		return fmt.Errorf("terminal sweep persistence pending; retry " +
+			"admission")
+	}
+
+	return nil
+}

--- a/unroll/legacy_reprice_test.go
+++ b/unroll/legacy_reprice_test.go
@@ -1,0 +1,133 @@
+package unroll
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/unrollplan"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLegacyFeeReadmissionGuards proves that permanent failures, mismatched
+// checkpoint identity and unfinished old ownership cannot start another actor.
+func TestLegacyFeeReadmissionGuards(t *testing.T) {
+	for _, name := range []string{
+		"permanent",
+		"candidateMismatch",
+		"policyMismatch",
+		"draining",
+		"persisting",
+		"writeFailure",
+	} {
+		t.Run(name, func(t *testing.T) {
+			testLegacyFeeReadmissionGuard(t, name)
+		})
+	}
+}
+
+// testLegacyFeeReadmissionGuard runs one legacy admission boundary case.
+func testLegacyFeeReadmissionGuard(t *testing.T, name string) {
+	t.Helper()
+	proof := buildLinearProof(t)
+	target := proof.TargetOutpoint()
+	desc := testDescriptor(t, target, proof.CSVDelay())
+	tx, err := buildSweepTx(
+		t.Context(), &fakeSweepWallet{}, &fakeChainSourceRef{}, proof,
+		desc, 0, 0, 104, NewStandardVTXOExitSpendPolicy(desc),
+	)
+	require.NoError(t, err)
+	txid := tx.TxHash()
+	reason := "sweep tx " + txid.String() + " failed: min relay fee not met"
+	if name == "permanent" {
+		reason = "sweep tx " + txid.String() +
+			" failed: mandatory-script-verify-flag-failed"
+	}
+	row := RegistryRecord{TargetOutpoint: target, ActorID: actorIDForTarget(
+		target,
+	),
+		Phase: PhaseFailed, FailReason: reason, SweepTxid: &txid}
+	cp := &actorCheckpoint{
+		Version: 1, Started: true, Height: 104,
+		SweepTx: tx, Fail: reason,
+		State: unrollplan.State{ConfirmedTxids: []chainhash.Hash{
+			proof.RootTxids()[0],
+			target.Hash,
+		},
+			TargetConfirmHeight: fn.Some[int32](102),
+			Sweep: unrollplan.SweepState{
+				Status: unrollplan.SweepStatusBroadcasted,
+				Txid:   fn.Some(txid),
+			}},
+	}
+	if name == "candidateMismatch" {
+		cp.SweepTx.TxOut[0].Value--
+	}
+	if name == "policyMismatch" {
+		cp.ExitPolicyKind = "other-policy"
+		cp.ExitPolicyRef = "other-ref"
+	}
+	raw, err := encodeCheckpoint(cp)
+	require.NoError(t, err)
+	delivery := newMemCheckpointStore()
+	require.NoError(
+		t,
+		delivery.SaveCheckpoint(
+			t.Context(), actor.CheckpointParams{
+				ActorID:   row.ActorID,
+				StateData: raw,
+			},
+		),
+	)
+	store := newMemRegistryStore()
+	require.NoError(t, store.UpsertRecord(t.Context(), row))
+	r := &registryBehavior{
+		cfg: RegistryConfig{
+			Store:         store,
+			DeliveryStore: delivery,
+		},
+	}
+	if name == "writeFailure" {
+		r.cfg.Store = &readmissionFailStore{store}
+	}
+	if name == "draining" {
+		r.feeFailureDrains = map[wire.OutPoint]<-chan struct{}{
+			target: make(chan struct{}),
+		}
+	}
+	if name == "persisting" {
+		r.pending = map[wire.OutPoint]RegistryRecord{
+			target: row,
+		}
+	}
+	_, err = r.
+		handleEnsure(
+			t.Context(),
+			&EnsureUnrollRequest{Outpoint: target},
+		).
+		Unpack()
+	if name == "permanent" {
+		require.NoError(t, err)
+	} else {
+		require.Error(t, err)
+	}
+	unchanged, err := store.GetRecord(t.Context(), target)
+	require.NoError(t, err)
+	require.Equal(t, row, *unchanged)
+	require.Empty(t, r.active)
+}
+
+// readmissionFailStore models a database failure before a legacy row is
+// revived.
+type readmissionFailStore struct{ *memRegistryStore }
+
+// UpsertRecord refuses the recovery write without modifying the durable record.
+func (s *readmissionFailStore) UpsertRecord(_ context.Context,
+	_ RegistryRecord) error {
+
+	return errors.New("readmission write unavailable")
+}

--- a/unroll/messages.go
+++ b/unroll/messages.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/txconfirm"
 	"github.com/lightninglabs/wavelength/unrollplan"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -72,6 +73,7 @@ const (
 
 	txFailedTxidRecType   tlv.Type = 1
 	txFailedReasonRecType tlv.Type = 3
+	txFailedClassRecType  tlv.Type = 5
 
 	spendObservedTxidRecType     tlv.Type = 1
 	spendObservedHeightRecType   tlv.Type = 3
@@ -463,6 +465,9 @@ type TxFailedMsg struct {
 
 	// Reason is the stable human-readable failure reason.
 	Reason string
+
+	// Class is optional in old messages; absence keeps the failure unknown.
+	Class txconfirm.BroadcastFailureClass
 }
 
 // MessageType returns the stable message type identifier.
@@ -484,10 +489,12 @@ func (m *TxFailedMsg) Priority() int {
 func (m *TxFailedMsg) Encode(w io.Writer) error {
 	txid := [32]byte(m.Txid)
 	reason := []byte(m.Reason)
+	class := uint8(m.Class)
 
 	stream, err := tlv.NewStream(
 		tlv.MakePrimitiveRecord(txFailedTxidRecType, &txid),
 		tlv.MakePrimitiveRecord(txFailedReasonRecType, &reason),
+		tlv.MakePrimitiveRecord(txFailedClassRecType, &class),
 	)
 	if err != nil {
 		return fmt.Errorf("create stream: %w", err)
@@ -501,11 +508,13 @@ func (m *TxFailedMsg) Decode(r io.Reader) error {
 	var (
 		txid   [32]byte
 		reason []byte
+		class  uint8
 	)
 
 	stream, err := tlv.NewStream(
 		tlv.MakePrimitiveRecord(txFailedTxidRecType, &txid),
 		tlv.MakePrimitiveRecord(txFailedReasonRecType, &reason),
+		tlv.MakePrimitiveRecord(txFailedClassRecType, &class),
 	)
 	if err != nil {
 		return fmt.Errorf("create stream: %w", err)
@@ -517,6 +526,7 @@ func (m *TxFailedMsg) Decode(r io.Reader) error {
 
 	m.Txid = chainhash.Hash(txid)
 	m.Reason = string(reason)
+	m.Class = txconfirm.BroadcastFailureClass(class)
 
 	return nil
 }

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -282,6 +282,10 @@ type registryBehavior struct {
 	pending    map[wire.OutPoint]RegistryRecord
 	persisting map[wire.OutPoint]RegistryRecord
 
+	// feeFailureDrains prevents legacy readmission before the old durable
+	// mailbox owner has acknowledged its terminal message and stopped.
+	feeFailureDrains map[wire.OutPoint]<-chan struct{}
+
 	proofNodeFloorAlerts *proofNodeFloorAlertDeduper
 
 	spawnFunc func(context.Context, wire.OutPoint) (*VTXOUnrollActor, error)
@@ -479,6 +483,10 @@ func (r *registryBehavior) handleEnsure(ctx context.Context,
 		})
 	}
 
+	if err := r.feeReadmissionReady(req.Outpoint); err != nil {
+		return fn.Err[RegistryResp](err)
+	}
+
 	// Terminal records leave the active map before their persistence
 	// write completes, so fall back to the in-memory pending cache and
 	// the durable store. Re-spawning a fresh actor on top of an existing
@@ -502,6 +510,12 @@ func (r *registryBehavior) handleEnsure(ctx context.Context,
 		return fn.Err[RegistryResp](
 			fmt.Errorf("lookup existing record: %w", err),
 		)
+	}
+	if existing != nil && feeRejectedRecord(*existing) {
+		err := r.prepareFeeReadmission(ctx, existing, req)
+		if err != nil {
+			return fn.Err[RegistryResp](err)
+		}
 	}
 	if existing != nil {
 		// A durable record exists but no child is live for it. Two
@@ -1019,7 +1033,15 @@ func (r *registryBehavior) handleTerminated(ctx context.Context,
 
 		// Terminal child drain uses its own bounded cleanup context.
 		//nolint:contextcheck
-		stopChildAfterDrain(child)
+		drained := stopChildAfterDrain(child)
+		if feeRejectedRecord(record) {
+			if r.feeFailureDrains == nil {
+				r.feeFailureDrains = make(
+					map[wire.OutPoint]<-chan struct{},
+				)
+			}
+			r.feeFailureDrains[req.Outpoint] = drained
+		}
 		delete(r.active, req.Outpoint)
 	}
 
@@ -1117,12 +1139,16 @@ func (r *registryBehavior) notifyVTXOExit(ctx context.Context,
 
 // stopChildAfterDrain stops a terminal child only after a queued status probe
 // has had a chance to run behind the currently-processing terminal message.
-func stopChildAfterDrain(child *VTXOUnrollActor) {
+func stopChildAfterDrain(child *VTXOUnrollActor) <-chan struct{} {
+	drained := make(chan struct{})
 	if child == nil || child.Ref() == nil {
-		return
+		close(drained)
+
+		return drained
 	}
 
 	go func() {
+		defer close(drained)
 		defer child.Stop()
 
 		ctx, cancel := context.WithTimeout(
@@ -1137,6 +1163,8 @@ func stopChildAfterDrain(child *VTXOUnrollActor) {
 		// been acked.
 		_ = child.Ref().Ask(ctx, &GetStateRequest{}).Await(ctx)
 	}()
+
+	return drained
 }
 
 // handleRestoreNonTerminal is the daemon's boot entry point for the

--- a/unroll/rejection_message_test.go
+++ b/unroll/rejection_message_test.go
@@ -1,0 +1,45 @@
+package unroll
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lightninglabs/wavelength/txconfirm"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFailureClassDurableRoundTrip proves the rejection disposition survives
+// the txconfirm adapter and durable mailbox, while old records stay unknown.
+func TestFailureClassDurableRoundTrip(t *testing.T) {
+	for _, class := range []txconfirm.BroadcastFailureClass{
+		txconfirm.BroadcastFailureUnknown,
+		txconfirm.BroadcastFailureFee,
+		txconfirm.BroadcastFailurePermanent,
+	} {
+		msg, ok := mapTxconfirmNotification(&txconfirm.TxFailed{
+			Class: class, Reason: "backend rejected transaction",
+		})
+		require.True(t, ok)
+		var buf bytes.Buffer
+		failed, ok := msg.(*TxFailedMsg)
+		require.True(t, ok)
+		require.NoError(t, failed.Encode(&buf))
+		var restored TxFailedMsg
+		require.NoError(t, restored.Decode(&buf))
+		require.Equal(t, class, restored.Class)
+	}
+
+	var txid [32]byte
+	reason := []byte("legacy failure")
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(txFailedTxidRecType, &txid),
+		tlv.MakePrimitiveRecord(txFailedReasonRecType, &reason),
+	)
+	require.NoError(t, err)
+	var legacy bytes.Buffer
+	require.NoError(t, stream.Encode(&legacy))
+	var restored TxFailedMsg
+	require.NoError(t, restored.Decode(&legacy))
+	require.Equal(t, txconfirm.BroadcastFailureUnknown, restored.Class)
+}

--- a/unroll/reprice_restart_test.go
+++ b/unroll/reprice_restart_test.go
@@ -1,0 +1,385 @@
+package unroll
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/chainsource"
+	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/db/actordelivery"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/recovery"
+	"github.com/lightninglabs/wavelength/txconfirm"
+	"github.com/lightninglabs/wavelength/unrollplan"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/clock"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/stretchr/testify/require"
+)
+
+// signedSweepWallet signs the actual timeout leaf for script-engine validation.
+type signedSweepWallet struct {
+	fakeSweepWallet
+	key *btcec.PrivateKey
+}
+
+// SignOutputRaw signs the complete transaction digest, including the new fee.
+func (w *signedSweepWallet) SignOutputRaw(tx *wire.MsgTx,
+	desc *input.SignDescriptor) (input.Signature, error) {
+
+	digest, err := txscript.CalcTapscriptSignaturehash(
+		desc.SigHashes, desc.HashType, tx, desc.InputIndex,
+		desc.PrevOutputFetcher,
+		txscript.NewBaseTapLeaf(desc.WitnessScript),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return schnorr.Sign(w.key, digest)
+}
+
+// feeFloorChain applies a deterministic relay floor after validating
+// signatures. The real txconfirm actor handles its broadcast errors and
+// notifications.
+type feeFloorChain struct {
+	*sweptSourceChain
+	target    *wire.TxOut
+	submitted chan *wire.MsgTx
+	verified  chan error
+}
+
+// Ask checks every signed candidate before simulating low-fee node rejection.
+func (c *feeFloorChain) Ask(ctx context.Context,
+	msg chainsource.ChainSourceMsg,
+) actor.Future[chainsource.ChainSourceResp] {
+
+	req, ok := msg.(*chainsource.BroadcastTxRequest)
+	if !ok {
+		return c.sweptSourceChain.Ask(ctx, msg)
+	}
+	p := actor.NewPromise[chainsource.ChainSourceResp]()
+	tx := req.Tx.Copy()
+	prev := txscript.NewCannedPrevOutputFetcher(
+		c.target.PkScript, c.target.Value,
+	)
+	engine, err := txscript.NewEngine(
+		c.target.PkScript, tx, 0, txscript.StandardVerifyFlags, nil,
+		txscript.NewTxSigHashes(tx, prev), c.target.Value, prev,
+	)
+	if err == nil {
+		err = engine.Execute()
+	}
+	c.verified <- err
+	if err == nil && c.target.Value-tx.TxOut[0].Value < 1000 {
+		err = errors.New("min relay fee not met")
+	}
+	c.submitted <- tx
+	if err != nil {
+		p.Complete(fn.Err[chainsource.ChainSourceResp](err))
+	} else {
+		p.Complete(
+			fn.Ok[chainsource.ChainSourceResp](
+				&chainsource.BroadcastTxResponse{
+					Txid: tx.TxHash(),
+				},
+			),
+		)
+	}
+
+	return p.Future()
+}
+
+// signedSweepFixture creates a proof with the actual taproot timeout output.
+func signedSweepFixture(t *testing.T) (*recovery.Proof, *vtxo.Descriptor,
+	*signedSweepWallet) {
+
+	t.Helper()
+	original := buildLinearProof(t)
+	desc := testDescriptor(
+		t, original.TargetOutpoint(), original.CSVDelay(),
+	)
+	key, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	desc.ClientKey.PubKey = key.PubKey()
+	desc.TapScript, err = arkscript.VTXOTapScript(
+		key.PubKey(), desc.OperatorKey, desc.RelativeExpiry,
+	)
+	require.NoError(t, err)
+	outputKey := txscript.ComputeTaprootOutputKey(
+		desc.TapScript.ControlBlock.InternalKey,
+		desc.TapScript.RootHash,
+	)
+	desc.PkScript, err = txscript.PayToTaprootScript(outputKey)
+	require.NoError(t, err)
+	root, _ := original.Node(original.RootTxids()[0])
+	target, _ := original.Node(original.TargetOutpoint().Hash)
+	tx := target.Tx.Copy()
+	tx.TxOut[0].PkScript = desc.PkScript
+	desc.Outpoint = wire.OutPoint{Hash: tx.TxHash()}
+	proof, err := recovery.NewProof(
+		desc.Outpoint, desc.RelativeExpiry, root, &recovery.Node{
+			Kind: recovery.NodeKindTree,
+			Tx:   tx,
+		},
+	)
+	require.NoError(t, err)
+
+	return proof, desc, &signedSweepWallet{key: key}
+}
+
+// TestFeeRejectedSweepDurableRestart covers both live typed rejection and a
+// version-1 terminal checkpoint through SQLite, registry admission, the durable
+// child and the production broadcaster. Completion requires chain evidence.
+func TestFeeRejectedSweepDurableRestart(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		t.Run(fmt.Sprintf("legacy=%v", legacy), func(t *testing.T) {
+			testFeeRejectedSweepDurableRestart(t, legacy)
+		})
+	}
+}
+
+// testFeeRejectedSweepDurableRestart runs one durable recovery scenario.
+func testFeeRejectedSweepDurableRestart(t *testing.T, legacy bool) {
+	t.Helper()
+	proof, desc, wallet := signedSweepFixture(t)
+	target := proof.TargetOutpoint()
+	output, err := proof.TargetOutput()
+	require.NoError(t, err)
+	chain := &feeFloorChain{
+		sweptSourceChain: &sweptSourceChain{
+			fakeChainSourceRef: &fakeChainSourceRef{
+				bestHeight: 104,
+				feeRate:    2,
+			},
+			blocks: nil,
+		},
+		verified: make(chan error, 16),
+		target:   output, submitted: make(
+			chan *wire.MsgTx, 16,
+		),
+	}
+	chain.blocks = make(
+		map[string]actor.TellOnlyRef[chainsource.BlockEpoch],
+	)
+	sqlDB := db.NewTestDB(t)
+	clk := clock.NewDefaultClock()
+	stores := db.NewStore(
+		sqlDB.DB, sqlDB.Queries, sqlDB.Backend(), btclog.Disabled,
+	)
+	delivery, err := actordelivery.NewTxAwareDeliveryStoreFromDB(
+		sqlDB.DB, sqlDB.Backend(), clk, btclog.Disabled,
+	)
+	require.NoError(t, err)
+	store := &DBRegistryStore{
+		UEStore: stores.NewUnilateralExitStore(clk),
+	}
+	id := actorIDForTarget(target)
+	cp := &actorCheckpoint{
+		Version: 1, Height: 104, Started: true, Trigger: TriggerRestart,
+		State: unrollplan.State{
+			ConfirmedTxids: []chainhash.Hash{
+				proof.RootTxids()[0],
+				target.Hash,
+			},
+			TargetConfirmHeight: fn.Some[int32](102),
+		},
+	}
+	row := RegistryRecord{TargetOutpoint: target, ActorID: id,
+		Phase: PhaseSweepBroadcast, Trigger: TriggerRestart}
+	var old *wire.MsgTx
+	if legacy {
+		old, err = buildSweepTx(
+			t.Context(), wallet, chain, proof, desc, 0, 0, 104,
+			NewStandardVTXOExitSpendPolicy(desc),
+		)
+		require.NoError(t, err)
+		oldID := old.TxHash()
+		cp.SweepTx = old
+		cp.State.Sweep = unrollplan.SweepState{
+			Status: unrollplan.SweepStatusBroadcasted,
+			Txid: fn.Some(
+				oldID,
+			),
+		}
+		cp.Fail = "sweep tx " + oldID.String() +
+			" failed: broadcast: min relay fee not met"
+		cp.SweepAttempts = maxSweepAttempts
+		row.Phase = PhaseFailed
+		row.FailReason, row.SweepTxid = cp.Fail, &oldID
+	}
+	raw, err := encodeCheckpoint(cp)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		delivery.SaveCheckpoint(
+			t.Context(), actor.CheckpointParams{
+				ActorID:   id,
+				StateType: checkpointStateType,
+				StateData: raw,
+				Version:   1,
+			},
+		),
+	)
+	require.NoError(t, store.UpsertRecord(t.Context(), row))
+	txBehavior := txconfirm.NewTxBroadcasterActor(
+		txconfirm.Config{
+			ChainSource:           chain,
+			FeeBumpIntervalBlocks: 1,
+		},
+	)
+	txActor := actor.NewActor(actor.ActorConfig[
+		txconfirm.Msg,
+		txconfirm.Resp,
+	]{
+		ID:       "fee-restart-txconfirm",
+		Behavior: txBehavior, MailboxSize: 64,
+	})
+	txBehavior.SetSelfRef(txActor.TellRef())
+	txActor.Start()
+	t.Cleanup(txActor.Stop)
+	cfg := RegistryConfig{
+		Store: store, DeliveryStore: delivery,
+		ProofAssembler: &mockProofAssembler{
+			proof: proof,
+		},
+		VTXOStore: &mockVTXOStore{
+			desc: desc,
+		},
+		TxConfirmRef: txActor.Ref(), ChainSource: chain, Wallet: wallet,
+	}
+	registry := NewUnrollRegistryActor(cfg)
+	t.Cleanup(func() { registry.Stop() })
+	ensure := func() {
+		t.Helper()
+		resp, err := registry.Ref().Ask(
+			t.Context(), &EnsureUnrollRequest{
+				Outpoint: target, Trigger: TriggerRestart,
+			},
+		).Await(t.Context()).Unpack()
+		require.NoError(t, err)
+		admitted, ok := resp.(*EnsureUnrollResp)
+		require.True(t, ok)
+		require.Equal(t, id, admitted.ActorID)
+		require.False(t, admitted.Created)
+	}
+	ensure()
+	if !legacy {
+		select {
+		case old = <-chain.submitted:
+			require.NoError(t, <-chain.verified)
+
+		case <-time.After(testTimeout):
+			t.Fatal("initial sweep not submitted")
+		}
+	}
+	require.Eventually(t, func() bool {
+		stored, err := delivery.LoadCheckpoint(
+			t.Context(), id,
+		)
+		if err != nil || stored == nil {
+			return false
+		}
+		decoded, err := decodeCheckpoint(
+			stored.StateData,
+		)
+
+		return err == nil && decoded.Fail == "" &&
+			decoded.RejectedSweep.UnwrapOr(
+				chainhash.Hash{},
+			) == old.TxHash()
+	}, testTimeout, 10*time.Millisecond)
+	registry.Stop()
+	chain.setFeeEstimate(
+		0, errors.New("estimator unavailable"),
+	)
+	registry = NewUnrollRegistryActor(cfg)
+	require.NoError(
+		t,
+		registry.RestoreNonTerminal(
+			t.Context(),
+		),
+	)
+	ensure()
+	ensure()
+	require.Empty(t, chain.submitted)
+	chain.setFeeEstimate(10, nil)
+	chain.emitBlock(t, 105)
+	var replacement *wire.MsgTx
+	select {
+	case replacement = <-chain.submitted:
+		require.NoError(t, <-chain.verified)
+
+	case <-time.After(testTimeout):
+		t.Fatal("replacement not submitted")
+	}
+	require.NotEqual(t, old.TxHash(), replacement.TxHash())
+	require.Equal(
+		t, old.TxIn[0].PreviousOutPoint,
+		replacement.TxIn[0].PreviousOutPoint,
+	)
+	require.Equal(
+		t, old.TxOut[0].PkScript, replacement.TxOut[0].PkScript,
+	)
+	require.Less(
+		t, replacement.TxOut[0].Value,
+		old.TxOut[0].Value,
+	)
+	require.Equal(
+		t, int64(1), wallet.pkScriptRequestCount(),
+	)
+	require.Eventually(t, func() bool {
+		stored, err := delivery.LoadCheckpoint(
+			t.Context(), id,
+		)
+		if err != nil || stored == nil {
+			return false
+		}
+		decoded, err := decodeCheckpoint(
+			stored.StateData,
+		)
+
+		if err != nil {
+			return false
+		}
+
+		return decoded.State.Sweep.Status ==
+			unrollplan.SweepStatusBroadcasted &&
+			decoded.SweepTx.TxHash() == replacement.TxHash() &&
+			decoded.Fail == ""
+	}, testTimeout, 10*time.Millisecond)
+	ensure()
+	require.Empty(t, chain.submitted)
+	rowBefore, err := store.GetRecord(t.Context(), target)
+	require.NoError(t, err)
+	require.False(t, rowBefore.IsTerminal())
+	chain.emitSpendForOutpoint(
+		t, target, replacement.TxHash(), 106,
+	)
+	require.Eventually(t, func() bool {
+		record, err := store.GetRecord(
+			t.Context(), target,
+		)
+
+		if err != nil || record == nil {
+			return false
+		}
+
+		return record.Phase == PhaseCompleted &&
+			record.SweepTxid != nil &&
+			*record.SweepTxid == replacement.TxHash()
+	}, testTimeout, 10*time.Millisecond)
+	ensure()
+	require.Empty(t, chain.submitted)
+}

--- a/unroll/snapshot.go
+++ b/unroll/snapshot.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/unrollplan"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -45,7 +47,10 @@ import (
 
 const (
 	checkpointStateType = "unroll.vtxo"
-	checkpointVersion   = 1
+	// Version 2 retains replacement history. Version 1 remains readable,
+	// but older binaries must refuse new checkpoints instead of forgetting
+	// an earlier candidate that can still confirm.
+	checkpointVersion = 2
 )
 
 // Outer record types for the actor checkpoint TLV stream. Odd type values are
@@ -100,6 +105,13 @@ const (
 	// entirely when false so a non-conflicted checkpoint encodes to the
 	// same bytes it did before this field existed (wavelength#1050).
 	checkpointConflictedRecordType tlv.Type = 23
+
+	// Repricing records preserve rejected identity, pacing, and all
+	// candidates.
+	checkpointRejectedSweepRecordType  tlv.Type = 25
+	checkpointRepriceAfterRecordType   tlv.Type = 27
+	checkpointReplacedSweepsRecordType tlv.Type = 29
+	checkpointRetrySameRecordType      tlv.Type = 31
 )
 
 // actorCheckpoint is the durable checkpoint shape for one VTXO unroll actor.
@@ -112,6 +124,10 @@ type actorCheckpoint struct {
 	ExitPolicyKind      ExitPolicyKind
 	ExitPolicyRef       string
 	SweepTx             *wire.MsgTx
+	RejectedSweep       fn.Option[chainhash.Hash]
+	RepriceAfter        int32
+	RetrySame           bool
+	ReplacedSweeps      []*wire.MsgTx
 	Fail                string
 	Conflicted          bool
 	SweepAttempts       int
@@ -234,15 +250,50 @@ func encodeCheckpoint(value *actorCheckpoint) ([]byte, error) {
 		)
 	}
 
-	// Conflicted (type 23) is the highest record type, so it is appended
-	// last to keep records in the ascending order tlv.NewStream requires.
-	// It is emitted only when true, so a non-conflicted checkpoint is
-	// byte-for- byte identical to one written before this field existed.
+	// Conflicted is emitted only when true. Optional recovery fields
+	// follow it in the ascending order required by tlv.NewStream.
 	if value.Conflicted {
 		conflicted := uint8(1)
 		records = append(
 			records, tlv.MakePrimitiveRecord(
 				checkpointConflictedRecordType, &conflicted,
+			),
+		)
+	}
+
+	if value.RejectedSweep.IsSome() {
+		rejected := [32]byte(value.RejectedSweep.UnsafeFromSome())
+		after := uint32(value.RepriceAfter)
+		records = append(
+			records, tlv.MakePrimitiveRecord(
+				checkpointRejectedSweepRecordType, &rejected,
+			),
+			tlv.MakePrimitiveRecord(
+				checkpointRepriceAfterRecordType, &after,
+			),
+		)
+	}
+	if len(value.ReplacedSweeps) > 0 {
+		var candidates bytes.Buffer
+		for _, candidate := range value.ReplacedSweeps {
+			if err := candidate.Serialize(&candidates); err != nil {
+				return nil, fmt.Errorf("serialize replaced "+
+					"sweep: %w", err)
+			}
+		}
+		raw := candidates.Bytes()
+		records = append(
+			records, tlv.MakePrimitiveRecord(
+				checkpointReplacedSweepsRecordType, &raw,
+			),
+		)
+	}
+
+	if value.RetrySame {
+		retrySame := uint8(1)
+		records = append(
+			records, tlv.MakePrimitiveRecord(
+				checkpointRetrySameRecordType, &retrySame,
 			),
 		)
 	}
@@ -276,18 +327,22 @@ func encodeCheckpoint(value *actorCheckpoint) ([]byte, error) {
 // truncated state.
 func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 	var (
-		version       uint8
-		height        uint32
-		started       uint8
-		trigger       uint32
-		stateBytes    []byte
-		sweepBytes    []byte
-		failBytes     []byte
-		attempts      uint32
-		deferredBytes []byte
-		policyKind    []byte
-		policyRef     []byte
-		conflicted    uint8
+		version        uint8
+		height         uint32
+		started        uint8
+		trigger        uint32
+		stateBytes     []byte
+		sweepBytes     []byte
+		failBytes      []byte
+		attempts       uint32
+		deferredBytes  []byte
+		policyKind     []byte
+		policyRef      []byte
+		conflicted     uint8
+		rejected       [32]byte
+		after          uint32
+		candidateBytes []byte
+		retrySame      uint8
 	)
 
 	stream, err := tlv.NewStream(
@@ -327,6 +382,18 @@ func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 		tlv.MakePrimitiveRecord(
 			checkpointConflictedRecordType, &conflicted,
 		),
+		tlv.MakePrimitiveRecord(
+			checkpointRejectedSweepRecordType, &rejected,
+		),
+		tlv.MakePrimitiveRecord(
+			checkpointRepriceAfterRecordType, &after,
+		),
+		tlv.MakePrimitiveRecord(
+			checkpointReplacedSweepsRecordType, &candidateBytes,
+		),
+		tlv.MakePrimitiveRecord(
+			checkpointRetrySameRecordType, &retrySame,
+		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create checkpoint stream: %w", err)
@@ -340,7 +407,7 @@ func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 	if _, ok := parsed[checkpointVersionRecordType]; !ok {
 		return nil, fmt.Errorf("checkpoint missing version record")
 	}
-	if version != checkpointVersion {
+	if version != checkpointVersion && version != 1 {
 		return nil, fmt.Errorf("unsupported checkpoint version %d "+
 			"(expected %d)", version, checkpointVersion)
 	}
@@ -394,6 +461,23 @@ func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 				"checkpoints: %w", err)
 		}
 		checkpoint.DeferredCheckpoints = checkpoints
+	}
+
+	if _, ok := parsed[checkpointRejectedSweepRecordType]; ok {
+		checkpoint.RejectedSweep = fn.Some(chainhash.Hash(rejected))
+		checkpoint.RepriceAfter = int32(after)
+		checkpoint.RetrySame = retrySame != 0
+	}
+	candidates := bytes.NewReader(candidateBytes)
+	for candidates.Len() > 0 {
+		candidate := wire.NewMsgTx(0)
+		if err := candidate.Deserialize(candidates); err != nil {
+			return nil, fmt.Errorf("deserialize replaced sweep: %w",
+				err)
+		}
+		checkpoint.ReplacedSweeps = append(
+			checkpoint.ReplacedSweeps, candidate,
+		)
 	}
 
 	return checkpoint, nil

--- a/unroll/state_snapshot.go
+++ b/unroll/state_snapshot.go
@@ -41,6 +41,9 @@ func checkpointFromState(state State, sweepTx *wire.MsgTx) *actorCheckpoint {
 	checkpoint.Fail = job.FailReason
 	checkpoint.Conflicted = job.Conflicted
 	checkpoint.SweepAttempts = job.SweepAttempts
+	checkpoint.RejectedSweep = job.RejectedSweep
+	checkpoint.RepriceAfter = job.RepriceAfter
+	checkpoint.RetrySame = job.RetrySame
 
 	return checkpoint
 }
@@ -112,6 +115,9 @@ func stateFromCheckpoint(checkpoint *actorCheckpoint) State {
 		FailReason:          checkpoint.Fail,
 		Conflicted:          checkpoint.Conflicted,
 		SweepAttempts:       checkpoint.SweepAttempts,
+		RejectedSweep:       checkpoint.RejectedSweep,
+		RepriceAfter:        checkpoint.RepriceAfter,
+		RetrySame:           checkpoint.RetrySame,
 	}
 
 	switch phaseFromPlannerState(job) {

--- a/unroll/sweep_reprice.go
+++ b/unroll/sweep_reprice.go
@@ -1,0 +1,183 @@
+package unroll
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/wallet/txrules"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/chainsource"
+	"github.com/lightninglabs/wavelength/txconfirm"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// repriceSweep builds a higher-fee candidate for the same target and wallet
+// destination. The existing candidate remains authoritative until its signed
+// replacement and history are staged. A flat estimate, exhausted fee budget,
+// unavailable signer, or changed policy leaves the obligation pending.
+func (b *behavior) repriceSweep(ctx context.Context) (bool, error) {
+	old := b.sweepTx
+	if old == nil || len(old.TxIn) != 1 || len(old.TxOut) != 1 ||
+		old.TxIn[0].PreviousOutPoint != b.cfg.TargetOutpoint {
+		return false, fmt.Errorf("replacement requires a " +
+			"single-target sweep")
+	}
+	policy, err := b.resolveExitSpendPolicy(ctx)
+	if err != nil {
+		return false, err
+	}
+	// A replacement must use an actual estimate. An emergency fallback
+	// cannot demonstrate that the previously rejected fee has recovered.
+	rate, err := estimateSweepFeeRate(
+		ctx, b.cfg.ChainSource, b.cfg.MaxSweepFeeRateSatPerVByte, 0,
+	)
+	if err != nil {
+		return false, err
+	}
+	target, err := b.proof.TargetOutput()
+	if err != nil {
+		return false, err
+	}
+	oldFee := target.Value - old.TxOut[0].Value
+	// Both current spend policies price against estimatedSweepVBytes.
+	// Skip signing when that estimate cannot improve the previous fee.
+	if rate*estimatedSweepVBytes <= oldFee {
+		return false, nil
+	}
+	candidate, err := policy.BuildSpendTx(ctx, ExitSpendRequest{
+		TargetOutpoint: b.cfg.TargetOutpoint,
+		TargetOutput:   target,
+		DestinationPkScript: append(
+			[]byte(nil), old.TxOut[0].PkScript...,
+		),
+		FeeRateSatPerVByte: rate,
+		CurrentHeight:      b.currentHeight(),
+		Signer:             b.cfg.Wallet,
+	})
+	if err != nil {
+		return false, err
+	}
+	if candidate == nil || len(candidate.TxIn) != 1 ||
+		len(candidate.TxOut) != 1 ||
+		candidate.Version != old.Version ||
+		candidate.LockTime != old.LockTime ||
+		candidate.TxIn[0].PreviousOutPoint !=
+			old.TxIn[0].PreviousOutPoint ||
+		candidate.TxIn[0].Sequence != old.TxIn[0].Sequence ||
+		!bytes.Equal(
+			candidate.TxOut[0].PkScript, old.TxOut[0].PkScript,
+		) {
+		return false, fmt.Errorf("replacement changed sweep obligation")
+	}
+	newFee := target.Value - candidate.TxOut[0].Value
+	oldSize := (txconfirm.EstimateWeight(old) + 3) / 4
+	newSize := (txconfirm.EstimateWeight(candidate) + 3) / 4
+	// Apply the direct-spend equivalents of txconfirm's replacement
+	// floors: strictly higher feerate and at least 1 sat/vB of additional
+	// relay fee. A stricter node can reject again without losing ownership.
+	if newFee-oldFee < newSize || newFee*oldSize <= oldFee*newSize ||
+		txrules.IsDustOutput(
+			candidate.TxOut[0], txrules.DefaultRelayFeePerKb,
+		) {
+		return false, nil
+	}
+	b.replacedSweeps = append(b.replacedSweeps, old.Copy())
+	b.sweepTx = candidate
+
+	return true, nil
+}
+
+// stopRejectedSweep relinquishes the rejected candidate's active broadcaster
+// interest before submitting a replacement. Wallet removal is best-effort
+// housekeeping: it cannot prove network absence and some backends retain a
+// separate rebroadcaster. Candidate history and the target spend watch preserve
+// the old transaction's evidence even if removal fails or it later confirms.
+func (b *behavior) stopRejectedSweep(ctx context.Context,
+	txid chainhash.Hash) error {
+
+	_, err := b.cfg.TxConfirmRef.Ask(ctx, &txconfirm.CancelInterestReq{
+		Txid:         txid,
+		SubscriberID: b.notificationRef().ID(),
+	}).Await(ctx).Unpack()
+	if err != nil {
+		return fmt.Errorf("cancel rejected sweep interest: %w", err)
+	}
+	_, err = b.cfg.ChainSource.Ask(ctx, &chainsource.RemoveTxRequest{
+		Txid: txid,
+	}).Await(ctx).Unpack()
+	if err != nil {
+		b.log.WarnS(ctx, "Unable to remove rejected sweep from wallet",
+			err,
+			slog.String("txid", txid.String()),
+		)
+	}
+
+	return nil
+}
+
+// sweepCandidate returns a signed candidate owned by this obligation. Keeping
+// earlier candidates prevents a delayed spend observation from falsely
+// classifying our own replacement race as an external spend.
+func (b *behavior) sweepCandidate(txid chainhash.Hash) *wire.MsgTx {
+	if b.sweepTx != nil && b.sweepTx.TxHash() == txid {
+		return b.sweepTx
+	}
+	for _, candidate := range b.replacedSweeps {
+		if candidate.TxHash() == txid {
+			return candidate
+		}
+	}
+
+	return nil
+}
+
+// confirmSweepCandidate selects the actual winner before completing the FSM.
+// A crash between selection and confirmation reattaches the winner's existing
+// confirmation watch rather than building another transaction.
+func (b *behavior) confirmSweepCandidate(ctx context.Context,
+	ax actor.Exec[unrollTx], txid chainhash.Hash,
+	height int32) fn.Result[Resp] {
+
+	if err := b.ensureLoaded(ctx); err != nil {
+		return fn.Err[Resp](err)
+	}
+
+	candidate := b.sweepCandidate(txid)
+	if candidate == nil {
+		return b.handleEvent(ctx, ax, &TxConfirmedEvent{
+			Txid: txid, Height: height,
+		})
+	}
+	if b.inTerminalState() {
+		return fn.Ok[Resp](&AckResp{})
+	}
+	b.sweepTx = candidate.Copy()
+	if err := b.driveEvent(
+		ctx, ax, &SweepBroadcastedEvent{
+			Txid: txid,
+		},
+	); err != nil {
+		return fn.Err[Resp](err)
+	}
+
+	return b.handleEvent(ctx, ax, &TxConfirmedEvent{
+		Txid: txid, Height: height,
+	})
+}
+
+// copySweepCandidates keeps checkpoint snapshots independent of actor state.
+func copySweepCandidates(candidates []*wire.MsgTx) []*wire.MsgTx {
+	if len(candidates) == 0 {
+		return nil
+	}
+	result := make([]*wire.MsgTx, len(candidates))
+	for i, candidate := range candidates {
+		result[i] = candidate.Copy()
+	}
+
+	return result
+}

--- a/unroll/sweep_reprice_test.go
+++ b/unroll/sweep_reprice_test.go
@@ -1,0 +1,403 @@
+package unroll
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/chainsource"
+	"github.com/lightninglabs/wavelength/txconfirm"
+	"github.com/lightninglabs/wavelength/unrollplan"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRejectedSweepRepricesAfterEstimateRecovery proves that fee rejection
+// preserves one obligation and destination across duplicate delivery, estimator
+// outage, restart, replacement, and either candidate winning on chain.
+func TestRejectedSweepRepricesAfterEstimateRecovery(t *testing.T) {
+	for _, restart := range []bool{false, true} {
+		for _, oldWins := range []bool{false, true} {
+			t.Run(repriceCaseName(restart, oldWins), func(
+				t *testing.T) {
+
+				proof := buildLinearProof(t)
+				desc := testDescriptor(
+					t, proof.TargetOutpoint(),
+					proof.CSVDelay(),
+				)
+				inst, b, confirmer, store := newActorHarness(
+					t, proof, desc,
+				)
+				source := b.cfg.ChainSource
+				chain, ok := source.(*fakeChainSourceRef)
+				require.True(t, ok)
+				wallet, ok := b.cfg.Wallet.(*fakeSweepWallet)
+				require.True(t, ok)
+				chain.setFeeEstimate(2, nil)
+				oldID := driveLinearToSweep(
+					t, inst.Ref(), confirmer, store, proof,
+				)
+				oldTx := confirmer.lastRequest(t).Tx.Copy()
+				rejection := &TxFailedMsg{
+					Txid:   oldID,
+					Reason: "min relay fee not met",
+					Class:  txconfirm.BroadcastFailureFee,
+				}
+				mustAsk(t, inst.Ref(), rejection)
+				mustAsk(t, inst.Ref(), rejection)
+				cp := mustDecodeCheckpoint(
+					t, store, "unroll-test",
+				)
+				require.Equal(t, 0, cp.SweepAttempts)
+				require.Empty(t, cp.Fail)
+				require.Equal(
+					t, oldID,
+					cp.RejectedSweep.UnsafeFromSome(),
+				)
+				require.Equal(
+					t, unrollplan.SweepStatusPending,
+					cp.State.Sweep.Status,
+				)
+				require.Equal(t, 3, confirmer.requestCount())
+
+				if restart {
+					inst.Stop()
+					inst, b = restartSweepActor(t, b.cfg)
+					mustAsk(
+						t, inst.Ref(),
+						&ResumeUnrollRequest{
+							Height: 104,
+						},
+					)
+				}
+				chain.setFeeEstimate(
+					0, errors.New("estimator unavailable"),
+				)
+				mustAsk(
+					t, inst.Ref(), &HeightObservedMsg{
+						Height: 105,
+					},
+				)
+				chain.setFeeEstimate(2, nil)
+				mustAsk(
+					t, inst.Ref(), &HeightObservedMsg{
+						Height: 106,
+					},
+				)
+				require.Equal(t, 3, confirmer.requestCount())
+				chain.setFeeEstimate(10, nil)
+				mustAsk(
+					t, inst.Ref(), &HeightObservedMsg{
+						Height: 107,
+					},
+				)
+				newTx := confirmer.lastRequest(t).Tx.Copy()
+				newID := newTx.TxHash()
+				require.NotEqual(t, oldID, newID)
+				require.Equal(
+					t, oldTx.TxIn[0].PreviousOutPoint,
+					newTx.TxIn[0].PreviousOutPoint,
+				)
+				require.Equal(
+					t, oldTx.TxOut[0].PkScript,
+					newTx.TxOut[0].PkScript,
+				)
+				require.Less(
+					t, newTx.TxOut[0].Value,
+					oldTx.TxOut[0].Value,
+				)
+				require.Equal(
+					t, int64(1),
+					wallet.pkScriptRequestCount(),
+				)
+				require.Equal(
+					t, []chainhash.Hash{oldID},
+					chain.removedTxSnapshot(),
+				)
+				cp = mustDecodeCheckpoint(
+					t, store, "unroll-test",
+				)
+				require.Len(t, cp.ReplacedSweeps, 1)
+				require.Equal(
+					t, oldID, cp.ReplacedSweeps[0].TxHash(),
+				)
+				require.Equal(t, newID, cp.SweepTx.TxHash())
+				require.True(t, cp.RejectedSweep.IsNone())
+				require.Empty(t, cp.Fail)
+				mustAsk(t, inst.Ref(), rejection)
+				mustAsk(
+					t, inst.Ref(), &HeightObservedMsg{
+						Height: 107,
+					},
+				)
+				require.Equal(t, 4, confirmer.requestCount())
+				state, ok := mustAsk(
+					t, inst.Ref(), &GetStateRequest{},
+				).(*GetStateResp)
+				require.True(t, ok)
+				require.Equal(
+					t, PhaseSweepConfirmation, state.Phase,
+				)
+
+				if oldWins {
+					// Conflict can arrive before the old
+					// sweep's spend notification. Duplicate
+					// errors cannot kill the exit.
+					conflict := &TxFailedMsg{
+						Txid:   newID,
+						Reason: "inputs spent",
+					}
+					for range maxSweepAttempts + 1 {
+						mustAsk(t, inst.Ref(), conflict)
+					}
+
+					cp = mustDecodeCheckpoint(
+						t, store, "unroll-test",
+					)
+					require.Empty(t, cp.Fail)
+					require.True(t, cp.RetrySame)
+				}
+
+				// Restore candidate history before receiving
+				// the winning spend, including when it is an
+				// older transaction.
+				if restart {
+					inst.Stop()
+					inst, _ = restartSweepActor(t, b.cfg)
+				}
+				winner := newID
+				if oldWins {
+					winner = oldID
+				}
+				mustAsk(t, inst.Ref(), &SpendObservedMsg{
+					Outpoint:       proof.TargetOutpoint(),
+					SpendingTxid:   winner,
+					SpendingHeight: 108,
+				})
+				cp = mustDecodeCheckpoint(
+					t, store, "unroll-test",
+				)
+				require.Equal(
+					t, unrollplan.SweepStatusConfirmed,
+					cp.State.Sweep.Status,
+				)
+				require.Equal(t, winner, cp.SweepTx.TxHash())
+				require.Empty(t, cp.Fail)
+			})
+		}
+	}
+}
+
+// repriceCaseName makes the two independent recovery choices visible in output.
+func repriceCaseName(restart, oldWins bool) string {
+	name := "live"
+	if restart {
+		name = "restart"
+	}
+	if oldWins {
+		return name + "/original-confirms"
+	}
+
+	return name + "/replacement-confirms"
+}
+
+// restartSweepActor reconstructs a new actor solely from its saved checkpoint.
+// The caller stops the previous actor before invoking this helper.
+func restartSweepActor(t *testing.T, cfg Config) (*actor.Actor[Msg, Resp],
+	*behavior) {
+
+	t.Helper()
+	b := &behavior{cfg: cfg, log: btclog.Disabled}
+	require.NoError(t, b.restoreCheckpoint(t.Context()))
+	inst := actor.NewActor(actor.ActorConfig[Msg, Resp]{
+		ID: cfg.ActorID, Behavior: adaptTx(b), MailboxSize: 64,
+	})
+	b.selfRef = inst.TellRef()
+	inst.Start()
+	t.Cleanup(inst.Stop)
+
+	return inst, b
+}
+
+// cleanupFailureRef injects a single old-tracker cleanup failure after the
+// signed replacement has been staged but before it can be submitted.
+type cleanupFailureRef struct {
+	*fakeTxConfirmRef
+	fail atomic.Bool
+}
+
+// Ask rejects one cancellation while preserving ordinary txconfirm behavior.
+func (f *cleanupFailureRef) Ask(ctx context.Context,
+	msg txconfirm.Msg) actor.Future[txconfirm.Resp] {
+
+	if _, ok := msg.(*txconfirm.CancelInterestReq); ok &&
+		f.fail.Swap(false) {
+
+		p := actor.NewPromise[txconfirm.Resp]()
+		p.Complete(
+			fn.Err[txconfirm.Resp](
+				errors.New("cleanup unavailable"),
+			),
+		)
+
+		return p.Future()
+	}
+
+	return f.fakeTxConfirmRef.Ask(ctx, msg)
+}
+
+// TestReplacementStageSurvivesCleanupFailure proves that a prepared replacement
+// survives a restart before admission and is reused without another estimate.
+func TestReplacementStageSurvivesCleanupFailure(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	inst, b, confirmer, store := newActorHarness(t, proof, desc)
+	chain, ok := b.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	chain.setFeeEstimate(2, nil)
+	oldID := driveLinearToSweep(t, inst.Ref(), confirmer, store, proof)
+	mustAsk(t, inst.Ref(), &TxFailedMsg{
+		Txid: oldID, Reason: "mempool min fee not met",
+		Class: txconfirm.BroadcastFailureFee,
+	})
+	inst.Stop()
+	failer := &cleanupFailureRef{fakeTxConfirmRef: confirmer}
+	failer.fail.Store(true)
+	cfg := b.cfg
+	cfg.TxConfirmRef = failer
+	inst, _ = restartSweepActor(t, cfg)
+	chain.setFeeEstimate(10, nil)
+	_, err := inst.
+		Ref().
+		Ask(t.Context(), &ResumeUnrollRequest{Height: 105}).
+		Await(t.Context()).
+		Unpack()
+	require.ErrorContains(t, err, "cleanup unavailable")
+	cp := mustDecodeCheckpoint(t, store, cfg.ActorID)
+	newID := cp.SweepTx.TxHash()
+	require.NotEqual(t, oldID, newID)
+	require.Equal(t, oldID, cp.RejectedSweep.UnsafeFromSome())
+	require.Equal(t, 3, confirmer.requestCount())
+	inst.Stop()
+	chain.setFeeEstimate(0, errors.New("estimator unavailable"))
+	calls := chain.feeRequestCount()
+	inst, _ = restartSweepActor(t, cfg)
+	mustAsk(t, inst.Ref(), &ResumeUnrollRequest{Height: 106})
+	require.Equal(t, newID, confirmer.lastRequest(t).Tx.TxHash())
+	require.Equal(t, calls, chain.feeRequestCount())
+	require.Equal(t, 4, confirmer.requestCount())
+}
+
+// TestPermanentSweepFailureDoesNotReprice keeps structural-invalid failures
+// on the existing bounded path even when the estimator would offer a new fee.
+func TestPermanentSweepFailureDoesNotReprice(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	inst, b, confirmer, store := newActorHarness(t, proof, desc)
+	oldID := driveLinearToSweep(t, inst.Ref(), confirmer, store, proof)
+	chain, ok := b.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	chain.setFeeEstimate(10, nil)
+	for range maxSweepAttempts {
+		mustAsk(t, inst.Ref(), &TxFailedMsg{
+			Txid:   oldID,
+			Reason: "mandatory-script-verify-flag-failed",
+			Class:  txconfirm.BroadcastFailurePermanent,
+		})
+	}
+	cp := mustDecodeCheckpoint(t, store, "unroll-test")
+	require.NotEmpty(t, cp.Fail)
+	require.Equal(t, oldID, cp.SweepTx.TxHash())
+	require.Empty(t, cp.ReplacedSweeps)
+	require.Equal(t, 1, chain.feeRequestCount())
+}
+
+// persistentRemoveFailureRef models a wallet RPC that cannot remove broadcasts.
+type persistentRemoveFailureRef struct {
+	*fakeChainSourceRef
+	calls atomic.Int32
+}
+
+// Ask always rejects removal while retaining normal fee and chain responses.
+func (f *persistentRemoveFailureRef) Ask(ctx context.Context,
+	msg chainsource.ChainSourceMsg,
+) actor.Future[chainsource.ChainSourceResp] {
+
+	if _, ok := msg.(*chainsource.RemoveTxRequest); ok {
+		f.calls.Add(1)
+		p := actor.NewPromise[chainsource.ChainSourceResp]()
+		p.Complete(
+			fn.Err[chainsource.ChainSourceResp](
+				errors.New("rpc error: code = Unimplemented " +
+					"desc = unknown method " +
+					"RemoveTransaction"),
+			),
+		)
+
+		return p.Future()
+	}
+
+	return f.fakeChainSourceRef.Ask(ctx, msg)
+}
+
+// TestReplacementSurvivesWalletRemovalFailure proves that failed wallet cleanup
+// cannot strand a staged replacement. A later invalid replacement also cannot
+// erase the still-valid earlier candidate's eventual confirmed spend.
+func TestReplacementSurvivesWalletRemovalFailure(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	inst, b, confirmer, store := newActorHarness(t, proof, desc)
+	chain, ok := b.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	chain.setFeeEstimate(2, nil)
+	oldID := driveLinearToSweep(t, inst.Ref(), confirmer, store, proof)
+	mustAsk(t, inst.Ref(), &TxFailedMsg{
+		Txid: oldID, Reason: "min relay fee not met",
+		Class: txconfirm.BroadcastFailureFee,
+	})
+	inst.Stop()
+	cfg := b.cfg
+	failer := &persistentRemoveFailureRef{fakeChainSourceRef: chain}
+	cfg.ChainSource = failer
+	chain.setFeeEstimate(10, nil)
+	inst, _ = restartSweepActor(t, cfg)
+	mustAsk(t, inst.Ref(), &ResumeUnrollRequest{Height: 105})
+	newID := confirmer.lastRequest(t).Tx.TxHash()
+	require.NotEqual(t, oldID, newID)
+	require.Equal(t, int32(1), failer.calls.Load())
+	cp := mustDecodeCheckpoint(t, store, cfg.ActorID)
+	require.Equal(t, oldID, cp.ReplacedSweeps[0].TxHash())
+	require.Equal(t, 4, confirmer.requestCount())
+
+	// A permanent rejection proves only that this replacement is invalid.
+	// It cannot prove the prior candidate was never accepted elsewhere.
+	for attempt := range maxSweepAttempts + 1 {
+		mustAsk(t, inst.Ref(), &TxFailedMsg{
+			Txid:   newID,
+			Reason: "mandatory-script-verify-flag-failed",
+			Class:  txconfirm.BroadcastFailurePermanent,
+		})
+		mustAsk(t, inst.Ref(), &HeightObservedMsg{
+			Height: 106 + int32(attempt),
+		})
+	}
+	cp = mustDecodeCheckpoint(t, store, cfg.ActorID)
+	require.Empty(t, cp.Fail)
+	require.Zero(t, cp.SweepAttempts)
+	require.Equal(t, newID, cp.SweepTx.TxHash())
+	inst.Stop()
+	inst, _ = restartSweepActor(t, cfg)
+	mustAsk(t, inst.Ref(), &SpendObservedMsg{
+		Outpoint: proof.TargetOutpoint(), SpendingTxid: oldID,
+		SpendingHeight: 111,
+	})
+	cp = mustDecodeCheckpoint(t, store, cfg.ActorID)
+	require.Equal(t, unrollplan.SweepStatusConfirmed, cp.State.Sweep.Status)
+	require.Equal(t, oldID, cp.SweepTx.TxHash())
+	require.Empty(t, cp.Fail)
+}


### PR DESCRIPTION
A final unilateral-exit sweep can be rejected below relay policy after its fixed fee was signed and persisted. Retrying the same transaction exhausts the exit's failure budget without improving its chance of confirmation. Historical failed rows then deduplicate every new admission request.

This change keeps the target outpoint as the exit obligation and treats an explicit fee rejection as a pending candidate. On a later block, a higher usable estimate can produce a new signed transaction with the same input, destination, sequence and locktime. Both absolute fee and feerate must increase within the existing cap. Unavailable or uneconomic estimates leave the exit pending.

Safety and recovery:

- Stage the signed replacement and previous candidates before cancelling old txconfirm interest or submitting the replacement. Cancellation retries and restart reuse the staged bytes. Wallet removal is best-effort housekeeping; errors warn without blocking replacement.
- Retain earlier signed candidates because cancellation cannot prove they will never confirm. Confirmation of either candidate completes the same exit and accounts for the actual winner's fee.
- Duplicate old failures cannot kill the replacement. Even permanent rejection of a replacement cannot prove an earlier candidate will never confirm, so the obligation remains pending for spend evidence. Initial unknown errors and permanent invalidity retain bounded behavior.
- Re-admit legacy terminal fee failures only after validating the saved candidate, target and policy. Wait for the old owner and terminal write to finish. Persist the existing registry row as resumable before restoring the same actor ID. The daemon's existing scan of VTXOs in unilateral exit supplies boot admission.

The fee/permanent/unknown failure class travels through the durable unroll notification codec. Explicit direct fee rejection precedes the broadcaster retry branch, so it hands control to the signing owner with the transient retry contract merged in #1314. Anchor package recovery and ordinary known/accepted broadcast handling stay unchanged. A whole-repository production search confirms only unroll’s two submission paths opt into RetryUntilAccepted; no other wallet caller changes behavior through that flag.

Every checkpoint written by this build uses version 2, including exits that have not repriced. Version 1 remains readable by the new code. Older binaries refuse version 2, so a downgrade cannot resume any in-flight exit checkpoint touched by this build. Keep a compatible binary available or finish those exits before downgrading. This deliberately uses one fail-closed checkpoint version boundary. No SQL migration or other repository change is required.

Validation:

- Full root and `baselib` unit suites; daemon and CLI builds.
- Full SQLite and PostgreSQL system suites, including reorg, exit/restart, vHTLC recovery, sweep-all, boarding, seed restore and OOR scenarios.
- Full unroll/txconfirm race suites after the review fix. Regressions cover estimator outage and recovery, duplicates, restart before rebuild, cancellation failure after staging, persistent wallet-removal failure, either candidate confirming, delayed conflicts, and initial permanent-invalid controls.
- SQLite durable actors with the production broadcaster validate actual signatures through the script engine and exercise both fresh rejection and legacy version-1 terminal recovery.
- Rebased onto merged #1314. Both packages' full race suites pass together, including explicit tests that fee/structural rejection overrides RetryUntilAccepted. The earlier isolated composition check also passed.
- Changed-code lint, formatting, module tidiness, declaration documentation audit and commit-message lint pass. The extra documentation cross-link check still reports the pre-existing missing `docs/mailbox_ingress_safety.md` index entry on `main`.

Gateway review identified the wallet-removal dependency; its failing regression and fix are folded into the signed history. Gateway withdrew its cache-loss finding, accepted the cleanup fix, and accepted the retained pending obligation as a deliberate trade-off. No blocker or major finding remains. Gateway's final review on the rebased head confirms no blocker or major issue. Its remaining observations are accepted trade-offs or clarified compatibility documentation. The previously reviewed head passed 19 CI checks, with a neutral Gateway review and two skipped Claude jobs. All eight prior review threads are resolved. Rebased onto main 8680c621 after #1320 merged; only three documentation conflicts needed resolution. Production and test patches are unchanged. On the rebased code, full unroll/txconfirm/chainbackends race suites, changed-code lint, formatting, module tidiness and commit-message checks pass. Gateway confirmed the #1320 integration has no new material defect and zero blockers or majors. Its remaining checkpoint wording correction is now in both unroll package documents. Final head is 354dd3e0. Final Gateway review on 354dd3e0 confirms no new issues, zero blockers and zero majors; the wording finding is closed and the two remaining minor observations are accepted. All review threads are resolved. Current-head CI is queued, so the rebased head is not yet CI-green. The local broad suites preceded that narrow cleanup change; the affected full race suites were rerun afterward.

