### PR TITLE
txconfirm: replace conflicting CPFP children

### DIFF
--- a/chainbackends/package_error.go
+++ b/chainbackends/package_error.go
@@ -3,10 +3,49 @@ package chainbackends
 import (
 	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
 
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/rpcclient"
 )
+
+var (
+	btcAmountPattern = `([0-9]+(?:\.[0-9]+)?)`
+
+	conflictingFeeRE = regexp.MustCompile(
+		`less fees than conflicting txs; ` + btcAmountPattern +
+			` < ` + btcAmountPattern,
+	)
+	additionalFeeRE = regexp.MustCompile(
+		`not enough additional fees to relay; ` + btcAmountPattern +
+			` < ` + btcAmountPattern,
+	)
+	conflictingFeeRateRE = regexp.MustCompile(
+		`new feerate ` + btcAmountPattern +
+			` BTC/kvB <= old feerate ` + btcAmountPattern +
+			` BTC/kvB`,
+	)
+)
+
+// ReplacementFeeConstraints contains fee information that Bitcoin Core
+// reports when a replacement child cannot evict a conflicting transaction.
+// Nil fields mean that the backend did not report that constraint.
+type ReplacementFeeConstraints struct {
+	// ConflictingFee is the total fee paid by the transactions that the
+	// replacement must evict.
+	ConflictingFee *btcutil.Amount
+
+	// AdditionalFeeDeficit is the extra fee the attempted replacement
+	// needed to satisfy the node's incremental relay fee.
+	AdditionalFeeDeficit *btcutil.Amount
+
+	// ConflictingFeeRateSatPerVByte is the integer part of the highest
+	// conflicting feerate. A replacement must pay at least one sat/vByte
+	// above this value to be strictly greater.
+	ConflictingFeeRateSatPerVByte *int64
+}
 
 // PackageTxError is one per-tx result error from a `SubmitPackage` response.
 // It preserves the original wtxid / txid / reject reason for diagnostics, and
@@ -32,6 +71,11 @@ type PackageTxError struct {
 	// It is `rpcclient.ErrUndefined` (wrapping the raw string) when no
 	// known sentinel matches.
 	mapped error
+
+	// replacement contains structured fee constraints parsed from stable
+	// Bitcoin Core replacement-policy diagnostics. It remains nil for
+	// unrelated or unrecognized rejection reasons.
+	replacement *ReplacementFeeConstraints
 }
 
 // NewPackageTxError builds a `PackageTxError` from a per-tx package result.
@@ -41,11 +85,113 @@ func NewPackageTxError(wtxid string, txid chainhash.Hash,
 	reason string) *PackageTxError {
 
 	return &PackageTxError{
-		Wtxid:  wtxid,
-		Txid:   txid,
-		Reason: reason,
-		mapped: rpcclient.MapRPCErr(errors.New(reason)),
+		Wtxid:       wtxid,
+		Txid:        txid,
+		Reason:      reason,
+		mapped:      rpcclient.MapRPCErr(errors.New(reason)),
+		replacement: parseReplacementFeeConstraints(reason),
 	}
+}
+
+// ReplacementConstraints returns the structured replacement-policy fee
+// information carried by this per-transaction rejection. The returned value
+// is a copy and is nil when the backend did not expose a recognized floor.
+func (e *PackageTxError) ReplacementConstraints() *ReplacementFeeConstraints {
+	if e == nil || e.replacement == nil {
+		return nil
+	}
+
+	constraints := *e.replacement
+	constraints.ConflictingFee = copyAmount(e.replacement.ConflictingFee)
+	constraints.AdditionalFeeDeficit = copyAmount(
+		e.replacement.AdditionalFeeDeficit,
+	)
+	if e.replacement.ConflictingFeeRateSatPerVByte != nil {
+		value := *e.replacement.ConflictingFeeRateSatPerVByte
+		constraints.ConflictingFeeRateSatPerVByte = &value
+	}
+
+	return &constraints
+}
+
+// parseReplacementFeeConstraints extracts fee floors from Bitcoin Core's
+// replacement-policy diagnostics. Core 28 through 31 use these messages for
+// total-fee and incremental-relay failures; Core 28 through 30 also report the
+// conflicting feerate before cluster mempool replaced that check.
+func parseReplacementFeeConstraints(reason string) *ReplacementFeeConstraints {
+	constraints := &ReplacementFeeConstraints{}
+	found := false
+
+	if match := conflictingFeeRE.FindStringSubmatch(
+		reason,
+	); len(match) == 3 {
+
+		if amount, ok := parseBTCAmount(match[2]); ok {
+			constraints.ConflictingFee = &amount
+			found = true
+		}
+	}
+
+	if match := additionalFeeRE.FindStringSubmatch(
+		reason,
+	); len(match) == 3 {
+
+		paid, paidOK := parseBTCAmount(match[1])
+		required, requiredOK := parseBTCAmount(match[2])
+		if paidOK && requiredOK && required > paid {
+			deficit := required - paid
+			constraints.AdditionalFeeDeficit = &deficit
+			found = true
+		}
+	}
+
+	if match := conflictingFeeRateRE.FindStringSubmatch(
+		reason,
+	); len(match) == 3 {
+
+		satsPerKvB, ok := parseBTCAmount(match[2])
+		if ok && satsPerKvB > 0 {
+			// One BTC/kvB equals 100,000 sat/vByte. Keep the
+			// integer floor because the broadcaster adds one
+			// sat/vByte when enforcing a strict replacement
+			// increase.
+			rate := int64(satsPerKvB) / 1000
+			constraints.ConflictingFeeRateSatPerVByte = &rate
+			found = true
+		}
+	}
+
+	if !found {
+		return nil
+	}
+
+	return constraints
+}
+
+// parseBTCAmount converts Core's fixed-point BTC diagnostic value to sats.
+func parseBTCAmount(value string) (btcutil.Amount, bool) {
+	btc, err := strconv.ParseFloat(value, 64)
+	if err != nil || btc < 0 {
+		return 0, false
+	}
+
+	amount, err := btcutil.NewAmount(btc)
+	if err != nil {
+		return 0, false
+	}
+
+	return amount, true
+}
+
+// copyAmount copies an optional amount without sharing its pointer.
+func copyAmount(amount *btcutil.Amount) *btcutil.Amount {
+	if amount == nil {
+		return nil
+	}
+
+	value := *amount
+
+	return &value
 }
 
 // Error implements the `error` interface and preserves the legacy

--- a/chainbackends/package_error_test.go
+++ b/chainbackends/package_error_test.go
@@ -1,0 +1,94 @@
+package chainbackends
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPackageTxErrorReplacementFeeConstraints verifies that Core replacement
+// diagnostics become structured fee floors while unrelated errors remain
+// unclassified.
+func TestPackageTxErrorReplacementFeeConstraints(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		reason  string
+		fee     *btcutil.Amount
+		deficit *btcutil.Amount
+		feeRate *int64
+	}{
+		{
+			name: "conflicting total fee",
+			reason: "insufficient fee, rejecting replacement tx, " +
+				"less fees than conflicting txs; " +
+				"0.00001 < 0.0001",
+			fee: amountPtr(10_000),
+		},
+		{
+			name: "incremental relay deficit",
+			reason: "insufficient fee, rejecting replacement tx, " +
+				"not enough additional fees to relay; " +
+				"0.00000001 < 0.00000016",
+			deficit: amountPtr(15),
+		},
+		{
+			name: "conflicting feerate",
+			reason: "insufficient fee, rejecting replacement tx; " +
+				"new feerate 0.00004 BTC/kvB <= old feerate " +
+				"0.00207 BTC/kvB",
+			feeRate: int64Ptr(207),
+		},
+		{
+			name:   "unrelated rejection",
+			reason: "bad-txns-inputs-missingorspent",
+		},
+		{
+			name: "malformed replacement amount",
+			reason: "less fees than conflicting txs; broken < " +
+				"also-broken",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := NewPackageTxError(
+				"wtxid", chainhash.Hash{1}, test.reason,
+			)
+			got := err.ReplacementConstraints()
+			if test.fee == nil && test.deficit == nil &&
+				test.feeRate == nil {
+
+				require.Nil(t, got)
+
+				return
+			}
+
+			require.NotNil(t, got)
+			require.Equal(t, test.fee, got.ConflictingFee)
+			require.Equal(
+				t, test.deficit, got.AdditionalFeeDeficit,
+			)
+			require.Equal(
+				t, test.feeRate,
+				got.ConflictingFeeRateSatPerVByte,
+			)
+		})
+	}
+}
+
+// amountPtr returns a pointer to a test amount.
+func amountPtr(value btcutil.Amount) *btcutil.Amount {
+	return &value
+}
+
+// int64Ptr returns a pointer to a test integer.
+func int64Ptr(value int64) *int64 {
+	return &value
+}

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -104,7 +104,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   fee input spent mid-submit) — the conditions CPFP retry exists to
   overcome. Only a structurally permanent error
   (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`) fails
-  terminally; `ErrParentAlreadyBroadcast` advances to
+  terminally. A rejected child with a reported replacement fee floor stays
+  in `Broadcasting` and retries above that floor;
+  `ErrParentAlreadyBroadcast` advances to
   `AwaitingConfirmation` (a live parent exists on another path). Rationale:
   a fraud-response checkpoint must land before the counterparty's
   CSV-timeout path, so the actor escalates to operators rather than
@@ -147,7 +149,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   BIP-125 Rule 4 (strictly higher feerate) and Rule 3 (strictly higher
   absolute fee by at least `IncrementalRelayFeeSatPerVByte *
   packageVSize`) against the last successful submission for the same
-  parent txid.
+  parent txid. Fee constraints learned from a foreign child use separate
+  fields and are clamped to `MaxFeeRateSatPerVByte` before wallet input
+  selection. This keeps fees bounded while retries continue to reach Core
+  and detect when the conflict disappears.
 - **Per-parent fee-input reservation**: each parent txid reserves the
   wallet UTXO(s) it has committed to. Reservations survive block
   boundaries and release only on eviction (terminal state) or when
@@ -207,11 +212,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   keeps `pendingConfirmed` set for the next tick. The same split applies on
   the deferred `handleTerminalNotifyResult` path, where a post-timeout stop
   is logged at debug and cancelled rather than warned.
-- **`ErrParentAlreadyBroadcast` is a race outcome, not a failure.** An initial
-  package attempt can lose to an existing broadcast path once the parent
-  reaches a mempool; the duplicate child is rejected, but the parent stays
-  under its confirmation watch, so the entry still advances to
-  `AwaitingConfirmation` and no operator action is possible. Both
+- **Classify an existing-parent child failure by recovery action.** If Core
+  reports a replacement fee constraint, retain the strongest floor and keep
+  the entry in `Broadcasting`; the next interval must construct a bounded
+  replacement. `ErrParentAlreadyBroadcast` is reserved for a spent or missing
+  anchor where no actionable floor exists, so the entry advances to
+  `AwaitingConfirmation`. Both
   `recordInitialBroadcastOutcome` and the later fee-bump path log this sentinel
   at debug — keep the two consistent if either is touched. Log severity here is
   deliberately **not** pinned by a unit test: the initial-package test asserts

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -104,7 +104,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   fee input spent mid-submit) — the conditions CPFP retry exists to
   overcome. Only a structurally permanent error
   (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`) fails
-  terminally; `ErrParentAlreadyBroadcast` advances to
+  terminally. A rejected child with a reported replacement fee floor stays
+  in `Broadcasting` and retries above that floor;
+  `ErrParentAlreadyBroadcast` advances to
   `AwaitingConfirmation` (a live parent exists on another path). Rationale:
   a fraud-response checkpoint must land before the counterparty's
   CSV-timeout path, so the actor escalates to operators rather than
@@ -147,7 +149,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   BIP-125 Rule 4 (strictly higher feerate) and Rule 3 (strictly higher
   absolute fee by at least `IncrementalRelayFeeSatPerVByte *
   packageVSize`) against the last successful submission for the same
-  parent txid.
+  parent txid. Fee constraints learned from a foreign child use separate
+  fields and are clamped to `MaxFeeRateSatPerVByte` before wallet input
+  selection. This keeps fees bounded while retries continue to reach Core
+  and detect when the conflict disappears.
 - **Per-parent fee-input reservation**: each parent txid reserves the
   wallet UTXO(s) it has committed to. Reservations survive block
   boundaries and release only on eviction (terminal state) or when
@@ -207,11 +212,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/txconfir
   keeps `pendingConfirmed` set for the next tick. The same split applies on
   the deferred `handleTerminalNotifyResult` path, where a post-timeout stop
   is logged at debug and cancelled rather than warned.
-- **`ErrParentAlreadyBroadcast` is a race outcome, not a failure.** An initial
-  package attempt can lose to an existing broadcast path once the parent
-  reaches a mempool; the duplicate child is rejected, but the parent stays
-  under its confirmation watch, so the entry still advances to
-  `AwaitingConfirmation` and no operator action is possible. Both
+- **Classify an existing-parent child failure by recovery action.** If Core
+  reports a replacement fee constraint, retain the strongest floor and keep
+  the entry in `Broadcasting`; the next interval must construct a bounded
+  replacement. `ErrParentAlreadyBroadcast` is reserved for a spent or missing
+  anchor where no actionable floor exists, so the entry advances to
+  `AwaitingConfirmation`. Both
   `recordInitialBroadcastOutcome` and the later fee-bump path log this sentinel
   at debug — keep the two consistent if either is touched. Log severity here is
   deliberately **not** pinned by a unit test: the initial-package test asserts

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -2560,6 +2560,67 @@ func TestEnsureConfirmedDefersToExistingParentBroadcast(t *testing.T) {
 	mustHaveNoNotification(t, sub)
 }
 
+// TestEnsureConfirmedRetriesConflictingChild verifies that a live foreign
+// child does not make the actor wait passively for the parent. The tx remains
+// in Broadcasting and the next interval submits a replacement above Core's
+// reported fee floor.
+func TestEnsureConfirmedRetriesConflictingChild(t *testing.T) {
+	chain := newFakeChainSourceRef(100)
+	tx := makeTestTx(true)
+	foreignFee := btcutil.Amount(10_000)
+	chain.packageErr = errors.Join(
+		chainbackends.NewPackageTxError(
+			"parent", tx.TxHash(),
+			"txn-already-known",
+		),
+		chainbackends.NewPackageTxError(
+			"child", chainhash.Hash{0xab}, "insufficient fee, "+
+				"rejecting replacement tx, less fees than "+
+				"conflicting txs; 0.00001 < 0.0001",
+		),
+	)
+
+	ref, behavior := newTestActor(t, Config{
+		ChainSource: chain,
+		Wallet: &fakeWallet{
+			utxos: []*walletcore.Utxo{
+				makeWalletUTXOWithAmount(10_000_000, 0xab),
+			},
+		},
+		FeeBumpIntervalBlocks: 1,
+	})
+
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub-a", 4)
+	resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+		Tx: tx, Subscriber: sub,
+	})
+	require.Equal(t, TxStateBroadcasting, resp.State)
+	require.Equal(
+		t, foreignFee, behavior.broadcaster.parentStates[tx.TxHash()].
+			ForeignChildFeeFloor,
+	)
+	mustHaveNoNotification(t, sub)
+
+	chain.mu.Lock()
+	chain.packageErr = nil
+	chain.mu.Unlock()
+	chain.emitBlock(t, 101)
+
+	require.Equal(
+		t, TxStateAwaitingConfirmation,
+		mustTrackedState(
+			t, ref.Ref(), tx, sub,
+		),
+	)
+	require.Equal(t, 2, chain.packageCallCount())
+	require.Greater(
+		t,
+		behavior.broadcaster.parentStates[tx.TxHash()].LastPackageFee,
+		foreignFee,
+	)
+	mustHaveNoNotification(t, sub)
+}
+
 // TestFeeBumpExistingParentLogsAtDebug verifies that a later fee bump does
 // not warn when another path already placed the parent in the mempool. The
 // original transaction remains live and the actor keeps its confirmation

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -103,24 +103,28 @@ var (
 
 	// ErrParentAlreadyBroadcast indicates that the SubmitPackage RPC
 	// reported the parent transaction as already known to the network
-	// while our CPFP child failed to land (e.g. RBF-replaced by a
-	// higher-fee child or its anchor input was already spent). The
+	// while our CPFP child failed to land because its anchor input was
+	// already spent or otherwise unavailable. The
 	// parent will confirm via whichever fee-bump won the race, so the
 	// caller should keep watching for confirmation rather than treat
 	// this as a terminal broadcast failure.
 	ErrParentAlreadyBroadcast = errors.New("parent already broadcast by " +
 		"another path; cpfp child rejected")
 
-	// ErrFeeRateCapReached indicates that satisfying the BIP-125 Rule 4
-	// replacement floor (a strictly higher feerate than the prior
-	// submission) would push the package above the configured
-	// MaxFeeRateSatPerVByte ceiling. The estimator is clamped to the cap,
-	// but the replacement floor ratchets past it once a prior bump already
-	// sat at the cap, so we fail the bump closed rather than pay above the
-	// operator's safety limit. The prior submission stays live, so callers
-	// treat this as a benign no-op (Bumped=false): the tx keeps its last
-	// in-cap fee and can still confirm; only the over-cap replacement is
-	// refused (wavelength#403).
+	// ErrConflictingChildRejected indicates that the parent is already in
+	// the mempool but the submitted CPFP child could not replace a
+	// conflicting child. The broadcaster records any fee floor reported by
+	// the backend before returning this error, so callers should keep the
+	// transaction in the initial broadcast retry loop.
+	ErrConflictingChildRejected = errors.New("parent accepted but cpfp " +
+		"child rejected by a conflicting child")
+
+	// ErrFeeRateCapReached indicates that replacing our own prior package
+	// would require a feerate or absolute fee above the configured
+	// MaxFeeRateSatPerVByte ceiling. Our prior submission stays live, so
+	// callers treat this as a benign no-op (Bumped=false). Constraints
+	// learned from a foreign child are instead clamped to the ceiling so a
+	// retry still reaches Core and detects when that conflict disappears.
 	ErrFeeRateCapReached = errors.New("replacement feerate floor exceeds " +
 		"the configured max fee rate cap")
 )
@@ -317,6 +321,16 @@ type parentBumpState struct {
 	// sats) paid by the most recent successful submission for this
 	// parent.
 	LastPackageFee btcutil.Amount
+
+	// ForeignFeeRateFloor is the strongest feerate reported for a
+	// conflicting child that we did not submit. It is kept separate from
+	// LastFeeRate because it may exceed our configured fee cap.
+	ForeignFeeRateFloor int64
+
+	// ForeignChildFeeFloor is the strongest absolute fee reported for a
+	// conflicting child that we did not submit. It is
+	// clamped to the configured cap when constructing each retry.
+	ForeignChildFeeFloor btcutil.Amount
 
 	// UsedFeeOutpoints is the set of wallet UTXOs this parent's child
 	// packages have consumed across the parent's submission history.
@@ -571,6 +585,8 @@ func (b *CPFPBroadcaster) releaseFeeOutpoint(ctx context.Context,
 	// drop the empty entry entirely so parentStates does not accumulate
 	// zero-value shells.
 	if state.LastFeeRate == 0 && state.LastPackageFee == 0 &&
+		state.ForeignFeeRateFloor == 0 &&
+		state.ForeignChildFeeFloor == 0 &&
 		len(state.UsedFeeOutpoints) == 0 &&
 		len(state.UsedFeeInputs) == 0 &&
 		len(state.PredictedFeeInputs) == 0 {
@@ -833,33 +849,11 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 		return nil, fmt.Errorf("estimate fee: %w", err)
 	}
 
-	totalFee, err := computePackageFee(
-		req.Tx, btcutil.Amount(feeRate), childVSize,
+	feeRate, totalFee, err := b.boundedPackageFee(
+		req.Tx, txid, feeRate, req.ParentFee, childVSize,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("estimate package fee: %w", err)
-	}
-
-	feeRate, totalFee = b.applyReplacementFloor(
-		req.Tx, txid, feeRate, totalFee, childVSize,
-	)
-
-	// The estimator (and any operator target) is clamped to
-	// MaxFeeRateSatPerVByte, but the replacement floor above ratchets the
-	// feerate to prev.LastFeeRate + 1 to satisfy BIP-125 Rule 4 without
-	// re-checking that ceiling. Once a prior bump already sat at the cap,
-	// each subsequent bump would escalate one sat/vB above it indefinitely,
-	// making the wallet pay fees over the configured safety limit. The cap
-	// is a hard ceiling, so fail closed here rather than pay past it: no
-	// compliant replacement exists within the cap once the prior submission
-	// is already at it. The bump is a benign no-op -- the prior tx stays
-	// live and can still confirm at its last in-cap fee -- so the actor's
-	// fee-bump-error path recovers to AwaitingConfirmation and retries
-	// (wavelength#403).
-	if feeRate > b.cfg.MaxFeeRateSatPerVByte {
-		return nil, fmt.Errorf("%w: replacement requires %d sat/vB, "+
-			"above the %d sat/vB cap", ErrFeeRateCapReached,
-			feeRate, b.cfg.MaxFeeRateSatPerVByte)
+		return nil, err
 	}
 
 	// A funded parent may already pay the whole package target on its own
@@ -959,6 +953,10 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 				)
 			}
 			if reselected.Outpoint != feeInput.Outpoint {
+				reselectedCarriedOver := b.feeOutpointReserved(
+					txid, reselected.Outpoint,
+				)
+
 				// The child will spend the reselected input, so
 				// release the abandoned original's reservation
 				// and wallet lease -- otherwise it stays locked
@@ -974,9 +972,22 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 				}
 
 				feeInput = reselected
+				feeInputCarriedOver = reselectedCarriedOver
 				b.reserveFeeInput(ctx, txid, feeInput)
 			}
 		}
+	}
+
+	// Mixed-script wallets can make the precise child estimate smaller than
+	// the conservative pre-selection estimate. The broadcaster never lowers
+	// totalFee in that case, so use the same conservative size for the cap.
+	err = b.validateFeeCap(
+		req.Tx, max(childVSize, preciseChildVSize), feeRate, totalFee,
+	)
+	if err != nil {
+		b.releaseNewFeeInput(ctx, txid, feeInput, feeInputCarriedOver)
+
+		return nil, err
 	}
 
 	child, err := BuildCPFPChild(
@@ -1023,6 +1034,15 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 		},
 	).Await(ctx).Unpack()
 	if pkgErr != nil {
+		parentKnown := isParentKnownChildFailed(txid, pkgErr)
+		learnedFloor := false
+		if parentKnown {
+			learnedFloor = learnReplacementFloor(
+				b.parentState(txid), pkgErr,
+				childFeeFromPackageFee(totalFee, req.ParentFee),
+			)
+		}
+
 		switch {
 		case IsIgnorableBroadcastError(pkgErr):
 			b.log.DebugS(
@@ -1043,7 +1063,21 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 					err)
 			}
 
-		case isParentKnownChildFailed(txid, pkgErr):
+		case learnedFloor:
+			// Core rejected this child against a live conflicting
+			// child and reported the fee constraint that failed.
+			// Keep that floor after releasing the unused wallet
+			// input so the next retry constructs a bounded
+			// replacement instead of repeating the same underpriced
+			// package.
+			b.releaseNewFeeInput(
+				ctx, txid, feeInput, feeInputCarriedOver,
+			)
+
+			return nil, fmt.Errorf("%w: %w",
+				ErrConflictingChildRejected, pkgErr)
+
+		case parentKnown:
 			// The parent is already in mempool or chain via
 			// another CPFP attempt, but our child was rejected
 			// (RBF replacement of a higher-fee child, or its
@@ -1067,22 +1101,155 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 		}
 	}
 
-	childTxid := child.TxHash()
+	return b.successfulPackageResult(
+		txid, child.TxHash(), feeRate, totalFee,
+	), nil
+}
 
-	// Record the submission so the next fee bump for this parent can
-	// enforce BIP-125 Rule 3/4 against it. The parentStates entry was
-	// already created (or updated) by reserveFeeOutpoint above, so we
-	// update the fee-history fields in place to preserve the
-	// UsedFeeOutpoints reservation accumulated over all prior bumps.
-	state := b.parentStates[txid]
+// boundedPackageFee computes the initial package fee, applies every local and
+// foreign replacement floor, and enforces the operator cap before the caller
+// selects or leases a wallet input.
+func (b *CPFPBroadcaster) boundedPackageFee(parent *wire.MsgTx,
+	parentTxid chainhash.Hash, feeRate int64, parentFee btcutil.Amount,
+	childVSize int64) (int64, btcutil.Amount, error) {
+
+	totalFee, err := computePackageFee(
+		parent, btcutil.Amount(feeRate), childVSize,
+	)
+	if err != nil {
+		return 0, 0, fmt.Errorf("estimate package fee: %w", err)
+	}
+
+	feeRate, totalFee = b.applyReplacementFloor(
+		parent, parentTxid, feeRate, totalFee, parentFee, childVSize,
+	)
+
+	// A foreign child can force an absolute-fee floor above the cap without
+	// forcing the nominal package feerate above it, so check both values.
+	if err := b.validateFeeCap(
+		parent, childVSize, feeRate, totalFee,
+	); err != nil {
+		return 0, 0, err
+	}
+
+	return feeRate, totalFee, nil
+}
+
+// successfulPackageResult records an accepted package and returns its public
+// result. The successful local fee history replaces any foreign constraint
+// learned while reaching this submission.
+func (b *CPFPBroadcaster) successfulPackageResult(
+	parentTxid, childTxid chainhash.Hash, feeRate int64,
+	totalFee btcutil.Amount) *BroadcastResult {
+
+	// The parentStates entry already exists because fee-input reservation
+	// precedes submission. Update it in place to preserve every outpoint
+	// committed across prior bumps.
+	state := b.parentStates[parentTxid]
 	state.LastFeeRate = feeRate
 	state.LastPackageFee = totalFee
+	state.ForeignFeeRateFloor = 0
+	state.ForeignChildFeeFloor = 0
 
 	return &BroadcastResult{
-		Txid:      txid,
+		Txid:      parentTxid,
 		ChildTxid: &childTxid,
 		FeeRate:   feeRate,
-	}, nil
+	}
+}
+
+// validateFeeRateCap refuses a replacement whose nominal feerate exceeds the
+// configured ceiling.
+func (b *CPFPBroadcaster) validateFeeRateCap(feeRate int64) error {
+	if feeRate <= b.cfg.MaxFeeRateSatPerVByte {
+		return nil
+	}
+
+	return fmt.Errorf("%w: replacement requires %d sat/vB, above the %d "+
+		"sat/vB cap", ErrFeeRateCapReached, feeRate,
+		b.cfg.MaxFeeRateSatPerVByte)
+}
+
+// validateFeeCap refuses a replacement whose nominal feerate or absolute
+// package fee exceeds the configured ceiling. Callers pass the child-size
+// estimate that produced totalFee.
+func (b *CPFPBroadcaster) validateFeeCap(parent *wire.MsgTx, childVSize,
+	feeRate int64, totalFee btcutil.Amount) error {
+
+	if err := b.validateFeeRateCap(feeRate); err != nil {
+		return err
+	}
+
+	parentVSize := (EstimateWeight(parent) + 3) / 4
+	maxFee := btcutil.Amount(parentVSize+childVSize) *
+		btcutil.Amount(b.cfg.MaxFeeRateSatPerVByte)
+	if totalFee > maxFee {
+		return fmt.Errorf("%w: replacement requires %d sat, above the "+
+			"%d sat package cap", ErrFeeRateCapReached, totalFee,
+			maxFee)
+	}
+
+	return nil
+}
+
+// releaseNewFeeInput releases an input selected for the failed attempt while
+// preserving an input that the currently live child already spends.
+func (b *CPFPBroadcaster) releaseNewFeeInput(ctx context.Context,
+	parentTxid chainhash.Hash, feeInput *FeeInput, carriedOver bool) {
+
+	if carriedOver {
+		return
+	}
+
+	b.releaseFeeOutpoint(ctx, parentTxid, feeInput.Outpoint)
+}
+
+// learnReplacementFloor records the strongest foreign replacement constraint
+// in a package rejection. It returns true only when the backend exposed a fee
+// floor, which proves that a conflicting child is live and the next submission
+// should remain on the retry path.
+func learnReplacementFloor(state *parentBumpState, err error,
+	attemptedFee btcutil.Amount) bool {
+
+	if state == nil || err == nil {
+		return false
+	}
+
+	found := false
+	chainbackends.WalkPackageTxErrors(
+		err, func(packageErr *chainbackends.PackageTxError) {
+			constraints := packageErr.ReplacementConstraints()
+			if constraints == nil {
+				return
+			}
+
+			found = true
+			conflictingFee := constraints.ConflictingFee
+			if conflictingFee != nil &&
+				*conflictingFee > state.ForeignChildFeeFloor {
+
+				state.ForeignChildFeeFloor = *conflictingFee
+			}
+
+			if constraints.AdditionalFeeDeficit != nil {
+				required := attemptedFee +
+					*constraints.AdditionalFeeDeficit
+				if required > state.ForeignChildFeeFloor {
+					state.ForeignChildFeeFloor = required
+				}
+			}
+
+			conflictingRate :=
+				constraints.ConflictingFeeRateSatPerVByte
+			if conflictingRate != nil &&
+				*conflictingRate > state.ForeignFeeRateFloor {
+
+				state.ForeignFeeRateFloor = *conflictingRate
+			}
+		},
+	)
+
+	return found
 }
 
 // applyReplacementFloor returns feerate and totalFee values adjusted so
@@ -1097,7 +1264,7 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 // details this helper does not have visibility into.
 func (b *CPFPBroadcaster) applyReplacementFloor(parent *wire.MsgTx,
 	txid chainhash.Hash, feeRate int64, totalFee btcutil.Amount,
-	childVSize int64) (int64, btcutil.Amount) {
+	parentFee btcutil.Amount, childVSize int64) (int64, btcutil.Amount) {
 
 	prev, havePrev := b.parentStates[txid]
 	if !havePrev {
@@ -1109,6 +1276,19 @@ func (b *CPFPBroadcaster) applyReplacementFloor(parent *wire.MsgTx,
 	// value, ratchet the feerate up by one sat/vB.
 	if feeRate <= prev.LastFeeRate {
 		feeRate = prev.LastFeeRate + 1
+	}
+
+	// A foreign child may report a feerate above our configured cap. Retry
+	// at the cap so a disappeared conflict can still be detected without
+	// poisoning every later attempt with an impossible local floor.
+	foreignFeeRate := prev.ForeignFeeRateFloor
+	if foreignFeeRate >= b.cfg.MaxFeeRateSatPerVByte {
+		foreignFeeRate = b.cfg.MaxFeeRateSatPerVByte
+	} else if foreignFeeRate > 0 {
+		foreignFeeRate++
+	}
+	if feeRate < foreignFeeRate {
+		feeRate = foreignFeeRate
 	}
 
 	// Recompute totalFee at the (possibly bumped) feerate so the
@@ -1133,6 +1313,34 @@ func (b *CPFPBroadcaster) applyReplacementFloor(parent *wire.MsgTx,
 	minRequired := prev.LastPackageFee + minAdditional
 	if totalFee < minRequired {
 		totalFee = minRequired
+	}
+
+	// Core reports replacement constraints for the child because the parent
+	// is already known. Convert that child floor back into a package target
+	// by adding the parent's fee. Keeping the raw observation in state lets
+	// retries recompute the bounded target when their child size changes.
+	maxFee := btcutil.Amount(packageVSize) *
+		btcutil.Amount(b.cfg.MaxFeeRateSatPerVByte)
+	foreignChildRequired := prev.ForeignChildFeeFloor
+	foreignRateFee := btcutil.Amount(foreignFeeRate) *
+		btcutil.Amount(childVSize)
+	if foreignChildRequired < foreignRateFee {
+		foreignChildRequired = foreignRateFee
+	}
+	if foreignChildRequired > 0 {
+		childAdditional := btcutil.Amount(
+			b.cfg.IncrementalRelayFeeSatPerVByte * childVSize,
+		)
+		extra := parentFee + childAdditional
+		foreignPackageRequired := foreignChildRequired
+		if foreignPackageRequired >= maxFee-min(extra, maxFee) {
+			foreignPackageRequired = maxFee
+		} else {
+			foreignPackageRequired += extra
+		}
+		if totalFee < foreignPackageRequired {
+			totalFee = foreignPackageRequired
+		}
 	}
 
 	return feeRate, totalFee

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -1056,6 +1056,46 @@ func TestCPFPBumpFailsClosedAtFeeRateCap(t *testing.T) {
 		require.NotErrorIs(t, err, ErrFeeRateCapReached)
 		require.Equal(t, 1, chain.packageCallCount())
 	})
+
+	t.Run("absolute fee above cap fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		chain := newFakeChainSourceRef(100)
+		chain.feeRate = 5
+		utxo := makeWalletUTXOWithAmount(10_000_000, 0xdd)
+		w := &fakeWallet{
+			utxos: []*walletcore.Utxo{
+				utxo,
+			},
+		}
+		b := NewCPFPBroadcaster(BroadcasterConfig{
+			ChainSource:           chain,
+			Wallet:                w,
+			MaxFeeRateSatPerVByte: feeCap,
+		})
+
+		_, err := b.Submit(t.Context(), 99, &BroadcastRequest{
+			Tx: parent, Label: "initial-package",
+		})
+		require.NoError(t, err)
+
+		// A foreign child may have a low nominal feerate but a high
+		// absolute fee. The replacement floor must still respect the
+		// operator's package-fee ceiling.
+		b.parentStates[txid].LastPackageFee = 1_000_000
+
+		_, err = b.Submit(t.Context(), 100, &BroadcastRequest{
+			Tx: parent, Label: "absolute-cap", IsFeeBump: true,
+		})
+		require.ErrorIs(t, err, ErrFeeRateCapReached)
+		require.Equal(t, 1, chain.packageCallCount())
+		require.Zero(t, chain.broadcastCallCount())
+		require.Contains(
+			t, b.parentStates[txid].UsedFeeOutpoints, utxo.Outpoint,
+		)
+		releaseCalls, _ := w.releaseSnapshot()
+		require.NotContains(t, releaseCalls, utxo.Outpoint)
+	})
 }
 
 // TestCPFPReselectReleasesAbandonedFeeInput reproduces wavelength#664: when the
@@ -1871,7 +1911,7 @@ func TestApplyReplacementFloor(t *testing.T) {
 		b := newBroadcaster(1)
 
 		feeRate, totalFee := b.applyReplacementFloor(
-			parent, txid, 7, btcutil.Amount(7*packageVSize),
+			parent, txid, 7, btcutil.Amount(7*packageVSize), 0,
 			childVSize,
 		)
 		require.Equal(t, int64(7), feeRate)
@@ -1890,7 +1930,7 @@ func TestApplyReplacementFloor(t *testing.T) {
 
 		feeRate, totalFee := b.applyReplacementFloor(
 			parent, txid, prevFeeRate,
-			btcutil.Amount(prevFeeRate*packageVSize), childVSize,
+			btcutil.Amount(prevFeeRate*packageVSize), 0, childVSize,
 		)
 
 		require.Equal(
@@ -1914,7 +1954,7 @@ func TestApplyReplacementFloor(t *testing.T) {
 		}
 
 		feeRate, totalFee := b.applyReplacementFloor(
-			parent, txid, 3, btcutil.Amount(3*packageVSize),
+			parent, txid, 3, btcutil.Amount(3*packageVSize), 0,
 			childVSize,
 		)
 
@@ -1950,6 +1990,7 @@ func TestApplyReplacementFloor(t *testing.T) {
 				parent, txid, prevFeeRate+1, btcutil.Amount(
 					(prevFeeRate+1)*packageVSize,
 				),
+				0,
 				childVSize,
 			)
 
@@ -1976,7 +2017,7 @@ func TestApplyReplacementFloor(t *testing.T) {
 
 		_, totalFee := b.applyReplacementFloor(
 			parent, txid, prevFeeRate, // flat estimator
-			btcutil.Amount(prevFeeRate*packageVSize), childVSize,
+			btcutil.Amount(prevFeeRate*packageVSize), 0, childVSize,
 		)
 
 		minAdditional := irf * packageVSize
@@ -2004,7 +2045,7 @@ func TestApplyReplacementFloor(t *testing.T) {
 			)
 
 			_, totalFee := b.applyReplacementFloor(
-				parent, txid, prevFeeRate, large, childVSize,
+				parent, txid, prevFeeRate, large, 0, childVSize,
 			)
 			require.Equal(
 				t, large, totalFee, "applyReplacementFloor "+
@@ -2539,6 +2580,346 @@ func TestCPFPBroadcasterFeeBumpReplacementFloor(t *testing.T) {
 				"estimator",
 		)
 	})
+}
+
+// TestCPFPBroadcasterLearnsForeignChildFloor verifies that a package retry
+// uses Core's reported replacement constraint instead of repeating the same
+// underpriced child.
+func TestCPFPBroadcasterLearnsForeignChildFloor(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	chain.feeRate = 5
+	parent := makeTestTx(true)
+	parentTxid := parent.TxHash()
+	foreignFee := btcutil.Amount(10_000)
+	parentFee := btcutil.Amount(500)
+	feeUTXO := makeWalletUTXOWithAmount(10_000_000, 0xee)
+	chain.packageErr = errors.Join(
+		chainbackends.NewPackageTxError(
+			"parent", parentTxid, "txn-already-known",
+		),
+		chainbackends.NewPackageTxError(
+			"child", chainhash.Hash{0xee}, "insufficient fee, "+
+				"rejecting replacement tx, less fees than "+
+				"conflicting txs; 0.00001 < 0.0001",
+		),
+	)
+
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet: &fakeWallet{
+			utxos: []*walletcore.Utxo{feeUTXO},
+		},
+		IncrementalRelayFeeSatPerVByte: 1,
+	})
+
+	_, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx: parent, ParentFee: parentFee, Label: "foreign-child",
+	})
+	require.ErrorIs(t, err, ErrConflictingChildRejected)
+	require.Equal(
+		t, foreignFee, b.parentStates[parentTxid].ForeignChildFeeFloor,
+	)
+
+	chain.mu.Lock()
+	chain.packageErr = nil
+	chain.mu.Unlock()
+
+	result, err := b.Submit(t.Context(), 101, &BroadcastRequest{
+		Tx: parent, ParentFee: parentFee, Label: "foreign-child-retry",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.ChildTxid)
+	require.Greater(
+		t, b.parentStates[parentTxid].LastPackageFee, foreignFee,
+	)
+	require.Zero(t, b.parentStates[parentTxid].ForeignChildFeeFloor)
+	require.Equal(t, 2, chain.packageCallCount())
+
+	chain.mu.Lock()
+	replacementChild := chain.packageCalls[1].Child.Copy()
+	chain.mu.Unlock()
+	childInputValue := feeUTXO.Amount + btcutil.Amount(
+		parent.TxOut[findAnchorOutput(parent)].Value,
+	)
+	var childOutputValue btcutil.Amount
+	for _, output := range replacementChild.TxOut {
+		childOutputValue += btcutil.Amount(output.Value)
+	}
+	require.Greater(
+		t, childInputValue-childOutputValue, foreignFee, "the "+
+			"replacement child itself must clear Core's child "+
+			"fee floor",
+	)
+}
+
+// TestCPFPBroadcasterRelearnsForeignFloorAfterRestart verifies that the
+// backend diagnostic restores the in-memory floor after process state is lost.
+func TestCPFPBroadcasterRelearnsForeignFloorAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	parent := makeTestTx(true)
+	parentTxid := parent.TxHash()
+	foreignFee := btcutil.Amount(10_000)
+	newChain := func() *fakeChainSourceRef {
+		chain := newFakeChainSourceRef(100)
+		chain.feeRate = 5
+		chain.packageErr = errors.Join(
+			chainbackends.NewPackageTxError(
+				"parent", parentTxid, "txn-already-known",
+			),
+			chainbackends.NewPackageTxError(
+				"child", chainhash.Hash{0xef}, "insufficient"+
+					" fee, rejecting replacement tx, "+
+					"less fees than conflicting txs; "+
+					"0.00001 < 0.0001",
+			),
+		)
+
+		return chain
+	}
+	newBroadcaster := func(chain *fakeChainSourceRef,
+		seed byte) *CPFPBroadcaster {
+
+		return NewCPFPBroadcaster(BroadcasterConfig{
+			ChainSource: chain,
+			Wallet: &fakeWallet{
+				utxos: []*walletcore.Utxo{
+					makeWalletUTXOWithAmount(
+						10_000_000, seed,
+					),
+				},
+			},
+		})
+	}
+
+	firstChain := newChain()
+	first := newBroadcaster(firstChain, 0xe1)
+	_, err := first.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx: parent, Label: "before-restart",
+	})
+	require.ErrorIs(t, err, ErrConflictingChildRejected)
+	require.Equal(
+		t, foreignFee,
+		first.parentStates[parentTxid].ForeignChildFeeFloor,
+	)
+
+	// A new broadcaster has no parent state. Core reports the same live
+	// conflict, allowing it to reconstruct the floor before retrying.
+	restartChain := newChain()
+	restarted := newBroadcaster(restartChain, 0xe2)
+	_, err = restarted.Submit(t.Context(), 101, &BroadcastRequest{
+		Tx: parent, Label: "after-restart",
+	})
+	require.ErrorIs(t, err, ErrConflictingChildRejected)
+	require.Equal(
+		t, foreignFee,
+		restarted.parentStates[parentTxid].ForeignChildFeeFloor,
+	)
+
+	restartChain.mu.Lock()
+	restartChain.packageErr = nil
+	restartChain.mu.Unlock()
+	_, err = restarted.Submit(t.Context(), 102, &BroadcastRequest{
+		Tx: parent, Label: "after-restart-retry",
+	})
+	require.NoError(t, err)
+	require.Greater(
+		t, restarted.parentStates[parentTxid].LastPackageFee,
+		foreignFee,
+	)
+	require.Zero(
+		t, restarted.parentStates[parentTxid].ForeignChildFeeFloor,
+	)
+}
+
+// TestCPFPBroadcasterClampsForeignFloor verifies that an unpayable foreign
+// constraint cannot prevent retries from reaching Core. A retry at the local
+// cap is required to detect that the foreign child has disappeared.
+func TestCPFPBroadcasterClampsForeignFloor(t *testing.T) {
+	t.Parallel()
+
+	const feeCap = 10
+
+	parent := makeTestTx(true)
+	parentTxid := parent.TxHash()
+	chain := newFakeChainSourceRef(100)
+	chain.feeRate = 5
+	chain.packageErr = errors.Join(
+		chainbackends.NewPackageTxError(
+			"parent", parentTxid, "txn-already-known",
+		),
+		chainbackends.NewPackageTxError(
+			"child", chainhash.Hash{0xf0}, "insufficient fee, "+
+				"rejecting replacement tx, less fees than "+
+				"conflicting txs; 0.00001 < 1.00000000; "+
+				"new feerate 0.00004 BTC/kvB <= old "+
+				"feerate 0.01000 BTC/kvB",
+		),
+	)
+
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet: &fakeWallet{
+			utxos: []*walletcore.Utxo{
+				makeWalletUTXOWithAmount(10_000_000, 0xf0),
+			},
+		},
+		MaxFeeRateSatPerVByte: feeCap,
+	})
+	req := &BroadcastRequest{Tx: parent, Label: "foreign-cap"}
+
+	_, err := b.Submit(t.Context(), 100, req)
+	require.ErrorIs(t, err, ErrConflictingChildRejected)
+	require.Equal(
+		t, btcutil.Amount(100_000_000),
+		b.parentStates[parentTxid].ForeignChildFeeFloor,
+	)
+	require.Equal(
+		t, int64(1_000), b.parentStates[parentTxid].ForeignFeeRateFloor,
+	)
+
+	// The learned values exceed both local caps. The retry must still
+	// submit a bounded package instead of failing fee selection or cap
+	// validation before it reaches Core.
+	_, err = b.Submit(t.Context(), 101, req)
+	require.ErrorIs(t, err, ErrConflictingChildRejected)
+	require.Equal(t, 2, chain.packageCallCount())
+
+	chain.mu.Lock()
+	chain.packageErr = nil
+	chain.mu.Unlock()
+	result, err := b.Submit(t.Context(), 102, req)
+	require.NoError(t, err)
+	require.Equal(t, int64(feeCap), result.FeeRate)
+	require.Equal(t, 3, chain.packageCallCount())
+	require.Zero(t, b.parentStates[parentTxid].ForeignChildFeeFloor)
+	require.Zero(t, b.parentStates[parentTxid].ForeignFeeRateFloor)
+}
+
+// TestCPFPBroadcasterPreservesLiveChildInputOnForeignConflict verifies that a
+// failed replacement does not release the fee input spent by our live child.
+func TestCPFPBroadcasterPreservesLiveChildInputOnForeignConflict(t *testing.T) {
+	t.Parallel()
+
+	parent := makeTestTx(true)
+	parentTxid := parent.TxHash()
+	utxo := makeWalletUTXOWithAmount(10_000_000, 0xf1)
+	wallet := &fakeWallet{utxos: []*walletcore.Utxo{utxo}}
+	chain := newFakeChainSourceRef(100)
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet:      wallet,
+	})
+	req := &BroadcastRequest{Tx: parent, Label: "preserve-input"}
+
+	_, err := b.Submit(t.Context(), 100, req)
+	require.NoError(t, err)
+	require.Contains(
+		t, b.parentStates[parentTxid].UsedFeeOutpoints, utxo.Outpoint,
+	)
+
+	chain.mu.Lock()
+	chain.packageErr = errors.Join(
+		chainbackends.NewPackageTxError(
+			"parent", parentTxid, "txn-already-known",
+		),
+		chainbackends.NewPackageTxError(
+			"child", chainhash.Hash{0xf1}, "insufficient fee, "+
+				"rejecting replacement tx, less fees than "+
+				"conflicting txs; 0.00001 < 0.0001",
+		),
+	)
+	chain.mu.Unlock()
+
+	_, err = b.Submit(t.Context(), 101, req)
+	require.ErrorIs(t, err, ErrConflictingChildRejected)
+	require.Contains(
+		t, b.parentStates[parentTxid].UsedFeeOutpoints, utxo.Outpoint,
+	)
+	require.Contains(
+		t, b.parentStates[parentTxid].UsedFeeInputs, utxo.Outpoint,
+	)
+	releaseCalls, _ := wallet.releaseSnapshot()
+	require.NotContains(t, releaseCalls, utxo.Outpoint)
+}
+
+// TestCPFPBroadcasterDoesNotLearnFromFatalParent verifies that a child fee
+// diagnostic is ignored unless Core also proves the parent is already known.
+func TestCPFPBroadcasterDoesNotLearnFromFatalParent(t *testing.T) {
+	t.Parallel()
+
+	parent := makeTestTx(true)
+	parentTxid := parent.TxHash()
+	chain := newFakeChainSourceRef(100)
+	chain.packageErr = errors.Join(
+		chainbackends.NewPackageTxError(
+			"parent", parentTxid, "bad-witness",
+		),
+		chainbackends.NewPackageTxError(
+			"child", chainhash.Hash{0xf2}, "insufficient fee, "+
+				"rejecting replacement tx, less fees than "+
+				"conflicting txs; 0.00001 < 0.0001",
+		),
+	)
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet: &fakeWallet{
+			utxos: []*walletcore.Utxo{
+				makeWalletUTXOWithAmount(10_000_000, 0xf2),
+			},
+		},
+	})
+
+	_, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx: parent, Label: "fatal-parent",
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrConflictingChildRejected)
+	require.Nil(t, b.parentStates[parentTxid])
+}
+
+// TestLearnReplacementFloor verifies that repeated policy diagnostics only
+// ratchet the remembered floor upward.
+func TestLearnReplacementFloor(t *testing.T) {
+	t.Parallel()
+
+	state := &parentBumpState{}
+	first := chainbackends.NewPackageTxError(
+		"child", chainhash.Hash{1},
+		"less fees than conflicting txs; 0.00001 < 0.0001",
+	)
+	require.True(t, learnReplacementFloor(state, first, 1_000))
+	require.Equal(
+		t, btcutil.Amount(10_000), state.ForeignChildFeeFloor,
+	)
+
+	deficit := chainbackends.NewPackageTxError(
+		"child", chainhash.Hash{1},
+		"not enough additional fees to relay; 0.00000001 < 0.00000016",
+	)
+	require.True(t, learnReplacementFloor(state, deficit, 10_001))
+	require.Equal(
+		t, btcutil.Amount(10_016), state.ForeignChildFeeFloor,
+	)
+
+	feeRate := chainbackends.NewPackageTxError(
+		"child", chainhash.Hash{1},
+		"new feerate 0.00004 BTC/kvB <= old feerate 0.00207 BTC/kvB",
+	)
+	require.True(t, learnReplacementFloor(state, feeRate, 1_000))
+	require.Equal(t, int64(207), state.ForeignFeeRateFloor)
+
+	require.False(
+		t,
+		learnReplacementFloor(
+			state, errors.New("unrelated"), 50_000,
+		),
+	)
+	require.Equal(
+		t, btcutil.Amount(10_016), state.ForeignChildFeeFloor,
+	)
 }
 
 // TestSignCPFPChildHandlesWalletInputRewrites exercises signCPFPChild with

--- a/txconfirm/doc.go
+++ b/txconfirm/doc.go
@@ -55,8 +55,9 @@
 // re-attempting every fee-bump interval, and is never failed
 // automatically — only a structurally permanent error (a non-TRUC
 // parent) is terminal. Transient conditions such as a missing confirmed
-// fee input, a min-relay-fee rejection of the zero-fee anchor parent, or
-// a mempool-full backend keep retrying. After
+// fee input, a min-relay-fee rejection of the zero-fee anchor parent, a
+// mempool-full backend, or a conflicting child with a reported replacement
+// fee floor keep retrying. After
 // Config.BroadcastFailureAlertThreshold consecutive failures the actor
 // emits a rate-limited operator escalation, because a fund-risk tx (e.g.
 // a fraud-response checkpoint) must eventually land rather than be
@@ -79,9 +80,12 @@
 //     enforces BIP-125 Rule 4 (strictly higher feerate) and Rule 3
 //     (strictly higher absolute fee, by at least
 //     IncrementalRelayFeeSatPerVByte * packageVSize) against the last
-//     successful submission for the same parent txid. Without this, a
-//     flat or dipping fee estimator would regenerate byte-identical or
-//     lower-fee packages that the mempool rejects.
+//     successful submission for the same parent txid. Foreign-child fee
+//     constraints use separate state and are clamped to the configured cap
+//     before wallet input selection, so retries stay bounded and still reach
+//     Core to detect a disappeared conflict. Without this, a flat or dipping
+//     fee estimator would regenerate lower-fee packages that the mempool
+//     rejects.
 //
 //  3. Fee-input reservation. Each parent txid reserves the wallet
 //     UTXO(s) it has committed to across its submission history.


### PR DESCRIPTION
A v3 parent can already be in the mempool while an unrelated child spends its P2A output. When that child pays more than our CPFP attempt, Core accepts the parent row and rejects our child as an underpriced replacement. Txconfirm previously treated every existing-parent child failure as a successful alternate broadcast path and moved to `AwaitingConfirmation`. A zero-fee parent can then remain pinned because the foreign child is not the child the caller needs to land.

This change keeps the parent in the initial broadcast retry loop when Core reports an actionable replacement constraint. The broadcaster keeps the foreign child's fee observations separate from its own successful submission history, converts the child constraint to a package target using the parent's fee, clamps the result to `MaxFeeRateSatPerVByte` before wallet input selection, and retries through the existing package-RBF path. A retry still reaches Core at the cap, so it detects when the conflict disappears. A spent or missing anchor with no actionable floor retains the existing `ErrParentAlreadyBroadcast` behavior.

Bitcoin Core 28 through 31 use the parsed total-fee and incremental-relay diagnostics. Core 28 through 30 can also emit the parsed conflicting-feerate diagnostic. The LND package submit adapter preserves these per-transaction rejection strings in `PackageTxError`.

Validation:

- Isolated Bitcoin Core 31 regtest: a 10,000 sat foreign child rejected repeated 1,000 sat attempts, rejected 10,001 sat for the incremental-relay deficit, and was evicted by a 10,150 sat replacement.
- Tests cover a funded parent whose replacement child must itself clear the foreign 10,000 sat floor, over-cap foreign fee and feerate observations, conflict disappearance, restart relearning, carried fee-input preservation, and fatal parent rejection.
- `go test -race ./chainbackends ./txconfirm`
- `go test -run='^$' ./...`
- `go vet ./chainbackends ./txconfirm`
- Changed-code custom lint, zero findings.
- Commit-message and signature checks pass for both commits.

The full local Docker lint run reached all analyzers, then its compiler was killed at 2.4 GB while type-checking the unrelated `scripts/check-sample-waved-conf` package. `make doc-check` still reports the pre-existing `origin/main` omission of `docs/mailbox_ingress_safety.md` from `docs/index.md`.
