### PR TITLE
docs: nightly doc-gardening sweep 2026-09-12

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,7 @@ package may import from a higher layer.
 | [`vhtlcrecovery`](vhtlcrecovery/) | Durable control-plane types for vHTLC on-chain recovery jobs (action, state, script parameters, swap linkage) |
 | [`credit`](credit/) | Client-side credit subsystem: supervisor/per-operation-actor pair driving fault-tolerant sub-floor pay, credit-receive, and redeem flows against the authoritative server ledger |
 | [`coinselect`](coinselect/) | Single coin-type-agnostic coin-selection algorithm shared across wallet backends |
+| [`tapassets`](tapassets/) | Adapts tap-sdk custom-anchor transitions to Ark trees: caller-funded asset batch outputs plus asset-aware VTXO tree materialization, over a journaled commit store. Holds no actor; not yet wired into a consumer |
 
 ### Layer 2: Infrastructure (Chain, Storage, Messaging)
 

--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -65,7 +65,7 @@ who want direct access.
 
 | Command | RPC | Description |
 |---------|-----|-------------|
-| `ark vtxos {list,refresh,leave}` | `ListVTXOs` / `RefreshVTXOs` / `LeaveVTXOs` | VTXO inventory and lifecycle |
+| `ark vtxos {list,refresh,leave}` | `ListVTXOs` / `RefreshVTXOs` / `LeaveVTXOs` | VTXO inventory and lifecycle; `list` takes a repeatable `--status` or a mutually exclusive `--all` |
 | `ark rounds {get,join,list,watch}` | `GetRound` / (join) / `ListRounds` / `WatchRounds` | Round FSM state; `join` commits queued intents into the next round (`vtxos refresh`/`leave` call it automatically); `watch --max-events`/`--for` bounds streams for machines |
 | `ark oor {receive,get,list}` | `NewReceiveScript` / `GetOORSession` / `ListOORSessions` | Receive-script allocation and OOR session inspection; `receive --idempotency-key` replays the allocation already made for that key |
 | `ark board` | `Board` | Trigger boarding with confirmed UTXOs |
@@ -172,6 +172,18 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   cannot dispatch that payment without first previewing it. The raw
   `ark.send.*` advanced MCP tools are NOT two-phase — they move funds in one
   call, gated only by their optional `dry_run` flag.
+- `ark vtxos list` defaults to the daemon's inventory set — every VTXO except
+  forfeited and spent ones, newest first. `--status` is a repeatable string
+  slice (each value must be a known status; `UNSPECIFIED` is rejected rather
+  than treated as "no filter"), and `--all` expands to every status in enum
+  order. The two are mutually exclusive, because `--all` overwrites the
+  accumulated `--status` set rather than adding to it, so accepting both would
+  silently discard the narrower request.
+- `ark vtxos list` suppresses OOR checkpoint PSBTs
+  (`ExcludeCheckpointPsbts`) unless `--fields` names
+  `oor_final_checkpoint_psbts`, or neither `--fields` nor `--all` was given.
+  This keeps a broad `--all` listing from dragging every checkpoint PSBT blob
+  through the wire by default; a caller that wants them must ask by field.
 - `exit` defaults to a cooperative leave; it only starts a unilateral
   on-chain unroll when `--force-unroll-ack` matches the literal string
   `I_KNOW_WHAT_I_AM_DOING`, and that flag is mutually exclusive with

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -65,7 +65,7 @@ who want direct access.
 
 | Command | RPC | Description |
 |---------|-----|-------------|
-| `ark vtxos {list,refresh,leave}` | `ListVTXOs` / `RefreshVTXOs` / `LeaveVTXOs` | VTXO inventory and lifecycle |
+| `ark vtxos {list,refresh,leave}` | `ListVTXOs` / `RefreshVTXOs` / `LeaveVTXOs` | VTXO inventory and lifecycle; `list` takes a repeatable `--status` or a mutually exclusive `--all` |
 | `ark rounds {get,join,list,watch}` | `GetRound` / (join) / `ListRounds` / `WatchRounds` | Round FSM state; `join` commits queued intents into the next round (`vtxos refresh`/`leave` call it automatically); `watch --max-events`/`--for` bounds streams for machines |
 | `ark oor {receive,get,list}` | `NewReceiveScript` / `GetOORSession` / `ListOORSessions` | Receive-script allocation and OOR session inspection; `receive --idempotency-key` replays the allocation already made for that key |
 | `ark board` | `Board` | Trigger boarding with confirmed UTXOs |
@@ -172,6 +172,18 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   cannot dispatch that payment without first previewing it. The raw
   `ark.send.*` advanced MCP tools are NOT two-phase — they move funds in one
   call, gated only by their optional `dry_run` flag.
+- `ark vtxos list` defaults to the daemon's inventory set — every VTXO except
+  forfeited and spent ones, newest first. `--status` is a repeatable string
+  slice (each value must be a known status; `UNSPECIFIED` is rejected rather
+  than treated as "no filter"), and `--all` expands to every status in enum
+  order. The two are mutually exclusive, because `--all` overwrites the
+  accumulated `--status` set rather than adding to it, so accepting both would
+  silently discard the narrower request.
+- `ark vtxos list` suppresses OOR checkpoint PSBTs
+  (`ExcludeCheckpointPsbts`) unless `--fields` names
+  `oor_final_checkpoint_psbts`, or neither `--fields` nor `--all` was given.
+  This keeps a broad `--all` listing from dragging every checkpoint PSBT blob
+  through the wire by default; a caller that wants them must ask by field.
 - `exit` defaults to a cooperative leave; it only starts a unilateral
   on-chain unroll when `--force-unroll-ack` matches the literal string
   `I_KNOW_WHAT_I_AM_DOING`, and that flag is mutually exclusive with

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ into specific topics below.
 | [mailbox_architecture.md](mailbox_architecture.md) | Three-layer mailbox system: pb, rpc, conn, serverconn |
 | [mailbox_durable_actor_layer.md](mailbox_durable_actor_layer.md) | The durable mailbox and durable actor: leases, dedup, transactional outbox, DurableAsk, and the classic vs. Read/Commit (`TxBehavior`/`Exec[S]`) execution paths |
 | [mailbox_transport_serverconn_clientconn.md](mailbox_transport_serverconn_clientconn.md) | The RPC-over-mailbox transport relating this client's `serverconn` to the operator's `clientconn`: envelope, edge API, shared `mailbox/conn` primitives, ack watermark, identity/auth/liveness, and the wire contract |
+| [mailbox_ingress_safety.md](mailbox_ingress_safety.md) | Ingress safety and recovery: `delivery-v1:` occurrence IDs and replay retention, commit-before-ack for durable routes, poison-envelope quarantine, and the cursor-consistency check that gates dispatch |
 | [RPC_MAILBOX_CONTRACT.md](RPC_MAILBOX_CONTRACT.md) | Envelope semantics, at-least-once delivery, ack watermarks |
 | [credit_durable_actor_design.md](credit_durable_actor_design.md) | Credit subsystem durable-actor design: supervisor + per-operation actors driving fault-tolerant sub-floor pay, credit-receive, and redeem flows against the authoritative server ledger |
 | [wavewalletdk_mobile.md](wavewalletdk_mobile.md) | gomobile-safe `sdk/wavewalletdk/mobile` facade: drives an embedded in-process `waved` wallet from Android/iOS over the private bufconn transport (bytes-out API, no daemon binary) |

--- a/lib/actormsg/AGENTS.md
+++ b/lib/actormsg/AGENTS.md
@@ -15,7 +15,11 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - `SelectAndReserveSpendRequest` / `SelectAndReserveSpendResponse` — Ask-message to select and lock VTXOs for OOR spend.
 - `SelectAndReserveForfeitRequest` / `SelectAndReserveForfeitResponse` — Ask-message to atomically select and reserve VTXOs for cooperative forfeit (directed sends). Combines coin selection and PendingForfeit reservation in one step to close a race window.
 - `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
-- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
+- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion
+  messages. `ReleaseSpendRequest.ReserveEpochs` optionally names, per outpoint,
+  the reservation epoch the releasing owner held, so a stale release from a
+  superseded session is refused instead of returning a coin a newer session is
+  actively spending.
 - `ForceUnrollRequest` / `ForceUnrollResponse` — Ask-message that routes an operator or chain-resolver unroll trigger through the VTXO manager into the per-VTXO FSM. `ForceUnrollRequest.Trigger` (a `UnrollTrigger`) names *why* the coin is exiting, and `ForceUnrollRequest.ExitPolicy` (an `fn.Option[ExitPolicy]`) names *which* exit-spend policy the target unrolls under, so a single admission path carries manual, critical-expiry, fraud, and vHTLC-recovery intent through to the unroll registry. `ForceUnrollResponse.Accepted` is true when the request caused a state transition; when false, `Reason` distinguishes `"no such vtxo"` from `"already terminal"` so callers don't misread a silent self-loop as success.
 - `UnrollTrigger` — String-typed enum naming why a unilateral exit was started (`UnrollTriggerCriticalExpiry` is the empty-string zero value and preserves the historical critical-expiry admission, `UnrollTriggerManual`, `UnrollTriggerFraudSpend`). It mirrors the unroll package's `StartTrigger` so `vtxo` and `actormsg` can thread the trigger through `ForceUnroll` without importing `unroll` (which would form a cycle); the waved chain resolver bridge converts it back at the seam.
 - `ExitPolicyKind` / `ExitPolicyRef` / `ExitPolicy` — Durable exit-spend policy identity for a forced exit. `ExitPolicyKind` is a string-typed enum of the non-standard policies that ride `ForceUnroll` (`ExitPolicyVHTLCClaim`, `ExitPolicyVHTLCRefundWithoutReceiver`), with `Valid()` true only for those two vHTLC kinds; `ExitPolicyRef` is the policy-specific durable reference (e.g. a vHTLC recovery job id), kept a distinct type so `Kind` and `Ref` can't be transposed; `ExitPolicy` bundles the pair as one identity validated at the registry admission boundary. A `None` `ExitPolicy` selects the standard VTXO timeout policy.
@@ -25,7 +29,11 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
   (`true` for directed sends) or parks in `PendingRoundAssembly` for
   batching (`false` for refresh/leave flows).
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
-- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
+- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount,
+  pkscript) plus the manager's monotonic `ReserveEpoch` for that reservation.
+  The epoch is echoed back so the spend that carries it into its durable state
+  can present it on release; it is zero for reservations that are not spend
+  reservations (e.g. forfeit inputs).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.
 
 ## Relationships
@@ -38,6 +46,13 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - All cross-boundary actor messages must implement the appropriate marker interface (`RoundReceivable`, `VTXOManagerMsg`, etc.) for type-safe actor routing.
 - Service key names are constants (`RoundActorServiceKeyName`, `VTXOManagerServiceKeyName`) shared across the codebase for consistent actor discovery.
 - `SelectedVTXO` intentionally duplicates minimal VTXO info to avoid `wallet` importing `vtxo.Descriptor`.
+- Reservation epochs are compare-and-release, not advisory. When
+  `ReleaseSpendRequest.ReserveEpochs` carries an entry for an outpoint, the
+  manager releases it only if the VTXO's current epoch still matches; an absent
+  entry (or a nil map) releases unconditionally, which preserves the behaviour
+  for callers that hold no epoch, such as a manual unlock. Dropping the epoch
+  from a release path reopens the window where a redelivered rollback returns a
+  coin the newer session is spending back to the live set.
 
 ## Deep Docs
 

--- a/lib/actormsg/CLAUDE.md
+++ b/lib/actormsg/CLAUDE.md
@@ -15,7 +15,11 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - `SelectAndReserveSpendRequest` / `SelectAndReserveSpendResponse` — Ask-message to select and lock VTXOs for OOR spend.
 - `SelectAndReserveForfeitRequest` / `SelectAndReserveForfeitResponse` — Ask-message to atomically select and reserve VTXOs for cooperative forfeit (directed sends). Combines coin selection and PendingForfeit reservation in one step to close a race window.
 - `ReserveForfeitRequest` / `ReleaseForfeitRequest` — Forfeit reservation admission messages.
-- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion messages.
+- `ReleaseSpendRequest` / `CompleteSpendRequest` — Spend lifecycle completion
+  messages. `ReleaseSpendRequest.ReserveEpochs` optionally names, per outpoint,
+  the reservation epoch the releasing owner held, so a stale release from a
+  superseded session is refused instead of returning a coin a newer session is
+  actively spending.
 - `ForceUnrollRequest` / `ForceUnrollResponse` — Ask-message that routes an operator or chain-resolver unroll trigger through the VTXO manager into the per-VTXO FSM. `ForceUnrollRequest.Trigger` (a `UnrollTrigger`) names *why* the coin is exiting, and `ForceUnrollRequest.ExitPolicy` (an `fn.Option[ExitPolicy]`) names *which* exit-spend policy the target unrolls under, so a single admission path carries manual, critical-expiry, fraud, and vHTLC-recovery intent through to the unroll registry. `ForceUnrollResponse.Accepted` is true when the request caused a state transition; when false, `Reason` distinguishes `"no such vtxo"` from `"already terminal"` so callers don't misread a silent self-loop as success.
 - `UnrollTrigger` — String-typed enum naming why a unilateral exit was started (`UnrollTriggerCriticalExpiry` is the empty-string zero value and preserves the historical critical-expiry admission, `UnrollTriggerManual`, `UnrollTriggerFraudSpend`). It mirrors the unroll package's `StartTrigger` so `vtxo` and `actormsg` can thread the trigger through `ForceUnroll` without importing `unroll` (which would form a cycle); the waved chain resolver bridge converts it back at the seam.
 - `ExitPolicyKind` / `ExitPolicyRef` / `ExitPolicy` — Durable exit-spend policy identity for a forced exit. `ExitPolicyKind` is a string-typed enum of the non-standard policies that ride `ForceUnroll` (`ExitPolicyVHTLCClaim`, `ExitPolicyVHTLCRefundWithoutReceiver`), with `Valid()` true only for those two vHTLC kinds; `ExitPolicyRef` is the policy-specific durable reference (e.g. a vHTLC recovery job id), kept a distinct type so `Kind` and `Ref` can't be transposed; `ExitPolicy` bundles the pair as one identity validated at the registry admission boundary. A `None` `ExitPolicy` selects the standard VTXO timeout policy.
@@ -25,7 +29,11 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
   (`true` for directed sends) or parks in `PendingRoundAssembly` for
   batching (`false` for refresh/leave flows).
 - `TriggerBoardMsg` — Carries VTXO amounts for boarding registration to round actor.
-- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount, pkscript).
+- `SelectedVTXO` — Describes a VTXO selected for spend (outpoint, amount,
+  pkscript) plus the manager's monotonic `ReserveEpoch` for that reservation.
+  The epoch is echoed back so the spend that carries it into its durable state
+  can present it on release; it is zero for reservations that are not spend
+  reservations (e.g. forfeit inputs).
 - `RoundActorServiceKey()` / `VTXOManagerServiceKey()` / `VTXOActorServiceKey(outpoint wire.OutPoint)` — Service key constructors for actor discovery. `VTXOActorServiceKey` encodes the target outpoint into the key so each per-VTXO actor gets a unique, deterministic key.
 
 ## Relationships
@@ -38,6 +46,13 @@ package boundaries. Lives in `lib/` to break import cycles between `vtxo`,
 - All cross-boundary actor messages must implement the appropriate marker interface (`RoundReceivable`, `VTXOManagerMsg`, etc.) for type-safe actor routing.
 - Service key names are constants (`RoundActorServiceKeyName`, `VTXOManagerServiceKeyName`) shared across the codebase for consistent actor discovery.
 - `SelectedVTXO` intentionally duplicates minimal VTXO info to avoid `wallet` importing `vtxo.Descriptor`.
+- Reservation epochs are compare-and-release, not advisory. When
+  `ReleaseSpendRequest.ReserveEpochs` carries an entry for an outpoint, the
+  manager releases it only if the VTXO's current epoch still matches; an absent
+  entry (or a nil map) releases unconditionally, which preserves the behaviour
+  for callers that hold no epoch, such as a manual unlock. Dropping the epoch
+  from a release path reopens the window where a redelivered rollback returns a
+  coin the newer session is spending back to the live set.
 
 ## Deep Docs
 

--- a/lib/recovery/AGENTS.md
+++ b/lib/recovery/AGENTS.md
@@ -23,6 +23,13 @@ scheduling live downstream in `unrollplan` and `unroll`.
   Optional fields use `fn.Option` instead of nilable pointers.
 - `ComputeMaturityHeight` — Overflow-safe `targetConfirmHeight + csvDelay`
   helper shared with `unrollplan`.
+- `Proof.RootExternalInputs()` — The outpoints consumed by root transactions
+  that no node in the proof produces: the external funding inputs the whole
+  recovery graph hangs off of. For a round-direct VTXO that is the
+  batch/commitment output the tree root spends; for an OOR-chained or fan-in
+  VTXO it is every distinct commitment output rooting a local lineage fragment.
+  Callers arm spend watches on these so a competing confirmed spend fails the
+  exit terminally instead of retrying a tree that can never confirm.
 
 ## Relationships
 
@@ -53,6 +60,10 @@ scheduling live downstream in `unrollplan` and `unroll`.
   helpers assume the caller already holds the lock.
 - The TLV codec is canonical (sorted by raw hash bytes) and carries an
   explicit version byte; version mismatch is a hard decode error.
+- `RootExternalInputs` is deduplicated and sorted deterministically (by hash,
+  then index), so two proofs built from the same node set yield byte-identical
+  output regardless of map iteration order. Downstream watch registration keys
+  off this ordering; do not make it map-order dependent.
 - `parseHash` via `chainhash.NewHashFromStr` is intentionally absent: raw
   32-byte hashes are encoded directly to avoid the short-form / zero-pad
   attack surface that JSON shipping with `chainhash.Hash.String()` would open.

--- a/lib/recovery/CLAUDE.md
+++ b/lib/recovery/CLAUDE.md
@@ -23,6 +23,13 @@ scheduling live downstream in `unrollplan` and `unroll`.
   Optional fields use `fn.Option` instead of nilable pointers.
 - `ComputeMaturityHeight` — Overflow-safe `targetConfirmHeight + csvDelay`
   helper shared with `unrollplan`.
+- `Proof.RootExternalInputs()` — The outpoints consumed by root transactions
+  that no node in the proof produces: the external funding inputs the whole
+  recovery graph hangs off of. For a round-direct VTXO that is the
+  batch/commitment output the tree root spends; for an OOR-chained or fan-in
+  VTXO it is every distinct commitment output rooting a local lineage fragment.
+  Callers arm spend watches on these so a competing confirmed spend fails the
+  exit terminally instead of retrying a tree that can never confirm.
 
 ## Relationships
 
@@ -53,6 +60,10 @@ scheduling live downstream in `unrollplan` and `unroll`.
   helpers assume the caller already holds the lock.
 - The TLV codec is canonical (sorted by raw hash bytes) and carries an
   explicit version byte; version mismatch is a hard decode error.
+- `RootExternalInputs` is deduplicated and sorted deterministically (by hash,
+  then index), so two proofs built from the same node set yield byte-identical
+  output regardless of map iteration order. Downstream watch registration keys
+  off this ordering; do not make it map-order dependent.
 - `parseHash` via `chainhash.NewHashFromStr` is intentionally absent: raw
   32-byte hashes are encoded directly to avoid the short-form / zero-pad
   attack surface that JSON shipping with `chainhash.Hash.String()` would open.

--- a/rpc/roundpb/AGENTS.md
+++ b/rpc/roundpb/AGENTS.md
@@ -24,11 +24,25 @@ All `*.pb.go` files are generated — never edit directly; regenerate with
   `MethodSubmitVTXOForfeitSigs` (VTXO forfeit sigs).
 - `TreeFromProto` / `TreeToProto` — Convert between `*VTXOTree` proto and
   `lib/tree.Tree`; `TreeFromProto` takes `WithMaxTreeNodes` to bound the
-  deserialized node count (`DefaultMaxTreeNodes` = 50,000).
+  deserialized node count (`DefaultMaxTreeNodes` = 50,000). Both round-trip a
+  `tree.AssetTreeContext` when the tree carries one. `TreeFromProto` now
+  recomputes each node's `FinalKey` from its cosigners and taproot tweak —
+  callers no longer have to run `Materialize` to populate it.
 - `OutpointFromProto`/`ToProto`, `TxOutFromProto`/`ToProto`,
   `PSBTFromBytes`/`ToBytes`, `MsgTxFromBytes`/`ToBytes`,
   `SchnorrSigFromBytes`/`ToBytes` — wire/proto ⇄ Go conversions for the
   round protocol's payload types.
+- Asset-aware tree fields — `VTXOTree.asset_ref` names the asset a tree
+  carries (empty for Bitcoin-only trees), and each `TreeNode` carries
+  `signing_tweak` (the node's taproot tweak for an asset tree; Bitcoin-only
+  trees use `sweep_tapscript_root` instead), `asset_amount` (asset units in
+  the subtree), and `asset_commitment_root` (set on asset leaves so the owner
+  can verify and persist the composed VTXO output).
+- Asset request/response fields — `VTXORequest.asset_ref` /
+  `VTXORequest.asset_amount` let a client request an asset VTXO (both empty /
+  zero for a Bitcoin VTXO), and `ClientBatchInfo.asset_leaf_packages` returns
+  the sealed transfer package for each asset VTXO created for that client,
+  keyed by VTXO outpoint.
 - `FlowVersion` / `FlowVersionV1` / `ValidateFlowVersion` — the per-round
   choreography version stamped by the operator and validated by the
   client; fails closed on any version this build does not understand.
@@ -41,7 +55,8 @@ distinction.
 ## Relationships
 
 - **Depends on**: `lib/tree`, `lib/types` (conversion targets in
-  `convert.go`); otherwise generated proto types only.
+  `convert.go`), `github.com/lightninglabs/tap-sdk` (`ParseAssetRef` for
+  canonical `asset_ref` validation); otherwise generated proto types only.
 - **Depended on by**: `round` (outbox routing, proto conversions, flow
   version), `db` (persisting round/VTXO proto blobs), `waved` (proto
   conversion, flow version).
@@ -70,6 +85,23 @@ distinction.
   the sibling decoder on the untrusted indexer receive path. Keep the
   two in step: a shape rejected by one and accepted by the other is a
   gap, not a difference in trust level.
+- **The taproot tweak a node's `FinalKey` is computed under depends on
+  whether the tree is an asset tree.** Bitcoin-only trees tweak with
+  `VTXOTree.sweep_tapscript_root`; asset trees tweak with the node's own
+  `TreeNode.signing_tweak` from the asset context. Using the wrong one yields a
+  key that fails signature verification for every node in the tree.
+- Asset fields and `asset_ref` are all-or-nothing: `assetContextFromProto`
+  rejects a tree that sets any per-node asset field (`signing_tweak`,
+  `asset_amount`, `asset_commitment_root`) without also setting
+  `VTXOTree.asset_ref`. A half-populated asset tree is a decode error, not a
+  Bitcoin-only tree with stray fields.
+- `asset_ref` must round-trip through `tapsdk.ParseAssetRef` to the *same*
+  string on both the encode (`validateAssetTree`) and decode
+  (`assetContextFromProto`) sides. Accepting a non-canonical encoding would let
+  two spellings of one asset ref key different contexts.
+- Both directions run `AssetContext.Validate(root)` before the tree is handed
+  on, so a tree whose per-node asset amounts do not reconcile against its root
+  never reaches the caller.
 - `ValidateFlowVersion` must reject any `FlowVersion` other than the
   versions this build implements (currently only `FlowVersionV1`); never
   make it permissive by default.

--- a/rpc/roundpb/CLAUDE.md
+++ b/rpc/roundpb/CLAUDE.md
@@ -24,11 +24,25 @@ All `*.pb.go` files are generated — never edit directly; regenerate with
   `MethodSubmitVTXOForfeitSigs` (VTXO forfeit sigs).
 - `TreeFromProto` / `TreeToProto` — Convert between `*VTXOTree` proto and
   `lib/tree.Tree`; `TreeFromProto` takes `WithMaxTreeNodes` to bound the
-  deserialized node count (`DefaultMaxTreeNodes` = 50,000).
+  deserialized node count (`DefaultMaxTreeNodes` = 50,000). Both round-trip a
+  `tree.AssetTreeContext` when the tree carries one. `TreeFromProto` now
+  recomputes each node's `FinalKey` from its cosigners and taproot tweak —
+  callers no longer have to run `Materialize` to populate it.
 - `OutpointFromProto`/`ToProto`, `TxOutFromProto`/`ToProto`,
   `PSBTFromBytes`/`ToBytes`, `MsgTxFromBytes`/`ToBytes`,
   `SchnorrSigFromBytes`/`ToBytes` — wire/proto ⇄ Go conversions for the
   round protocol's payload types.
+- Asset-aware tree fields — `VTXOTree.asset_ref` names the asset a tree
+  carries (empty for Bitcoin-only trees), and each `TreeNode` carries
+  `signing_tweak` (the node's taproot tweak for an asset tree; Bitcoin-only
+  trees use `sweep_tapscript_root` instead), `asset_amount` (asset units in
+  the subtree), and `asset_commitment_root` (set on asset leaves so the owner
+  can verify and persist the composed VTXO output).
+- Asset request/response fields — `VTXORequest.asset_ref` /
+  `VTXORequest.asset_amount` let a client request an asset VTXO (both empty /
+  zero for a Bitcoin VTXO), and `ClientBatchInfo.asset_leaf_packages` returns
+  the sealed transfer package for each asset VTXO created for that client,
+  keyed by VTXO outpoint.
 - `FlowVersion` / `FlowVersionV1` / `ValidateFlowVersion` — the per-round
   choreography version stamped by the operator and validated by the
   client; fails closed on any version this build does not understand.
@@ -41,7 +55,8 @@ distinction.
 ## Relationships
 
 - **Depends on**: `lib/tree`, `lib/types` (conversion targets in
-  `convert.go`); otherwise generated proto types only.
+  `convert.go`), `github.com/lightninglabs/tap-sdk` (`ParseAssetRef` for
+  canonical `asset_ref` validation); otherwise generated proto types only.
 - **Depended on by**: `round` (outbox routing, proto conversions, flow
   version), `db` (persisting round/VTXO proto blobs), `waved` (proto
   conversion, flow version).
@@ -70,6 +85,23 @@ distinction.
   the sibling decoder on the untrusted indexer receive path. Keep the
   two in step: a shape rejected by one and accepted by the other is a
   gap, not a difference in trust level.
+- **The taproot tweak a node's `FinalKey` is computed under depends on
+  whether the tree is an asset tree.** Bitcoin-only trees tweak with
+  `VTXOTree.sweep_tapscript_root`; asset trees tweak with the node's own
+  `TreeNode.signing_tweak` from the asset context. Using the wrong one yields a
+  key that fails signature verification for every node in the tree.
+- Asset fields and `asset_ref` are all-or-nothing: `assetContextFromProto`
+  rejects a tree that sets any per-node asset field (`signing_tweak`,
+  `asset_amount`, `asset_commitment_root`) without also setting
+  `VTXOTree.asset_ref`. A half-populated asset tree is a decode error, not a
+  Bitcoin-only tree with stray fields.
+- `asset_ref` must round-trip through `tapsdk.ParseAssetRef` to the *same*
+  string on both the encode (`validateAssetTree`) and decode
+  (`assetContextFromProto`) sides. Accepting a non-canonical encoding would let
+  two spellings of one asset ref key different contexts.
+- Both directions run `AssetContext.Validate(root)` before the tree is handed
+  on, so a tree whose per-node asset amounts do not reconcile against its root
+  never reaches the caller.
 - `ValidateFlowVersion` must reject any `FlowVersion` other than the
   versions this build implements (currently only `FlowVersionV1`); never
   make it permissive by default.

--- a/sdk/ark/AGENTS.md
+++ b/sdk/ark/AGENTS.md
@@ -78,6 +78,16 @@ transport, without duplicating Ark runtime behavior.
 - `ServerInfo` is a bootstrap-time operator-terms snapshot, including the
   advisory `FreeRefreshWindowBlocks`; refresh after reconnect is not wired
   through yet.
+- `ServerInfo.MinConfirmations` and `ServerInfo.VTXOConfirmations` are
+  **different depths and not interchangeable**: the former is the confirmation
+  depth required of boarding inputs, the latter the depth at which VTXOs
+  created by a round become spendable off-chain. Reading one for the other
+  either gates boarding on the wrong depth or treats a VTXO as spendable
+  early.
+- `ListVTXOs(ctx, nil)` lists the **inventory set** — every VTXO except
+  forfeited and spent ones, newest first — not a daemon-default subset. Only
+  the live entries in that result are spendable, so a caller that treats the
+  whole list as balance will over-count.
 - Pre-1.0, some methods intentionally return `waverpc` protobuf types
   directly. Those passthrough APIs are not yet treated as stable SDK-owned
   models.

--- a/sdk/ark/CLAUDE.md
+++ b/sdk/ark/CLAUDE.md
@@ -78,6 +78,16 @@ transport, without duplicating Ark runtime behavior.
 - `ServerInfo` is a bootstrap-time operator-terms snapshot, including the
   advisory `FreeRefreshWindowBlocks`; refresh after reconnect is not wired
   through yet.
+- `ServerInfo.MinConfirmations` and `ServerInfo.VTXOConfirmations` are
+  **different depths and not interchangeable**: the former is the confirmation
+  depth required of boarding inputs, the latter the depth at which VTXOs
+  created by a round become spendable off-chain. Reading one for the other
+  either gates boarding on the wrong depth or treats a VTXO as spendable
+  early.
+- `ListVTXOs(ctx, nil)` lists the **inventory set** — every VTXO except
+  forfeited and spent ones, newest first — not a daemon-default subset. Only
+  the live entries in that result are spendable, so a caller that treats the
+  whole list as balance will over-count.
 - Pre-1.0, some methods intentionally return `waverpc` protobuf types
   directly. Those passthrough APIs are not yet treated as stable SDK-owned
   models.

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -169,6 +169,37 @@ default builds avoid the swap executor's dependency graph.
   calls `listLiveVTXOsForLeave` for sweep-all enumeration.
 - `SendResponse.actual_amount_sat` carries the true outflow for sweep-all
   sends and SHOULD be echoed back before the send is treated as confirmed.
+- **The on-chain send preview quotes per selected input, not once for the
+  destination amount.** `quoteOnchainInputs` calls `EstimateFee` for each
+  selected VTXO, keyed and memoized by `(amountSat, remainingBlocks)` so
+  identical inputs cost one round trip. Every input pays its own fixed forfeit
+  components even when they all belong to one wallet; quoting the destination
+  amount once both misses those charges and prices the wrong principal when a
+  bounded send returns change. `remainingBlocks` is
+  `max(batchExpiry - blockHeight, 1)` — clamped to one block for an expiring
+  input, because zero means "use the full default lifetime" to the operator.
+- **A partial per-input quote is discarded whole.** Missing chain height, a
+  missing `batch_expiry`/`amount_sat`, a failed `EstimateFee`, or an overflow
+  in the running total all drop the entire remote estimate and fall back to
+  the local batch-size-1 floor as `LOCAL_ONLY`. A partial sum must never be
+  reported as a `COMPLETE` quote.
+- An input the operator flags `below_dust_warning` is the one case that
+  **rejects** the preview (`FailedPrecondition`, naming the outpoint, amount,
+  and fee) rather than falling back. Substituting the local floor there would
+  hide an operator quote already known to be uneconomic.
+- `fetchOnchainTerms` now also carries `blockHeight` from the same `GetInfo`
+  call, and no longer bails out on a nil `ServerInfo` — the generated getters
+  are nil-safe, so a missing `ServerInfo` leaves selection headroom and the
+  local floor at zero while still yielding a usable height.
+- A sweep-all preview checks that `selectedTotal - feeSat` still meets
+  `max(dustLimit, 1)`. A sweep absorbs the fee into its leave output, so
+  "a sweep is affordable by construction" does not hold: the leave output can
+  be driven below the operator's advertised floor.
+- `stampLateTransition` advances a projection's `updated_at` past the stored
+  row's when the derived value does not. Ledger-derived transitions carry
+  their *source row's* creation time, which would otherwise hide the change
+  from recency ordering, pollers, and subscriber payloads. The stamp never
+  regresses a stored value under a stepped-back clock.
 - **Cooperative-leave EXIT fee**: at completion
   (`applyCooperativeLeaveForfeited`), the forfeited source VTXO's
   settlement carries the forfeit round's operator fee (from the daemon

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -169,6 +169,37 @@ default builds avoid the swap executor's dependency graph.
   calls `listLiveVTXOsForLeave` for sweep-all enumeration.
 - `SendResponse.actual_amount_sat` carries the true outflow for sweep-all
   sends and SHOULD be echoed back before the send is treated as confirmed.
+- **The on-chain send preview quotes per selected input, not once for the
+  destination amount.** `quoteOnchainInputs` calls `EstimateFee` for each
+  selected VTXO, keyed and memoized by `(amountSat, remainingBlocks)` so
+  identical inputs cost one round trip. Every input pays its own fixed forfeit
+  components even when they all belong to one wallet; quoting the destination
+  amount once both misses those charges and prices the wrong principal when a
+  bounded send returns change. `remainingBlocks` is
+  `max(batchExpiry - blockHeight, 1)` — clamped to one block for an expiring
+  input, because zero means "use the full default lifetime" to the operator.
+- **A partial per-input quote is discarded whole.** Missing chain height, a
+  missing `batch_expiry`/`amount_sat`, a failed `EstimateFee`, or an overflow
+  in the running total all drop the entire remote estimate and fall back to
+  the local batch-size-1 floor as `LOCAL_ONLY`. A partial sum must never be
+  reported as a `COMPLETE` quote.
+- An input the operator flags `below_dust_warning` is the one case that
+  **rejects** the preview (`FailedPrecondition`, naming the outpoint, amount,
+  and fee) rather than falling back. Substituting the local floor there would
+  hide an operator quote already known to be uneconomic.
+- `fetchOnchainTerms` now also carries `blockHeight` from the same `GetInfo`
+  call, and no longer bails out on a nil `ServerInfo` — the generated getters
+  are nil-safe, so a missing `ServerInfo` leaves selection headroom and the
+  local floor at zero while still yielding a usable height.
+- A sweep-all preview checks that `selectedTotal - feeSat` still meets
+  `max(dustLimit, 1)`. A sweep absorbs the fee into its leave output, so
+  "a sweep is affordable by construction" does not hold: the leave output can
+  be driven below the operator's advertised floor.
+- `stampLateTransition` advances a projection's `updated_at` past the stored
+  row's when the derived value does not. Ledger-derived transitions carry
+  their *source row's* creation time, which would otherwise hide the change
+  from recency ordering, pollers, and subscriber payloads. The stamp never
+  regresses a stored value under a stepped-back clock.
 - **Cooperative-leave EXIT fee**: at completion
   (`applyCooperativeLeaveForfeited`), the forfeited source VTXO's
   settlement carries the forfeit round's operator fee (from the daemon

--- a/tapassets/AGENTS.md
+++ b/tapassets/AGENTS.md
@@ -1,0 +1,126 @@
+# tapassets
+
+## Purpose
+
+Adapts tap-sdk custom-anchor transitions to Ark VTXO trees, so a batch output
+can carry Taproot Asset units alongside its Bitcoin carrier value. The package
+does two things: it moves confirmed assets into one caller-funded batch output
+(`BatchAnchorCommitter`), and it materializes an asset-aware VTXO tree beneath
+that output (`BuildAssetTree`), committing one tap-sdk transition per node.
+Every commit is journaled so a restart replays the sealed package instead of
+re-committing a transition tapd has already recorded.
+
+## Key Types
+
+- `BatchAnchorCommitter` — Creates caller-funded asset batch outputs in three
+  phases: `DeriveScript` (compute the batch output script *before* Bitcoin
+  funding, so the funder knows what to pay to), `Commit` (seal and validate the
+  transition against the funded anchor transaction), and `Publish` (verify the
+  finalized PSBT and record it in tapd). Constructed via
+  `NewBatchAnchorCommitter(BatchAnchorCommitterConfig{Wallet, Store})`.
+- `BatchAnchorRequest` — One caller-funded batch output: `AssetRef`, `Amount`,
+  confirmed `Sources`, `Cosigners` (aggregated into the output's internal key),
+  the operator `SweepLeaf` timeout path, a `Digest` scoping the deterministic
+  asset script key, the `OutputIndex`/`OutputValueSat` of the batch output, and
+  an optional `Change` output returning surplus assets to the tapd wallet.
+- `BatchAnchorScript` — Derived batch output: `PkScript`, untweaked
+  `InternalKey`, `SigningTweak` (commits to sweep leaf + asset root),
+  `AssetRoot`, and `ChangePkScript` when the request carries change.
+- `BatchAnchorCommit` — Sealed transition: `PackageBytes`, `AnchorPSBT`, the
+  echoed `Script`, and the `RootSource` the tree materializer spends.
+- `BatchAnchorSource` / `BatchAnchorChange` / `DeriveBatchAnchorChange` — One
+  confirmed asset input (proof file, amount, optional witness, verifier, anchor
+  outpoint/internal key), and the wallet-owned change output plus its key
+  derivation helper.
+- `BuildAssetTree(ctx, TreeMaterializerConfig, AssetTreeRequest)` — Builds the
+  asset VTXO tree below a batch output. Validates leaf/asset conservation,
+  calls `tree.BuildStructure` + `tree.Materialize` with the internal
+  `treeMaterializer`, and returns a verified `*tree.Tree` carrying an
+  `AssetContext`.
+- `AssetTreeRequest` — Tree inputs: `Leaves` (each with a non-zero
+  `AssetAmount`), `OperatorKey`, `Radix`, `BatchOutpoint`, `BatchOutput`, and
+  the total `AssetAmount`.
+- `TreeMaterializerConfig` — Materialization wiring: tap-sdk `Wallet`, commit
+  journal `Store`, `AssetRef`, operator `SweepLeaf`, a `LeafAnchor` callback
+  returning per-leaf taproot data, the `Root` asset source, and the `Digest`
+  scoping deterministic script keys.
+- `TreeRootAssetSource` / `TreeRootAssetInput` — The asset states the root node
+  spends, plus the batch output's `SigningTweak` and `BatchPkScript`. Each
+  input carries **exactly one** of `ProofFile` (confirmed) or `ProofPath`
+  (unconfirmed transitions).
+- `TreeLeafAnchor` / `StandardVTXOLeafAnchor` — Taproot data for a leaf VTXO
+  output (uncomposed pkScript, internal key, canonically ordered tap leaves);
+  the helper builds it for a standard owner/operator + exit-delay VTXO policy
+  via `lib/arkscript`.
+- `Store` / `ErrStoreNotFound` — Durable commit journal: `Load`/`Store` keyed by
+  string. Implementations must replace each value **atomically**.
+  `ErrStoreNotFound` is the sentinel a missing key must return.
+- `ErrReconciliationRequired` — Publication may have succeeded; the outcome must
+  be checked before any retry.
+
+## Relationships
+
+- **Depends on**: `lib/tree` (`Tree`, `Node`, `LeafDescriptor`,
+  `BuildStructure`, `Materialize`, and the tree `AssetContext`),
+  `lib/arkscript` (VTXO policy templates and compiled taproot leaves),
+  `lib/tx/psbtutil` (anchor PSBT parse/encode),
+  `github.com/lightninglabs/tap-sdk` (custom-anchor wallet, transfer packages,
+  proof verifiers).
+- **Depended on by**: nothing yet — `tapassets` is a standalone building block.
+  It is consumed through the asset-tree plumbing landing in `round` and
+  `rpc/roundpb` (`VTXOTree.asset_ref`, `TreeNode.signing_tweak` /
+  `asset_amount` / `asset_commitment_root`, and
+  `ClientBatchInfo.asset_leaf_packages`), not by importing this package
+  directly. Wire a new consumer through `TreeMaterializerConfig` /
+  `BatchAnchorCommitterConfig` rather than reaching at internals.
+- **Sends / Receives**: none. This package holds no actor; it is called
+  synchronously and performs no message passing.
+
+## Invariants
+
+- **Node transactions are zero fee.** The leaf carrier values must sum exactly
+  to `BatchOutput.Value`, and the leaf asset amounts must sum exactly to
+  `AssetTreeRequest.AssetAmount`, which must in turn equal the sum of the root
+  source input amounts. All three totals are overflow-checked before use.
+- Each leaf cosigner key must be unique within a tree; a repeated cosigner is
+  rejected rather than silently collapsed.
+- `req.BatchOutput.PkScript` must equal `cfg.Root.BatchPkScript` — the tree is
+  refused if the output being spent is not the one the asset source describes.
+- `Radix` must be at least 2, and proof capacity is validated against the built
+  structure's depth (`validateTreeProofCapacity`) before any transition is
+  committed, so a tree too deep for its proof budget fails early.
+- **The commit journal is keyed by request digest, not just by key.** A journal
+  entry records the sha256 of `(digestDomain, request)`; reloading a key with a
+  *different* request is a hard error ("journal key reused with a different
+  request") rather than a silent re-commit. A present package is decoded and
+  returned as-is — tapd has already recorded that transition and must not see
+  it twice.
+- Journal writes after a successful commit run under
+  `context.WithoutCancel` with a 5s timeout (`commitJournalWriteTimeout`), so a
+  cancelled caller cannot lose the record of a transition tapd already
+  committed.
+- `ErrReconciliationRequired` is joined onto a `Publish` failure **only** when
+  tap-sdk reports `OutcomeUnknown`. Treat it as "may have landed": reconcile
+  before retrying, never blind-retry.
+- `Commit` binds the sealed transition to the funded transaction: the committed
+  anchor PSBT's txid must match the funded transaction's, and the committed
+  batch outpoint must equal `(finalTx.TxHash(), req.OutputIndex)`. Output
+  indexes must therefore be final before deriving a request with change.
+- `commitResultFromPackage` requires every output to have a matching proof
+  update, keyed by `(packetRole, packetIndex, virtualOutputIndex)`; an output
+  with no proof is a hard error, not an empty blob.
+- A failure converting an already-committed tapd response is wrapped in
+  `commitResponseError` so callers can tell "tapd never committed" from "tapd
+  committed and we failed locally afterwards" — the latter needs the journal,
+  not a retry.
+- All byte slices crossing the package boundary (`packageBytes`, `anchorPSBT`,
+  proof blobs) are defensively copied, so a caller cannot mutate journaled
+  state.
+
+## Deep Docs
+
+- [lib/tree/CLAUDE.md](../lib/tree/CLAUDE.md) — Tree structure, materialization
+  interface, and the asset context this package populates.
+- [lib/arkscript/CLAUDE.md](../lib/arkscript/CLAUDE.md) — Policy templates and
+  compiled taproot leaves used for leaf anchors.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/tapassets/CLAUDE.md
+++ b/tapassets/CLAUDE.md
@@ -1,0 +1,126 @@
+# tapassets
+
+## Purpose
+
+Adapts tap-sdk custom-anchor transitions to Ark VTXO trees, so a batch output
+can carry Taproot Asset units alongside its Bitcoin carrier value. The package
+does two things: it moves confirmed assets into one caller-funded batch output
+(`BatchAnchorCommitter`), and it materializes an asset-aware VTXO tree beneath
+that output (`BuildAssetTree`), committing one tap-sdk transition per node.
+Every commit is journaled so a restart replays the sealed package instead of
+re-committing a transition tapd has already recorded.
+
+## Key Types
+
+- `BatchAnchorCommitter` — Creates caller-funded asset batch outputs in three
+  phases: `DeriveScript` (compute the batch output script *before* Bitcoin
+  funding, so the funder knows what to pay to), `Commit` (seal and validate the
+  transition against the funded anchor transaction), and `Publish` (verify the
+  finalized PSBT and record it in tapd). Constructed via
+  `NewBatchAnchorCommitter(BatchAnchorCommitterConfig{Wallet, Store})`.
+- `BatchAnchorRequest` — One caller-funded batch output: `AssetRef`, `Amount`,
+  confirmed `Sources`, `Cosigners` (aggregated into the output's internal key),
+  the operator `SweepLeaf` timeout path, a `Digest` scoping the deterministic
+  asset script key, the `OutputIndex`/`OutputValueSat` of the batch output, and
+  an optional `Change` output returning surplus assets to the tapd wallet.
+- `BatchAnchorScript` — Derived batch output: `PkScript`, untweaked
+  `InternalKey`, `SigningTweak` (commits to sweep leaf + asset root),
+  `AssetRoot`, and `ChangePkScript` when the request carries change.
+- `BatchAnchorCommit` — Sealed transition: `PackageBytes`, `AnchorPSBT`, the
+  echoed `Script`, and the `RootSource` the tree materializer spends.
+- `BatchAnchorSource` / `BatchAnchorChange` / `DeriveBatchAnchorChange` — One
+  confirmed asset input (proof file, amount, optional witness, verifier, anchor
+  outpoint/internal key), and the wallet-owned change output plus its key
+  derivation helper.
+- `BuildAssetTree(ctx, TreeMaterializerConfig, AssetTreeRequest)` — Builds the
+  asset VTXO tree below a batch output. Validates leaf/asset conservation,
+  calls `tree.BuildStructure` + `tree.Materialize` with the internal
+  `treeMaterializer`, and returns a verified `*tree.Tree` carrying an
+  `AssetContext`.
+- `AssetTreeRequest` — Tree inputs: `Leaves` (each with a non-zero
+  `AssetAmount`), `OperatorKey`, `Radix`, `BatchOutpoint`, `BatchOutput`, and
+  the total `AssetAmount`.
+- `TreeMaterializerConfig` — Materialization wiring: tap-sdk `Wallet`, commit
+  journal `Store`, `AssetRef`, operator `SweepLeaf`, a `LeafAnchor` callback
+  returning per-leaf taproot data, the `Root` asset source, and the `Digest`
+  scoping deterministic script keys.
+- `TreeRootAssetSource` / `TreeRootAssetInput` — The asset states the root node
+  spends, plus the batch output's `SigningTweak` and `BatchPkScript`. Each
+  input carries **exactly one** of `ProofFile` (confirmed) or `ProofPath`
+  (unconfirmed transitions).
+- `TreeLeafAnchor` / `StandardVTXOLeafAnchor` — Taproot data for a leaf VTXO
+  output (uncomposed pkScript, internal key, canonically ordered tap leaves);
+  the helper builds it for a standard owner/operator + exit-delay VTXO policy
+  via `lib/arkscript`.
+- `Store` / `ErrStoreNotFound` — Durable commit journal: `Load`/`Store` keyed by
+  string. Implementations must replace each value **atomically**.
+  `ErrStoreNotFound` is the sentinel a missing key must return.
+- `ErrReconciliationRequired` — Publication may have succeeded; the outcome must
+  be checked before any retry.
+
+## Relationships
+
+- **Depends on**: `lib/tree` (`Tree`, `Node`, `LeafDescriptor`,
+  `BuildStructure`, `Materialize`, and the tree `AssetContext`),
+  `lib/arkscript` (VTXO policy templates and compiled taproot leaves),
+  `lib/tx/psbtutil` (anchor PSBT parse/encode),
+  `github.com/lightninglabs/tap-sdk` (custom-anchor wallet, transfer packages,
+  proof verifiers).
+- **Depended on by**: nothing yet — `tapassets` is a standalone building block.
+  It is consumed through the asset-tree plumbing landing in `round` and
+  `rpc/roundpb` (`VTXOTree.asset_ref`, `TreeNode.signing_tweak` /
+  `asset_amount` / `asset_commitment_root`, and
+  `ClientBatchInfo.asset_leaf_packages`), not by importing this package
+  directly. Wire a new consumer through `TreeMaterializerConfig` /
+  `BatchAnchorCommitterConfig` rather than reaching at internals.
+- **Sends / Receives**: none. This package holds no actor; it is called
+  synchronously and performs no message passing.
+
+## Invariants
+
+- **Node transactions are zero fee.** The leaf carrier values must sum exactly
+  to `BatchOutput.Value`, and the leaf asset amounts must sum exactly to
+  `AssetTreeRequest.AssetAmount`, which must in turn equal the sum of the root
+  source input amounts. All three totals are overflow-checked before use.
+- Each leaf cosigner key must be unique within a tree; a repeated cosigner is
+  rejected rather than silently collapsed.
+- `req.BatchOutput.PkScript` must equal `cfg.Root.BatchPkScript` — the tree is
+  refused if the output being spent is not the one the asset source describes.
+- `Radix` must be at least 2, and proof capacity is validated against the built
+  structure's depth (`validateTreeProofCapacity`) before any transition is
+  committed, so a tree too deep for its proof budget fails early.
+- **The commit journal is keyed by request digest, not just by key.** A journal
+  entry records the sha256 of `(digestDomain, request)`; reloading a key with a
+  *different* request is a hard error ("journal key reused with a different
+  request") rather than a silent re-commit. A present package is decoded and
+  returned as-is — tapd has already recorded that transition and must not see
+  it twice.
+- Journal writes after a successful commit run under
+  `context.WithoutCancel` with a 5s timeout (`commitJournalWriteTimeout`), so a
+  cancelled caller cannot lose the record of a transition tapd already
+  committed.
+- `ErrReconciliationRequired` is joined onto a `Publish` failure **only** when
+  tap-sdk reports `OutcomeUnknown`. Treat it as "may have landed": reconcile
+  before retrying, never blind-retry.
+- `Commit` binds the sealed transition to the funded transaction: the committed
+  anchor PSBT's txid must match the funded transaction's, and the committed
+  batch outpoint must equal `(finalTx.TxHash(), req.OutputIndex)`. Output
+  indexes must therefore be final before deriving a request with change.
+- `commitResultFromPackage` requires every output to have a matching proof
+  update, keyed by `(packetRole, packetIndex, virtualOutputIndex)`; an output
+  with no proof is a hard error, not an empty blob.
+- A failure converting an already-committed tapd response is wrapped in
+  `commitResponseError` so callers can tell "tapd never committed" from "tapd
+  committed and we failed locally afterwards" — the latter needs the journal,
+  not a retry.
+- All byte slices crossing the package boundary (`packageBytes`, `anchorPSBT`,
+  proof blobs) are defensively copied, so a caller cannot mutate journaled
+  state.
+
+## Deep Docs
+
+- [lib/tree/CLAUDE.md](../lib/tree/CLAUDE.md) — Tree structure, materialization
+  interface, and the asset context this package populates.
+- [lib/arkscript/CLAUDE.md](../lib/arkscript/CLAUDE.md) — Policy templates and
+  compiled taproot leaves used for leaf anchors.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -20,7 +20,7 @@ refresh, leave, OOR spend, and directed send flows.
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
-- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
+- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle. Also carries the manager's `ReserveEpoch` for the reservation, so the OOR transfer that spends it can name the reservation on release (see `oor.TransferInput.ReserveEpoch`).
 - `CreateBoardingAddressRequest` / `CreateBoardingAddressResponse` — Ask-request for deriving new address.
 - `BlockEpochNotification` — Tell-message from chain source triggering UTXO polling.
 - `BoardingUtxoConfirmedEvent` — Tell-message sent when a VTXO confirms.
@@ -70,10 +70,17 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendOnChainStatus` — Terminal outcome enum: `SendOnChainStatusSubmitted` (intent queued for next round), `SendOnChainStatusPreview` (dry-run preview, no commitment).
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `BoardingChainInfo.TxProof` — `fn.Option[types.TxProof]`: the Bitcoin
+  inclusion proof for a confirmed boarding input, giving the server the block
+  header and output construction details it needs without querying its own
+  chain source. `None` when the proof has not been constructed yet (e.g. block
+  data unavailable). The type is owned by `lib/types`, **not**
+  `taproot-assets/proof` — the wallet no longer imports the tapd proof package
+  on this path.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager / round admission types, incl. custom-forfeit activation), `lib/arkscript` (custom-refresh spend paths), `lib/types` (`Ancestry`, `LeaveRequest`, `OperatorTerms`), `lib/tx/arktx` (tx version constant), `walletcore` (`LockID`/`OutputLeaser` aliases, `Utxo`), `txconfirm` (boarding-sweep confirmation tracking), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants), `metrics` (optional background-task-error sink).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager / round admission types, incl. custom-forfeit activation), `lib/arkscript` (custom-refresh spend paths), `lib/types` (`Ancestry`, `LeaveRequest`, `OperatorTerms`, `TxProof` / `NewTxMerkleProof` for boarding inclusion proofs), `lib/tx/arktx` (tx version constant), `walletcore` (`LockID`/`OutputLeaser` aliases, `Utxo`), `txconfirm` (boarding-sweep confirmation tracking), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants), `metrics` (optional background-task-error sink).
 - **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `waved` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
@@ -104,6 +111,14 @@ refresh, leave, OOR spend, and directed send flows.
 - Local ownership of a round-produced VTXO is no longer tracked with a per-intent `IsOwner` flag. `types.VTXORequest` / `round.VTXOIntent` no longer carry `IsOwner`; at round confirmation time the round FSM asks a `round.OwnedScriptChecker` (backed in production by the OOR owned-receive-scripts store) which pkScripts to persist as local balance. The wallet's only job is to supply the correct `OwnerKey` per intent — local-origin owner keys keep their populated `KeyLocator` so `handleRegisterIntent` registers them via `OwnedScriptRegistrar`, while remote recipients carry a zero `KeyLocator` and are intentionally left unregistered.
 - `handleSendVTXOs` uses a `defer`-based release rather than a `releaseAndFail` helper: any error path (including dry-run) falls through to the deferred release, and the `committed` flag is set only after the round actor accepts the intent. Context is preserved via `context.WithoutCancel` so cleanup is not dropped when the caller disconnects.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
+- Refresh intents leave `SigningKey` empty rather than reusing the VTXO's
+  `ClientKey`. Round registration derives a fresh locator-backed key for the
+  MuSig2 tree; reusing the old owner descriptor breaks for legacy VTXOs that
+  retain the pubkey but not its LND key locator.
+- `handleSelectAndLockVTXOs` propagates the VTXO manager's `ReserveEpoch` onto
+  each `SelectedVTXO`. Dropping it strands the spender with no way to name its
+  reservation on release, which is what lets a superseded session return a coin
+  a newer session is actively spending.
 - `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
 - The wallet tracks, in memory, boarding outpoints already handed to the round
   actor via `TriggerBoardMsg` that have not yet left the confirmed set, and

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -20,7 +20,7 @@ refresh, leave, OOR spend, and directed send flows.
 - `BoardingStore` — Interface for persisting boarding addresses and intents.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
-- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
+- `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle. Also carries the manager's `ReserveEpoch` for the reservation, so the OOR transfer that spends it can name the reservation on release (see `oor.TransferInput.ReserveEpoch`).
 - `CreateBoardingAddressRequest` / `CreateBoardingAddressResponse` — Ask-request for deriving new address.
 - `BlockEpochNotification` — Tell-message from chain source triggering UTXO polling.
 - `BoardingUtxoConfirmedEvent` — Tell-message sent when a VTXO confirms.
@@ -70,10 +70,17 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendOnChainStatus` — Terminal outcome enum: `SendOnChainStatusSubmitted` (intent queued for next round), `SendOnChainStatusPreview` (dry-run preview, no commitment).
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `BoardingChainInfo.TxProof` — `fn.Option[types.TxProof]`: the Bitcoin
+  inclusion proof for a confirmed boarding input, giving the server the block
+  header and output construction details it needs without querying its own
+  chain source. `None` when the proof has not been constructed yet (e.g. block
+  data unavailable). The type is owned by `lib/types`, **not**
+  `taproot-assets/proof` — the wallet no longer imports the tapd proof package
+  on this path.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager / round admission types, incl. custom-forfeit activation), `lib/arkscript` (custom-refresh spend paths), `lib/types` (`Ancestry`, `LeaveRequest`, `OperatorTerms`), `lib/tx/arktx` (tx version constant), `walletcore` (`LockID`/`OutputLeaser` aliases, `Utxo`), `txconfirm` (boarding-sweep confirmation tracking), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants), `metrics` (optional background-task-error sink).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager / round admission types, incl. custom-forfeit activation), `lib/arkscript` (custom-refresh spend paths), `lib/types` (`Ancestry`, `LeaveRequest`, `OperatorTerms`, `TxProof` / `NewTxMerkleProof` for boarding inclusion proofs), `lib/tx/arktx` (tx version constant), `walletcore` (`LockID`/`OutputLeaser` aliases, `Utxo`), `txconfirm` (boarding-sweep confirmation tracking), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants), `metrics` (optional background-task-error sink).
 - **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `waved` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
@@ -104,6 +111,14 @@ refresh, leave, OOR spend, and directed send flows.
 - Local ownership of a round-produced VTXO is no longer tracked with a per-intent `IsOwner` flag. `types.VTXORequest` / `round.VTXOIntent` no longer carry `IsOwner`; at round confirmation time the round FSM asks a `round.OwnedScriptChecker` (backed in production by the OOR owned-receive-scripts store) which pkScripts to persist as local balance. The wallet's only job is to supply the correct `OwnerKey` per intent — local-origin owner keys keep their populated `KeyLocator` so `handleRegisterIntent` registers them via `OwnedScriptRegistrar`, while remote recipients carry a zero `KeyLocator` and are intentionally left unregistered.
 - `handleSendVTXOs` uses a `defer`-based release rather than a `releaseAndFail` helper: any error path (including dry-run) falls through to the deferred release, and the `committed` flag is set only after the round actor accepts the intent. Context is preserved via `context.WithoutCancel` so cleanup is not dropped when the caller disconnects.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
+- Refresh intents leave `SigningKey` empty rather than reusing the VTXO's
+  `ClientKey`. Round registration derives a fresh locator-backed key for the
+  MuSig2 tree; reusing the old owner descriptor breaks for legacy VTXOs that
+  retain the pubkey but not its LND key locator.
+- `handleSelectAndLockVTXOs` propagates the VTXO manager's `ReserveEpoch` onto
+  each `SelectedVTXO`. Dropping it strands the spender with no way to name its
+  reservation on release, which is what lets a superseded session return a coin
+  a newer session is actively spending.
 - `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
 - The wallet tracks, in memory, boarding outpoints already handed to the round
   actor via `TriggerBoardMsg` that have not yet left the confirmed set, and


### PR DESCRIPTION
Automated nightly documentation sweep via `.claude/skills/doc-gardening`, run over everything that changed since the last merged sweep.

Workflow run: https://github.com/lightninglabs/wavelength/actions

## What changed

- **New package doc**: `tapassets/` had no `CLAUDE.md`/`AGENTS.md`. Added one covering the batch-anchor committer, asset tree materialization, the commit journal, and the reconciliation contract. Also added the package to the Layer 1 table in `ARCHITECTURE.md`.
- **`docs/index.md`**: added the missing `mailbox_ingress_safety.md` entry. This was an outright `make doc-check` failure on `main` before this PR.
- **Stale per-package docs** refreshed against their source: `lib/actormsg` and `wallet` (reservation epochs), `lib/recovery` (`RootExternalInputs`), `rpc/roundpb` (asset tree fields and the per-node tweak rule), `sdk/ark` (`VTXOConfirmations` vs `MinConfirmations`, `ListVTXOs` default), `swapwallet` (per-input on-chain fee quoting, sweep output floor, late-transition stamping), `cmd/wavecli/waveclicommands` (repeatable `--status` / `--all`).

## Review notes

Please review the updated `CLAUDE.md`/`AGENTS.md` and `ARCHITECTURE.md` diffs — each `CLAUDE.md` is mirrored byte-identically to its sibling `AGENTS.md`, so review either side of each pair.

`make doc-check` passes. This branch is docs-only; no Go source was touched.
